### PR TITLE
upd(docker): update maven version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ COPY --from=sw360thriftbuild /usr/local/bin/thrift /usr/local/bin/thrift
 FROM eclipse-temurin:11.0.19_7-jdk-jammy as sw360build
 
 # Thanks to Liferay, we need fix the java version
-ENV MAVEN_VERSION=3.9.3
+ENV MAVEN_VERSION=3.9.4
 ENV MAVEN_HOME /usr/share/maven
 ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 ARG COUCHDB_HOST=localhost


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
Updated maven env to current patch version 3.9.3 => 3.9.4
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
I didn't open an issue as it's a very minor change. I'd be happy to open one if it is still necessary.
> * Did you add or update any new dependencies that are required for your change?
No.

Issue: 
`./docker_build.sh` was failing because on 404 on `https://downloads.apache.org/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz`

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
Run `./docker_build.sh`

> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

