### PR TITLE
fix(rest): Removed the copyright text from REST API docs

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/packages.adoc
+++ b/rest/resource-server/src/docs/asciidoc/packages.adoc
@@ -1,12 +1,12 @@
-/*
- * Copyright Siemens Healthineers GmBH, 2023. Part of the SW360 Portal package.
- *
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- */
+//
+// Copyright Siemens Healthineers GmBH, 2023. Part of the SW360 Portal package.
+//
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
 
 [[resources-packages]]
 === Packages


### PR DESCRIPTION
Issue #2097 
Copyright text from the REST API docs is removed