### PR TITLE
fix(rest): disable URI decoding in search by external ids in release

### DIFF
--- a/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360Client.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360Client.java
@@ -137,6 +137,25 @@ public abstract class SW360Client {
     }
 
     /**
+     * Executes a request to SW360 with authentication and retry logic that
+     * expects a JSON response. This method performs the same checks as
+     * {@code executeRequest()}, but it creates the {@code ResponseProcessor}
+     * automatically that can convert the JSON response to the desired target
+     * type.
+     *
+     * @param producer    the {@code RequestProducer}
+     * @param resultClass the class to which the JSON payload is to be
+     *                    converted
+     * @param tag         a tag to identify the request
+     * @param <T>         the type of the result
+     * @return a future with the result of the request
+     */
+    protected <T> CompletableFuture<T> executeJsonRequestNew(Consumer<? super RequestBuilder> producer,
+            Class<T> resultClass, String tag) {
+        return executeRequest(producer, HttpUtils.jsonResultNew(getClientConfig().getObjectMapper(), resultClass), tag);
+    }
+
+    /**
      * Executes a request to delete multiple entities of a given resource.
      * SW360 typically supports DELETE operations on resources that accept a
      * list of IDs. Result is a {@code MultiStatusResponse} with information

--- a/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360ReleaseClient.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360ReleaseClient.java
@@ -12,19 +12,19 @@
  */
 package org.eclipse.sw360.clients.rest;
 
-import org.eclipse.sw360.http.RequestBuilder;
-import org.eclipse.sw360.http.utils.HttpUtils;
-import org.eclipse.sw360.clients.config.SW360ClientConfig;
-import org.eclipse.sw360.clients.auth.AccessTokenProvider;
-import org.eclipse.sw360.clients.utils.SW360ResourceUtils;
-import org.eclipse.sw360.clients.rest.resource.releases.SW360Release;
-import org.eclipse.sw360.clients.rest.resource.releases.SW360ReleaseList;
-import org.eclipse.sw360.clients.rest.resource.releases.SW360SparseRelease;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.sw360.clients.auth.AccessTokenProvider;
+import org.eclipse.sw360.clients.config.SW360ClientConfig;
+import org.eclipse.sw360.clients.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.clients.rest.resource.releases.SW360ReleaseList;
+import org.eclipse.sw360.clients.rest.resource.releases.SW360SparseRelease;
+import org.eclipse.sw360.clients.utils.SW360ResourceUtils;
+import org.eclipse.sw360.http.RequestBuilder;
+import org.eclipse.sw360.http.utils.HttpUtils;
 
 /**
  * <p>
@@ -102,15 +102,10 @@ public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release>
     // which are mapped to numbered keys like `hash_1=...`, `hash_2=...`, ...
     // but can change in the order of the values
     public CompletableFuture<List<SW360SparseRelease>> getReleasesByExternalIds(Map<String, ?> externalIds) {
-        String url = getExternalIdUrl(externalIds);
-        return executeJsonRequestWithDefault(HttpUtils.get(url), SW360ReleaseList.class,
-                TAG_GET_RELEASES_BY_EXTERNAL_IDS, SW360ReleaseList::new)
+        return executeJsonRequestNew(builder -> builder.method(RequestBuilder.Method.GET)
+                .uri(resourceUrl(RELEASES_ENDPOINT_APPENDIX, PATH_SEARCH_EXT_IDS)).body(body -> body.json(externalIds)),
+                SW360ReleaseList.class, TAG_GET_RELEASES_BY_EXTERNAL_IDS)
                 .thenApply(SW360ResourceUtils::getSw360SparseReleases);
-    }
-
-    private String getExternalIdUrl(Map<String, ?> externalIds) {
-        return HttpUtils.addQueryParameters(resourceUrl(RELEASES_ENDPOINT_APPENDIX, PATH_SEARCH_EXT_IDS),
-                externalIds);
     }
 
     /**

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/rest/AbstractMockServerTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/rest/AbstractMockServerTest.java
@@ -339,6 +339,28 @@ public class AbstractMockServerTest {
         HttpClientFactory clientFactory = new HttpClientFactoryImpl();
         HttpClientConfig httpClientConfig = HttpClientConfig.basicConfig();
         HttpClient httpClient = clientFactory.newHttpClient(httpClientConfig);
+        objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+
+        if (RUN_REST_INTEGRATION_TEST) {
+            return SW360ClientConfig.createConfig(REST_BASE_URL, OAUTH_BASE_URL, USERNAME, USER_PASSWORD,
+                    OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_TOKEN, httpClient, objectMapper);
+        }
+
+        return SW360ClientConfig.createConfig(wireMockRule.baseUrl(), wireMockRule.url(TOKEN_ENDPOINT), USER, PASSWORD,
+                CLIENT_ID, CLIENT_PASSWORD, USER_TOKEN, httpClient, objectMapper);
+    }
+
+    /**
+     * Creates a configuration for the new(native java) client library with test properties.
+     * This configuration also contains a fully configured HTTP client and an
+     * object mapper.
+     *
+     * @return the SW360 client configuration
+     */
+    protected SW360ClientConfig createClientConfigAlt() {
+        HttpClientFactory clientFactory = new HttpClientFactoryImpl();
+        HttpClientConfig httpClientConfig = HttpClientConfig.basicConfig();
+        HttpClient httpClient = clientFactory.newHttpClientAlt(httpClientConfig);
 
         if (RUN_REST_INTEGRATION_TEST) {
             return SW360ClientConfig.createConfig(REST_BASE_URL, OAUTH_BASE_URL, USERNAME, USER_PASSWORD,

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/rest/SW360ReleaseClientIT.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/rest/SW360ReleaseClientIT.java
@@ -23,6 +23,7 @@ import org.eclipse.sw360.clients.rest.resource.components.SW360SparseComponent;
 import org.eclipse.sw360.clients.rest.resource.releases.SW360Release;
 import org.eclipse.sw360.clients.rest.resource.releases.SW360SparseRelease;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -66,6 +67,7 @@ public class SW360ReleaseClientIT extends AbstractMockServerTest {
     };
 
     private SW360ReleaseClient releaseClient;
+    private SW360ReleaseClient releaseClientAlt;
     private SW360ComponentClient componentClient;
     private static final String FILE_COMPONENT = "component.json";
 
@@ -77,11 +79,16 @@ public class SW360ReleaseClientIT extends AbstractMockServerTest {
                     .getReleaseAdapterAsync();
             SW360ComponentClientAdapterAsync componentClientAsync = scf.newConnection(createClientConfig())
                     .getComponentAdapterAsync();
+            SW360ReleaseClientAdapterAsync releaseClientAsyncAlt = scf.newConnection(createClientConfigAlt())
+                    .getReleaseAdapterAsync();
             componentClient = componentClientAsync.getComponentClient();
             releaseClient = releaseClientAsync.getReleaseClient();
+            releaseClientAlt = releaseClientAsyncAlt.getReleaseClient();
         } else {
             releaseClient = new SW360ReleaseClient(createClientConfig(), createMockTokenProvider());
+            releaseClientAlt = new SW360ReleaseClient(createClientConfigAlt(), createMockTokenProvider());
             prepareAccessTokens(releaseClient.getTokenProvider(), CompletableFuture.completedFuture(ACCESS_TOKEN));
+            prepareAccessTokens(releaseClientAlt.getTokenProvider(), CompletableFuture.completedFuture(ACCESS_TOKEN));
         }
     }
 
@@ -152,19 +159,21 @@ public class SW360ReleaseClientIT extends AbstractMockServerTest {
     public void testGetReleasesByExternalIds() throws IOException {
         if(!RUN_REST_INTEGRATION_TEST) {
             Map<String, Object> idMap = new LinkedHashMap<>();
-            idMap.put("id 1", "testRelease");
+            idMap.put("id+1", "testRelease");
             idMap.put("id2", "otherFilter");
             wireMockRule.stubFor(get(urlPathEqualTo("/releases/searchByExternalIds"))
-                    .withQueryParam("id+1", equalTo("testRelease"))
-                    .withQueryParam("id2", equalTo("otherFilter"))
+                    .withRequestBody(equalToJson("{\"id+1\": \"testRelease\", \"id2\": \"otherFilter\"}"))
                     .willReturn(aJsonResponse(HttpConstants.STATUS_OK)
                             .withBodyFile("all_releases.json")));
 
-            List<SW360SparseRelease> releases = waitFor(releaseClient.getReleasesByExternalIds(idMap));
+            List<SW360SparseRelease> releases = waitFor(releaseClientAlt.getReleasesByExternalIds(idMap));
             checkReleaseData(releases);
         } else {
+            Map<String, List<String>> externalIds = new LinkedHashMap<>();
+            externalIds.put("id1", List.of("testRelease"));
+            externalIds.put("id2", List.of("otherFilter"));
             Map<String, String> idMap = new LinkedHashMap<>();
-            idMap.put("id 1", "testRelease");
+            idMap.put("id1", "testRelease");
             idMap.put("id2", "otherFilter");
             cleanupComponent(componentClient);
             SW360Component component = componentFromJsonForIntegrationTest();
@@ -174,7 +183,7 @@ public class SW360ReleaseClientIT extends AbstractMockServerTest {
             sw360Release.setComponentId(createdComponent.getId());
             sw360Release.setVersion("1.1");
             SW360Release release = waitFor(releaseClient.createRelease(sw360Release));
-            List<SW360SparseRelease> releases = waitFor(releaseClient.getReleasesByExternalIds(idMap));
+            List<SW360SparseRelease> releases = waitFor(releaseClientAlt.getReleasesByExternalIds(externalIds));
             assertEquals(releases.size(), 1);
             cleanupRelease(release, releaseClient);
             cleanupComponent(componentClient);
@@ -186,7 +195,7 @@ public class SW360ReleaseClientIT extends AbstractMockServerTest {
         wireMockRule.stubFor(get(urlPathEqualTo("/releases/searchByExternalIds"))
                 .willReturn(aResponse().withStatus(HttpConstants.STATUS_NO_CONTENT)));
 
-        List<SW360SparseRelease> releases = waitFor(releaseClient.getReleasesByExternalIds(new HashMap<>()));
+        List<SW360SparseRelease> releases = waitFor(releaseClientAlt.getReleasesByExternalIds(new HashMap<String, List<String>>()));
         assertThat(releases).isEmpty();
     }
 
@@ -197,11 +206,11 @@ public class SW360ReleaseClientIT extends AbstractMockServerTest {
                     .willReturn(aJsonResponse(HttpConstants.STATUS_ERR_BAD_REQUEST)));
 
             FailedRequestException exception = expectFailedRequest(
-                    releaseClient.getReleasesByExternalIds(new HashMap<>()), HttpConstants.STATUS_ERR_BAD_REQUEST);
+                    releaseClientAlt.getReleasesByExternalIds(new HashMap<String, List<String>>()), HttpConstants.STATUS_ERR_BAD_REQUEST);
             assertThat(exception.getTag()).isEqualTo(SW360ReleaseClient.TAG_GET_RELEASES_BY_EXTERNAL_IDS);
         } else {
             cleanupComponent(componentClient);
-            List<SW360SparseRelease> releases = waitFor(releaseClient.getReleasesByExternalIds(new HashMap<>()));
+            List<SW360SparseRelease> releases = waitFor(releaseClientAlt.getReleasesByExternalIds(new HashMap<String, List<String>>()));
             assertEquals(releases.size(), 0);
         }
     }

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/HttpClientFactory.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/HttpClientFactory.java
@@ -32,4 +32,13 @@ public interface HttpClientFactory {
      * @return the new {@code HttpClient} instance
      */
     HttpClient newHttpClient(HttpClientConfig config);
+
+    /**
+     * Creates a new instance of {@code HttpClient} and configures it
+     * according to the passed in configuration object.
+     *
+     * @param config the configuration for the new(native java) client
+     * @return the new {@code HttpClient} instance
+     */
+    HttpClient newHttpClientAlt(HttpClientConfig config);
 }

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/HttpClientFactoryImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/HttpClientFactoryImpl.java
@@ -35,6 +35,11 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
         return new HttpClientImpl(createClient(config), config.getOrCreateObjectMapper());
     }
 
+    @Override
+    public HttpClient newHttpClientAlt(HttpClientConfig config) {
+        return new NewHttpClientImpl(createClientAlt(config), config.getOrCreateObjectMapper());
+    }
+
     /**
      * Creates a new {@code OkHttpClient} object that is correctly configured.
      *
@@ -56,6 +61,17 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
     }
 
     /**
+     * Creates a new {@code java.net.http.HttpClient} object that is correctly configured.
+     *
+     * @param config the client configuration
+     * @return the new client object
+     */
+    private static java.net.http.HttpClient createClientAlt(HttpClientConfig config) {
+        java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
+        return client;
+    }
+
+    /**
      * Using the Property CLIENT_ACCESS_UNVERIFIED_PROPERTY, the connection to
      * the client can be done without verification of the ssl certificate
      *
@@ -73,7 +89,6 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
      * @return the corresponding {@code Proxy} representation
      */
     private static Proxy createProxy(ProxySettings settings) {
-        return new Proxy(Proxy.Type.HTTP,
-                new InetSocketAddress(settings.getProxyHost(), settings.getProxyPort()));
+        return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(settings.getProxyHost(), settings.getProxyPort()));
     }
 }

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewHttpClientImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewHttpClientImpl.java
@@ -1,0 +1,85 @@
+/*
+SPDX-FileCopyrightText: © 2022 Siemens AG
+SPDX-License-Identifier: EPL-2.0
+*/
+package org.eclipse.sw360.http;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ *
+ * This class implements the java native client library.
+ *
+ * @author smruti.sahoo@siemens.com
+ *
+ */
+public class NewHttpClientImpl implements org.eclipse.sw360.http.HttpClient {
+
+    /**
+     * The underlying HTTP client.
+     */
+    private final HttpClient client;
+
+    /**
+     * The JSON object mapper.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * Creates a new instance of {@code NewHttpClientImpl} with the dependencies passed
+     * in.
+     * @param client the underlying HTTP client
+     * @param mapper the JSON object mapper
+     */
+    public NewHttpClientImpl(HttpClient client, ObjectMapper mapper) {
+        this.client = client;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public <T> CompletableFuture<T> execute(Consumer<? super RequestBuilder> producer,
+            ResponseProcessor<? extends T> processor) {
+        CompletableFuture<HttpResponse<String>> asyncResponse = null;
+        CompletableFuture<T> resultFuture = new CompletableFuture<>();
+        NewRequestBuilderImpl builder = new NewRequestBuilderImpl(getMapper());
+        producer.accept(builder);
+        HttpRequest request = builder.build();
+        asyncResponse = getClient().sendAsync(request, BodyHandlers.ofString());
+        try {
+            HttpResponse<String> response = asyncResponse.get();
+            T result = processor.process(new NewResponseImpl<>(response));
+            resultFuture.complete(result);
+        } catch (InterruptedException | ExecutionException | IOException e) {
+            resultFuture.completeExceptionally(e);
+        }
+        return resultFuture;
+    }
+
+    /**
+     * Returns a reference to the JSON mapper used by this client.
+     *
+     * @return the JSON mapper
+     */
+    ObjectMapper getMapper() {
+        return mapper;
+    }
+
+    /**
+     * Returns a reference to the underlying {@code HttpClient}.
+     *
+     * @return the underlying client
+     */
+    HttpClient getClient() {
+        return client;
+    }
+
+}

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
@@ -1,0 +1,97 @@
+/*
+SPDX-FileCopyrightText: © 2022 Siemens AG
+SPDX-License-Identifier: EPL-2.0
+*/
+package org.eclipse.sw360.http;
+
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+
+/**
+ * <p>
+ * Implementation of the {@code RequestBodyBuilder} interface on top of the
+ * Native Http library.
+ * </p>
+ * <p>
+ * The class allows defining a request body in different flavours. For a
+ * specific request, only a single variant can be used; attempts to call
+ * multiple defining methods yield an {@code IllegalStateException} exception.
+ * </p>
+ */
+class NewRequestBodyBuilderImpl implements RequestBodyBuilder {
+    /**
+     * The mapper for doing JSON serialization.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * Stores a representation of the body that has been set so far.
+     */
+    private BodyPublisher body;
+
+    /**
+     * Creates a new {@code RequestBodyBuilderImpl} object and initializes it
+     * with the JSON object mapper.
+     *
+     * @param mapper the JSON mapper
+     */
+    public NewRequestBodyBuilderImpl(ObjectMapper mapper) {
+        this.mapper = mapper;
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE);
+    }
+
+    @Override
+    public void string(String str, String mediaType) {
+        initBody(BodyPublishers.ofString(str));
+    }
+
+    @Override
+    public void file(Path path, String mediaType) {
+        //TODO: implementation pending.
+    }
+
+    @Override
+    public void json(Object payload) {
+        try {
+            string(mapper.writeValueAsString(payload), "application/json");
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Returns the request body that has been generated based on the
+     * interactions with this builder. Throws an exception if no body has been
+     * set. (We assume that it is an error in the usage of this library to
+     * request a body builder, but do not actually define a body.)
+     *
+     * @return the {@code RequestBody}
+     * @throws IllegalStateException if the request body is undefined
+     */
+    public BodyPublisher getBody() {
+        if (body == null) {
+            throw new IllegalStateException("A RequestBodyBuilder was requested, but no body was defined.");
+        }
+        return body;
+    }
+
+    /**
+     * Initializes the body created by this builder. Throws an exception if a
+     * body has already been defined.
+     *
+     * @param b the new request body
+     * @throws IllegalStateException if there is already a body
+     */
+    private void initBody(BodyPublisher b) {
+        if (body != null) {
+            throw new IllegalStateException("Multiple body definitions. Only a single request body can " +
+                    "be defined using a RequestBodyBuilder.");
+        }
+        body = b;
+    }
+}

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBuilderImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBuilderImpl.java
@@ -1,0 +1,125 @@
+/*
+SPDX-FileCopyrightText: © 2022 Siemens AG
+SPDX-License-Identifier: EPL-2.0
+*/
+package org.eclipse.sw360.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * <p>
+ * Implementation of the {@code RequestBuilder} interface based on the builder
+ * class of HttpClient.
+ * </p>
+ * <p>
+ * This class allows defining the various properties of an HTTP request. Note
+ * that you can either set a regular request body using the
+ * {@link #body(Consumer)} method or define a multipart
+ * request by invoking {@link #multiPart(String, Consumer)} an arbitrary number
+ * of times; but it is not possible to call both of these methods.
+ * </p>
+ */
+class NewRequestBuilderImpl implements RequestBuilder {
+    /**
+     * The mapper for doing JSON serialization.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * The internal builder to delegate method calls to.
+     */
+    private final HttpRequest.Builder requestBuilder;
+
+    /**
+     * The name of the HTTP method to be invoked.
+     */
+    private String httpMethod;
+
+    /**
+     * The body of the request.
+     */
+
+    private BodyPublisher body;
+
+    /**
+     * Creates a new instance of {@code NewRequestBuilderImpl} to build a new
+     * request.
+     *
+     * @param mapper the JSON object mapper
+     */
+    public NewRequestBuilderImpl(ObjectMapper mapper) {
+        this.mapper = mapper;
+        requestBuilder = HttpRequest.newBuilder();
+        httpMethod = Method.GET.name();
+    }
+
+    @Override
+    public RequestBuilder method(Method method) {
+        httpMethod = method.name();
+        return this;
+    }
+
+    @Override
+    public RequestBuilder uri(String uri) {
+        try {
+            requestBuilder.uri(new URI(uri));
+        } catch (URISyntaxException e) {
+
+        }
+        return this;
+    }
+
+    @Override
+    public RequestBuilder header(String name, String value) {
+        requestBuilder.header(name, value);
+        return this;
+    }
+
+    @Override
+    public RequestBuilder body(Consumer<RequestBodyBuilder> bodyProducer) {
+        if (getBody() != null) {
+            throw new IllegalStateException("A request can only have a single body");
+        }
+        NewRequestBodyBuilderImpl bodyBuilder = new NewRequestBodyBuilderImpl(mapper);
+        bodyProducer.accept(bodyBuilder);
+        body = bodyBuilder.getBody();
+        return this;
+    }
+
+    @Override
+    public RequestBuilder multiPart(String name, Consumer<RequestBodyBuilder> partProducer) {
+        if (getBody() != null) {
+            throw new IllegalStateException("The request already has a normal body. You can either "
+                    + "have a body or a multipart request, but not both.");
+        }
+
+        NewRequestBodyBuilderImpl bodyBuilder = new NewRequestBodyBuilderImpl(mapper);
+        partProducer.accept(bodyBuilder);
+        return this;
+    }
+
+    /**
+     * Returns the final request that has been configured so far.
+     *
+     * @return the request constructed by this builder
+     */
+    public HttpRequest build() {
+        BodyPublisher requestBody = getBody();
+        return requestBuilder.method(httpMethod, requestBody).header("Content-Type", "application/json").build();
+    }
+
+    /**
+     * Returns the request body that has been defined using this builder.
+     *
+     * @return the request body (may be <strong>null</strong>)
+     */
+    BodyPublisher getBody() {
+        return body;
+    }
+}

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewResponseImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewResponseImpl.java
@@ -1,0 +1,57 @@
+/*
+SPDX-FileCopyrightText: © 2022 Siemens AG
+SPDX-License-Identifier: EPL-2.0
+*/
+package org.eclipse.sw360.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.net.http.HttpResponse;
+import java.util.Set;
+
+
+/**
+ * <p>
+ * An adapter class that implements the {@code Response} interface of the
+ * SW360 HTTP library on top of a response object from HttpClient.
+ * </p>
+ */
+class NewResponseImpl<T extends Serializable> implements org.eclipse.sw360.http.Response {
+
+    /** An empty stream to be returned if a response has no body. */
+    private static final InputStream EMPTY_STREAM = new ByteArrayInputStream(new byte[0]);
+
+    /** The underlying response wrapped by this instance. */
+    private final HttpResponse response;
+
+    NewResponseImpl(HttpResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public int statusCode() {
+        return response.statusCode();
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return String.valueOf(response.statusCode()).startsWith("2");
+    }
+
+    @Override
+    public Set<String> headerNames() {
+        return response.headers().map().keySet();
+    }
+
+    @Override
+    public String header(String name) {
+        return response.headers().firstValue(name).orElse("");
+    }
+
+    @Override
+    public InputStream bodyStream() {
+        String responseInString = response.body().toString();
+        return responseInString.equals("") ? EMPTY_STREAM : new ByteArrayInputStream(responseInString.getBytes());
+    }
+}

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/utils/HttpUtils.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/utils/HttpUtils.java
@@ -269,6 +269,34 @@ public final class HttpUtils {
     /**
      * Returns a {@code ResponseProcessor} that uses the {@code ObjectMapper}
      * specified to map the JSON payload of a response to an object of the
+     * given result class. The resulting processor directly accesses the
+     * payload of the response; it can be combined with one of the
+     * {@code checkResponse()} methods to make sure that the response is
+     * successful before it is processed.
+     *
+     * @param mapper      the JSON mapper
+     * @param resultClass the result class
+     * @param <T>         the type of the resulting object
+     * @return the {@code ResponseProcessor} doing a JSON de-serialization
+     */
+    public static <T> ResponseProcessor<T> jsonResultNew(ObjectMapper mapper, Class<T> resultClass) {
+        return response -> {
+            if (response.bodyStream().available() != 0) {
+                return mapper.readValue(response.bodyStream(), resultClass);
+            } else {
+                try {
+                    return resultClass.newInstance();
+                } catch (InstantiationException | IllegalAccessException e) {
+
+                }
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Returns a {@code ResponseProcessor} that uses the {@code ObjectMapper}
+     * specified to map the JSON payload of a response to an object of the
      * type defined by the given reference. This is analogous to the overloaded
      * method, but allows for more flexibility  to specify the result type.
      *

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -109,9 +109,7 @@ include::{snippets}/should_document_get_releases_by_name/links.adoc[]
 [[resources-releases-get-by-externalids]]
 ==== Listing by external ids
 
-A `GET` request will get all releases corresponding to external ids +
-The request parameter supports MultiValueMap (allows to add duplicate keys with different values) +
-It's possible to search for releases only by the external id key by leaving the value.
+A `GET` request will get all releases corresponding to external ids. A request body has to be passed where a single key(external ID) can take different values. It is possible to search for releases by omitting the values and passing the external ID as the key.
 
 ===== Response structure
 include::{snippets}/should_document_get_releases_by_external-ids/response-fields.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -27,7 +27,6 @@ import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
-import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcess;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -50,7 +49,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.util.MultiValueMap;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -223,8 +222,8 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     }
 
     @GetMapping(value = RELEASES_URL + "/searchByExternalIds")
-    public ResponseEntity searchByExternalIds(@RequestParam MultiValueMap<String, String> externalIdsMultiMap) throws TException {
-        return restControllerHelper.searchByExternalIds(externalIdsMultiMap, releaseService, null);
+    public ResponseEntity searchByExternalIds(@RequestBody(required = false) Map<String, List<String>> externalIdsMultiMap) throws TException {
+        return restControllerHelper.searchByExternalIds(new LinkedMultiValueMap<String, String>(externalIdsMultiMap), releaseService, null);
     }
 
     @PreAuthorize("hasAuthority('WRITE')")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -49,6 +49,8 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -608,9 +610,12 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_document_get_releases_by_externalIds() throws Exception {
+        MultiValueMap<String, String> externalIds = new LinkedMultiValueMap<>();
+        externalIds.put("mainline-id-component", List.of("1432","4876"));
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(get("/api/releases/searchByExternalIds?mainline-id-component=1432&mainline-id-component=4876")
+        mockMvc.perform(get("/api/releases/searchByExternalIds")
                 .contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(externalIds))
                 .header("Authorization", "Bearer " + accessToken))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(


### PR DESCRIPTION
Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>



[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Converted request parameter to request body to disable external id decoding.

> * Which issue is this pull request belonging to and how is it solving it? (*#1659*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Please refer the issue

> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
