### PR TITLE
feat(rest) asynchronous end point for downloading reports.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -4,10 +4,13 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.resourceserver.report;
 
+import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
+
+import java.net.URL;
 import java.nio.ByteBuffer;
-import java.util.List;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
@@ -20,41 +23,69 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class SW360ReportService {
-	
-	ThriftClients thriftClients = new ThriftClients();
+
+    ThriftClients thriftClients = new ThriftClients();
     ProjectService.Iface projectclient = thriftClients.makeProjectClient();
     ComponentService.Iface componentclient = thriftClients.makeComponentClient();
 
-    public ByteBuffer getProjectBuffer(User user, boolean extendedByReleases)
-            throws TException {
+    public ByteBuffer getProjectBuffer(User user, boolean extendedByReleases) throws TException {
         return projectclient.getReportDataStream(user, extendedByReleases);
     }
 
-    public String getUploadedProjectPath(User user, boolean extendedByReleases) throws TException{
-        return projectclient.getReportInEmail(user, extendedByReleases);
+    public void getUploadedProjectPath(User user, boolean withLinkedReleases, String base){
+        Runnable asyncRunnable = () -> wrapTException(() -> {
+            try {
+                String projectPath = projectclient.getReportInEmail(user, withLinkedReleases);
+                String backendURL = base + "api/reports/download?user=" + user.getEmail() + "&module=projects"
+                        + "&extendedByReleases=" + withLinkedReleases + "&token=";
+                URL emailURL = new URL(backendURL + projectPath);
+                if (!CommonUtils.isNullEmptyOrWhitespace(projectPath)) {
+                    sendExportSpreadsheetSuccessMail(emailURL.toString(), user.getEmail());
+                }
+            } catch (Exception exp) {
+                throw new TException(exp.getMessage());
+            }
+        });
+        Thread asyncThread = new Thread(asyncRunnable);
+        asyncThread.start();
     }
-    
-    public ByteBuffer getReportStreamFromURl(User user,boolean extendedByReleases, String token) 
-            throws TException{
-        return projectclient.downloadExcel(user,extendedByReleases, token);
-    }
-    public void sendExportSpreadsheetSuccessMail(String emailURL, String email) throws TException{
-    	projectclient.sendExportSpreadsheetSuccessMail(emailURL, email);
-	}
 
-	public String getUploadedComponentPath(User sw360User, boolean withLinkedReleases) throws TException{
-		return componentclient.getComponentReportInEmail(sw360User, withLinkedReleases);
-	}
-
-	public ByteBuffer getComponentBuffer(User sw360User, boolean withLinkedReleases) throws TException{
-		return componentclient.getComponentReportDataStream(sw360User, withLinkedReleases);
-	}
-	
-	public ByteBuffer getComponentReportStreamFromURl(User user,boolean extendedByReleases, String token) 
-            throws TException{
-        return componentclient.downloadExcel(user,extendedByReleases, token);
+    public ByteBuffer getReportStreamFromURl(User user, boolean extendedByReleases, String token) throws TException {
+        return projectclient.downloadExcel(user, extendedByReleases, token);
     }
-    public void sendComponentExportSpreadsheetSuccessMail(String emailURL, String email) throws TException{
-    	componentclient.sendExportSpreadsheetSuccessMail(emailURL, email);
-	}
+
+    public void sendExportSpreadsheetSuccessMail(String emailURL, String email) throws TException {
+        projectclient.sendExportSpreadsheetSuccessMail(emailURL, email);
+    }
+
+    public void getUploadedComponentPath(User sw360User, boolean withLinkedReleases, String base) {
+        Runnable asyncRunnable = () -> wrapTException(() -> {
+            try {
+                String componentPath = componentclient.getComponentReportInEmail(sw360User, withLinkedReleases);
+                String backendURL = base + "api/reports/download?user=" + sw360User.getEmail() + "&module=components"
+                        + "&extendedByReleases=" + withLinkedReleases + "&token=";
+                URL emailURL = new URL(backendURL + componentPath);
+                if (!CommonUtils.isNullEmptyOrWhitespace(componentPath)) {
+                    sendComponentExportSpreadsheetSuccessMail(emailURL.toString(), sw360User.getEmail());
+                }
+            } catch (Exception exp) {
+                throw new TException(exp.getMessage());
+            }
+        });
+        Thread asyncThread = new Thread(asyncRunnable);
+        asyncThread.start();
+    }
+
+    public ByteBuffer getComponentBuffer(User sw360User, boolean withLinkedReleases) throws TException {
+        return componentclient.getComponentReportDataStream(sw360User, withLinkedReleases);
+    }
+
+    public ByteBuffer getComponentReportStreamFromURl(User user, boolean extendedByReleases, String token)
+            throws TException {
+        return componentclient.downloadExcel(user, extendedByReleases, token);
+    }
+
+    public void sendComponentExportSpreadsheetSuccessMail(String emailURL, String email) throws TException {
+        componentclient.sendExportSpreadsheetSuccessMail(emailURL, email);
+    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -1307,8 +1307,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                              parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
                              parameterWithName("mailrequest").description("Downloading components report requirted mail link. Possible values are `<true|false>`")
                      ),responseFields(
-                             subsectionWithPath("response").description("The response message displayed").optional(),
-                             subsectionWithPath("url").description("The components download path will be displayed").optional()
+                             subsectionWithPath("response").description("The response message displayed").optional()
                              )
                      ));
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -1874,8 +1874,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("mailrequest").description("Downloading project report requirted mail link. Possible values are `<true|false>`"),
                                 parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`")
                         ),responseFields(
-                                subsectionWithPath("response").description("The response message displayed").optional(),
-                                subsectionWithPath("url").description("The project download path will be displayed").optional()
+                                subsectionWithPath("response").description("The response message displayed").optional()
                                 )
                         ));
     }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
#2023 

> * Did you add or update any new dependencies that are required for your change?
No

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Use postman for testing.

Sample URL : 
 http://localhost:8080/resource/api/reports?withlinkedreleases=true&mimetype=xlsx&mailrequest=true&module=components

Sample response:

{
"response": "E-mail sent succesfully to the end user.",
"url": "http://127.0.0.1:8080/resource/api/reports/download?user=keerthi.bl@sw360.org&module=components&extendedByReleases=true&token=/tmp/keerthi.bl@sw360.org/2023-05-17_a990c489-acf8-4600-911c-2d89015b8bba"
}


> Have you implemented any additional tests?

No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
