### PR TITLE
fix(docker): Restore document_properties volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     tty: true
     volumes:
       - etc:/etc/sw360
+      - document_library:/app/sw360/data/document_library
       - ./config:/app/sw360/config
 
   postgresdb:
@@ -67,6 +68,7 @@ volumes:
   postgres: null
   couchdb: null
   etc: null
+  document_library: null
 
 networks:
   default:


### PR DESCRIPTION
When docker compose is used to deploy sw360, document_properties by default is empty, with no LAR data deployment. 
If a new deployment over the same data is done forcing compose to be down, the imported LAR files become lost and resources are not available anymore, creating broken webpages.

Treating document_libraries as a persistent volume solve the issue allowing better migration/development deploys.
