### PR TITLE
Fix(Rest): Add more fields in get components response (support new Front-end)

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
@@ -103,6 +103,9 @@ public class ComponentSummary extends DocumentSummary<Component> {
         copyField(document, copy, Component._Fields.CREATED_BY);
         copyField(document, copy, Component._Fields.CREATED_ON);
         copyField(document, copy, Component._Fields.VENDOR_NAMES);
+        copyField(document, copy, Component._Fields.MAIN_LICENSE_IDS);
+        copyField(document, copy, Component._Fields.COMPONENT_TYPE);
+        copyField(document, copy, Component._Fields.DEFAULT_VENDOR_ID);
 
 
         for (Release release : releases) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -315,14 +315,12 @@ public class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties(value = {
-                "id",
                 "revision",
                 "attachments",
                 "createdBy",
                 "subscribers",
                 "moderators",
                 "releases",
-                "mainLicenseIds",
                 "softwarePlatforms",
                 "wiki",
                 "blog",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -523,6 +523,11 @@ public class RestControllerHelper<T> {
         embeddedComponent.setName(component.getName());
         embeddedComponent.setComponentType(component.getComponentType());
         embeddedComponent.setVisbility(component.getVisbility());
+        embeddedComponent.setMainLicenseIds(component.getMainLicenseIds());
+        if (CommonUtils.isNotNullEmptyOrWhitespace(component.getDefaultVendorId())) {
+            Vendor defaultVendor = vendorService.getVendorById(component.getDefaultVendorId());
+            embeddedComponent.setDefaultVendor(defaultVendor);
+        }
         embeddedComponent.setType(null);
         return embeddedComponent;
     }


### PR DESCRIPTION
Refer issue: #1958 


## Prerequisite:
- Some components have main licenses and default vendor

## Procedures:
Send API request to Urls:
 1. http://localhost:8080/resource/api/components
 2. http://localhost:8080/resource/api/components?name={component_name}
 3. http://localhost:8080/resource/api/components?type={component_type}
 
## Expect:
Have these fields in responses:
- id
- mainLicenseIds
- defaultVendor (when default vendor exist)
- componentType

Example Response:

```
{
    "_embedded": {
        "sw360:components": [
            {
                "id": "000fa58564cd41d0838eb6702c87f189",
                "name": "CompName",
                "componentType": "OSS",
                "visbility": "EVERYONE",
                "mainLicenseIds": [
                    "GPL-3.0+"
                ],
                "setVisbility": true,
                "setBusinessUnit": false,
                "defaultVendor": {
                    "type": "vendor",
                    "url": "http://localhost:8080/group/guest/vendors",
                    "shortName": "sads",
                    "fullName": "dasd"
                },
                "_links": {
                    "self": {
                        "href": "http://localhost:8080/resource/api/components/000fa58564cd41d0838eb6702c87f189"
                    }
                }
            }
        ]
    },
    "_links": {
        "curies": [
            {
                "href": "http://localhost:8080/resource/docs/{rel}.html",
                "name": "sw360",
                "templated": true
            }
        ]
    }
}
```


