### PR TITLE
feat(REST): New endpoint to write SPDX license info into release (New Frontend)

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -485,3 +485,20 @@ include::{snippets}/should_document_update_release_vulnerabilities/http-response
 
 ===== Links
 include::{snippets}/should_document_update_release_vulnerabilities/links.adoc[]
+
+[[resources-write-spdx-license-info-into-release]]
+==== Write SPDX license info into release
+
+A `POST` request will write SPDX license info into release
+
+===== Request structure
+include::{snippets}/should_document_write_spdx_licenses_info_into_release/request-fields.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_write_spdx_licenses_info_into_release/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_write_spdx_licenses_info_into_release/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_write_spdx_licenses_info_into_release/http-response.adoc[]


### PR DESCRIPTION
## New endpoint to write SPDX license info into release

### How to test:
- Request URL: http://localhost:8080/resource/api/releases/{releaseId}/spdxLicenses
- Request method: POST
- Example request body:
```
{
  "mainLicenseIds" : [ "ML1", "ML2" ],
  "otherLicenseIds" : [ "OL1", "OL2" ]
}
```

- Expected: License ids are added into main license and other license field of release