### PR TITLE
feat(rest) : Update data without moderation request And This features' configurable setting

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Build SW360
       run: |
-        mvn clean package --no-transfer-progress -P deploy -Dhelp-docs=true -Dbase.deploy.dir=. -Dliferay.deploy.dir=${PWD}/deploy -Dbackend.deploy.dir=${PWD}/deploy/webapps -Drest.deploy.dir=${PWD}/deploy/webapps -DRunComponentVisibilityRestrictionTest=false -DRunPrivateProjectAccessTest=false
+        mvn clean package --no-transfer-progress -P deploy -Dhelp-docs=true -Dbase.deploy.dir=. -Dliferay.deploy.dir=${PWD}/deploy -Dbackend.deploy.dir=${PWD}/deploy/webapps -Drest.deploy.dir=${PWD}/deploy/webapps -DRunComponentVisibilityRestrictionTest=false -DRunPrivateProjectAccessTest=false -DRunRestForceUpdateTest=false
 
     - name: Run PrivateProjectAccessTest
       run: |
@@ -86,7 +86,7 @@ jobs:
         mvn install
         cd ..
         cd libraries/datahandler
-        mvn test -Dtest=ProjectPermissionsVisibilityTest -DRunPrivateProjectAccessTest=true
+        mvn test -Dtest=ProjectPermissionsVisibilityTest -DRunPrivateProjectAccessTest=true -DRunRestForceUpdateTest=true
 
     - name: Deploy Backend and Rest Server
       run: |

--- a/backend/src-common/src/main/java/org/eclipse/sw360/common/utils/BackendUtils.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/common/utils/BackendUtils.java
@@ -18,10 +18,13 @@ public class BackendUtils {
     private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
     protected static final Properties loadedProperties;
     public static final Boolean MAINLINE_STATE_ENABLED_FOR_USER;
+    public static final Boolean IS_FORCE_UPDATE_ENABLED;
 
     static {
         loadedProperties = CommonUtils.loadProperties(BackendUtils.class, PROPERTIES_FILE_PATH);
         MAINLINE_STATE_ENABLED_FOR_USER = Boolean.parseBoolean(loadedProperties.getProperty("mainline.state.enabled.for.user", "false"));
+        IS_FORCE_UPDATE_ENABLED = Boolean.parseBoolean(
+                System.getProperty("RunRestForceUpdateTest", loadedProperties.getProperty("rest.force.update.enabled", "false")));
     }
 
     protected BackendUtils() {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -389,8 +389,11 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     ///////////////////////////////
     // UPDATE INDIVIDUAL OBJECTS //
     ///////////////////////////////
-
     public RequestStatus updateProject(Project project, User user) throws SW360Exception {
+        return updateProject(project, user, false);
+    }
+
+    public RequestStatus updateProject(Project project, User user, boolean forceUpdate) throws SW360Exception {
         removeLeadingTrailingWhitespace(project);
         String name = project.getName();
         if (name == null || name.isEmpty()) {
@@ -416,7 +419,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return RequestStatus.FAILED_SANITY_CHECK;
         } else if (!isDependenciesExists(project, user)) {
             return RequestStatus.INVALID_INPUT;
-        } else if (isWriteActionAllowedOnProject(actual, user)) {
+        } else if (isWriteActionAllowedOnProject(actual, user) || forceUpdate) {
             copyImmutableFields(project,actual);
             setRequestedDateAndTrimComment(project, actual, user);
             project.setAttachments( getAllAttachmentsToKeep(toSource(actual), actual.getAttachments(), project.getAttachments()) );
@@ -759,8 +762,11 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     ///////////////////////////////
     // DELETE INDIVIDUAL OBJECTS //
     ///////////////////////////////
-
     public RequestStatus deleteProject(String id, User user) throws SW360Exception {
+        return deleteProject(id, user, false);
+    }
+
+    public RequestStatus deleteProject(String id, User user, boolean forceDelete) throws SW360Exception {
         Project project = repository.get(id);
         assertNotNull(project);
 
@@ -769,7 +775,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
 
         // Remove the project if the user is allowed to do it by himself
-        if (makePermission(project, user).isActionAllowed(RequestedAction.DELETE)) {
+        if (makePermission(project, user).isActionAllowed(RequestedAction.DELETE) || forceDelete) {
             removeProjectAndCleanUp(project, user);
             dbHandlerUtil.addChangeLogs(null, project, user.getEmail(), Operation.DELETE, attachmentConnector,
                     Lists.newArrayList(), null, null);

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -351,7 +351,16 @@ public class ComponentHandler implements ComponentService.Iface {
 
         return handler.updateComponent(component, user);
     }
+    
+    @Override
+    public RequestStatus updateComponentWithForceFlag(Component component, User user, boolean forceUpdate) throws TException {
+        assertNotNull(component);
+        assertId(component.getId());
+        assertUser(user);
 
+        return handler.updateComponent(component, user, forceUpdate);
+    }
+    
     @Override
     public RequestSummary updateComponents(Set<Component> components, User user) throws TException {
         assertUser(user);
@@ -378,6 +387,15 @@ public class ComponentHandler implements ComponentService.Iface {
         return handler.updateRelease(release, user, ThriftUtils.IMMUTABLE_OF_RELEASE);
     }
 
+    @Override
+    public RequestStatus updateReleaseWithForceFlag(Release release, User user, boolean forceUpdate) throws TException {
+        assertNotNull(release);
+        assertId(release.getId());
+        assertUser(user);
+        removeSelfLink(release);
+        return handler.updateRelease(release, user, ThriftUtils.IMMUTABLE_OF_RELEASE, forceUpdate);
+    }
+    
     private void removeSelfLink(Release release) {
         if(release.releaseIdToRelationship != null && !release.releaseIdToRelationship.isEmpty()) {
             release.releaseIdToRelationship.remove(release.id);
@@ -433,6 +451,14 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
+    public RequestStatus deleteComponentWithForceFlag(String id, User user, boolean forceDelete) throws TException {
+        assertUser(user);
+        assertId(id);
+
+        return handler.deleteComponent(id, user, forceDelete);
+    }
+    
+    @Override
     public RequestStatus deleteRelease(String id, User user) throws TException {
         assertUser(user);
         assertId(id);
@@ -440,6 +466,14 @@ public class ComponentHandler implements ComponentService.Iface {
         return handler.deleteRelease(id, user);
     }
 
+    @Override
+    public RequestStatus deleteReleaseWithForceFlag(String id, User user, boolean forceDelete) throws TException {
+        assertUser(user);
+        assertId(id);
+
+        return handler.deleteRelease(id, user, forceDelete);
+    }
+    
     @Override
     public List<Release> getReleasesByComponentId(String id, User user) throws TException {
         assertUser(user);

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -262,6 +262,15 @@ public class ProjectHandler implements ProjectService.Iface {
         return handler.updateProject(project, user);
     }
 
+    @Override
+    public RequestStatus updateProjectWithForceFlag(Project project, User user, boolean forceUpdate) throws TException {
+        assertNotNull(project);
+        assertId(project.getId());
+        assertUser(user);
+
+        return handler.updateProject(project, user, forceUpdate);
+    }
+    
     public RequestStatus updateProjectFromModerationRequest(Project projectAdditions, Project projectDeletions, User user) {
         return handler.updateProjectFromAdditionsAndDeletions(projectAdditions, projectDeletions, user);
     }
@@ -276,6 +285,14 @@ public class ProjectHandler implements ProjectService.Iface {
         assertUser(user);
 
         return handler.deleteProject(id, user);
+    }
+    
+    @Override
+    public RequestStatus deleteProjectWithForceFlag(String id, User user, boolean forceDelete) throws TException {
+        assertId(id);
+        assertUser(user);
+
+        return handler.deleteProject(id, user, forceDelete);
     }
 
 

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -103,6 +103,7 @@ release.externalId.to.be.removed.while.cloning=
 #rest.apitoken.write.validity.days=30
 #rest.apitoken.hash.salt=$2a$04$Software360RestApiSalt
 #rest.write.access.usergroup=Administrator
+#rest.force.update.enabled=false
 
 
 # ---------------------------------------

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -529,6 +529,13 @@ service ComponentService {
     RequestStatus updateComponent(1: Component component, 2: User user);
 
     /**
+     * update component in database if user has permissions
+     * otherwise create moderation request
+     * If forceUpdate is true, this function can update regardless of write permissions.
+     **/
+    RequestStatus updateComponentWithForceFlag(1: Component component, 2: User user, 3: bool forceUpdate);
+
+    /**
     * update the bulk of components in database if user is admin
     **/
     RequestSummary updateComponents(1: set<Component> components, 2: User user);
@@ -538,6 +545,13 @@ service ComponentService {
      * otherwise create moderation request
      **/
     RequestStatus deleteComponent(1: string id, 2: User user);
+
+    /**
+     * delete component from database if user has permissions,
+     * otherwise create moderation request
+     * If forceDelete is true, this function can delete regardless of delete permissions.
+     **/
+    RequestStatus deleteComponentWithForceFlag(1: string id, 2: User user, 3: bool forceDelete);
 
     /**
      * update component in database if user has permissions, additions and deletions are the parts of the moderation request
@@ -639,6 +653,13 @@ service ComponentService {
     RequestStatus updateRelease(1: Release release, 2: User user);
 
     /**
+     * update release in database if user has permissions
+     * otherwise create moderation request
+     * If forceUpdate is true, this function can update regardless of write permissions.
+     **/
+    RequestStatus updateReleaseWithForceFlag(1: Release release, 2: User user, 3: bool forceUpdate);
+
+    /**
      * update release called only by fossology service - is allowed to manipulate external requests.
      * update release in database if user has permissions
      * otherwise create moderation request
@@ -668,6 +689,13 @@ service ComponentService {
      * otherwise create moderation request
      **/
     RequestStatus deleteRelease(1: string id, 2: User user);
+
+    /**
+     * delete release from database if user has permissions
+     * otherwise create moderation request
+     * If forceDelete is true, this function can delete regardless of delete permissions.
+     **/
+    RequestStatus deleteReleaseWithForceFlag(1: string id, 2: User user, 3: bool forceDelete);
 
     /**
      * update release in database if user has permissions, additions and deletions are the parts of the moderation request

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -344,10 +344,24 @@ service ProjectService {
     RequestStatus updateProject(1: Project project, 2: User user);
 
     /**
+     * try to update a project as a user, if user has no permission, a moderation request is created
+     * (part of project CRUD support)
+     * If forceUpdate is true, this function can update regardless of write permissions.
+     */
+    RequestStatus updateProjectWithForceFlag(1: Project project, 2: User user, 3: bool forceUpdate);
+
+    /**
      * try to delete a project as a user, if user has no permission, a moderation request is created
      * (part of project CRUD support)
      */
     RequestStatus deleteProject(1: string id, 2: User user);
+
+    /**
+     * try to delete a project as a user, if user has no permission, a moderation request is created
+     * (part of project CRUD support)
+     * If forceDelete is true, this function can delete regardless of delete permissions.
+     */
+    RequestStatus deleteProjectWithForceFlag(1: string id, 2: User user, 3: bool forceDelete);
 
     /**
      * updateproject in database if user has permissions, additions and deletions are the parts of the moderation request

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -54,6 +54,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     public static final String JWKS_ISSUER_URL;
     public static final String JWKS_ENDPOINT_URL;
     public static final Boolean IS_JWKS_VALIDATION_ENABLED;
+    public static final Boolean IS_FORCE_UPDATE_ENABLED;
 
     static {
         Properties props = CommonUtils.loadProperties(Sw360ResourceServer.class, SW360_PROPERTIES_FILE_PATH);
@@ -66,6 +67,8 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
         JWKS_ISSUER_URL = props.getProperty("jwks.issuer.url", null);
         JWKS_ENDPOINT_URL = props.getProperty("jwks.endpoint.url", null);
         IS_JWKS_VALIDATION_ENABLED = Boolean.parseBoolean(props.getProperty("jwks.validation.enabled", "false"));
+        IS_FORCE_UPDATE_ENABLED = Boolean.parseBoolean(
+                System.getProperty("RunRestForceUpdateTest", props.getProperty("rest.force.update.enabled", "false")));
     }
 
     @Bean

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -39,6 +39,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectData;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -188,7 +189,12 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             project.setVendorId(project.getVendor().getId());
         }
 
-        RequestStatus requestStatus = sw360ProjectClient.updateProject(project, sw360User);
+        RequestStatus requestStatus;
+        if (Sw360ResourceServer.IS_FORCE_UPDATE_ENABLED) {
+            requestStatus = sw360ProjectClient.updateProjectWithForceFlag(project, sw360User, true);
+        } else {
+            requestStatus = sw360ProjectClient.updateProject(project, sw360User);
+        }
         if (requestStatus == RequestStatus.NAMINGERROR) {
             throw new HttpMessageNotReadableException("Project name field cannot be empty or contain only whitespace character");
         }
@@ -205,7 +211,12 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
     public void deleteProject(String projectId, User sw360User) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        RequestStatus requestStatus = sw360ProjectClient.deleteProject(projectId, sw360User);
+        RequestStatus requestStatus;
+        if (Sw360ResourceServer.IS_FORCE_UPDATE_ENABLED) {
+            requestStatus = sw360ProjectClient.deleteProjectWithForceFlag(projectId, sw360User, true);
+        } else {
+            requestStatus = sw360ProjectClient.deleteProject(projectId, sw360User);
+        }
         if (requestStatus == RequestStatus.IN_USE) {
             throw new HttpMessageNotReadableException("Unable to delete project. Project is in Use");
         } else if (requestStatus != RequestStatus.SUCCESS) {
@@ -217,7 +228,11 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         List<Project> projects = sw360ProjectClient.getAccessibleProjectsSummary(sw360User);
         for (Project project : projects) {
-            sw360ProjectClient.deleteProject(project.getId(), sw360User);
+            if (Sw360ResourceServer.IS_FORCE_UPDATE_ENABLED) {
+                sw360ProjectClient.deleteProjectWithForceFlag(project.getId(), sw360User, true);
+            } else {
+                sw360ProjectClient.deleteProject(project.getId(), sw360User);
+            }
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -40,6 +40,7 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -186,7 +187,12 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         rch.checkForCyclicOrInvalidDependencies(sw360ComponentClient, release, sw360User);
 
-        RequestStatus requestStatus = sw360ComponentClient.updateRelease(release, sw360User);
+        RequestStatus requestStatus;
+        if (Sw360ResourceServer.IS_FORCE_UPDATE_ENABLED) {
+            requestStatus = sw360ComponentClient.updateReleaseWithForceFlag(release, sw360User, true);
+        } else {
+            requestStatus = sw360ComponentClient.updateRelease(release, sw360User);
+        }
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
         } else if (requestStatus == RequestStatus.NAMINGERROR) {
@@ -201,7 +207,12 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
 
     public RequestStatus deleteRelease(String releaseId, User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        RequestStatus deleteStatus = sw360ComponentClient.deleteRelease(releaseId, sw360User);
+        RequestStatus deleteStatus;
+        if (Sw360ResourceServer.IS_FORCE_UPDATE_ENABLED) {
+            deleteStatus = sw360ComponentClient.deleteReleaseWithForceFlag(releaseId, sw360User, true);
+        } else {
+            deleteStatus = sw360ComponentClient.deleteRelease(releaseId, sw360User);
+        }
         if (deleteStatus.equals(RequestStatus.SUCCESS)) {
             SW360Utils.removeReleaseVulnerabilityRelation(releaseId, sw360User);
         }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue:  #1861 

API Enhancements: API access without ModerationRequest

# Overview of improvements

## Purpose
In SW360, the update process by general users generates Moderation Requests, so when general users register a large amount of data in a batch file, the approval process of the request becomes a problem.  
Therefore, we will add a function to enable data updating without Moderation Requests when data is submitted via RestAPI.
This function can be enabled/disabled as an option.  
The update operation on the GUI will generate Moderation Requests as before, regardless of whether the option is enabled or disabled.  

The following is an image of the operation when a batch file is executed by a general user.

Function disabled :   
![image](https://user-images.githubusercontent.com/39894802/223581354-0ae572a2-e912-4030-9079-1c820e871c65.png)
<BR>
Function enabled :  
![image](https://user-images.githubusercontent.com/39894802/223581421-5783624f-0c44-4afa-a5ce-2ac5baacab2b.png)
<BR>

## Summary of Functional Changes  
- Addition of option to enable/disable switching of functionality  
    If the following option is set to true in sw360.properties, update processing is enabled without Moderation Requests for RestAPI access, regardless of the WRITE and DELETE permissions held by the user. This change is effective for Project, Component, and Release endpoints.
    ```toml
    rest.force.update.enabled=true
    ```

- Changes of data class  
    None  

- Changes of front end (GUI)   
    None  

- Changes of Backend  
    - Add method with forced update flag  
        Add methods to Project and Component thrift interfaces (ProjectHandler, ComponentHandler) to perform update processing without Moderation Requests.  
    - Change DabaseHandler update/delete methods  
        Modify update/delete methods to accept the forceUpdate flag (or forceDelete flag for deletion) and allow update processing if the flag is true, regardless of document permissions.  
    - Impact on existing update processing  
        Existing update/delete methods will remain and be called with the default value of the forceUpdate flag (or forceDelete flag for deletion) = false.
        This allows existing update processing to continue to operate as before.  
- Changes of RestAPI  
    RestAPI will be changed to call the above backend methods that do not generate Moderation Requests when the function option is enabled.

## How to test  
- GUI  
    - Project  
        - Update
            1. Create a record by any user.
            1. Update operation is performed by another user who does not have write permission to the created record.
            1. Sign in as an Admin user and confirm that the corresponding Moderation Request is created on the Request tab.
        - Delete
            1. Create a record by any user.
            1. Delete operation is performed by another user who does not have delete permission to the created record.
            1. Sign in as an Admin user and confirm that the corresponding Moderation Request is created on the Request tab.
    - Component  
        - Update
            1. Create a record by any user.
            1. Update operation is performed by another user who does not have write permission to the created record.
            1. Sign in as an Admin user and confirm that the corresponding Moderation Request is created on the Request tab.
        - Delete
            1. Create a record by any user.
            1. Delete operation is performed by another user who does not have delete permission to the created record.
            1. Sign in as an Admin user and confirm that the corresponding Moderation Request is created on the Request tab.
    - Release  
        - Update
            1. Create a record by any user.
            1. Update operation is performed by another user who does not have write permission to the created record.
            1. Sign in as an Admin user and confirm that the corresponding Moderation Request is created on the Request tab.
        - Delete
            1. Create a record by any user.
            1. Delete operation is performed by another user who does not have delete permission to the created record.
            1. Sign in as an Admin user and confirm that the corresponding Moderation Request is created on the Request tab.

- RestAPI  
    Send the following update/delete requests to records that the user does not have write/delete privileges for, using the user's access token.  
    If the function is disabled, confirm that the update/deletion process is not performed and status code 202 (acceptance of request and generation of Moderation Request) is returned.
    If the function is enabled, confirm that the update/delete process is performed and a success status code is returned.

    - Project  
        |Endpoint|Method|Note|
        |---|---|---|
        |/projects/{id}|DELETE|Existing issues<BR>Sending a delete request with a USER token does not generate an Moderation Request and returns a 500 error. See restrictions below|
        |/projects/{id}|PATCH||
        |/projects/{id}/attachment/{attachmentId}|PATCH||
        |/projects/{id}/release/{releaseId}|PATCH||
        |/projects/{id}/releases|POST|This request is a POST method, but it executes an update process with Moderation Request.|
        |/projects/{id}/releases|PATCH|
        |/projects/{projectId}/attachments|POST|This request is a POST method, but it executes an update process with Moderation Request.|

    - Component  
        |Endpoint|Method|Note|
        |---|---|---|
        |/components/{componentId}/attachments|POST|This request is a POST method, but it executes an update process with Moderation Request.|
        |/components/{componentId}/attachments/{attachmentIds}|DELETE|This request is a DELETE method, but it executes an update process with Moderation Request.|
        |/components/{id}|PATCH||
        |/components/{id}/attachment/{attachmentId}|PATCH||
        |/components/{ids}|DELETE||

    - Release  
        |Endpoint|Method|Note|
        |---|---|---|
        |/releases/{id}|PATCH||
        |/releases/{id}/attachment/{attachmentId}|PATCH||
        |/releases/{id}/releases|POST|This request is a POST method, but it executes an update process with Moderation Request.|
        |/releases/{ids}|DELETE||
        |/releases/{releaseId}/attachments|POST|This request is a POST method, but it executes an update process with Moderation Request.|
        |/releases/{releaseId}/attachments/{attachmentIds}|DELETE|This request is a DELETE method, but it executes an update process with Moderation Request.|

- Maven test   
    When the function is enabled, execute update/delete processing for records that general users do not have authority for, and confirm that Moderation Request is not generated and that update/delete processing is performed.
    - ComponentDatabaseHandlerTest  
        /src-components/src/test/java/org/eclipse/sw360/components/db/  ComponentDatabaseHandlerTest.java  
    - ProjectDatabaseHandlerTest  
        /src-common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java  

## Limitations    
- Option settings    
    When using this function, in addition to enabling RestAPI, it is necessary to set the following option in sw360.properties and allow RestAPI update process by general users.
    ```toml
	rest.write.access.usergroup = USER
    ```    
- Known issue    
    Internal server error (500) occurs when requesting deletion of a project using an access token with USER authority in RestAPI.  
    Curl command：
    ```bash
    $ curl -X DELETE "http://[SERVICE-URL]/resource/api/projects/dcf088c855614970a664dcdc2fb14165" --header 'Authorization: Bearer [USER-TOKEN]'
    ```
    Response：  
    ```json
    {
        "timestamp": "2023-02-10T02:46:06.758101Z",
        "status": 500,
        "error": "Internal Server Error",
        "message": "sw360 project with id 'dcf088c855614970a664dcdc2fb14165 cannot be deleted."
    }
    ```
    This is an known issue, and we have confirmed that it can be reproduced with the Github HEAD (3cd88e009f178c8dcfb92d2e7304a972e1d1b6da).
    
