### PR TITLE
feat(EditCR): Admin will be able to reassign/edit the Requesting User of CR

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -460,6 +460,8 @@ public class ModerationPortlet extends FossologyAwarePortlet {
         final String clearingId = request.getParameter(CLEARING_REQUEST_ID);
         final User user = UserCacheHolder.getUserFromRequest(request);
 
+        request.setAttribute(IS_USER_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user) ? "Yes" : "No");
+
         if (CommonUtils.isNullEmptyOrWhitespace(clearingId)) {
             throw new PortletException("Clearing request ID not set!");
         }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
@@ -104,6 +104,14 @@ public class ModerationPortletUtils {
                 String isClearingExpertEdit = request.getParameter(PortalConstants.IS_CLEARING_EXPERT);
                 ModerationService.Iface client = new ThriftClients().makeModerationClient();
                 ClearingRequest clearingRequest = client.getClearingRequestByIdForEdit(id, user);
+
+                String requestingUser = request.getParameter(ClearingRequest._Fields.REQUESTING_USER.toString());
+                if (CommonUtils.isNullEmptyOrWhitespace(requestingUser)) {
+                    log.warn("Invalid requesting user email: " + requestingUser + " is entered, by user: "+ user.getEmail());
+                    return requestSummary.setMessage("Invalid requesting user email");
+                }
+                clearingRequest.setRequestingUser(requestingUser);
+
                 String clearingTeam = request.getParameter(ClearingRequest._Fields.CLEARING_TEAM.toString());
                 if (CommonUtils.isNullEmptyOrWhitespace(clearingTeam)) {
                     log.warn("Invalid clearingTeam email: " + clearingTeam + " is entered, by user: "+ user.getEmail());

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
@@ -31,7 +31,7 @@
 <jsp:useBean id="printDate" class="java.util.Date"/>
 <jsp:useBean id="approvedReleaseCount" class="java.lang.Integer" scope="request" />
 <jsp:useBean id="PreferredClearingDateLimit" class="java.lang.String" scope="request" />
-
+<jsp:useBean id="isUserAdmin" class="java.lang.String" scope="request" />
 
 <core_rt:if test="${not empty clearingRequest.id}">
 
@@ -137,7 +137,19 @@
                                         <tbody>
                                             <tr>
                                                 <td><label class="form-group"><liferay-ui:message key="requesting.user" />:</label></td>
-                                                <td><sw360:DisplayUserEmail email="${clearingRequest.requestingUser}" /></td>
+                                                <td>
+                                                <core_rt:choose>
+                                                    <core_rt:when test="${isUserAdmin == 'Yes' and isEditable}">
+                                                        <sw360:DisplayUserEdit id="REQUESTING_USER" email="${clearingRequest.requestingUser}" description="" multiUsers="false" />
+                                                        <div class="invalid-feedback" id="clearingTeamEmailErrorMsg">
+                                                             <liferay-ui:message key="email.should.be.in.valid.format" />
+                                                        </div>
+                                                    </core_rt:when>
+                                                    <core_rt:otherwise>
+                                                        <sw360:DisplayUserEmail email="${clearingRequest.requestingUser}" />
+                                                    </core_rt:otherwise>
+                                                </core_rt:choose>
+                                                </td>
                                             </tr>
                                             <tr>
                                                 <td><label class="form-group"><liferay-ui:message key="created.on" />:</label></td>


### PR DESCRIPTION

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Description:
> Admin will now be able to edit the Requesting User field while editing a clearing request in Requests Portlet
>An empty comment will not be generated when clicking on 'update Request' without actually making a change

Issue: #1892 and #1903

Screenshot:
![image](https://user-images.githubusercontent.com/115608771/230289785-f8fb95da-3506-4051-8b70-07fd8ac3fda9.png)

