### PR TITLE
feat(ProjectObligationsEdit): Save comment and status fields on edit

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
@@ -319,6 +319,7 @@ require(['jquery', 'modules/autocomplete', 'modules/dialog', 'modules/listgroup'
         </core_rt:if>
         $(document).find(".checkStatus select").attr("disabled", false);
         $(document).find(".checkedComment input").attr("disabled", false);
+        localStorage.clear();
         $('#projectEditForm').submit();
     }
 
@@ -331,6 +332,7 @@ require(['jquery', 'modules/autocomplete', 'modules/dialog', 'modules/listgroup'
                 "<portlet:namespace/><%=PortalConstants.DOCUMENT_ID%>": "${project.id}"
             }
         }).always(function() {
+            localStorage.clear();
             var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>',
                 portletURL = Liferay.PortletURL.createURL(baseUrl)
             <core_rt:if test="${not addMode}">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
@@ -203,6 +203,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
         actionOptions = {};
     var jsonObject = {},
         obligationsFromLicenseDatabase = "",
+        projectId = "<sw360:out value='${projectid}'/>",
         licenseTableData=$("#spinnerForLicenseObligation").html().toString();
     $("#spinnerForLicenseObligation").remove();
     <core_rt:forEach items="${obligationsActionSet}" var="action">
@@ -327,7 +328,25 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
                 "action": updateObligations
             }
         ],
-        "initComplete": datatables.showPageContainer
+        "initComplete": datatables.showPageContainer,
+        "fnDrawCallback": function() {
+            var table = document.getElementById("editObligationsTable");
+            for (var i = 1, row; row = table.rows[i]; i++) {
+                var statusTD = row.cells[4];
+                var commentTD = row.cells[7];
+                var oblTD = row.cells[1];
+                var obl = $(oblTD).find('span').text();
+
+                if (localStorage.getItem(obl+"- "+projectId)) {
+	                var json = JSON.parse(localStorage.getItem(obl+"- "+projectId));
+
+	                dataMap.set(obl, '');
+
+	                $(statusTD).find('select').val(json['status']);
+	                $(commentTD).find('input').val(json['comment']);
+                }
+            }
+          }
     }, undefined, [0, 4, 7]);
 
     function renderStatus(status, type, row) {
@@ -374,6 +393,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
     /* Add event listener for change in any editable fields in table */
     $("#editObligationsTable tbody").on("change", 'td select.obl_status', function () {
         storeData($(this));
+        saveStatusAndComment($(this));
     });
 
     /* $("#editObligationsTable tbody").on("change", 'td select.obl_action',function () {
@@ -383,8 +403,19 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
     $("#editObligationsTable tbody").on("change", 'td input.obl_comment', function () {
         if ($(this).closest('tr').find("input.obl_comment").val()) {
             storeData($(this));
+            saveStatusAndComment($(this));
         }
     });
+
+    function saveStatusAndComment(thisObj) {
+        let $tr = thisObj.closest("tr");
+        let localJsonObject = {};
+
+        localJsonObject["comment"] = $tr.find("input.obl_comment").val();
+        localJsonObject["status"] = $tr.find("select.obl_status").val();
+
+        localStorage.setItem($tr.find("span").text()+"- "+projectId, JSON.stringify(localJsonObject));
+    }
 
     function storeData(thisObj) {
         let $tr = thisObj.closest("tr");


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

**Description:**
1. The comment and status fields of License Obligations in a project will be saved on editing.
2. On change in these 2 fields, their data is stored in the local storage which is then restored back on re-opening the edit page.
3. The local storage is clearing on submitting the project edit form.

Issue: #2004 

Screenshot:
![image](https://github.com/eclipse-sw360/sw360/assets/115608771/26c7dc60-d127-4dad-8795-965a91eac14f)


