### PR TITLE
fix(rest):new endpoint to delete all license information in admin tab

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/licenses.adoc
+++ b/rest/resource-server/src/docs/asciidoc/licenses.adoc
@@ -87,3 +87,14 @@ include::{snippets}/should_document_delete_license/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_delete_license/http-response.adoc[]
+
+[[delete-all-license-info]]
+==== Delete all licenses info
+
+A `DELETE` request will delete all licenses info.
+
+===== Example request
+include::{snippets}/should_document_delete_all_license_info/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_delete_all_license_info/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -158,4 +158,12 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         }
         return halLicense;
     }
+
+    @PreAuthorize("hasAuthority('WRITE')")
+    @RequestMapping(value = LICENSES_URL + "/deleteAll", method = RequestMethod.DELETE)
+    public ResponseEntity deleteAllLicense() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        licenseService.deleteAllLicenseInfo(sw360User);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -16,13 +16,16 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -72,6 +75,15 @@ public class Sw360LicenseService {
             throw new HttpMessageNotReadableException("Unable to delete license. License is in Use");
         } else if (deleteLicenseStatus == RequestStatus.FAILURE) {
             throw new RuntimeException("Unable to delete License");
+        }
+    }
+
+    public void deleteAllLicenseInfo(User user) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user)) {
+            RequestSummary deleteLicenseStatus = sw360LicenseClient.deleteAllLicenseInformation(user);
+        } else {
+            throw new HttpMessageNotReadableException("Unable to delete license. User is not admin");
         }
     }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -89,6 +89,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         given(this.licenseServiceMock.getLicenses()).willReturn(licenseList);
         given(this.licenseServiceMock.getLicenseById(eq(license.getId()))).willReturn(license);
         Mockito.doNothing().when(licenseServiceMock).deleteLicenseById(any(), any());
+        Mockito.doNothing().when(licenseServiceMock).deleteAllLicenseInfo(any());
         obligation1 = new Obligation();
         obligation1.setId("0001");
         obligation1.setTitle("Obligation 1");
@@ -202,4 +203,14 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                 .header("Authorization", "Bearer " + accessToken))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    public void should_document_delete_all_license_info() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(delete("/api/licenses/" + "/delete")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
+
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2064 
Create a new rest endpoint to delete all license information in admin tab
### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1: http://localhost:8080/resource/api/licenses/delete
2: login with admin user and create token 
3: use token in postman. 
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
