### PR TITLE
feat(rest): optimize fetch project

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.sw360.datahandler.resourcelists;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -38,6 +37,13 @@ public class ResourceListController<T> {
             toIndex = sortedResources.size();
         }
         return new PaginationResult<>(sortedResources.subList(fromIndex, toIndex), sortedResources.size(), paginationOptions);
+    }
+
+    public PaginationResult<T> getPaginationResultFromPaginatedList(List<T> resources,
+                                                                    PaginationOptions<T> paginationOptions,
+                                                                    int totalCount) {
+        return new PaginationResult<>(this.sortList(resources, paginationOptions.getSortComparator()),
+                totalCount, paginationOptions);
     }
 
     private List<T> sortList(List<T> resources, Comparator<T> comparator) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -139,6 +139,18 @@ public class RestControllerHelper<T> {
         return paginationResult;
     }
 
+    public PaginationResult<T> paginationResultFromPaginatedList(HttpServletRequest request, Pageable pageable,
+                                                                 List<T> resources, String resourceType, int totalCount)
+            throws ResourceClassNotFoundException {
+        if (!requestContainsPaging(request)) {
+            request.setAttribute(PAGINATION_PARAM_PAGE, pageable.getPageNumber());
+            request.setAttribute(PAGINATION_PARAM_PAGE_ENTRIES, pageable.getPageSize());
+        }
+        PaginationOptions<T> paginationOptions = paginationOptionsFromPageable(pageable, resourceType);
+        return resourceListController.getPaginationResultFromPaginatedList(resources,
+                paginationOptions, totalCount);
+    }
+
     private boolean requestContainsPaging(HttpServletRequest request) {
         return request.getParameterMap().containsKey(PAGINATION_PARAM_PAGE) || request.getParameterMap().containsKey(PAGINATION_PARAM_PAGE_ENTRIES);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -190,6 +190,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         boolean isSearchByTag = CommonUtils.isNotNullEmptyOrWhitespace(tag);
         boolean isSearchByType = CommonUtils.isNotNullEmptyOrWhitespace(projectType);
         boolean isSearchByGroup = CommonUtils.isNotNullEmptyOrWhitespace(group);
+        boolean isNoFilter = false;
         List<Project> sw360Projects = new ArrayList<>();
         Map<String, Set<String>> filterMap = new HashMap<>();
         if (luceneSearch) {
@@ -224,21 +225,29 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             } else if (isSearchByType) {
                 sw360Projects.addAll(projectService.searchProjectByType(projectType, sw360User));
             } else {
-                sw360Projects.addAll(projectService.getProjectsForUser(sw360User));
+                sw360Projects.addAll(projectService.getProjectsForUser(sw360User, pageable));
+                isNoFilter = true;
             }
         }
         return getProjectResponse(pageable, projectType, group, tag, allDetails, luceneSearch, request, sw360User,
-                mapOfProjects, isSearchByName, sw360Projects);
+                mapOfProjects, isSearchByName, sw360Projects, isNoFilter);
     }
 
     @NotNull
     private ResponseEntity<CollectionModel<EntityModel<Project>>> getProjectResponse(Pageable pageable,
-            String projectType, String group, String tag, boolean allDetails, boolean luceneSearch,
-            HttpServletRequest request, User sw360User, Map<String, Project> mapOfProjects, boolean isSearchByName,
-            List<Project> sw360Projects) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException {
+                                                                                     String projectType, String group, String tag, boolean allDetails, boolean luceneSearch,
+                                                                                     HttpServletRequest request, User sw360User, Map<String, Project> mapOfProjects, boolean isSearchByName,
+                                                                                     List<Project> sw360Projects, boolean isNoFilter) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException, TException {
         sw360Projects.stream().forEach(prj -> mapOfProjects.put(prj.getId(), prj));
-        PaginationResult<Project> paginationResult = restControllerHelper.createPaginationResult(request, pageable,
-                sw360Projects, SW360Constants.TYPE_PROJECT);
+        PaginationResult<Project> paginationResult;
+        if (isNoFilter) {
+            int totalCount = projectService.getMyAccessibleProjectCounts(sw360User);
+            paginationResult = restControllerHelper.paginationResultFromPaginatedList(request, pageable,
+                    sw360Projects, SW360Constants.TYPE_PROJECT, totalCount);
+        } else {
+            paginationResult = restControllerHelper.createPaginationResult(request, pageable,
+                    sw360Projects, SW360Constants.TYPE_PROJECT);
+        }
 
         List<EntityModel<Project>> projectResources = new ArrayList<>();
         Consumer<Project> consumer = p -> {
@@ -313,7 +322,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         sw360Projects = projectService.getWithFilledClearingStatus(sw360Projects, clearingState);
 
         return getProjectResponse(pageable, null, null, null, allDetails, true, request, sw360User,
-                mapOfProjects, true, sw360Projects);
+                mapOfProjects, true, sw360Projects, false);
     }
 
     @RequestMapping(value = PROJECTS_URL + "/{id}", method = RequestMethod.GET)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -48,6 +48,7 @@ import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.Link;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -95,24 +96,14 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
     public static final ExecutorService releaseExecutor = Executors.newFixedThreadPool(10);
 
-    public Set<Project> getProjectsForUser(User sw360User) throws TException {
+    public Set<Project> getProjectsForUser(User sw360User, Pageable pageable) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        int total = sw360ProjectClient.getMyAccessibleProjectCounts(sw360User);
-        PaginationData pageData = new PaginationData();
-        pageData.setAscending(true);
-        Map<PaginationData, List<Project>> pageDtToProjects;
-        Set<Project> projects = new HashSet<>();
-        int displayStart = 0;
-        int rowsPerPage = 500;
-        while (0 < total) {
-            pageData.setDisplayStart(displayStart);
-            pageData.setRowsPerPage(rowsPerPage);
-            displayStart = displayStart + rowsPerPage;
-            pageDtToProjects = sw360ProjectClient.getAccessibleProjectsSummaryWithPagination(sw360User, pageData);
-            projects.addAll(pageDtToProjects.entrySet().iterator().next().getValue());
-            total = total - rowsPerPage;
-        }
-        return projects;
+        PaginationData pageData = new PaginationData()
+                .setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize())
+                .setSortColumnNumber(0);
+        Map<PaginationData, List<Project>> pageDtToProjects = sw360ProjectClient.getAccessibleProjectsSummaryWithPagination(sw360User, pageData);
+        return new HashSet<>(pageDtToProjects.entrySet().iterator().next().getValue());
     }
 
     public Project getProjectForUserById(String projectId, User sw360User) throws TException {
@@ -484,5 +475,16 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public List<Project> getMyProjects(User user, Map<String, Boolean> userRoles) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         return sw360ProjectClient.getMyProjects(user, userRoles);
+    }
+
+    /**
+     * Get count of projects accessible by given user.
+     * @param sw360User User to get the count for.
+     * @return Total count of projects accessible by user.
+     * @throws TException
+     */
+    public int getMyAccessibleProjectCounts(User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.getMyAccessibleProjectCounts(sw360User);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -53,7 +53,7 @@ public class ProjectTest extends TestIntegrationBase {
         project.setDescription("Project description");
         projectList.add(project);
 
-        given(this.projectServiceMock.getProjectsForUser(any())).willReturn(projectList);
+        given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(projectList);
 
         User user = new User();
         user.setId("123456789");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -286,7 +286,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         Set<String> releaseIds = new HashSet<>(Collections.singletonList("3765276512"));
         Set<String> releaseIdsTransitive = new HashSet<>(Arrays.asList("3765276512", "5578999"));
 
-        given(this.projectServiceMock.getProjectsForUser(any())).willReturn(projectList);
+        given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(projectList);
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), any())).willReturn(project);
         given(this.projectServiceMock.getProjectForUserById(eq(project2.getId()), any())).willReturn(project2);
         given(this.projectServiceMock.getProjectForUserById(eq(projectForAtt.getId()), any())).willReturn(projectForAtt);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)

While fetching the projects without filter on `/projects` endpoint, optimize the call to `getAccessibleProjectsSummary()`.
> * Did you add or update any new dependencies that are required for your change?

No

Issue: #1899

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

@smrutis1

### How To Test?
For big database, fetch projects from REST API without any filter. Try with different pagination patterns.

- `GET /projects`
- `GET /projects?page_entries=100`
- `GET /projects?page_entries=100&page=2`

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
