### PR TITLE
fix(license): Fix attachment type when importing SBOM

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/spdx/SpdxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/spdx/SpdxBOMImporter.java
@@ -698,7 +698,7 @@ public class SpdxBOMImporter {
     private Attachment makeAttachmentFromContent(AttachmentContent attachmentContent) {
         Attachment attachment = new Attachment();
         attachment.setAttachmentContentId(attachmentContent.getId());
-        attachment.setAttachmentType(AttachmentType.SBOM);
+        attachment.setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_COMBINED);
         attachment.setCreatedComment("Used for SPDX Bom import");
         attachment.setFilename(attachmentContent.getFilename());
         attachment.setCheckStatus(CheckStatus.NOTCHECKED);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: https://github.com/eclipse-sw360/sw360/issues/1871
From Akapti's comment (https://github.com/eclipse-sw360/sw360/pull/1872#issuecomment-1521219796), I created this PR.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?

1. Import a SBOM file to the component page (Change the attached file from SPDXRdfExample-v2.2.spdx.rdf.txt to SPDXRdfExample-v2.2.spdx.rdf before importing)
[SPDXRdfExample-v2.2.spdx.rdf.txt](https://github.com/eclipse-sw360/sw360/files/11483717/SPDXRdfExample-v2.2.spdx.rdf.txt)
2. Go to "glibc-2.11.1" release page, click the Attachments tab. Attachment type is CLI
3. Click the Clearing detail tab on "glibc-2.11.1" release page

- Expected: SPDXRdfExample-v2.2.spdx.rdf and "Show license info" button appear in the "SPDX attachments" section. User can see the license info by clicking on "Show license info" button.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

