### PR TITLE
fix(rest): create new endpoint for import spdx information in admin tab

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/licenses.adoc
+++ b/rest/resource-server/src/docs/asciidoc/licenses.adoc
@@ -98,3 +98,14 @@ include::{snippets}/should_document_delete_all_license_info/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_delete_all_license_info/http-response.adoc[]
+
+[[import-spdx-info]]
+==== Import SPDX information
+
+A `POST` request will import SPDX info.
+
+===== Example requestimport-SPDX-info
+include::{snippets}/should_document_import_spdx_info/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_import_spdx_info/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -166,4 +166,12 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         licenseService.deleteAllLicenseInfo(sw360User);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+    @PreAuthorize("hasAuthority('WRITE')")
+    @RequestMapping(value = LICENSES_URL + "/import/SPDX", method = RequestMethod.POST)
+    public ResponseEntity importSPDX() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        licenseService.importSpdxInformation(sw360User);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -153,4 +153,12 @@ public class Sw360LicenseService {
         TProtocol protocol = new TCompactProtocol(thriftClient);
         return new LicenseService.Client(protocol);
     }
+    public void importSpdxInformation(User sw360User) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+            RequestSummary allSPDXLicenseStatus = sw360LicenseClient.importAllSpdxLicenses(sw360User);
+        } else {
+            throw new HttpMessageNotReadableException("Unable to import All Spdx license. User is not admin");
+        }
+    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -90,6 +90,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         given(this.licenseServiceMock.getLicenseById(eq(license.getId()))).willReturn(license);
         Mockito.doNothing().when(licenseServiceMock).deleteLicenseById(any(), any());
         Mockito.doNothing().when(licenseServiceMock).deleteAllLicenseInfo(any());
+        Mockito.doNothing().when(licenseServiceMock).importSpdxInformation(any());
         obligation1 = new Obligation();
         obligation1.setId("0001");
         obligation1.setTitle("Obligation 1");
@@ -213,4 +214,12 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    public void should_document_import_spdx_info() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(post("/api/licenses/" + "/import/SPDX")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2111 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1: login sw360 with admin user
2: /resource/api/licenses/import/SPDX

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
