### PR TITLE
feat(ProjectUI):ExternalIds and Additional Data fields in Export Excel in License Clearing

### DIFF
--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -94,10 +94,6 @@ struct Project {
     6: optional string version,
     7: optional string domain,
 
-    // information from external data sources
-    9: optional map<string, string> externalIds,
-    300: optional map<string, string> additionalData,
-
     // Additional informations
     10: optional set<Attachment> attachments,
     11: optional string createdOn, // Creation date YYYY-MM-dd
@@ -134,6 +130,11 @@ struct Project {
     44: optional string deliveryStart,
     45: optional string phaseOutSince,
     46: optional bool enableSvm, // flag for enabling Security Vulnerability Monitoring
+
+    // information from external data sources
+    9: optional map<string, string> externalIds,
+    300: optional map<string, string> additionalData,
+
     49: optional bool considerReleasesFromExternalList, // Consider list of releases from existing external list
     47: optional string licenseInfoHeaderText;
     48: optional bool enableVulnerabilitiesDisplay, // flag for enabling displaying vulnerabilities in project view

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
@@ -19,7 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.exporter.helper.ExporterHelper;
 import org.eclipse.sw360.exporter.helper.ProjectHelper;
 import org.eclipse.sw360.exporter.helper.ReleaseHelper;
@@ -46,7 +45,6 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
         nameToDisplayName.put(TAG.getFieldName(), "project tag");
         nameToDisplayName.put(BUSINESS_UNIT.getFieldName(), "group");
         nameToDisplayName.put(RELEASE_CLEARING_STATE_SUMMARY.getFieldName(), "release clearing state summary");
-        nameToDisplayName.put(EXTERNAL_IDS.getFieldName(), "external IDs");
         nameToDisplayName.put(VISBILITY.getFieldName(), "visibility");
         nameToDisplayName.put(PROJECT_TYPE.getFieldName(), "project type");
         nameToDisplayName.put(LINKED_PROJECTS.getFieldName(), "linked projects with relationship");
@@ -65,6 +63,8 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
         nameToDisplayName.put(SECURITY_RESPONSIBLES.getFieldName(), "security responsibles");
         nameToDisplayName.put(CREATED_ON.getFieldName(), "created on");
         nameToDisplayName.put(ENABLE_SVM.getFieldName(), "enable svm");
+        nameToDisplayName.put(EXTERNAL_IDS.getFieldName(), "external IDs");
+        nameToDisplayName.put(ADDITIONAL_DATA.getFieldName(), "additional data");
         nameToDisplayName.put(VISBILITY.getFieldName(), "Project visibility");
     }
 
@@ -80,6 +80,8 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
             .add(SECURITY_RESPONSIBLES)
             .add(CREATED_ON)
             .add(ENABLE_SVM)
+            .add(EXTERNAL_IDS)
+            .add(ADDITIONAL_DATA)
             .add(VISBILITY)
             .build();
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)
Description:
Two more fields "ExternalIds" and "Additional Data" have been added to the Excel exported from License Clearing in Project Portlet.

Issue: #1897 


