### PR TITLE
Restore original portlet naming and configs

### DIFF
--- a/libraries/datahandler/pom.xml
+++ b/libraries/datahandler/pom.xml
@@ -113,9 +113,55 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-build-configuration-resources</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <artifactItems combine.children="append">
+                                <artifactItem>
+                                    <groupId>
+                                        org.eclipse.sw360</groupId>
+                                    <artifactId>build-configuration</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>
+                                        jar</type>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-build-configuration-test-resources</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-test-resources</phase>
+                        <configuration>
+                            <artifactItems combine.children="append">
+                                <artifactItem>
+                                    <groupId>
+                                        org.eclipse.sw360</groupId>
+                                    <artifactId>build-configuration</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>
+                                        test-jar</type>
+                                    <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
@@ -175,12 +175,13 @@ public class LuceneAwareDatabaseConnector extends LuceneAwareCouchDbConnector {
         HttpURLConnection connection = null;
         try {
             connection = makeLuceneRequest(luceneResourceUrl);
+            log.debug("Lucene search URL = " + luceneResourceUrl.toString());
             int responseCode = connection.getResponseCode();
             if (responseCode == 200) {
                 return objectMapper.readValue(connection.getInputStream(), LuceneResult.class);
             } else {
                 connection.disconnect();
-                log.error("Getting error with reponse code = " + responseCode + ".Retrying with stale parameter");
+                log.error("Getting error with response code = " + responseCode + ".Retrying with stale parameter");
                 queryURI.param("stale", "ok");
                 luceneResourceUrl = new URL(DatabaseSettings.COUCH_DB_LUCENE_URL + queryURI.toString());
                 connection = makeLuceneRequest(luceneResourceUrl);

--- a/third-party/couchdb-lucene/pom.xml
+++ b/third-party/couchdb-lucene/pom.xml
@@ -193,6 +193,7 @@
         </developer>
     </developers>
     <build>
+        <finalName>couchdb-lucene</finalName>
         <defaultGoal>assembly:assembly</defaultGoal>
         <plugins>
             <plugin>
@@ -235,7 +236,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-4</version>
+                <version>3.6.0</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/assembly/dist.xml</descriptor>
@@ -257,6 +258,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>


### PR DESCRIPTION
- Restore original couchdb-lucene portlet naming, no more 2.2.0-SNAPSHOT
- Restore couchdb.properties config in datahandler
- Add debug info for couchdb-lucene url handler
