### PR TITLE
fix(rest) : Modifications to improve API GET result speed for name search

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -150,10 +150,6 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             sw360Releases.addAll(releaseService.getReleasesForUser(sw360User));
         }
 
-        for(Release release: sw360Releases) {
-            releaseService.setComponentDependentFieldsInRelease(release, sw360User);
-        }
-
         sw360Releases = sw360Releases.stream()
                 .filter(release -> name == null || name.isEmpty() || release.getName().equalsIgnoreCase(name))
                 .collect(Collectors.toList());
@@ -164,6 +160,15 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                 }
             }
         }
+        
+        if (CommonUtils.isNotNullEmptyOrWhitespace(sha1) || CommonUtils.isNotNullEmptyOrWhitespace(name)) {
+            for(Release release: sw360Releases) {
+                releaseService.setComponentDependentFieldsInRelease(release, sw360User);
+            }
+        } else {
+            releaseService.setComponentDependentFieldsInRelease(sw360Releases, sw360User);
+        }
+        
         PaginationResult<Release> paginationResult = restControllerHelper.createPaginationResult(request, pageable, sw360Releases, SW360Constants.TYPE_RELEASE);
 
         List<EntityModel> releaseResources = new ArrayList<>();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -143,6 +143,31 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return releaseById;
     }
 
+    public List<Release> setComponentDependentFieldsInRelease(List<Release> releases, User sw360User) {
+        Map<String, Component> componentIdMap;
+
+        try {
+            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+            List<Component> components = sw360ComponentClient.getComponentSummary(sw360User);
+            componentIdMap = components.stream().collect(Collectors.toMap(Component::getId, c -> c));
+        } catch (TException e) {
+            throw new HttpMessageNotReadableException("No Components found");
+        }
+        
+        for (Release release : releases) {
+            String componentId = release.getComponentId();
+            if (CommonUtils.isNullEmptyOrWhitespace(componentId)) {
+                throw new HttpMessageNotReadableException("ComponentId must be present");
+            }
+            if (!componentIdMap.containsKey(componentId)) {
+            	throw new HttpMessageNotReadableException("No Component found with Id - " + componentId);
+            }
+            Component component = componentIdMap.get(componentId);
+            release.setComponentType(component.getComponentType());
+        }
+        return releases;
+    }
+    
     public List<Release> getReleaseSubscriptions(User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.getSubscribedReleases(sw360User);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 　#2078

Performance Issues with Name Search via API 

### Suggest Reviewer
> You can suggest reviewers here with an @ag4ums 




## How to test
Using the Rest API of Release, "Acquisition of all records" and "Filtering by name" are executed, and confirm that there is no difference in the response JSON before and after the modification.  

### Preparation
Use the script below to register 10,000 Release and Component records for testing.  
[make_dummy_data.zip](https://github.com/eclipse-sw360/sw360/files/12415176/make_dummy_data.zip)


### 1. Retrieving the response before modification
Start the system before merging the changes in this pull request and execute the following commands.

- Acquisition of all records  
    Command line  
    ```bash
    curl --location 'https://sw360.org/resource/api/releases' \
    --header 'Authorization: Bearer *****' \
    ```
    Expected Output  
    ```json
    {
        "_embedded": {
            "sw360:releases": [
                {
                    "name": "APIPerformanceCheck_A_2758",
                    "version": "1.00",
                    "_links": {
                        "self": {
                            "href": "https://sw360.org/resource/api/releases/0004585d3d634a5589b196221f169f66"
                        }
                    }
                },
                {
                    "name": "APIPerformanceCheck_A_8970",
                    "version": "1.00",
                    "_links": {
                        "self": {
                            "href": "https://sw360.org/resource/api/releases/00045947d9ec4f9aa58d02c3a4e8d2e1"
                        }
                    }
                },
                .
                .
                .
    ```
- Filtering by name  
    Command line  
    ```bash
    curl --location 'https://sw360.org/resource/api/releases?name=APIPerformanceCheck_A_9999' \
    --header 'Authorization: Bearer *****' \
    ```
    Expected Output  
    ```json
    {
        "_embedded": {
            "sw360:releases": [
                {
                    "name": "APIPerformanceCheck_A_9999",
                    "version": "1.00",
                    "_links": {
                        "self": {
                            "href": "https://sw360.org/resource/api/releases/0004585d3d634a5589b196221f169f66"
                        }
                    }
                }
            ]
        },
        "_links": {
            "curies": [
                {
                    "href": "https://sw360.org/resource/docs/{rel}.html",
                    "name": "sw360",
                    "templated": true
                }
            ]
        }
    }
    ```

### 2. Retrieving the response after modification
Start the system after merging the changes in this pull request and execute the following commands.

- Acquisition of all records  
    Command line  
    ```bash
    curl --location 'https://sw360.org/resource/api/releases' \
    --header 'Authorization: Bearer *****' \
    ```
    Expected Output  
    ```json
    {
        "_embedded": {
            "sw360:releases": [
                {
                    "name": "APIPerformanceCheck_A_2758",
                    "version": "1.00",
                    "_links": {
                        "self": {
                            "href": "https://sw360.org/resource/api/releases/0004585d3d634a5589b196221f169f66"
                        }
                    }
                },
                {
                    "name": "APIPerformanceCheck_A_8970",
                    "version": "1.00",
                    "_links": {
                        "self": {
                            "href": "https://sw360.org/resource/api/releases/00045947d9ec4f9aa58d02c3a4e8d2e1"
                        }
                    }
                },
                .
                .
                .
    ```    

- Filtering by name  
    Command line  
    ```bash
    curl --location 'https://sw360.org/resource/api/releases?name=APIPerformanceCheck_A_9999' \
    --header 'Authorization: Bearer *****' \
    ```
    Expected Output  
    ```json
    {
        "_embedded": {
            "sw360:releases": [
                {
                    "name": "APIPerformanceCheck_A_9999",
                    "version": "1.00",
                    "_links": {
                        "self": {
                            "href": "https://sw360.org/resource/api/releases/0004585d3d634a5589b196221f169f66"
                        }
                    }
                }
            ]
        },
        "_links": {
            "curies": [
                {
                    "href": "https://sw360.org/resource/docs/{rel}.html",
                    "name": "sw360",
                    "templated": true
                }
            ]
        }
    }
    ```

### 3. Comparison of response JSON before and after changes
Confirm that there is no difference in the response JSON before and after applying the changes in this pull request.

# fix(rest) : Modifications to improve GET result speed

## Purpose
Fix bottlenecks in Release API performance issues. 

- The related issue  
    Performance Issues with Name Search via API #2078  
    https://github.com/eclipse-sw360/sw360/issues/2078  

- Bottlenecks  
    In the Rest API for Relaese, when "Acquisition of all records" or "Filtering by name" is executed, the process of retrieving the ComponentType accounts for about 92% of the processing time.

    ReleaseController.getReleasesForUser method：  
    ```java
    for(Release release: sw360Releases) {
        releaseService.setComponentDependentFieldsInRelease(release, sw360User);
    }
    ```
- Improvement effect of this modification  
    Comparison of processing times (unit: second)  
    DB has 10000 Release and Component records  
    |Endpoint|Method|Before modification (average)|After modification (average)|Remarks|
    |---|---|---|---|---|
    |/releases|GET|70.900|13.61|Acquisition of all records|
    |/releases?name=***|GET|69.343|5.55|Filtering by name (1 record is retrieved)|

## The outline of changes
- Replacing processing order  
    The order of execution of the filtering process by name of Release and the acquisition process of ComponentType is switched.  
    This reduces unnecessary Component acquisition processing, which is performed for Release records excluded by filter processing.
- Add batch acquisition of Component  
    If the "sha1" or "name" filter is not specified in the request, it is treated as a request to acquire all Release records.
    In this case, the process is changed so that all Components records are retrieved in a batch. and the ComponentType is acquired.  
    If the number of Release records is sufficiently narrowed down by filter conditions, it is more efficient to acquire Component individually, so the conventional processing is performed.

## The detail of changes
### ReleaseController.java  
rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java  
- Replacing the processing order  
- Added batch acquisition of Component

### Sw360ReleaseService.java
rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java  
- Added setComponentDependentFieldsInRelease method for batch acquisition of Component


## Limitations
The following Rest API changes may cause performance issues similar to the ComponentType acquisition process.

feat(rest): Add Information Vendor to response Get all Releases detail #2089  
https://github.com/eclipse-sw360/sw360/pull/2089  

However, since this change is limited to cases where "allDetails" is enabled and also skips Release that do not have a vendor id, we believe the impact is limited.
This pull request does not consider the impact of #2089. 