### PR TITLE
fix(UI):word correction of Initial use scan in attachment type

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -118,7 +118,7 @@ public class ThriftEnumUtils {
             .put(AttachmentType.SECURITY_ASSESSMENT, "Security Assessment")
             .put(AttachmentType.SBOM, "SBOM")
             .put(AttachmentType.INITIAL_SCAN_REPORT, "Initial Scan Report")
-            .put(AttachmentType.INTERNAL_USE_SCAN, "Initial Use Scan")
+            .put(AttachmentType.INTERNAL_USE_SCAN, "Internal Use Scan")
             .build();
 
     // @formatter:off


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
I rename "Initial use scan" to "Internal use scan".
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?No

Issue: #2034 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1: Login sw360
2: Go to project tab.
3: click on Attachments tab
4: click on attachments type.

![image](https://github.com/eclipse-sw360/sw360/assets/49710817/45ceb9fd-a0bc-4f8e-a107-3cff698d1bdb)

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
