### PR TITLE
feat(rest): new endpoint /components/recentComponents

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -31,6 +31,25 @@ include::{snippets}/should_document_get_components/http-response.adoc[]
 ===== Links
 include::{snippets}/should_document_get_components/links.adoc[]
 
+
+[[resources-recent-components-list]]
+==== Listing recent components
+
+A `GET` request will list 5 of the service's most recently created components.
+
+===== Response structure
+include::{snippets}/should_document_get_recent_components/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_recent_components/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_recent_components/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_recent_components/links.adoc[]
+
+
 [[resources-components-list-with-fields]]
 ==== Listing components with fields
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -177,6 +177,21 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
         return new ResponseEntity<>(userHalResource, HttpStatus.OK);
     }
 
+    @RequestMapping(value = COMPONENTS_URL + "/recentComponents", method = RequestMethod.GET)
+    public ResponseEntity<CollectionModel<EntityModel>> getRecentComponent () throws TException {
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        List<Component> sw360Components = componentService.getRecentComponents(user);
+
+        List<EntityModel> resources = new ArrayList<>();
+        sw360Components.forEach(c -> {
+            Component embeddedComponent = restControllerHelper.convertToEmbeddedComponent(c);
+            resources.add(EntityModel.of(embeddedComponent));
+        });
+
+        CollectionModel<EntityModel> finalResources = CollectionModel.of(resources);
+        return new ResponseEntity<>(finalResources, HttpStatus.OK);
+    }
+
     @RequestMapping(value = COMPONENTS_URL + "/searchByExternalIds", method = RequestMethod.GET)
     public ResponseEntity searchByExternalIds(@RequestParam MultiValueMap<String, String> externalIdsMultiMap) throws TException {
         return restControllerHelper.searchByExternalIds(externalIdsMultiMap, componentService, null);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -89,6 +89,11 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         return projectService.getProjectsByReleaseIds(releaseIds, sw360User);
     }
 
+    public List<Component> getRecentComponents(User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.getRecentComponentsSummary(5, sw360User);
+    }
+
     public Set<Component> getUsingComponentsForComponent(String componentId, User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         Component component = sw360ComponentClient.getComponentById(componentId, sw360User);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -189,6 +189,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         .setCreatedOn(new SimpleDateFormat("yyyy-MM-dd").format(new Date())));
 
         given(this.componentServiceMock.getComponentsForUser(any())).willReturn(componentList);
+        given(this.componentServiceMock.getRecentComponents(any())).willReturn(componentList);
         given(this.componentServiceMock.getComponentForUserById(eq("17653524"), any())).willReturn(angularComponent);
         given(this.componentServiceMock.getComponentForUserById(eq("98745"), any())).willReturn(testComponent);
         given(this.componentServiceMock.getProjectsByComponentId(eq("17653524"), any())).willReturn(projectList);
@@ -275,6 +276,25 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("page.totalElements").description("Total number of all existing components"),
                                 fieldWithPath("page.totalPages").description("Total number of pages"),
                                 fieldWithPath("page.number").description("Number of the current page")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_recent_components() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/components/recentComponents")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:components.[]name").description("The name of the component"),
+                                subsectionWithPath("_embedded.sw360:components.[]componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
+                                subsectionWithPath("_embedded.sw360:components").description("An array of <<resources-components, Components resources>>"),
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }
 


### PR DESCRIPTION
Issue: #1846 

Description: this endpoint returns the recent created 5 components in alphabetical order.

How to test:
Run this endpoint and you will get recent created components as response.

