### PR TITLE
fix(rest): API create component's businessUnit is always set as the user's department

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -308,7 +308,10 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             component.setVendorNames(vendors);
         }
 
-        component.setBusinessUnit(user.getDepartment());
+        if (CommonUtils.isNullEmptyOrWhitespace(component.getBusinessUnit())) {
+            component.setBusinessUnit(user.getDepartment());
+        }
+
         Component sw360Component = componentService.createComponent(component, user);
         HalResource<Component> halResource = createHalComponent(sw360Component, user);
 


### PR DESCRIPTION

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2037

- use API create component

### How To Test?

  *  If the inputted businessUnit is null, set businessUnit = user's department
  *  If the inputted businessUnit is not null, set businessUnit = inputted businessUnit

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
