### PR TITLE
feat(ExportSpreadsheet): Add project and release ID to the exported excel

### DIFF
--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
@@ -70,6 +70,7 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
 
     private static final List<Project._Fields> PROJECT_REQUIRED_FIELDS = ImmutableList.<Project._Fields>builder()
             .add(NAME)
+            .add(ID)
             .add(VERSION)
             .add(BUSINESS_UNIT)
             .add(PROJECT_TYPE)

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -61,6 +61,7 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
             .build();
 
    public static final List<Release._Fields> RELEASE_REQUIRED_FIELDS = ImmutableList.<Release._Fields>builder()
+            .add(ID)
             .add(COMPONENT_ID)
             .add(NAME)
             .add(VERSION)


### PR DESCRIPTION


[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### **Description**:
Now we can the project id and release id in the excel exported on clicking "Export Spreadsheet" button available on the projects listing and project details page. 

Issue: #2041 

### **Screenshots:**
**Projects listing page: (Projects only option selected)**
![image](https://github.com/eclipse-sw360/sw360/assets/115608771/1952d6af-0c1e-4503-baa7-81b02b92317d)
![image](https://github.com/eclipse-sw360/sw360/assets/115608771/d1479a09-7acc-4b4e-aba6-e307773b0901)

**Project details page: (Project with linked releases option selected)**
![image](https://github.com/eclipse-sw360/sw360/assets/115608771/d72ccafb-ec72-41cf-88ad-2760861d6602)

