### PR TITLE
fix(ProjectUI):External Id not visible in Vulnerability Tracking Status

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/vulnerabilityTrackingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/vulnerabilityTrackingStatus.jspf
@@ -44,7 +44,7 @@
             ${svmMonitoringListId}:
         </div>
         <div class="col">
-            <sw360:DisplayExternalId value="${project.externalIds['${svmMonitoringListId}']}"/>
+            <sw360:DisplayExternalId value="${project.externalIds[svmMonitoringListId]}"/>
         </div>
     </div>
     <core_rt:if test="${releasesAndProjects.size() == 0 }">


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Description:
ExternalId will now be displayed next to 'com.siemens.svm.monitoringlist.id:' under Vulnerability State Information when 'Do not create monitoring list, but use list from external id' checkbox is enabled.

Solves Issue: #1868 

Screenshot:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/115608771/225577153-20e4fc43-8f2c-4f08-8727-902cbb6345cd.png)

