### PR TITLE
chore(rest): Change docs reference in HAL Browser

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -101,16 +101,16 @@ include::{snippets}/should_document_get_release/links.adoc[]
 A `PATCH` request is used to update an existing release
 
 ===== Response structure
-include::{snippets}/should_update_release/response-fields.adoc[]
+include::{snippets}/should_document_update_release/response-fields.adoc[]
 
 ===== Example request
-include::{snippets}/should_update_release/curl-request.adoc[]
+include::{snippets}/should_document_update_release/curl-request.adoc[]
 
 ===== Example response
-include::{snippets}/should_update_release/http-response.adoc[]
+include::{snippets}/should_document_update_release/http-response.adoc[]
 
 ===== Links
-include::{snippets}/should_update_release/links.adoc[]
+include::{snippets}/should_document_update_release/links.adoc[]
 
 
 [[resources-release-delete]]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -34,7 +34,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
 
     public @Bean
     CurieProvider curieProvider() {
-        return new DefaultCurieProvider(CURIE_NAMESPACE, new UriTemplate("/docs/html5/{rel}.html"));
+        return new DefaultCurieProvider(CURIE_NAMESPACE, new UriTemplate("/docs/{rel}.html"));
     }
 
     @Override

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
@@ -62,7 +62,7 @@ public class TestHelper {
         assertThat(linksNode.has("curies"), is(true));
 
         JsonNode curiesNode = linksNode.get("curies").get(0);
-        assertThat(curiesNode.get("href").asText(), endsWith("docs/html5/{rel}.html"));
+        assertThat(curiesNode.get("href").asText(), endsWith("docs/{rel}.html"));
         assertThat(curiesNode.get("name").asText(), is("sw360"));
         assertThat(curiesNode.get("templated").asBoolean(), is(true));
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
@@ -64,7 +64,7 @@ abstract public class TestIntegrationBase {
         assertThat(linksNode.has("curies"), is(true));
 
         JsonNode curiesNode = linksNode.get("curies").get(0);
-        assertThat(curiesNode.get("href").asText(), endsWith("docs/html5/{rel}.html"));
+        assertThat(curiesNode.get("href").asText(), endsWith("docs/{rel}.html"));
         assertThat(curiesNode.get("name").asText(), is("sw360"));
         assertThat(curiesNode.get("templated").asBoolean(), is(true));
     }


### PR DESCRIPTION
Change the docs reference (href) of sw360 resources for HAL Browser.

closes eclipse/sw360#342

Signed-off-by: Thomas Maier <thomas.maier@evosoft.com>