### PR TITLE
Revert httpcore and fix httpcore and spring-boot

### DIFF
--- a/libraries/datahandler/pom.xml
+++ b/libraries/datahandler/pom.xml
@@ -182,8 +182,8 @@
             <artifactId>findbugs-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5</artifactId>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <guava.version>31.1-jre</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <httpcore5.version>5.2.1</httpcore5.version>
+    <httpcore.version>4.4.16</httpcore.version>
     <jakarta-xml-bind.version>2.3.2</jakarta-xml-bind.version>
     <jackson.core.version>2.13.4</jackson.core.version>
     <jackson.databind.version>2.13.4.2</jackson.databind.version>
@@ -134,7 +134,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <spotless.version>2.29.0</spotless.version>
     <spring.version>5.3.19</spring.version>
-    <spring-boot.version>2.6.6</spring-boot.version>
+    <spring-boot.version>2.7.11</spring-boot.version>
     <spring-restdocs.version>2.0.6.RELEASE</spring-restdocs.version>
     <spring-security-oauth2.version>2.5.1.RELEASE</spring-security-oauth2.version>
     <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
@@ -342,9 +342,9 @@
         <version>${jackson.annotations.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId>
-        <artifactId>httpcore5</artifactId>
-        <version>${httpcore5.version}</version>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${httpcore.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>


### PR DESCRIPTION
Spring boot 2.x requires httpcore series 4 as dependencies, so usage of httpcore5 would force to upgrade to newer spring boot, too big change to simply normalize a single version.
