### PR TITLE
New endpoint allow to re-generate fossology report (New Frontend)

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -294,6 +294,20 @@ include::{snippets}/should_document_check_fossology_process_status/curl-request.
 ===== Example response
 include::{snippets}/should_document_check_fossology_process_status/http-response.adoc[]
 
+[[resources-trigger_reload_fossology_report-get]]
+==== Re-generate fossology report
+
+A `GET` request will allow you to Re-generate fossology report
+
+===== Response structure
+include::{snippets}/should_document_trigger_reload_fossology_report/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_trigger_reload_fossology_report/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_trigger_reload_fossology_report/http-response.adoc[]
+
 [[resources-release-get]]
 ==== Get a single release
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -49,6 +49,7 @@ import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyString;
@@ -661,5 +662,17 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         }
 
         return fossologyClient;
+    }
+
+    /**
+     * Re-generate Fossology report for release
+     * @param releaseId                Id of Release need to re-generate report
+     * @param user                     Request User
+     * @return RequestStatus
+     * @throws TException
+     */
+    public RequestStatus triggerReportGenerationFossology(String releaseId, User user) throws TException {
+        FossologyService.Iface fossologyClient = getThriftFossologyClient();
+        return fossologyClient.triggerReportGenerationFossology(releaseId, user);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -1005,4 +1005,18 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }
+
+    @Test
+    public void should_document_trigger_reload_fossology_report() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(
+                        get("/api/releases/" + release3.getId() + "/reloadFossologyReport")
+                                .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(responseFields(
+                        fieldWithPath("message").description(
+                                "Message indicating whether re-generate FOSSology's report Process for Release triggered or not"),
+                        subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"))));
+    }
+
 }


### PR DESCRIPTION
# New endpoint allow to re-generate Fossology report
### How To Test?

Request url: http://localhost:8080/resource/api/releases/{releaseId}/reloadFossologyReport

Expected:
- Success:

```
HTTP status: 200
{
    "_links": {
        "self": {
            "href": "http://localhost:8080/resource/api/releases/{releaseId}/checkFossologyProcessStatus"
        }
    },
    "message": "Re-generate FOSSology's report process for Release Id : {releaseId} has been triggered."
}
```

- Release had another fossology process

HTTP status: 406
```
{
    "_links": {
        "self": {
            "href": "http://localhost:8080/resource/api/releases/{releaseId}/checkFossologyProcessStatus"
        }
    },
    "message": "Another FOSSology Process for Release Id : {releaseId} is already running. Please wait till it is completed."
}
```


- Reload report not available (Fossology process of release has never been run before):

HTTP status: 500
```
{
    "message": "Could not trigger report generation for this release"
}
```

- There are more than 10 fossology processes are running

HTTP status: 429
```
{
    "message": "Max 10 FOSSology Process can be triggered simultaneously. Please try after sometime."
}
```

