### PR TITLE
fix(liferay) Fix liferay "unable to load filter" issue

### DIFF
--- a/frontend/liferay-theme/src/main/webapp/WEB-INF/liferay-plugin-package.properties
+++ b/frontend/liferay-theme/src/main/webapp/WEB-INF/liferay-plugin-package.properties
@@ -19,4 +19,5 @@ name=SW360
 page-url=http://sw360.github.io
 required-for-startup=false
 short-description=Part of SW360. Optimizes the work with SW360 portlets.
+Import-Package=com.liferay.portal.servlet.filters.invoker,com.liferay.portal.webserver
 tags=


### PR DESCRIPTION
When loading liferay, the ERROR
  unable to load filter com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilter
is logged.
The fix found in
https://liferay.dev/ask/questions/development/vaadin-portlet-bundle-is-unable-to-load-filter-1
is working.

Signed-off-by: Lutz Jaenicke <ljaenicke@phoenixcontact.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue:  #1810

### How To Test?
Review log files without/with the fix

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
