### PR TITLE
fix(doc): remove merge conflict notation

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -409,7 +409,6 @@ include::{snippets}/should_document_get_mycomponents_components/http-response.ad
 ===== Links
 include::{snippets}/should_document_get_mycomponents_components/links.adoc[]
 
-<<<<<<< HEAD
 [[resources-component-get-component-vulnerabilities]]
 ==== Listing component vulnerabilities
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Found a merge conflict in doc. Removed the conflict notation line.