### PR TITLE
Fix(REST): Add COTS details information when fetch a single release that has component type COTS

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -38,6 +38,8 @@ import org.eclipse.sw360.datahandler.thrift.attachments.UsageAttachment;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentDTO;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.components.COTSDetails;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
@@ -318,6 +320,7 @@ public class RestControllerHelper<T> {
         addEmbeddedCreatedByToHalResourceRelease(halResource, sw360Release.getCreatedBy());
         addEmbeddedModifiedByToHalResourceRelease(halResource, sw360Release.getModifiedBy());
         addEmbeddedSubcribeToHalResourceRelease(halResource, sw360Release);
+        addEmbeddedCotsDetails(halResource, sw360Release);
     }
 
     public void addEmbeddedContributorsToHalResourceRelease(HalResource halResource, Release sw360Release) {
@@ -1294,5 +1297,18 @@ public class RestControllerHelper<T> {
         embeddedProject.setVisbility(project.getVisbility());
         embeddedProject.setType(null);
         return embeddedProject;
+    }
+
+    public void addEmbeddedCotsDetails(HalResource halResource, Release release) {
+        if (null != release.getCotsDetails() && release.getComponentType().equals(ComponentType.COTS)) {
+            HalResource<COTSDetails> cotsDetailsHalResource = new HalResource<>(release.getCotsDetails());
+            if (CommonUtils.isNotNullEmptyOrWhitespace(release.getCotsDetails().getCotsResponsible())) {
+                User sw360User = userService.getUserByEmail(release.getCotsDetails().getCotsResponsible());
+                if (null != sw360User) {
+                    addEmbeddedUser(cotsDetailsHalResource, sw360User, "sw360:cotsResponsible");
+                }
+            }
+            addEmbeddedFields("sw360:cotsDetails", cotsDetailsHalResource, halResource);
+        }
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -185,7 +185,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         component.setDescription("Angular is a development platform for building mobile and desktop web applications.");
         component.setCreatedOn("2016-12-15");
         component.setCreatedBy("admin@sw360.org");
-        component.setComponentType(ComponentType.OSS);
+        component.setComponentType(ComponentType.COTS);
         component.setVendorNames(new HashSet<>(Collections.singletonList("Google")));
         component.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "john@sw360.org")));
         usedByComponent.add(component);
@@ -221,6 +221,10 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         clearingInformation.setComponentClearingReportIsSet(false);
         clearingInformation.setExternalUrl("https://external.url");
 
+        COTSDetails cotsDetails1 = new COTSDetails().setClearingDeadline("2016-12-18").setContainsOSS(true)
+                .setCotsResponsible("admin@sw360.org").setLicenseClearingReportURL("http://licenseclearingreporturl.com")
+                .setOssInformationURL("http://ossinformationurl.com").setUsedLicense("MIT");
+
         release.setId(releaseId);
         owner.setReleaseId(release.getId());
         release.setName("Spring Core 4.3.4");
@@ -250,6 +254,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release.setSoftwarePlatforms(new HashSet<>(Arrays.asList("Java SE", ".NET")));
         release.setEccInformation(eccInformation);
         release.setClearingInformation(clearingInformation);
+        release.setCotsDetails(cotsDetails1);
+        release.setComponentType(ComponentType.COTS);
 
         Set<String> licenseIds = new HashSet<>();
         licenseIds.add("MIT");
@@ -695,6 +701,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:modifiedBy").description("A release modifiedBy with email and link to their <<resources-user-get,User resource>>"),
                                 subsectionWithPath("_embedded.sw360:createdBy").description("A release createdBy with email and link to their <<resources-user-get,User resource>>"),
                                 subsectionWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),
+                                subsectionWithPath("_embedded.sw360:cotsDetails").description("Cots details information of release has component type = COTS "),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
## Add COTS details information when fetch a single release that has component type COTS

### How To Test?
Procedure:
- From GUI create a release with Component type = OSS
- Edit Ecommercial Details information of that Release
- Send a GET request to: https://localhost:8080/resource/api/releases/{releaseId}

Expected:
- Responsed release contains **sw360:cotsDetails** in **_embedded**


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
