### PR TITLE
feat(obligations): Read component obligations from CLI

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
@@ -204,20 +204,22 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
         var obligText = "<sw360:out value='${projectObligations.text}' stripNewlines='false' jsQuoting='true'/>";
         obligText = obligText.replace(/[\r\n]/g, '<br>');
         obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
-        obligationJSON.push({
-            "obligation": "<sw360:out value='${entry.key}'/>",
-            "lIds": licenseIds.join(', <br>'),
-            "rIds": releaseIds,
-            "rNames": releaseNames.join(', <br>'),
-            "status": "<sw360:DisplayEnum value='${projectObligations.status}'/>",
-            /* "action": '${projectObligations.action}', */
-            "type": "<sw360:DisplayEnum value='${projectObligations.obligationType}'/>",
-            "id": "<sw360:out value='${projectObligations.id}'/>",
-            "comment": "<sw360:out value='${projectObligations.comment}'/>",
-            "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
-            "modifiedBy": '${projectObligations.modifiedBy}',
-            "modifiedOn": '${projectObligations.modifiedOn}'
-        });
+        <core_rt:if test="${projectObligations.obligationLevel ne 'COMPONENT_OBLIGATION'}">
+            obligationJSON.push({
+                "obligation": "<sw360:out value='${entry.key}'/>",
+                "lIds": licenseIds.join(', <br>'),
+                "rIds": releaseIds,
+                "rNames": releaseNames.join(', <br>'),
+                "status": "<sw360:DisplayEnum value='${projectObligations.status}'/>",
+                /* "action": '${projectObligations.action}', */
+                "type": "<sw360:DisplayEnum value='${projectObligations.obligationType}'/>",
+                "id": "<sw360:out value='${projectObligations.id}'/>",
+                "comment": "<sw360:out value='${projectObligations.comment}'/>",
+                "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
+                "modifiedBy": '${projectObligations.modifiedBy}',
+                "modifiedOn": '${projectObligations.modifiedOn}'
+            });
+        </core_rt:if>
     </core_rt:forEach >
 
     /* create table */
@@ -358,7 +360,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
         "modifiedOn": '${projOblig.value.modifiedOn}'
     });
     </core_rt:forEach >
-    
+
     /* create table */
     var projectTable = datatables.create('#project-obligationsDetailTable', {
         "data": projectObligationJSON,
@@ -432,20 +434,23 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
     });
 
     //Comp Obligation
-    <core_rt:forEach items="${componentLevelObligations}" var="compOblig" varStatus="loop">
-      var obligText = "<sw360:out value='${compOblig.value.text}' stripNewlines='false' jsQuoting='true'/>";
-      obligText = obligText.replace(/[\r\n]/g, '<br>');
-      obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
-      compObligationJSON.push({
-        "obligation": "<sw360:out value='${compOblig.key}'/>",
-        "status": "<sw360:DisplayEnum value='${compOblig.value.status}'/>",
-        "type": "<sw360:DisplayEnum value='${compOblig.value.obligationType}'/>",
-        "id": "<sw360:out value='${compOblig.value.id}'/>",
-        "comment": "<sw360:out value='${compOblig.value.comment}'/>",
-        "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
-        "modifiedBy": '${compOblig.value.modifiedBy}',
-        "modifiedOn": '${compOblig.value.modifiedOn}'
-      });
+    <core_rt:forEach items="${obligationData.linkedObligationStatus}" var="entry" varStatus="loop">
+        <core_rt:set var="componentObligations" value="${entry.value}" />
+        var obligText = "<sw360:out value='${componentObligations.text}' stripNewlines='false' jsQuoting='true'/>";
+        obligText = obligText.replace(/[\r\n]/g, '<br>');
+        obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
+        <core_rt:if test="${componentObligations.obligationLevel eq 'COMPONENT_OBLIGATION'}">
+            compObligationJSON.push({
+              "obligation": "<sw360:out value='${entry.key}'/>",
+              "status": "<sw360:DisplayEnum value='${componentObligations.status}'/>",
+              "type": "<sw360:DisplayEnum value='${componentObligations.obligationType}'/>",
+              "id": "<sw360:out value='${componentObligations.id}'/>",
+              "comment": "<sw360:out value='${componentObligations.comment}'/>",
+              "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
+              "modifiedBy": '${componentObligations.modifiedBy}',
+              "modifiedOn": '${componentObligations.modifiedOn}'
+          });
+        </core_rt:if>
     </core_rt:forEach >
     
     /* create table */

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
@@ -233,20 +233,21 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
         var obligText = "<sw360:out value='${projectObligations.text}' stripNewlines='false' jsQuoting='true'/>";
         obligText = obligText.replace(/[\r\n]/g, '<br>');
         obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
-        obligationJSON.push({
-            "obligation": "<sw360:out value='${entry.key}'/>",
-            "licenseLinks": licenseLinks,
-            "releaseLinks": releaseLinks,
-            "status": '<sw360:DisplayEnumOptions type="<%=ObligationStatus.class%>" selected="${projectObligations.status}" />',
-            /* "action": "${projectObligations.action}", */
-            "type": "<sw360:DisplayEnum value='${projectObligations.obligationType}'/>",
-            "level": "${projectObligations.obligationLevel}",
-            "id": "<sw360:out value='${projectObligations.id}'/>",
-            "comment": "<sw360:out value='${projectObligations.comment}'/>",
-            "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
-            "modifiedBy": "${projectObligations.modifiedBy}",
-            "modifiedOn": "${projectObligations.modifiedOn}"
-        });
+        <core_rt:if test="${projectObligations.obligationLevel ne 'COMPONENT_OBLIGATION'}">
+            obligationJSON.push({
+              "obligation": "<sw360:out value='${entry.key}'/>",
+              "licenseLinks": licenseLinks,
+              "releaseLinks": releaseLinks,
+              "status": '<sw360:DisplayEnumOptions type="<%=ObligationStatus.class%>" selected="${projectObligations.status}" />',
+              "type": "<sw360:DisplayEnum value='${projectObligations.obligationType}'/>",
+              "level": "${projectObligations.obligationLevel}",
+              "id": "<sw360:out value='${projectObligations.id}'/>",
+              "comment": "<sw360:out value='${projectObligations.comment}'/>",
+              "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
+              "modifiedBy": "${projectObligations.modifiedBy}",
+              "modifiedOn": "${projectObligations.modifiedOn}"
+            });
+        </core_rt:if>
     </core_rt:forEach >
 
     /* create table */
@@ -806,7 +807,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
 
       /* collect all the component obligation status */
       function compUpdateObligations(event, data, node, config) {
-          updateprojectCompOrgObligations(event, data, node, config, "<%=ObligationLevel.COMPONENT_OBLIGATION%>",compTable, compDataMap);
+          updateCompObligations(event, data, node, config, "<%=ObligationLevel.COMPONENT_OBLIGATION%>", compDataMap);
       }
       /* collect all the org obligation status */
       function orgUpdateObligations(event, data, node, config) {
@@ -830,7 +831,42 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
 
           otherObligTable.rows().every(function (rowIdx, tableLoop, rowLoop) {
               let rowData = this.data(),
-                  mapKey = $.parseHTML(rowData.text)[0].nodeValue,
+                  mapKey = $.parseHTML(rowData.obligation)[0].nodeValue,
+                  ids = [];
+              let mapValue = {};
+              if (otherDataMap.has(mapKey)) {
+                  $node = $(this.node()),
+                  mapValue.status = $node.find('select.obl_status option:selected').val();
+                  mapValue.comment = $node.find("input.obl_comment").val();
+                  mapValue.id=rowData.id;
+                  let type=$node.find("td.obl_type").text().trim();
+                  mapValue.obligationType=type.length==0?"<%=ObligationType.OBLIGATION%>":type.toUpperCase();
+                  mapValue.modifiedOn = date;
+                  mapValue.obligationLevel = level;
+                  obligationMap.set(mapKey, mapValue);
+              }
+          });
+
+          let projJsonObject = {};
+          for (const [key, value] of obligationMap.entries()) {
+              projJsonObject[key] = value;
+          }
+          jsonObject = Object.assign(projJsonObject, jsonObject);
+          obligationMap.clear();
+      }
+
+      function updateCompObligations(event, data, node, config, level, otherDataMap) {
+          let btnData = node.data(),
+              date = new Date().toISOString().split('T')[0],
+              obligationMap = new Map();
+
+          if (otherDataMap.size < 1) {
+              return;
+          }
+
+          compTable.rows().every(function (rowIdx, tableLoop, rowLoop) {
+              let rowData = this.data(),
+                  mapKey = $.parseHTML(rowData.obligation)[0].nodeValue,
                   ids = [];
               let mapValue = {};
               if (otherDataMap.has(mapKey)) {
@@ -883,7 +919,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
           let $tr = thisObj.closest("tr");
           if (!$tr.hasClass('orphan')) {
               // get obligatoin topic/text from second column (index -> 1) in table.
-              projectCompOrgObligationDataMap.set($.parseHTML($tr.attr('data-text'))[0].nodeValue, '');
+              projectCompOrgObligationDataMap.set($.parseHTML($tr.find('td:eq(1)').text())[0].nodeValue, '');
           }
       }
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -72,6 +72,21 @@ public class SW360Constants {
     public static final String TYPE_VULNERABILITYDTO = "vulDTO";
     public static final String TYPE_OBLIGATIONELEMENT = "obligationElement";
     public static final String TYPE_OBLIGATIONNODE = "obligationNode";
+    public static final String CRITICALFILESFOUND_OBLIGATION_TITLE = "Source / binary integration notes:";
+    public static final String NO_CRITICAL_FILES_FOUND = "no critical files found, source code and binaries can be used as is";
+    public static final String CRITICAL_FILES_FOUND = "critical files found, source code needs to be adapted and binaries possibly re-built";
+    public static final String DEPENDENCY_NOTES = "Dependency notes:";
+    public static final String SOURCE_DEPENDENCIES_FOUND = "SourceDependenciesFound";
+    public static final String BINARY_DEPENDENCIES_FOUND = "BinaryDependenciesFound";
+    public static final String SOURCE_DEPENDENCIES_FOUND_TEXT = "dependencies found in source code (see obligations)";
+    public static final String BINARY_DEPENDENCIES_FOUND_TEXT = "dependencies found in binaries (see obligations)";
+    public static final String NO_DEPENDENCIES_FOUND_TEXT = "no dependencies found, neither in source code nor in binaries";
+    public static final String EXPORT_RESTRICTIONS_TITLE = "Export restrictions by copyright owner:";
+    public static final String EXPORT_RESTRICTIONS_FOUND_TEXT = "Export restrictions found (see obligations)";
+    public static final String EXPORT_RESTRICTIONS_NOT_FOUND_TEXT = "no export restrictions found";
+    public static final String USAGE_RESTRICTIONS_TITLE = "Restrictions for use by copyright owner (e.g. not for Nuclear Power):";
+    public static final String USAGE_RESTRICTIONS_FOUND_TEXT = "restrictions for use found (see obligations)";
+    public static final String USAGE_RESTRICTIONS_NOT_FOUND_TEXT = "no restrictions for use found";
 
     /**
      * Hashmap containing the name field for each type.

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -11,6 +11,7 @@
 include "users.thrift"
 include "components.thrift"
 include "projects.thrift"
+include "licenses.thrift"
 
 namespace java org.eclipse.sw360.datahandler.thrift.licenseinfo
 namespace php sw360.thrift.licenseinfo
@@ -20,6 +21,7 @@ typedef components.Attachment Attachment
 typedef users.User User
 typedef projects.Project Project
 typedef projects.ObligationStatusInfo ObligationStatusInfo
+typedef licenses.Obligation Obligation
 
 enum LicenseInfoRequestStatus{
     SUCCESS = 0,
@@ -93,6 +95,7 @@ struct ObligationParsingResult {
     4: optional Release release,
     5: optional string attachmentContentId,
     6: optional string sha1Hash,
+    7: optional list<Obligation> componentObligations
 }
 
 struct ObligationAtProject {


### PR DESCRIPTION
Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*#1437*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

closes: #1437 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

* Upload CLI having component level obligations(i.e AssessmentSummary),  Check if it is being displayed in Project -> Obligations -> Component Obligations

> Have you implemented any additional tests? - No



### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
