### PR TITLE
fix(Rest): Allowing search for externalIds without encoding

### DIFF
--- a/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360ReleaseClient.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360ReleaseClient.java
@@ -26,6 +26,15 @@ import org.eclipse.sw360.clients.utils.SW360ResourceUtils;
 import org.eclipse.sw360.http.RequestBuilder;
 import org.eclipse.sw360.http.utils.HttpUtils;
 
+import org.eclipse.sw360.http.RequestBuilder;
+import org.eclipse.sw360.http.utils.HttpUtils;
+import org.eclipse.sw360.clients.config.SW360ClientConfig;
+import org.eclipse.sw360.clients.auth.AccessTokenProvider;
+import org.eclipse.sw360.clients.utils.SW360ResourceUtils;
+import org.eclipse.sw360.clients.rest.resource.releases.SW360Release;
+import org.eclipse.sw360.clients.rest.resource.releases.SW360ReleaseList;
+import org.eclipse.sw360.clients.rest.resource.releases.SW360SparseRelease;
+
 /**
  * <p>
  * An SW360 REST client implementation providing basic functionality related to
@@ -102,10 +111,15 @@ public class SW360ReleaseClient extends SW360AttachmentAwareClient<SW360Release>
     // which are mapped to numbered keys like `hash_1=...`, `hash_2=...`, ...
     // but can change in the order of the values
     public CompletableFuture<List<SW360SparseRelease>> getReleasesByExternalIds(Map<String, ?> externalIds) {
-        return executeJsonRequestNew(builder -> builder.method(RequestBuilder.Method.GET)
-                .uri(resourceUrl(RELEASES_ENDPOINT_APPENDIX, PATH_SEARCH_EXT_IDS)).body(body -> body.json(externalIds)),
-                SW360ReleaseList.class, TAG_GET_RELEASES_BY_EXTERNAL_IDS)
+        String url = getExternalIdUrl(externalIds);
+        return executeJsonRequestWithDefault(HttpUtils.get(url), SW360ReleaseList.class,
+                TAG_GET_RELEASES_BY_EXTERNAL_IDS, SW360ReleaseList::new)
                 .thenApply(SW360ResourceUtils::getSw360SparseReleases);
+    }
+    
+    private String getExternalIdUrl(Map<String, ?> externalIds) {
+        return HttpUtils.addQueryParameters(resourceUrl(RELEASES_ENDPOINT_APPENDIX, PATH_SEARCH_EXT_IDS),
+                externalIds);
     }
 
     /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -53,6 +53,7 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -247,8 +248,28 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     }
 
     @GetMapping(value = RELEASES_URL + "/searchByExternalIds")
-    public ResponseEntity searchByExternalIds(@RequestBody(required = false) Map<String, List<String>> externalIdsMultiMap) throws TException {
+    public ResponseEntity searchByExternalIds(HttpServletRequest request) throws TException {
+        String queryString = request.getQueryString();
+        MultiValueMap<String, String> externalIdsMultiMap = parseQueryString(queryString);
         return restControllerHelper.searchByExternalIds(new LinkedMultiValueMap<String, String>(externalIdsMultiMap), releaseService, null);
+    }
+
+    private MultiValueMap<String, String> parseQueryString(String queryString) {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+
+        if (queryString != null && !queryString.isEmpty()) {
+            String[] params = queryString.split("&");
+            for (String param : params) {
+                String[] keyValue = param.split("=");
+                if (keyValue.length == 2) {
+                    String key = keyValue[0];
+                    String value = keyValue[1];
+                    parameters.add(key, value);
+                }
+            }
+        }
+
+        return parameters;
     }
 
     @PreAuthorize("hasAuthority('WRITE')")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -744,7 +744,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         MultiValueMap<String, String> externalIds = new LinkedMultiValueMap<>();
         externalIds.put("mainline-id-component", List.of("1432","4876"));
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(get("/api/releases/searchByExternalIds")
+        mockMvc.perform(get("/api/releases/searchByExternalIds?mainline-id-component=1432&mainline-id-component=4876")
                 .contentType(MediaTypes.HAL_JSON)
                 .content(this.objectMapper.writeValueAsString(externalIds))
                 .header("Authorization", "Bearer " + accessToken))


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Modified code such that while searching for releases using externalIds via Rest endpoint, encoding is skipped
> * Which issue is this pull request belonging to and how is it solving it? (#1659)


### Suggest Reviewer
@ag4ums 

### How To Test?
Search for releases using externalId such that in key-value pair there are values that usually encodes to special characters(eg: %40)

