### PR TITLE
fix(GUI): Fix edit dependency network GUI broken

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/main.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/main.scss
@@ -328,4 +328,18 @@
         cursor: pointer;
         pointer-events: auto !important;
     }
+
+    .component-name {
+        display: block;
+        width: max-content;
+        padding-right: 5px;
+        padding-top: 5px;
+    }
+
+    .component-name-col {
+        font-size: 1rem;
+        display: flex;
+        width: 100%;
+        border: none;
+    }
 }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleaseInNetwork.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleaseInNetwork.jsp
@@ -21,21 +21,6 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.MainlineState" %>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 
-<style>
-    .component-name {
-        display: block;
-        width: max-content;
-        padding-right: 5px;
-        padding-top: 5px;
-    }
-    .component-name-col {
-        font-size: 1rem;
-        display: flex;
-        width: 100%;
-        border: none;
-    }
-</style>
-
 <jsp:useBean id="releasesInNetwork" type="java.util.List<org.eclipse.sw360.datahandler.thrift.components.ReleaseLink>"  scope="request"/>
 <core_rt:set var="mainlineStateEnabledForUserRole" value='<%=PortalConstants.MAINLINE_STATE_ENABLED_FOR_USER%>'/>
 <core_rt:forEach items="${releasesInNetwork}" var="releaseLink" varStatus="loop">
@@ -46,10 +31,7 @@
             <tr id="releaseLinkRow${uuid}" parent-node="${releaseLink.parentNodeId}" data-layer="${releaseLink.layer}" data-index="${releaseLink.index}">
                 <td class="form-group">
                     <div class="component-name-col">
-                        <div class="component-name">
-                            <core_rt:forEach begin="1" end="${releaseLink.layer}" var="val">
-                                  &nbsp;&nbsp;&nbsp;&nbsp;
-                            </core_rt:forEach>
+                        <div class="component-name" style="padding-left: ${releaseLink.layer*19}px">
                             <sw360:out value="${releaseLink.name}"/>
                         </div>
                         <button type="button" class="btn btn-secondary add-child float-right" style="margin-left: auto; margin-right: 0px;">


### PR DESCRIPTION
### Precondition
 - Add following option to **/etc/sw360/sw360.properties** file **enable.flexible.project.release.relationship=true**
### Issue

#2100 


- When user click **Add release** button to add a release to dependency network, the GUI will be broken as bellow
![MicrosoftTeams-image](https://github.com/eclipse-sw360/sw360/assets/94659621/34e1a69a-d4f1-474d-abc2-aab9d8eb0d94)

### This PR will fix above issue

### How To Test?
 Steps:
  - User click edit project
  - User select a release and click
  
 Expected:
  - The GUI will work normally
![image](https://github.com/eclipse-sw360/sw360/assets/94659621/dc397380-0d84-4191-abb8-2575c59af2e3)


