### PR TITLE
fix(rest): New endpoint to download license archive files in admin page

### DIFF
--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicsExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicsExporter.java
@@ -37,6 +37,10 @@ public class LicsExporter {
         this.licenseClient = licenseClient;
     }
 
+    public LicsExporter() {
+        this.licenseClient = null;
+    }
+
     private ByteArrayInputStream getCsvStream(List<List<String>> listList) throws TException, IOException {
         return new ByteArrayInputStream(writeCsvStream(listList).toByteArray());
     }

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -38,6 +38,11 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>exporters</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/rest/resource-server/src/docs/asciidoc/licenses.adoc
+++ b/rest/resource-server/src/docs/asciidoc/licenses.adoc
@@ -104,8 +104,20 @@ include::{snippets}/should_document_delete_all_license_info/http-response.adoc[]
 
 A `POST` request will import SPDX info.
 
-===== Example requestimport-SPDX-info
+===== Example request
 include::{snippets}/should_document_import_spdx_info/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_import_spdx_info/http-response.adoc[]
+
+[[download-license-archive]]
+==== Download license archive
+
+A `GET` request help to download the license archive.
+
+===== Example request
+include::{snippets}/should_document_get_download_license_archive/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_download_license_archive/http-response.adoc[]
+

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -37,11 +37,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
@@ -173,5 +177,13 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         licenseService.importSpdxInformation(sw360User);
         return new ResponseEntity<>(HttpStatus.OK);
+    }   
+
+    @PreAuthorize("hasAuthority('WRITE')")
+    @RequestMapping(value = LICENSES_URL + "/downloadLicenses", method = RequestMethod.GET, produces = "application/zip")
+    public void downloadLicenseArchive(HttpServletRequest request,HttpServletResponse response) throws TException,IOException  {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        licenseService.getDownloadLicenseArchive(sw360User,request,response);
+
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.IOException;
 import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -62,7 +63,8 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
     private Obligation obligation1, obligation2;
 
     @Before
-    public void before() throws TException {
+    @SuppressWarnings("unchecked")
+    public void before() throws TException, IOException {
         license = new License();
         license.setId("Apache-2.0");
         license.setFullname("Apache License 2.0");
@@ -91,6 +93,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         Mockito.doNothing().when(licenseServiceMock).deleteLicenseById(any(), any());
         Mockito.doNothing().when(licenseServiceMock).deleteAllLicenseInfo(any());
         Mockito.doNothing().when(licenseServiceMock).importSpdxInformation(any());
+        Mockito.doNothing().when(licenseServiceMock).getDownloadLicenseArchive(any(), any(), any());
         obligation1 = new Obligation();
         obligation1.setId("0001");
         obligation1.setTitle("Obligation 1");
@@ -212,6 +215,15 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk());
+    }
+    @Test
+    public void should_document_get_download_license_archive() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/licenses" + "/downloadLicenses")
+         .header("Authorization", "Bearer " + accessToken)
+         .accept("application/zip"))
+         .andExpect(status().isOk())
+         .andDo(this.documentationHandler.document());
     }
 
     @Test


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2105 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
URL:  /resource/api/licenses/downloadLicenses
1: user should have admin access.
2: Go to admin tab.
3: download licenses archive.

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
