### PR TITLE
fix(rest): componentType field  will show when allDetails true in rel…

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -127,10 +127,13 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             sw360Releases.addAll(releaseService.getReleasesForUser(sw360User));
         }
 
+        for(Release release: sw360Releases) {
+            releaseService.setComponentDependentFieldsInRelease(release, sw360User);
+        }
+
         sw360Releases = sw360Releases.stream()
                 .filter(release -> name == null || name.isEmpty() || release.getName().equalsIgnoreCase(name))
                 .collect(Collectors.toList());
-
         PaginationResult<Release> paginationResult = restControllerHelper.createPaginationResult(request, pageable, sw360Releases, SW360Constants.TYPE_RELEASE);
 
         List<EntityModel> releaseResources = new ArrayList<>();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -117,8 +117,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return releaseById;
     }
 
-    public void setComponentDependentFieldsInRelease(Release releaseById, User sw360User) {
-
+    public Release setComponentDependentFieldsInRelease(Release releaseById, User sw360User) {
         String componentId = releaseById.getComponentId();
         if (CommonUtils.isNullEmptyOrWhitespace(componentId)) {
             throw new HttpMessageNotReadableException("ComponentId must be present");
@@ -131,7 +130,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
             throw new HttpMessageNotReadableException("No Component found with Id - " + componentId);
         }
         releaseById.setComponentType(componentById.getComponentType());
-
+        return releaseById;
     }
 
     @Override


### PR DESCRIPTION
…ease

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? #1878 
> * Did you add or update any new dependencies that are required for your change? No

Issue: 
Added field componentType when allDetails=true in release. 
### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Please hit the below url and check whether componentType field is present or in release block. 
/resource/api/releases?allDetails=true
![image](https://user-images.githubusercontent.com/49710817/227429517-c0374158-42d1-43d9-878e-8b5e33364c67.png)

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
