### PR TITLE
feat(rest): modify moderation requests

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/moderationRequests.adoc
+++ b/rest/resource-server/src/docs/asciidoc/moderationRequests.adoc
@@ -90,3 +90,42 @@ include::{snippets}/should_document_get_moderationrequests_by_state/curl-request
 ===== Example response
 include::{snippets}/should_document_get_moderationrequests_by_state/http-response.adoc[]
 
+[[resources-moderationRequest-accept-reject]]
+==== Accepting or rejecting a moderation request
+
+A `PATCH` request will accept or reject the ModerationRequest, save the comment by the reviewer and send email notifications.
+
+===== Request body
+include::{snippets}/should_document_get_moderationrequests_accept/request-body.adoc[]
+
+===== Request structure
+include::{snippets}/should_document_get_moderationrequests_accept/request-fields.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_moderationrequests_accept/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_moderationrequests_accept/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_moderationrequests_accept/http-response.adoc[]
+
+[[resources-moderationRequest-assign-unassign]]
+==== Assign or Unassign a moderation request
+
+A `PATCH` request will assign a ModerationRequest to the user. The request can be used to unassign the user from the ModerationRequest as well.
+
+===== Request body
+include::{snippets}/should_document_get_moderationrequests_assign/request-body.adoc[]
+
+===== Request structure
+include::{snippets}/should_document_get_moderationrequests_assign/request-fields.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_moderationrequests_assign/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_moderationrequests_assign/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_moderationrequests_assign/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -42,6 +42,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonProjectRelationSerializer;
 import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonReleaseRelationSerializer;
 import org.eclipse.sw360.rest.resourceserver.moderationrequest.EmbeddedModerationRequest;
+import org.eclipse.sw360.rest.resourceserver.moderationrequest.ModerationPatch;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProject;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -74,8 +75,6 @@ public class JacksonCustomizations {
             setMixInAnnotation(VulnerabilityState.class, Sw360Module.VulnerabilityStateMixin.class);
             setMixInAnnotation(ReleaseVulnerabilityRelationDTO.class, Sw360Module.ReleaseVulnerabilityRelationDTOMixin.class);
             setMixInAnnotation(VulnerabilityDTO.class, Sw360Module.VulnerabilityDTOMixin.class);
-            setMixInAnnotation(VulnerabilityState.class, Sw360Module.VulnerabilityStateMixin.class);
-            setMixInAnnotation(ReleaseVulnerabilityRelationDTO.class, Sw360Module.ReleaseVulnerabilityRelationDTOMixin.class);
             setMixInAnnotation(VulnerabilityApiDTO.class, Sw360Module.VulnerabilityApiDTOMixin.class);
             setMixInAnnotation(EccInformation.class, Sw360Module.EccInformationMixin.class);
             setMixInAnnotation(EmbeddedProject.class, Sw360Module.EmbeddedProjectMixin.class);
@@ -97,6 +96,7 @@ public class JacksonCustomizations {
             setMixInAnnotation(ModerationRequest.class, Sw360Module.ModerationRequestMixin.class);
             setMixInAnnotation(EmbeddedModerationRequest.class, Sw360Module.EmbeddedModerationRequestMixin.class);
             setMixInAnnotation(ImportBomRequestPreparation.class, Sw360Module.ImportBomRequestPreparationMixin.class);
+            setMixInAnnotation(ModerationPatch.class, Sw360Module.ModerationPatchMixin.class);
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1367,6 +1367,10 @@ public class JacksonCustomizations {
                 "setRequestStatus"
         })
         public static abstract class ImportBomRequestPreparationMixin extends ImportBomRequestPreparation {
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static abstract class ModerationPatchMixin extends ModerationPatch {
         }
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -28,6 +28,7 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.time.Instant;
 
@@ -62,6 +63,11 @@ public class RestExceptionHandler {
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
     public ResponseEntity<ErrorMessage> handleMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.UNSUPPORTED_MEDIA_TYPE), HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<ErrorMessage> handleClientError(HttpClientErrorException e) {
+        return new ResponseEntity<>(new ErrorMessage(e, e.getStatusCode()), e.getStatusCode());
     }
 
     @ExceptionHandler({OptimisticLockingFailureException.class, DataIntegrityViolationException.class})

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationPatch.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationPatch.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Siemens AG, 2023. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * SPDX-FileCopyrightText: 2023, Siemens AG. Part of the SW360 Portal Project.
+ * SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
+ */
+
+package org.eclipse.sw360.rest.resourceserver.moderationrequest;
+
+/**
+ * Input for PATCH request on moderation request to accept/reject it.
+ */
+public class ModerationPatch {
+    private ModerationAction action;
+    private String comment;
+
+    public ModerationPatch() {
+        this.action = null;
+        this.comment = null;
+    }
+
+    public ModerationAction getAction() {
+        return action;
+    }
+
+    public void setAction(ModerationAction action) {
+        this.action = action;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    /**
+     * Actions which can be performed on the moderation request
+     */
+    public enum ModerationAction {
+        ACCEPT,
+        REJECT,
+        UNASSIGN,
+        ASSIGN
+    }
+}


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

The PR adds new HTTP verbs to endpoint `/moderationrequest` to modify ModerationRequests from REST API.

* Which issue is this pull request belonging to and how is it solving it?
> PR is related to issue #1849
* Did you add or update any new dependencies that are required for your change?
> No

Issue: #1849

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Create several moderation requests to perform following actions on the endpoint.
- `PATCH` `/moderationrequest/{id}`
  - With `action` as `ACCEPT` in body and some `comment`, the request should accept the MR.
- `PATCH` `/moderationrequest/{id}`
  - With `action` as `REJECT` in body and some `comment`, the request should reject the MR.
- `PATCH` `/moderationrequest/{id}`
  - With `action` as `ASSIGN` in body, the request should assign the MR to the caller and set the status to "in progress".
- `PATCH` `/moderationrequest/{id}`
  - With `action` as `ASSIGN` in body, for a MR where caller is not a moderator should throw error.
- `PATCH` `/moderationrequest/{id}`
  - With `action` as `UNASSIGN` in body, the request should remove the caller from the moderator list of the MR and set the status to "pending".
- `PATCH` `/moderationrequest/{id}`
  - With `action` as `UNASSIGN` in body, for a MR with only one moderator should throw error.

> Have you implemented any additional tests?

REST documentation tests.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
