### PR TITLE
fix(lucene): Use old javax.servlet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,16 @@ COPY --from=sw360thriftbuild /usr/local/bin/thrift /usr/local/bin/thrift
 # So when decide to use as development, only this last stage
 # is triggered by buildkit images
 
-FROM maven:3.9-eclipse-temurin-11 as sw360build
+FROM eclipse-temurin:11.0.19_7-jdk-jammy as sw360build
+
+# Thanks to Liferay, we need fix the java version
+ENV MAVEN_VERSION=3.9.3
+ENV MAVEN_HOME /usr/share/maven
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
+RUN set -eux; curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+RUN mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+    && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+    && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 WORKDIR /build
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <javax-annotation.version>1.3.2</javax-annotation.version>
     <jcip-annotations.version>1.0</jcip-annotations.version>
     <jcraft.version>0.1.54</jcraft.version>
-    <jetty.version>11.0.15</jetty.version>
+    <jetty.version>10.0.15</jetty.version>
     <jgiven.version>0.17.0</jgiven.version>
     <jquery.confirm.version>3.3.2</jquery.confirm.version>
     <jquery.datatables.buttons.version>1.5.3</jquery.datatables.buttons.version>
@@ -122,7 +122,7 @@
     <json.version>20230227</json.version>
     <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
     <junit.version>4.13.2</junit.version>
-    <liferay.css.builder.version>3.1.0</liferay.css.builder.version>
+    <liferay.css.builder.version>3.1.2</liferay.css.builder.version>
     <liferay.frontend.css.common.version>6.0.3</liferay.frontend.css.common.version>
     <liferay.frontend.theme.styled.version>6.0.27</liferay.frontend.theme.styled.version>
     <liferay.frontend.theme.unstyled.version>6.0.29</liferay.frontend.theme.unstyled.version>
@@ -154,7 +154,7 @@
     <thrift.version>0.16.0</thrift.version>
     <tika.version>1.28.5</tika.version>
     <wiremock.version>2.26.0</wiremock.version>
-    <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
+    <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
 
     <!--  User must provide below property configuration based on his/her liferay deployment
     environment -->

--- a/third-party/couchdb-lucene/pom.xml
+++ b/third-party/couchdb-lucene/pom.xml
@@ -163,7 +163,11 @@
             <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <issueManagement>
         <system>github</system>

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
@@ -47,8 +47,8 @@ import org.json.JSONObject;
 import org.mozilla.javascript.ClassShutter;
 import org.mozilla.javascript.Context;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.SocketException;
 import java.util.*;

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/IndexKey.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/IndexKey.java
@@ -16,7 +16,7 @@
 
 package com.github.rnewson.couchdb.lucene;
 
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 @Deprecated
 public class IndexKey {

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/JSONErrorHandler.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/JSONErrorHandler.java
@@ -22,8 +22,8 @@ import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
@@ -33,10 +33,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/Main.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/Main.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
-import jakarta.servlet.DispatcherType;
+import javax.servlet.DispatcherType;
 import java.io.File;
 import java.util.EnumSet;
 
@@ -60,7 +60,6 @@ public final class Main {
                 ServletContextHandler.NO_SESSIONS | ServletContextHandler.NO_SECURITY);
         context.addServlet(new ServletHolder(servlet), "/*");
         context.setErrorHandler(new JSONErrorHandler());
-        context.setGzipHandler(new GzipHandler());
         server.setHandler(context);
 
         server.start();

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/PathParts.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/PathParts.java
@@ -16,7 +16,7 @@
 
 package com.github.rnewson.couchdb.lucene;
 
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/util/ServletUtils.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/util/ServletUtils.java
@@ -19,8 +19,8 @@ package com.github.rnewson.couchdb.lucene.util;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Writer;
 

--- a/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/util/Utils.java
+++ b/third-party/couchdb-lucene/src/main/java/com/github/rnewson/couchdb/lucene/util/Utils.java
@@ -24,7 +24,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.store.Directory;
 
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;


### PR DESCRIPTION
Due to old tomcat available in Liferay, we need use javax.servlet and jetty series 10 for couchdb-clucene.

Updated Dockerfile to fix Liferay breakage on Java 11.0.20 release
