### PR TITLE
fix(rest): Create duplicate project clearing state should always be open and not copied

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -49,6 +49,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatInfo;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.Source;
@@ -310,6 +311,7 @@ public class ProjectController implements ResourceProcessor<RepositoryLinksResou
         sw360Project.unsetRevision();
         sw360Project.unsetAttachments();
         sw360Project.unsetClearingRequestId();
+        sw360Project.setClearingState(ProjectClearingState.OPEN);
         String linkedObligationId = sw360Project.getLinkedObligationId();
         sw360Project.unsetLinkedObligationId();
         Project createDuplicateProject = projectService.createProject(sw360Project, user);


### PR DESCRIPTION
> Create duplicate project clearing state should always be open and not copied.
> * Which issue is this pull request belonging to and how is it solving it? (*#1401*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: 

### How To Test?
> Create duplicate project by Rest api
>    - Clearing State of ne duplicate project should be `open` even if original project is `closed or in progress`

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>