### PR TITLE
fix(rest): Added endpoint url for summary and administration page info

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -664,3 +664,17 @@ include::{snippets}/should_document_get_project_count/response-fields.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_get_project_count/http-response.adoc[]
+
+[[resources-project-get-summaryadministraion-project]]
+==== Administration and Summary Info
+
+A `GET` request will get summary and administration page of project tab.
+
+===== Response structure
+include::{snippets}/should_document_create_summary_administration/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_create_summary_administration/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_create_summary_administration/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -198,14 +198,11 @@ public class JacksonCustomizations {
                 "setConsiderReleasesFromExternalList",
                 "externalUrlsSize",
                 "setExternalUrls",
-                "externalUrls",
                 "setVendor",
                 "setVendorId",
                 "setSpdxId",
                 "setModifiedOn",
-                "modifiedOn",
                 "setModifiedBy",
-                "modifiedBy"
         })
         static abstract class ProjectMixin extends Project {
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1106,7 +1106,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         if (sw360Project.getVendor() != null) {
             Vendor vendor = sw360Project.getVendor();
-            HalResource<Vendor> vendorHalResource = restControllerHelper.addEmbeddedVendor(vendor.getFullname());
+            Vendor vendorHalResource = restControllerHelper.convertToEmbeddedVendor(vendor);
             halProject.addEmbeddedResource("sw360:vendors", vendorHalResource);
             sw360Project.setVendor(null);
         }
@@ -1227,4 +1227,20 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             throw new SW360Exception(e.getMessage());
         }
     }
+    @RequestMapping(value = PROJECTS_URL + "/{id}/summaryAdministration", method = RequestMethod.GET)
+    public ResponseEntity<EntityModel<Project>> getAdministration(
+            @PathVariable("id") String id) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+        Map<String, String> sortedExternalURLs = CommonUtils.getSortedMap(sw360Project.getExternalUrls(), true);
+        sw360Project.setExternalUrls(sortedExternalURLs);
+        sw360Project.setReleaseIdToUsage(null);
+        sw360Project.setLinkedProjects(null);
+        HalResource<Project> userHalResource = createHalProject(sw360Project, sw360User);
+        sw360Project.unsetLinkedProjects();
+        sw360Project.unsetReleaseIdToUsage();
+
+        return new ResponseEntity<>(userHalResource, HttpStatus.OK);
+    }
+
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -218,6 +218,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project.setSpecialRisksOSS("Lorem Ipsum");
         project.setGeneralRisks3rdParty("Lorem Ipsum");
         project.setSpecialRisks3rdParty("Lorem Ipsum");
+        project.setLicenseInfoHeaderText("Lorem Ipsum");
         project.setDeliveryChannels("Lorem Ipsum");
         project.setVendor(new Vendor());
         project.setRemarksAdditionalRequirements("Lorem Ipsum");
@@ -232,6 +233,10 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project.setAdditionalData(additionalData);
         project.setPhaseOutSince("2020-06-24");
         project.setClearingRequestId("CR-1");
+        Map<String, String> externalURLs1 = new HashMap<>();
+        externalURLs1.put("homepage", "http://test_wiki_url.com");
+        externalURLs1.put("wiki", "http://test_wiki_url.com");
+        project.setExternalUrls(externalURLs1);
 
         projectListByName.add(project);
         projectList.add(project);
@@ -266,6 +271,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project2.setSpecialRisks3rdParty("Lorem Ipsum");
         project2.setDeliveryChannels("Lorem Ipsum");
         project2.setRemarksAdditionalRequirements("Lorem Ipsum");
+        project2.setLicenseInfoHeaderText("Lorem Ipsum");
         project2.setVendor(new Vendor());
         project2.setSecurityResponsibles(new HashSet<>(Arrays.asList("securityresponsible1@sw360.org", "securityresponsible2@sw360.org")));
         project2.setProjectResponsible("projectresponsible@sw360.org");
@@ -678,6 +684,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:projects.[]_embedded.clearingTeam").description("The clearingTeam of the project").optional(),
                                 subsectionWithPath("_embedded.sw360:projects.[]_embedded.homepage").description("The homepage url of the project").optional(),
                                 subsectionWithPath("_embedded.sw360:projects.[]_embedded.wiki").description("The wiki url of the project").optional(),
+                                subsectionWithPath("_embedded.sw360:projects.[]licenseInfoHeaderText").description("The licenseInfoHeaderText text of the project"),
+                                subsectionWithPath("_embedded.sw360:projects.[]externalUrls").description("A place to store additional data used by external tools").optional(),
                                 subsectionWithPath("_embedded.sw360:projects.[]_embedded.sw360:moderators").description("An array of all project moderators with email").optional(),
                                 subsectionWithPath("_embedded.sw360:projects.[]_embedded.sw360:contributors").description("An array of all project contributors with email").optional(),
                                 subsectionWithPath("_embedded.sw360:projects.[]_embedded.sw360:attachments").description("An array of all project attachments").optional(),
@@ -737,6 +745,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
                                 fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
                                 fieldWithPath("phaseOutSince").description("The project phase-out date"),
+                                fieldWithPath("licenseInfoHeaderText").description("The licenseInfoHeaderText text of the project"),
+                                subsectionWithPath("externalUrls").description("A place to store additional data used by external URLs"),
                                 fieldWithPath("clearingRequestId").description("Clearing Request id associated with project."),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 subsectionWithPath("_embedded.createdBy").description("The user who created this project"),
@@ -1438,6 +1448,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                         subsectionWithPath("_embedded.createdBy").description("The user who created this project"),
                         fieldWithPath("enableSvm").description("Security vulnerability monitoring flag"),
+                        fieldWithPath("licenseInfoHeaderText").description("The licenseInfoHeaderText text of the project"),
+                        subsectionWithPath("externalUrls").description("A place to store additional data used by external URLs"),
                         fieldWithPath("considerReleasesFromExternalList").description("Consider list of releases from existing external list"),
                         fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
                         subsectionWithPath("_embedded.sw360:moderators").description("An array of moderators"),
@@ -1680,5 +1692,56 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                fieldWithPath("status").description("status of the API. Possible values are `<success|failure>`").optional(),
                                fieldWithPath("count").description("Count of projects for a user.").optional()
                        )));
+    }
+    @Test
+    public void should_document_create_summary_administration() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects/" + project.getId()+ "/summaryAdministration")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("name").description("The name of the project"),
+                                fieldWithPath("version").description("The project version"),
+                                fieldWithPath("createdOn").description("The date the project was created"),
+                                fieldWithPath("projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
+                                fieldWithPath("domain").description("The domain, possible values are:"  + Sw360ResourceServer.DOMAIN.toString()),
+                                fieldWithPath("visibility").description("The project visibility, possible values are: " + Arrays.asList(Visibility.values())),
+                                subsectionWithPath("externalIds").description("When projects are imported from other tools, the external ids can be stored here. Store as 'Single String' when single value, or 'Array of String' when multi-values"),
+                                subsectionWithPath("additionalData").description("A place to store additional data used by external tools"),
+                                fieldWithPath("ownerAccountingUnit").description("The owner accounting unit of the project"),
+                                fieldWithPath("ownerGroup").description("The owner group of the project"),
+                                fieldWithPath("description").description("The project description"),
+                                fieldWithPath("ownerCountry").description("The owner country of the project"),
+                                fieldWithPath("obligationsText").description("The obligations text of the project"),
+                                fieldWithPath("clearingSummary").description("The clearing summary text of the project"),
+                                fieldWithPath("specialRisksOSS").description("The special risks OSS text of the project"),
+                                fieldWithPath("generalRisks3rdParty").description("The general risks 3rd party text of the project"),
+                                fieldWithPath("specialRisks3rdParty").description("The special risks 3rd party text of the project"),
+                                fieldWithPath("deliveryChannels").description("The sales and delivery channels text of the project"),
+                                fieldWithPath("remarksAdditionalRequirements").description("The remark additional requirements text of the project"),
+                                fieldWithPath("tag").description("The project tag"),
+                                fieldWithPath("businessUnit").description("The business unit this project belongs to"),
+                                fieldWithPath("deliveryStart").description("The project delivery start date"),
+                                fieldWithPath("preevaluationDeadline").description("The project preevaluation deadline"),
+                                fieldWithPath("systemTestStart").description("Date of the project system begin phase"),
+                                fieldWithPath("systemTestEnd").description("Date of the project system end phase"),
+                                fieldWithPath("securityResponsibles").description("An array of users responsible for security of the project."),
+                                fieldWithPath("projectResponsible").description("A user who is responsible for the project."),
+                                fieldWithPath("enableSvm").description("Security vulnerability monitoring flag"),
+                                fieldWithPath("considerReleasesFromExternalList").description("Consider list of releases from existing external list"),
+                                fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
+                                fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
+                                fieldWithPath("phaseOutSince").description("The project phase-out date"),
+                                fieldWithPath("clearingRequestId").description("Clearing Request id associated with project."),
+                                fieldWithPath("licenseInfoHeaderText").description("Display licenseInfoHeaderText info"),
+                                subsectionWithPath("externalUrls").description("A place to store additional data used by external URLs"),
+                                subsectionWithPath("_embedded.createdBy").description("The user who created this project"),
+                                subsectionWithPath("_embedded.sw360:moderators").description("An array of moderators"),
+                                subsectionWithPath("_embedded.sw360:vendors").description("An array of all component vendors with full name and link to their <<resources-vendor-get,Vendor resource>>"),
+                                subsectionWithPath("_embedded.sw360:attachments").description("An array of all project attachments and link to their <<resources-attachment-get,Attachment resource>>"),
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
     }
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
I have created a new endpoint URL for summary and administrative page info.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #1894 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?

resource/api/projects/{id}/summary/administration
ex: resource/api/projects/c109935d14e846c4afe03a8f3e97798b/summary/administration

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
