### PR TITLE
feat(REST): Endpoint for SBOM import

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -617,3 +617,36 @@ include::{snippets}/should_document_update_project_vulnerabilities/http-response
 
 ===== Links
 include::{snippets}/should_document_update_project_vulnerabilities/links.adoc[]
+
+[[resources-import-sbom]]
+==== Import SBOM
+
+A `POST` request is used to import SBOM in SPDX format.
+
+[red]#Request parameters#
+|===
+|Parameter |Description
+
+|type
+|File type of SBOM
+|===
+
+[red]#Request structure#
+|===
+Type |Description
+
+|file
+|Path of the SBOM file
+|===
+
+
+[red]#Response structure#
+|===
+|Complete Project will be returned
+|===
+
+===== Example request
+include::{snippets}/should_document_import_sbom/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_import_sbom/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -26,6 +26,7 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -480,5 +481,17 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public int getMyAccessibleProjectCounts(User sw360User) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         return sw360ProjectClient.getMyAccessibleProjectCounts(sw360User);
+    }
+
+    /**
+     * Import SBOM using the method on the thrift client.
+     * @param user                User uploading the SBOM
+     * @param attachmentContentId Id of the attachment uploaded
+     * @return RequestSummary
+     * @throws TException
+     */
+    public RequestSummary importSBOM(User user, String attachmentContentId) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.importBomFromAttachmentContent(user, attachmentContentId);
     }
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Description:
Provided a new endpoint for SBOM import. This currently only supports SPDX files.

Issue: #1904 


![image](https://user-images.githubusercontent.com/115608771/232735322-d8c32714-1a77-47a7-a401-f8493767a274.png)
