### PR TITLE
feat(REST): Add restricted project counter for component and release usedBy API

### DIFF
--- a/libraries/datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/datahandler/src/main/thrift/sw360.thrift
@@ -251,3 +251,7 @@ union Source {
   2: string componentId
   3: string releaseId
 }
+
+struct RestrictedResource {
+    1: optional i32 projects,
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundExceptio
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.ImportBomRequestPreparation;
+import org.eclipse.sw360.datahandler.thrift.RestrictedResource;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.VerificationStateInfo;
@@ -200,6 +201,10 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                     Component embeddedComponent = restControllerHelper.convertToEmbeddedComponent(c);
                     resources.add(EntityModel.of(embeddedComponent));
                 });
+
+        RestrictedResource restrictedResource = new RestrictedResource();
+        restrictedResource.setProjects(componentService.countProjectsByComponentId(id, user) - sw360Projects.size());
+        resources.add(EntityModel.of(restrictedResource));
 
         CollectionModel<EntityModel> finalResources = CollectionModel.of(resources);
         return new ResponseEntity(finalResources, HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -309,4 +309,18 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
 
         return requestStatus;
     }
+
+    /**
+     * Count the number of projects are using the component that has componentId
+     *
+     * @param componentId Ids of Component
+     * @return int                    Number of projects
+     * @throws TException
+     */
+    public int countProjectsByComponentId(String componentId, User sw360user) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        Component component = sw360ComponentClient.getComponentById(componentId, sw360user);
+        Set<String> releaseIds = SW360Utils.getReleaseIds(component.getReleases());
+        return projectService.countProjectsByReleaseIds(releaseIds);
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -113,6 +113,7 @@ public class JacksonCustomizations {
             setMixInAnnotation(ProjectDTO.class, Sw360Module.ProjectDTOMixin.class);
             setMixInAnnotation(EmbeddedProjectDTO.class, Sw360Module.EmbeddedProjectDTOMixin.class);
             setMixInAnnotation(ReleaseNode.class, Sw360Module.ReleaseNodeMixin.class);
+            setMixInAnnotation(RestrictedResource.class, Sw360Module.RestrictedResourceMixin.class);
 
             // Make spring doc aware of the mixin(s)
             SpringDocUtils.getConfig()
@@ -159,7 +160,8 @@ public class JacksonCustomizations {
                     .replaceWithClass(ModerationPatch.class, Sw360Module.ModerationPatchMixin.class)
                     .replaceWithClass(ProjectDTO.class, Sw360Module.ProjectDTOMixin.class)
                     .replaceWithClass(EmbeddedProjectDTO.class, Sw360Module.EmbeddedProjectDTOMixin.class)
-                    .replaceWithClass(ReleaseNode.class, Sw360Module.ReleaseNodeMixin.class);
+                    .replaceWithClass(ReleaseNode.class, Sw360Module.ReleaseNodeMixin.class)
+                    .replaceWithClass(RestrictedResource.class, Sw360Module.RestrictedResourceMixin.class);
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1753,6 +1755,14 @@ public class JacksonCustomizations {
                 "setReleaseRelationship"
         })
         public abstract static class ReleaseNodeMixin extends ReleaseNode {
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties({
+                "setProjects",
+                "setComponents"
+        })
+        public abstract static class RestrictedResourceMixin extends RestrictedResource {
         }
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -547,4 +547,20 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public void syncReleaseRelationNetworkAndReleaseIdToUsage(Project project, User user) throws TException {
         SW360Utils.syncReleaseRelationNetworkAndReleaseIdToUsage(project, user);
     }
+
+    /**
+     * Count the number of projects are using the releases that has releaseIds
+     * @param releaseIds              Ids of Releases
+     * @return int                    Number of projects
+     * @throws TException
+     */
+    public int countProjectsByReleaseIds(Set<String> releaseIds) {
+        try {
+            ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+            return sw360ProjectClient.getCountByReleaseIds(releaseIds);
+        } catch (TException e) {
+            log.error(e.getMessage());
+            return 0;
+        }
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -50,6 +50,7 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.VerificationState;
 import org.eclipse.sw360.datahandler.thrift.VerificationStateInfo;
+import org.eclipse.sw360.datahandler.thrift.RestrictedResource;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentDTO;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
@@ -286,6 +287,10 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     Component embeddedComponent = restControllerHelper.convertToEmbeddedComponent(c);
                     resources.add(EntityModel.of(embeddedComponent));
                 });
+
+        RestrictedResource restrictedResource = new RestrictedResource();
+        restrictedResource.setProjects(releaseService.countProjectsByReleaseId(id) - sw360Projects.size());
+        resources.add(EntityModel.of(restrictedResource));
 
         CollectionModel<EntityModel> finalResources = restControllerHelper.createResources(resources);
         HttpStatus status = finalResources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -34,6 +34,7 @@ import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
@@ -682,5 +683,15 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
     public RequestStatus triggerReportGenerationFossology(String releaseId, User user) throws TException {
         FossologyService.Iface fossologyClient = getThriftFossologyClient();
         return fossologyClient.triggerReportGenerationFossology(releaseId, user);
+    }
+
+    /**
+     * Count the number of projects are using the release that has releaseId
+     * @param releaseId              Id of release
+     * @return int                    Number of project
+     * @throws TException
+     */
+    public int countProjectsByReleaseId(String releaseId) {
+        return projectService.countProjectsByReleaseIds(Collections.singleton(releaseId));
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -338,6 +338,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         .setComponentType(ComponentType.OSS)
                         .setExternalIds(Collections.singletonMap("component-id-key", "c77321"))
         );
+        given(this.componentServiceMock.countProjectsByComponentId(eq("17653524"), any())).willReturn(2);
 
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789"));
@@ -684,6 +685,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:projects.[]version").description("The project version"),
                                 subsectionWithPath("_embedded.sw360:projects.[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
                                 subsectionWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
+                                subsectionWithPath("_embedded.sw360:restrictedResources.[]projects").description("Number of restricted projects"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -418,6 +418,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         when(this.releaseServiceMock.createRelease(any(), any())).then(invocation ->
                 new Release("Test Release", "1.0", component.getId())
                         .setId("1234567890"));
+        given(this.releaseServiceMock.countProjectsByReleaseId(eq(release.getId()))).willReturn(2);
 
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789"));
@@ -762,6 +763,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:projects.[]version").description("The project version"),
                                 subsectionWithPath("_embedded.sw360:projects.[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
                                 subsectionWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
+                                subsectionWithPath("_embedded.sw360:restrictedResources.[]projects").description("Number of restricted projects"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
### Add restricted projects counter for component and release usedBy API

### How To Test?
- Send GET request to
    + http://localhost:8080/resource/api/components/usedBy/{componentId}
    + http://localhost:8080/resource/api/releases/usedBy/{releaseId}

- Expected:
   + The response will contain number of restricted projects (of current user) :
    ```
      "sw360:restrictedResources" : [ {
            "projects" : {number_of_restricted_projects}
       } ]
    ```
