### PR TITLE
fix(rest): Missing moderators field when creating component using API

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -320,7 +320,6 @@ public class JacksonCustomizations {
                 "revision",
                 "attachments",
                 "createdBy",
-                "moderators",
                 "releases",
                 "wikipedia",
                 "openHub",

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -544,6 +544,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:components.[]modifiedOn").description("The date the component was modified"),
 
                                 subsectionWithPath("_embedded.sw360:components.[]categories").description("The component categories"),
+                                subsectionWithPath("_embedded.sw360:components.[]moderators").description("The component moderators"),
                                 subsectionWithPath("_embedded.sw360:components.[]languages").description("The language of the component"),
 
                                 subsectionWithPath("_embedded.sw360:components.[]operatingSystems").description("The OS on which the component operates"),
@@ -712,6 +713,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("ownerGroup").description("The owner group of the component"),
                                 fieldWithPath("ownerCountry").description("The owner country of the component"),
                                 fieldWithPath("categories").description("The component categories"),
+                                fieldWithPath("moderators").description("The component moderators"),
                                 fieldWithPath("languages").description("The language of the component"),
                                 subsectionWithPath("externalIds").description("When components are imported from other tools, the external ids can be stored here. Store as 'Single String' when single value, or 'Array of String' when multi-values"),
                                 subsectionWithPath("additionalData").description("A place to store additional data used by external tools"),
@@ -1011,6 +1013,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("wiki").description("The wiki of component"),
                         fieldWithPath("blog").description("The blog of component"),
                         fieldWithPath("categories").description("The component categories"),
+                        fieldWithPath("moderators").description("The component moderators"),
                         fieldWithPath("languages").description("The language of the component"),
                         fieldWithPath("mailinglist").description("Component mailing lists"),
                         fieldWithPath("operatingSystems").description("The OS on which the component operates"),


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


Issue: #1979


### How To Test?

- Run command line: 
```
$ curl 'https://sw360.org/api/components' -i -X POST \
    -H 'Content-Type: application/hal+json' \
    -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsic3czNjAtUkVTVC1BUEkiXSwidXNlcl9uYW1lIjoiYWRtaW5Ac3czNjAub3JnIiwic2NvcGUiOlsiYWxsIl0sImV4cCI6MTY4NzgzODQyNywiYXV0aG9yaXRpZXMiOlsiUkVBRCIsIldSSVRFIl0sImp0aSI6InhTbHI3TGxqcXEwRExzUWpIXzNqRUN6NExaSSIsImNsaWVudF9pZCI6InRydXN0ZWQtc3czNjAtY2xpZW50In0.HHee-GclgRaNSiox3b8yJY8ZipDAU85WGFlbU1EnVLNmqnay98X6M8p_jxGl4S-3oheORXmojF5Y50aX8NMqysrSqvHO9I7jKFw66RbWhba0vOjEbnCkp4rOOq0ExfUwVw6fDUsCIIhokE7Gh73ZkZieRexgWT4_2-J9pen07GMNHjsuxC7O-Vb1f0YcFWUa1hWBTjnr-u1spbwZ6PDq9Vt2P8ZPrEa-Mhd4JT64hO7R9Pou91OPBFtL-MPO4A-6Zxo1O4GjWrJMH-8O26DDcdjJBCxN972D0-CpjX2zKA0jX73k3aEl0XD6j2ZMAVUO-GawYQZHzVoATS-A5BECeA' \
    -d '{
  "componentType" : "OSS",
  "name" : "Spring Framework",
  "description" : "The Spring Framework provides a comprehensive programming and configuration model for modern Java-based enterprise applications.",
  "homepage" : "https://angular.io",
  "moderators": [
    "admin1@sw360.org",
    "admin3@sw360.org"
  ],
}'
```
- Expected Output:
![fixCreateComponentModerators](https://github.com/eclipse-sw360/sw360/assets/94596393/179c95fe-000e-4a24-b3b4-d91b71cf6121)


