### PR TITLE
fix(UI): Sorting release versions in drop down menu 

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1840,10 +1840,37 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
             component = client.getAccessibleComponentById(id, user);
             request.setAttribute(COMPONENT, component);
-            for (int i=0; i<component.releases.size(); i++) {
-                Collections.sort(component.releases, (release1, release2) -> release1.getVersion() .compareTo(release2.getVersion()) );
-            }
-            Collections.reverse(component.releases);
+            Comparator<Release> releaseVersionComparator = new Comparator<Release>() {
+                @Override
+                public int compare(Release vo1, Release vo2) {
+                    String version1 = vo1.getVersion();
+                    String version2 = vo2.getVersion();
+
+                    String[] v1 = version1.split("\\.");
+                    String[] v2 = version2.split("\\.");
+
+                    int length = Math.max(v1.length, v2.length);
+
+                    for (int i = 0; i < length; i++) {
+                        int num1 = i < v1.length ? parseVersion(v1[i]) : 0;
+                        int num2 = i < v2.length ? parseVersion(v2[i]) : 0;
+
+                        if (num1 != num2) {
+                            return Integer.compare(num2, num1);
+                        }
+                    }
+                    return 0;
+                }
+
+                private int parseVersion(String version) {
+                    try {
+                        return Integer.parseInt(version.replaceAll("[^\\d]", ""));
+                    } catch (NumberFormatException e) {
+                        return Integer.MIN_VALUE;
+                    }
+                }
+            };
+            Collections.sort(component.releases, releaseVersionComparator);
 
             addComponentBreadcrumb(request, response, component);
             if (release != null) {


### PR DESCRIPTION
Issue: #1726 

Description : Apply sorting (from newest to oldest) on versions in drop down menu when inspecting a specific component. 
with newest meaning 'highest version'.  (i.e. NOT the last one added in sw360)

![image](https://github.com/eclipse-sw360/sw360/assets/58290634/4a1b6b48-ec97-4ac2-ab88-76a9c13251b9)

