### PR TITLE
fix(UI): Attachments tab not loading in UI

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAttachments.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAttachments.jspf
@@ -30,7 +30,10 @@
     <portlet:param name="<%=PortalConstants.DOCUMENT_ID%>" value="${documentID}"/>
     <portlet:param name="<%=PortalConstants.DOCUMENT_TYPE%>" value="${documentType}"/>
     <portlet:param name="<%=PortalConstants.IS_ERROR_IN_UPDATE_OR_CREATE%>"  value="${isErrorInUpdateOrCreate}" />
-    <portlet:param name="<%=PortalConstants.ATTACHMENTS%>"  value="${attachments}" />
+    <core_rt:set var="isError" value="${isErrorInUpdateOrCreate}"/>
+    <core_rt:if test="${isError}">
+        <portlet:param name="<%=PortalConstants.ATTACHMENTS%>"  value="${attachments}" />
+    </core_rt:if>
 </portlet:resourceURL>
 
 <table id="attachmentInfo" class="table edit-table attachments" title="<liferay-ui:message key="attachment.information" /> ${documentType}"


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

- Attachment info will be sent in Ajax GET request only if there is duplicate error while updating the document.

Issue: #1886 

### Suggest Reviewer
@afsahsyeda 

### How To Test?
See the issue #1886  description

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR


### UPDATE

The other way to fix this issue is to configure the `/tomcat/conf/server.xml` and `Liferay/portal-ext.properties` file to increase the default GET request size.

Changes in `Liferay/portal-ext.properties`:

- `invoker.filter.uri.max.length=8000` -> Refer: https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/portal.properties#L6852

Changes in  `/tomcat/conf/server.xml`:

- `maxHttpRequestHeaderSize="16384"` -> from default 8Kb to 16Kb or more (as per your need) Refer: https://tomcat.apache.org/tomcat-9.0-doc/config/http.html

- Ideally 8Kb is more than enough for `GET` request, changing this value might not be required, and changing only in `.portal-ext.properties` should be sufficient

```
    <Connector port="8080" protocol="HTTP/1.1"
               connectionTimeout="20000" maxHttpRequestHeaderSize="16384"
               redirectPort="8443" URIEncoding="UTF-8" />
```

### PS:
In case `tomcat` is running as proxy behind `apache2` server, then following property needs to be added in `apache2.conf` file:
`LimitRequestLine 16384`