### PR TITLE
feat(spdx): Added support for pasring of SPDX-2.3 (ISR) generated via FOSSology 

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -122,7 +122,7 @@ public class PortalConstants {
     public static final String LICENSE_TYPE_GLOBAL = "global";
     public static final String LICENSE_TYPE_OTHERS = "Others";
     public static final String LICENSE_IDS = "licenseIds";
-    public static final String MAIN_LICENSE_FILES = "LICENSE.*|license|license.txt|license.html|COPYING.*|copying|copying.txt|copying.html";
+    public static final String MAIN_LICENSE_FILES = "LICENSE.*|License.*|license|license.txt|license.html|COPYING.*|Copying.*|copying|copying.txt|copying.html";
 
     //! Specialized keys for moderation
     public static final String MODERATION_PORTLET_NAME = PORTLET_NAME_PREFIX + "moderations";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -2930,20 +2930,20 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                         attachmentContentId, true, user);
                 List<LicenseNameWithText> licenseWithTexts = licenseInfoResult.stream()
                         .filter(filterLicenseResult)
-                        .flatMap(result -> result.getLicenseInfo().getLicenseNamesWithTexts().stream())
+                        .map(LicenseInfoParsingResult::getLicenseInfo).map(LicenseInfo::getLicenseNamesWithTexts).flatMap(Set::stream)
                         .filter(license -> !license.getLicenseName().equalsIgnoreCase(SW360Constants.LICENSE_NAME_UNKNOWN)
                                 && !license.getLicenseName().equalsIgnoreCase(SW360Constants.NA)
                                 && !license.getLicenseName().equalsIgnoreCase(SW360Constants.NO_ASSERTION)) // exclude unknown, n/a and noassertion
                         .collect(Collectors.toList());
                 if (attachmentName.endsWith(PortalConstants.RDF_FILE_EXTENSION)) {
-                    totalFileCount = licenseInfoResult.stream().flatMap(result -> result.getLicenseInfo().getLicenseNamesWithTexts().stream())
-                            .map(LicenseNameWithText::getSourceFiles).filter(Objects::nonNull).flatMap(Set::stream).collect(Collectors.toSet()).size();
+                    totalFileCount = licenseInfoResult.stream().map(LicenseInfoParsingResult::getLicenseInfo).map(LicenseInfo::getLicenseNamesWithTexts).flatMap(Set::stream)
+                            .map(LicenseNameWithText::getSourceFiles).filter(Objects::nonNull).flatMap(Set::stream).distinct().count();
                     concludedLicenseIds = licenseInfoResult.stream()
                             .filter(filterConcludedLicense)
                             .flatMap(singleResult -> singleResult.getLicenseInfo().getConcludedLicenseIds().stream())
-                            .collect(Collectors.toCollection(TreeSet::new));
+                            .collect(Collectors.toCollection(() -> new TreeSet<String>(String.CASE_INSENSITIVE_ORDER)));
                     otherLicenseNames = licenseWithTexts.stream().map(LicenseNameWithText::getLicenseName)
-                            .collect(Collectors.toCollection(TreeSet::new));
+                            .collect(Collectors.toCollection(() -> new TreeSet<String>(String.CASE_INSENSITIVE_ORDER)));
                     otherLicenseNames.removeAll(concludedLicenseIds);
                 }
                 try {


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### I accidentally deleted the remote branch `feat/SPDX-2.3-Support_For_ISR-1915`, instead of force pushing, which closed the PR #1952 , So creating this new PR.


> Please provide a summary of your changes here. <br>
- This PR fixes the newly generated SPDX-2.3 version Initial Scan Report (`.rdf` for ISR attachment) parsing issue.
- The  SPDX-2.3 version Initial Scan Report (`.rdf` for ISR attachment) should be generated from latest version of FOSSology.


Issue: #1915 

### Suggest Reviewer
@afsahsyeda 

### How To Test? <br>
**Release portlet:**<br>
1. Create a release and upload SPDX-2.3 standard file as attachment of type `ISR` to release.
2. Go to `Clearing Details` tab of release and click on `Show License Info` tab.
3. It should display all the list of licenses available in ISR, and an `info` icon beside each license.
4. Clicking on `info` icon should open a modal pop-up and list all the source files associated with that particular license.
5. Please manually verify the license to source file mapping in ISR attachment.

**Project portlet:**

1. Linked the release created in above step to a project.
2. Go to `License Clearing` tab in project details page.
3. Click on `info` icon beside the linked release on step 1.
4. It should open a pop-up with all the available licenses inside the ISR attachment of release.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
