### PR TITLE
docs(rest): generate OpenAPI docs for ProjectController

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
   <properties>
     <revision>17.0.${patchlevel}</revision>
     <patchlevel>0-SNAPSHOT</patchlevel>
+    <rest.version>1.0.0</rest.version>
 
     <!-- Build version properties -->
     <java_source.version>11</java_source.version>
@@ -150,6 +151,10 @@
     <spring-restdocs.version>2.0.6.RELEASE</spring-restdocs.version>
     <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
     <spring-security-oauth2.version>2.5.1.RELEASE</spring-security-oauth2.version>
+    <springdoc-openapi-hateos.version>1.7.0</springdoc-openapi-hateos.version>
+    <springdoc-openapi-ui.version>1.7.0</springdoc-openapi-ui.version>
+    <springdoc-openapi-security.version>1.7.0</springdoc-openapi-security.version>
+    <springdoc-openapi-webmvc.version>1.7.0</springdoc-openapi-webmvc.version>
     <springframework.version>5.3.27</springframework.version>
     <thrift.version>0.16.0</thrift.version>
     <tika.version>1.28.5</tika.version>

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -206,6 +206,26 @@
             <artifactId>jose4j</artifactId>
             <version>0.9.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>${springdoc-openapi-ui.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-hateoas</artifactId>
+            <version>${springdoc-openapi-hateos.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-security</artifactId>
+            <version>${springdoc-openapi-security.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-webmvc-core</artifactId>
+            <version>${springdoc-openapi-webmvc.version}</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -312,6 +332,29 @@
                                         ../../frontend/sw360-portlet/target/mkdocs/generate-mkdocs</directory>
                                 </resource>
                             </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.internetitem</groupId>
+                <artifactId>write-properties-file-maven-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>one</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>write-properties-file</goal>
+                        </goals>
+                        <configuration>
+                            <filename>restInfo.properties</filename>
+                            <properties>
+                                <property>
+                                    <name>sw360RestVersion</name>
+                                    <value>${rest.version}</value>
+                                </property>
+                            </properties>
                         </configuration>
                     </execution>
                 </executions>

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -50,6 +50,7 @@ import org.eclipse.sw360.rest.resourceserver.moderationrequest.EmbeddedModeratio
 import org.eclipse.sw360.rest.resourceserver.moderationrequest.ModerationPatch;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProject;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProjectDTO;
+import org.springdoc.core.SpringDocUtils;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -112,6 +113,53 @@ public class JacksonCustomizations {
             setMixInAnnotation(ProjectDTO.class, Sw360Module.ProjectDTOMixin.class);
             setMixInAnnotation(EmbeddedProjectDTO.class, Sw360Module.EmbeddedProjectDTOMixin.class);
             setMixInAnnotation(ReleaseNode.class, Sw360Module.ReleaseNodeMixin.class);
+
+            // Make spring doc aware of the mixin(s)
+            SpringDocUtils.getConfig()
+                    .replaceWithClass(Project.class, Sw360Module.ProjectMixin.class)
+                    .replaceWithClass(MultiStatus.class, MultiStatusMixin.class)
+                    .replaceWithClass(User.class, Sw360Module.UserMixin.class)
+                    .replaceWithClass(Component.class, Sw360Module.ComponentMixin.class)
+                    .replaceWithClass(ComponentDTO.class, Sw360Module.ComponentDTOMixin.class)
+                    .replaceWithClass(Release.class, Sw360Module.ReleaseMixin.class)
+                    .replaceWithClass(ReleaseLink.class, Sw360Module.ReleaseLinkMixin.class)
+                    .replaceWithClass(ClearingReport.class, Sw360Module.ClearingReportMixin.class)
+                    .replaceWithClass(Attachment.class, Sw360Module.AttachmentMixin.class)
+                    .replaceWithClass(AttachmentDTO.class, Sw360Module.AttachmentDTOMixin.class)
+                    .replaceWithClass(UsageAttachment.class, Sw360Module.UsageAttachmentMixin.class)
+                    .replaceWithClass(ProjectUsage.class, Sw360Module.ProjectUsageMixin.class)
+                    .replaceWithClass(Vendor.class, Sw360Module.VendorMixin.class)
+                    .replaceWithClass(License.class, Sw360Module.LicenseMixin.class)
+                    .replaceWithClass(Obligation.class, Sw360Module.ObligationMixin.class)
+                    .replaceWithClass(Vulnerability.class, Sw360Module.VulnerabilityMixin.class)
+                    .replaceWithClass(VulnerabilityState.class, Sw360Module.VulnerabilityStateMixin.class)
+                    .replaceWithClass(ReleaseVulnerabilityRelationDTO.class, Sw360Module.ReleaseVulnerabilityRelationDTOMixin.class)
+                    .replaceWithClass(VulnerabilityDTO.class, Sw360Module.VulnerabilityDTOMixin.class)
+                    .replaceWithClass(VulnerabilityApiDTO.class, Sw360Module.VulnerabilityApiDTOMixin.class)
+                    .replaceWithClass(EccInformation.class, Sw360Module.EccInformationMixin.class)
+                    .replaceWithClass(EmbeddedProject.class, Sw360Module.EmbeddedProjectMixin.class)
+                    .replaceWithClass(ExternalToolProcess.class, Sw360Module.ExternalToolProcessMixin.class)
+                    .replaceWithClass(ExternalToolProcessStep.class, Sw360Module.ExternalToolProcessStepMixin.class)
+                    .replaceWithClass(COTSDetails.class, Sw360Module.COTSDetailsMixin.class)
+                    .replaceWithClass(ClearingInformation.class, Sw360Module.ClearingInformationMixin.class)
+                    .replaceWithClass(Repository.class, Sw360Module.RepositoryMixin.class)
+                    .replaceWithClass(SearchResult.class, Sw360Module.SearchResultMixin.class)
+                    .replaceWithClass(ChangeLogs.class, Sw360Module.ChangeLogsMixin.class)
+                    .replaceWithClass(ChangedFields.class, Sw360Module.ChangedFieldsMixin.class)
+                    .replaceWithClass(ReferenceDocData.class, Sw360Module.ReferenceDocDataMixin.class)
+                    .replaceWithClass(ClearingRequest.class, Sw360Module.ClearingRequestMixin.class)
+                    .replaceWithClass(Comment.class, Sw360Module.CommentMixin.class)
+                    .replaceWithClass(ProjectReleaseRelationship.class, Sw360Module.ProjectReleaseRelationshipMixin.class)
+                    .replaceWithClass(ReleaseVulnerabilityRelation.class, Sw360Module.ReleaseVulnerabilityRelationMixin.class)
+                    .replaceWithClass(VerificationStateInfo.class, Sw360Module.VerificationStateInfoMixin.class)
+                    .replaceWithClass(ProjectProjectRelationship.class, Sw360Module.ProjectProjectRelationshipMixin.class)
+                    .replaceWithClass(ModerationRequest.class, Sw360Module.ModerationRequestMixin.class)
+                    .replaceWithClass(EmbeddedModerationRequest.class, Sw360Module.EmbeddedModerationRequestMixin.class)
+                    .replaceWithClass(ImportBomRequestPreparation.class, Sw360Module.ImportBomRequestPreparationMixin.class)
+                    .replaceWithClass(ModerationPatch.class, Sw360Module.ModerationPatchMixin.class)
+                    .replaceWithClass(ProjectDTO.class, Sw360Module.ProjectDTOMixin.class)
+                    .replaceWithClass(EmbeddedProjectDTO.class, Sw360Module.EmbeddedProjectDTOMixin.class)
+                    .replaceWithClass(ReleaseNode.class, Sw360Module.ReleaseNodeMixin.class);
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/OpenAPIPaginationHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/OpenAPIPaginationHelper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Siemens AG, 2023. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.core;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Pojo class to show correct options for pagination in OpenAPI doc.
+ */
+//@JsonMixin
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema
+public class OpenAPIPaginationHelper {
+    @Schema(description = "Page number to fetch, starts from 0", type = "int",
+            defaultValue = "0", name = "page")
+    private int pageNumber;
+    @Schema(description = "Number of entries per page", type = "int",
+            defaultValue = "10", name = "page_entries")
+    private int pageEntries;
+    @Schema(description = "Sorting of entries", type = "string",
+            example = "name,desc", name = "sort")
+    private String sort;
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -49,7 +49,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -63,7 +62,6 @@ import java.util.Map;
 import static org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService.isOpenModerationRequest;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
-@RestController
 @BasePathAwareController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class ModerationRequestController implements RepresentationModelProcessor<RepositoryLinksResource> {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -247,9 +247,9 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return getAllRequiredProjects(projectData, sw360User);
     }
 
-    public Set<String> getReleaseIds(String projectId, User sw360User, String transitive) throws TException {
+    public Set<String> getReleaseIds(String projectId, User sw360User, boolean transitive) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        if (Boolean.parseBoolean(transitive)) {
+        if (transitive) {
             List<ReleaseClearingStatusData> releaseClearingStatusData = sw360ProjectClient.getReleaseClearingStatuses(projectId, sw360User);
             return releaseClearingStatusData.stream().map(r -> r.release.getId()).collect(Collectors.toSet());
         } else {
@@ -355,7 +355,8 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return linkedProjects.stream().map(projectLinkMapper).collect(Collectors.toList());
     }
 
-    public Set<Release> getReleasesFromProjectIds(List<String> projectIds, String transitive, final User sw360User, Sw360ReleaseService releaseService) {
+    public Set<Release> getReleasesFromProjectIds(List<String> projectIds, boolean transitive, final User sw360User,
+                                                  Sw360ReleaseService releaseService) {
         final List<Callable<List<Release>>> callableTasksToGetReleases = new ArrayList<Callable<List<Release>>>();
 
         projectIds.stream().forEach(id -> {

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -11,6 +11,8 @@
 
 server:
   port: 8091
+  servlet:
+    context-path: /resource/api
 
 management:
   endpoints:
@@ -65,3 +67,14 @@ blacklist:
     rest:
       api:
         endpoints: /resource/api/users:POST
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /api-docs
+  show-oauth2-endpoints: true
+  swagger-ui:
+    enabled: true
+    path: /api/swagger-ui
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/hal+json

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -452,8 +452,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.searchProjectByType(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.searchProjectByGroup(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.refineSearch(any(), any())).willReturn(projectListByName);
-        given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq("false"))).willReturn(releaseIds);
-        given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq("true"))).willReturn(releaseIdsTransitive);
+        given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(false))).willReturn(releaseIds);
+        given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(true))).willReturn(releaseIdsTransitive);
         given(this.projectServiceMock.deleteProject(eq(project.getId()), any())).willReturn(RequestStatus.SUCCESS);
         given(this.projectServiceMock.updateProjectReleaseRelationship(any(), any(), any())).willReturn(projectReleaseRelationshipResponseBody);
         given(this.projectServiceMock.convertToEmbeddedWithExternalIds(eq(project))).willReturn(
@@ -674,7 +674,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         given(this.vulnerabilityMockService.fillVulnerabilityMetadata(any(), any())).willReturn(vulIdToRelIdToRatings);
         given(this.vulnerabilityMockService.updateProjectVulnerabilityRating(any(), any())).willReturn(RequestStatus.SUCCESS);
-        given(this.projectServiceMock.getReleasesFromProjectIds(any(), any(), any(), any())).willReturn(Set.of(rel));
+        given(this.projectServiceMock.getReleasesFromProjectIds(any(), anyBoolean(), any(), any())).willReturn(Set.of(rel));
     }
 
     @Test
@@ -1977,7 +1977,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"))
                         		));
     }
-    
+
     @Test
     public void should_document_get_project_report() throws Exception{
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);

--- a/rest/resource-server/src/test/resources/application.properties
+++ b/rest/resource-server/src/test/resources/application.properties
@@ -13,3 +13,4 @@ management.endpoints.web.base-path=/
 management.endpoint.health.show-details=always
 management.endpoint.info.enabled=true
 management.endpoints.web.exposure.include=health,info
+server.servlet.context-path=/


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Use `org.springdoc.springdoc-openapi-ui` to generate openAPI docs as well as swagger UI.

New dependencies:
* [org.springdoc.springdoc-openapi-ui:1.7.0](https://central.sonatype.com/artifact/org.springdoc/springdoc-openapi-ui/1.7.0)
* [org.springdoc.springdoc-openapi-hateoas:1.7.0](https://central.sonatype.com/artifact/org.springdoc/springdoc-openapi-hateoas/1.7.0)
* [org.springdoc.springdoc-openapi-security:1.7.0](https://central.sonatype.com/artifact/org.springdoc/springdoc-openapi-security/1.7.0)
* [org.springdoc.springdoc-openapi-webmvc-core:1.7.0](https://central.sonatype.com/artifact/org.springdoc/springdoc-openapi-webmvc-core/1.7.0)

### How To Test?
* The Swagger UI for the API should be available at http://localhost:8080/resource/api/swagger-ui/index.html
  * Read the documentation for the endpoints.
* OpenAPI JSON file should be available at http://localhost:8080/resource/api-docs

### Known issue
hateoas responses for all endpoints put properties of the class inside `content`. The `EntityModel` class of spring-hateoas uses `@JsonUnwrapped` to unwrap the content from Jackson. Need to understand how to make springdoc understand this and unwrap the `content` for OpenAPI doc.