### PR TITLE
fix(license): Can not generate license from SPDX file in release

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1750,10 +1750,12 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         Set<Attachment> attachments = CommonUtils.nullToEmptySet(release.getAttachments());
         Set<AttachmentType> attTypes = attachments.stream().map(Attachment::getAttachmentType).collect(Collectors.toUnmodifiableSet());
         Set<Attachment> spdxAttachments = Sets.newHashSet();
-        if (attTypes.contains(AttachmentType.COMPONENT_LICENSE_INFO_COMBINED) || attTypes.contains(AttachmentType.COMPONENT_LICENSE_INFO_XML)) {
+        if (attTypes.contains(AttachmentType.COMPONENT_LICENSE_INFO_COMBINED) || attTypes.contains(AttachmentType.COMPONENT_LICENSE_INFO_XML)
+        || attTypes.contains(AttachmentType.SBOM)) {
             spdxAttachments = attachments.stream()
                     .filter(a -> AttachmentType.COMPONENT_LICENSE_INFO_COMBINED.equals(a.getAttachmentType())
-                            || AttachmentType.COMPONENT_LICENSE_INFO_XML.equals(a.getAttachmentType()))
+                            || AttachmentType.COMPONENT_LICENSE_INFO_XML.equals(a.getAttachmentType())
+                            || AttachmentType.SBOM.equals(a.getAttachmentType()))
                     .collect(Collectors.toSet());
         } else if (attTypes.contains(AttachmentType.INITIAL_SCAN_REPORT)) {
             spdxAttachments = attachments.stream()


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #1871

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Pre-condition: Exist a release (time 1.9)

Step 1: Edit release time 1.9
Step 2: Go to attachments tab, attach a SPDX file (See attachment file in issue #1871) with type SBOM
Step 3: Click "Update Release" button
Step 4: In the view details of release, go to "Clearing details" tab

Expected: SPDX file name and "Show license info" button appear in the "SPDX attachments" section

![time1 9-afterfix](https://user-images.githubusercontent.com/15809618/225585988-0188c699-dc23-470f-81ca-d4ab2fedc3a3.png)

Please check with other SPDX files:
1. SPDX file generated by different tool
Example:
- spdx-sbom-generator (https://github.com/opensbom-generator/spdx-sbom-generator)
- sbom-tool (https://github.com/microsoft/sbom-tool)
- NTIA SwiftBOM Web Tool (https://sbom.democert.org/sbom/)

2. SPDX versions
- SPDX 2.2 and SPDX 2.3

3. File which is not an entire SPDX file
- Add some fields/attributes to an entire SPDX file

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
