### PR TITLE
fix(Rest): Allowing search for components without encoding

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -123,8 +123,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
         List<Component> allComponents = new ArrayList<>();
+        String queryString = request.getQueryString();
+        Map<String, String> params = parseQueryString(queryString);
+
         if (name != null && !name.isEmpty()) {
-            allComponents.addAll(componentService.searchComponentByName(name));
+            allComponents.addAll(componentService.searchComponentByName(params.get("name")));
         } else {
             allComponents.addAll(componentService.getComponentsForUser(sw360User));
         }
@@ -159,6 +162,24 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             resources = restControllerHelper.generatePagesResource(paginationResult, componentResources);
         }
         return new ResponseEntity<>(resources, HttpStatus.OK);
+    }
+
+    private Map<String, String> parseQueryString(String queryString) {
+        Map<String, String> parameters = new HashMap<>();
+
+        if (queryString != null && !queryString.isEmpty()) {
+            String[] params = queryString.split("&");
+            for (String param : params) {
+                String[] keyValue = param.split("=");
+                if (keyValue.length == 2) {
+                    String key = keyValue[0];
+                    String value = keyValue[1];
+                    parameters.put(key, value);
+                }
+            }
+        }
+
+        return parameters;
     }
 
     @RequestMapping(value = COMPONENTS_URL + "/usedBy" + "/{id}", method = RequestMethod.GET)


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> * Which issue is this pull request belonging to and how is it solving it? #2042 

Issue: Component name search over endpoint with prefix ++ is returning an empty list

### Suggest Reviewer
@ag4ums

### How To Test?
Search for any component with name such as 'Angular++' over the rest endpoint

