### PR TITLE
feat(CycloneDX): support CPE in import and export

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMExporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMExporter.java
@@ -208,6 +208,10 @@ public class CycloneDxBOMExporter {
                 comp.setPurl(String.join(", ", purlSet));
             }
 
+            if (CommonUtils.isNotNullEmptyOrWhitespace(release.getCpeid())) {
+                comp.setCpe(release.getCpeid());
+            }
+
             // set CycloneDx component type
             if (sw360Comp.isSetCdxComponentType()) {
                 comp.setType(getCdxComponentType(sw360Comp.getCdxComponentType()));

--- a/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -861,6 +861,9 @@ public class CycloneDxBOMImporter {
         } else {
             release.setMainLicenseIds(licenses);
         }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(componentFromBom.getCpe())) {
+            release.setCpeid(componentFromBom.getCpe());
+        }
         if (CommonUtils.isNotNullEmptyOrWhitespace(componentFromBom.getPurl())) {
             String purl = componentFromBom.getPurl();
             try {


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Add handling of CPE fields during import and export of CycloneDX files.

Issue: #2072 

To test:
- import an SBOM in CycloneDX format including CPE information
- export a project with CPE information set

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
