### PR TITLE
fix(rest): create new endpoint for import OSADL information in admin.

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/licenses.adoc
+++ b/rest/resource-server/src/docs/asciidoc/licenses.adoc
@@ -131,3 +131,14 @@ include::{snippets}/should_document_upload_license/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_upload_license/http-response.adoc[]
+
+[[import-osadl-info]]
+==== Import osadl information
+
+A `POST` request will import osadl licenses info.
+
+===== Example request
+include::{snippets}/should_document_import_osadl_info/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_import_osadl_info/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -204,5 +205,16 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             throw new TException(e.getMessage());
 	    }
        return ResponseEntity.ok(Series.SUCCESSFUL);
+     }
+   
+    @RequestMapping(value = LICENSES_URL + "/import/OSADL", method = RequestMethod.POST)
+    public ResponseEntity<RequestSummary> importOsadlInfo() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary requestSummary=licenseService.importOsadlInformation(sw360User);
+        requestSummary.setMessage("OSADL license has imported successfully");
+        requestSummary.unsetTotalAffectedElements();
+        requestSummary.unsetTotalElements();
+        HttpStatus status = HttpStatus.OK;
+        return new ResponseEntity<>(requestSummary,status);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -231,4 +231,13 @@ public class Sw360LicenseService {
             }
         }
 	}
+    public RequestSummary importOsadlInformation(User sw360User) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+            RequestSummary osdlLicenseStatus = sw360LicenseClient.importAllOSADLLicenses(sw360User);
+            return osdlLicenseStatus;
+        } else {
+            throw new HttpMessageNotReadableException("Unable to import All Spdx license. User is not admin");
+        }
+    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -17,6 +17,8 @@ import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
 import org.eclipse.sw360.datahandler.thrift.Quadratic;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,6 +67,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
 
     private License license;
     private Obligation obligation1, obligation2;
+    private RequestSummary requestSummary = new RequestSummary();
 
     @Before
     @SuppressWarnings("unchecked")
@@ -91,6 +94,8 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         List<License> licenseList = new ArrayList<>();
         licenseList.add(license);
         licenseList.add(license2);
+        
+        requestSummary.setRequestStatus(RequestStatus.SUCCESS);
 
         given(this.licenseServiceMock.getLicenses()).willReturn(licenseList);
         given(this.licenseServiceMock.getLicenseById(eq(license.getId()))).willReturn(license);
@@ -99,6 +104,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         Mockito.doNothing().when(licenseServiceMock).importSpdxInformation(any());
         Mockito.doNothing().when(licenseServiceMock).getDownloadLicenseArchive(any(), any(), any());
         Mockito.doNothing().when(licenseServiceMock).uploadLicense(any(), any(), anyBoolean(), anyBoolean());
+        given(this.licenseServiceMock.importOsadlInformation(any())).willReturn(requestSummary);
         obligation1 = new Obligation();
         obligation1.setId("0001");
         obligation1.setTitle("Obligation 1");
@@ -248,5 +254,13 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                 .file(file)
                 .header("Authorization", "Bearer " + accessToken);
         this.mockMvc.perform(builder).andExpect(status().isOk());
+    }
+        		
+    public void should_document_import_osadl_info() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(post("/api/licenses/import/OSADL")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
You will import SPDX information in admin license.

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2113 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1: login sw360 with admin user
2: /resource/api/licenses/import/OSADL

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
