### PR TITLE
Normalize json versions

### DIFF
--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -32,10 +32,6 @@
             <artifactId>tools-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
         </dependency>

--- a/backend/src/src-licenses/pom.xml
+++ b/backend/src/src-licenses/pom.xml
@@ -9,8 +9,8 @@
   ~ SPDX-License-Identifier: EPL-2.0
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -22,7 +22,7 @@
     <artifactId>src-licenses</artifactId>
     <packaging>jar</packaging>
     <name>src-licenses</name>
-        
+
     <properties>
         <liferay.petra.function.version>5.1.2</liferay.petra.function.version>
     </properties>
@@ -31,10 +31,6 @@
         <dependency>
             <groupId>org.spdx</groupId>
             <artifactId>tools-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
         </dependency>
         <!-- Needed by spdx-tools -->
         <dependency>

--- a/backend/src/src-vmcomponents/pom.xml
+++ b/backend/src/src-vmcomponents/pom.xml
@@ -4,8 +4,8 @@
   ~ SPDX-License-Identifier: EPL-2.0
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -29,11 +29,6 @@
             <groupId>org.eclipse.sw360</groupId>
             <artifactId>src-vulnerabilities</artifactId>
             <version>${revision}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,14 @@
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
     <versions-maven-plugin.version>2.12.0</versions-maven-plugin.version>
 
+    <!-- JSON Libraries used in the project -->
+    <gson.version>2.10.1</gson.version>
+    <json.version>20230227</json.version>
+    <json-path.version>2.8.0</json-path.version>
+    <json-smart.version>2.4.10</json-smart.version>
+    <json-simple.version>2.3.1</json-simple.version>
+    <jackson.version>2.14.2</jackson.version>
+
     <!-- Dependencies version properties -->
     <byte-buddy.version>1.12.13</byte-buddy.version>
     <cloudant.version>2.19.1</cloudant.version>
@@ -91,15 +99,11 @@
     <failureaccess.version>1.0.1</failureaccess.version>
     <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
     <glassfish-jaxb.version>2.3.2</glassfish-jaxb.version>
-    <gson.version>2.8.9</gson.version>
     <guava.version>31.1-jre</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpcore.version>4.4.16</httpcore.version>
     <jakarta-xml-bind.version>2.3.2</jakarta-xml-bind.version>
-    <jackson.core.version>2.13.4</jackson.core.version>
-    <jackson.databind.version>2.13.4.2</jackson.databind.version>
-    <jackson.annotations.version>2.13.4</jackson.annotations.version>
     <javax-annotation.version>1.3.2</javax-annotation.version>
     <javax-activation.version>1.1.1</javax-activation.version>
     <jcraft.version>0.1.54</jcraft.version>
@@ -142,7 +146,6 @@
     <thrift.version>0.16.0</thrift.version>
     <wiremock.version>2.26.0</wiremock.version>
     <org.spdx.tools.java.version>1.1.5</org.spdx.tools.java.version>
-    <com.googlecode.json-simple.version>1.1.1</com.googlecode.json-simple.version>
 
     <!--  User must provide below property configuration based on his/her liferay deployment
     environment -->
@@ -191,7 +194,22 @@
       <dependency>
         <groupId>com.github.cliftonlabs</groupId>
         <artifactId>json-simple</artifactId>
-        <version>2.3.1</version>
+        <version>${json-simple.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>${json.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${json-smart.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.jayway.jsonpath</groupId>
+        <artifactId>json-path</artifactId>
+        <version>${json-path.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.package-url</groupId>
@@ -329,17 +347,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.databind.version}</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>${jackson.core.version}</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.annotations.version}</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -365,12 +383,6 @@
         <groupId>org.spdx</groupId>
         <artifactId>tools-java</artifactId>
         <version>${org.spdx.tools.java.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.googlecode.json-simple</groupId>
-        <artifactId>json-simple</artifactId>
-        <version>${com.googlecode.json-simple.version}</version>
-        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -10,7 +10,9 @@
   ~ SPDX-License-Identifier: EPL-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sw360</artifactId>
         <groupId>org.eclipse.sw360</groupId>
@@ -34,7 +36,8 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <!-- <outputDirectory>${session.executionRootDirectory}/deps/jars</outputDirectory> -->
+                            <!--
+                            <outputDirectory>${session.executionRootDirectory}/deps/jars</outputDirectory> -->
                             <outputDirectory>${jars.deploy.dir}</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
@@ -44,7 +47,7 @@
                     </execution>
                 </executions>
             </plugin>
-          </plugins>
+        </plugins>
     </build>
 
     <dependencies>
@@ -56,22 +59,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>${gson.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
On current codebase, sw360 is using 6 different json libraries. 

Google old json-simple and Cliftonlabs json had name clash. Google library was removed.

JSON Issue reference: https://github.com/eclipse-sw360/sw360/issues/1921
Issue: https://github.com/eclipse-sw360/sw360/issues/1808

TODO: Change all code to use one single library

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
