### PR TITLE
feat(Release): Get linked releases of release

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -516,3 +516,37 @@ include::{snippets}/should_document_load_spdx_licenses_info_from_isr/http-respon
 
 ===== Example response for Component license information (CLX or CLI) type
 include::{snippets}/should_document_load_spdx_licenses_info_from_clx_or_cli/http-response.adoc[]
+
+[[resources-get-linked-releases-of-release]]
+==== Get direct linked releases
+
+A `GET` request will get direct linked releases of a single release
+
+===== Response structure
+include::{snippets}/should_document_get_direct_linked_releases/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_direct_linked_releases/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_direct_linked_releases/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_direct_linked_releases/links.adoc[]
+
+[[resources-get-linked-releases-of-release-transitive]]
+==== Get linked releases (transitive)
+
+A `GET` request will get linked releases of a single release (transitive)
+
+===== Response structure
+include::{snippets}/should_document_get_linked_releases_transitively/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_linked_releases_transitively/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_linked_releases_transitively/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_linked_releases_transitively/links.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -697,7 +697,18 @@ public class JacksonCustomizations {
                 "setLicenseNames",
                 "setAccessible",
                 "setId",
-                "setClearingReport"
+                "setClearingReport",
+                "hasSubreleases",
+                "accessible",
+                "layer",
+                "index",
+                "setIndex",
+                "releaseWithSameComponentSize",
+                "setReleaseWithSameComponent",
+                "setLayer",
+                "setDefaultValue",
+                "setProjectId",
+                "setReleaseMainLineState"
 
         })
         static abstract class ReleaseLinkMixin {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -31,6 +31,7 @@ import org.eclipse.sw360.datahandler.resourcelists.ResourceListController;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentDTO;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
@@ -1310,5 +1311,16 @@ public class RestControllerHelper<T> {
             }
             addEmbeddedFields("sw360:cotsDetails", cotsDetailsHalResource, halResource);
         }
+    }
+
+    public ReleaseLink convertToReleaseLink(Release release, ReleaseRelationship relationship) {
+        ReleaseLink releaseLink = new ReleaseLink();
+        releaseLink.setId(release.getId());
+        releaseLink.setClearingState(release.getClearingState());
+        releaseLink.setLicenseIds(release.getMainLicenseIds());
+        releaseLink.setName(release.getName());
+        releaseLink.setVersion(release.getVersion());
+        releaseLink.setReleaseRelationship(relationship);
+        return releaseLink;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -54,6 +55,7 @@ import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcess;
 import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcessStatus;
 import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcessStep;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.packages.PackageManager;
@@ -68,6 +70,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityState;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
@@ -130,7 +133,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     @MockBean
     private Sw360LicenseInfoService licenseInfoMockService;
 
-    private Release release, release3, releaseTest;
+    private Release release, release3, releaseTest, release5;
     private Attachment attachment;
     Component component;
     private Project project;
@@ -325,6 +328,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release2.setClearingInformation(clearingInfo);
         release2.setCotsDetails(cotsDetails);
         release2.setEccInformation(eccInformation);
+        release2.setMainLicenseIds(Set.of("MIT", "GPL"));
+        release2.setOtherLicenseIds(Set.of("MIT"));
         releaseList.add(release2);
 
         Package package2 = new Package()
@@ -355,6 +360,31 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release3.setCreatedOn("2016-12-18");
         release3.setCreatedBy("admin@sw360.org");
         release3.setComponentId("1234");
+        release3.setMainLicenseIds(Set.of("MIT", "GPL 2+"));
+        release3.setClearingState(ClearingState.APPROVED);
+        release3.setMainlineState(MainlineState.MAINLINE);
+        release3.setOtherLicenseIds(Set.of("MIT"));
+
+        Release release4 = new Release();
+        release4.setId("90876");
+        release4.setName("Numpy");
+        release4.setVersion("1.19.5");
+        release4.setMainLicenseIds(Set.of("MIT"));
+        release4.setClearingState(ClearingState.APPROVED);
+        release4.setOtherLicenseIds(Collections.emptySet());
+
+        ReleaseLink releaseLink4 = new ReleaseLink();
+        releaseLink4.setId(release4.getId());
+        releaseLink4.setName(release4.getName());
+        releaseLink4.setVersion(release4.getVersion());
+        releaseLink4.setLicenseIds(release4.getMainLicenseIds());
+        releaseLink4.setClearingState(release4.getClearingState());
+        releaseLink4.setReleaseRelationship(ReleaseRelationship.CODE_SNIPPET);
+
+        release5 = new Release();
+        release5.setId("3333333");
+        release5.setReleaseIdToRelationship(Map.of(release2.getId(), ReleaseRelationship.DYNAMICALLY_LINKED, release3.getId(), ReleaseRelationship.CODE_SNIPPET));
+
         Attachment attachment3 = new Attachment(attachment);
         attachment3.setAttachmentContentId("34535345");
         attachment3.setAttachmentType(AttachmentType.SOURCE);
@@ -402,6 +432,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         given(this.releaseServiceMock.getRecentReleases(any())).willReturn(releaseList);
         given(this.releaseServiceMock.getReleaseSubscriptions(any())).willReturn(releaseList);
         given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), any())).willReturn(release);
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), any())).willReturn(release2);
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release5.getId()), any())).willReturn(release5);
         given(this.releaseServiceMock.getReleaseForUserById(eq(testRelease.getId()), any())).willReturn(testRelease);
         given(this.releaseServiceMock.getProjectsByRelease(eq(release.getId()), any())).willReturn(projectList);
         given(this.releaseServiceMock.getUsingComponentsForRelease(eq(release.getId()), any())).willReturn(usedByComponent);
@@ -418,6 +450,9 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         when(this.releaseServiceMock.createRelease(any(), any())).then(invocation ->
                 new Release("Test Release", "1.0", component.getId())
                         .setId("1234567890"));
+        doCallRealMethod().when(this.releaseServiceMock).addEmbeddedLinkedRelease(any(), any(), any(), any());
+        given(this.releaseServiceMock.getReleaseForUserById(eq("90876"), any())).willReturn(release4);
+        given(this.releaseServiceMock.convertToEmbeddedLinkedRelease(any(), any())).willReturn(releaseLink4);
 
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789"));
@@ -1235,6 +1270,48 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                         .header("Authorization", "Bearer " + accessToken)
                         .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void should_document_get_direct_linked_releases() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/releases/" + release5.getId() + "/releases")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("transitive", "false")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        requestParameters(
+                                parameterWithName("transitive").description("Get the transitive releases")
+                        ),
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:releaseLinks").description("An array of <<resources-releases, Releases resources>>"),
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_linked_releases_transitively() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/releases/" + release5.getId() + "/releases")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("transitive", "true")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        requestParameters(
+                                parameterWithName("transitive").description("Get the transitive releases")
+                        ),
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:releaseLinks").description("An array of <<resources-releases, Releases resources>>"),
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
     }
 
     public void mockLicensesInfo(AttachmentType attachmentType) throws TException{


### PR DESCRIPTION
### Get linked releases of release

### How To Test?
- Send GET request to http://localhost:8080/resource/api/releases/{releaseId}/releases (add transitive=true param if you want to get linked releases transitively)
- Example response:
```
{
  "_embedded" : {
    "sw360:releaseLinks" : [ {
      "id" : "6868686868",
      "name" : "Angular",
      "version" : "2.3.1",
      "releaseRelationship" : "DYNAMICALLY_LINKED",
      "clearingState" : "APPROVED",
      "licenseIds" : [ "MIT", "GPL" ],
      "_embedded" : {
        "sw360:releaseLinks" : [ {
          "id" : "90876",
          "name" : "Numpy",
          "version" : "1.19.5",
          "releaseRelationship" : "CODE_SNIPPET",
          "clearingState" : "APPROVED",
          "licenseIds" : [ "MIT" ]
        } ]
      }
    }, {
      "id" : "987456",
      "name" : "Angular",
      "version" : "2.3.1",
      "releaseRelationship" : "CODE_SNIPPET",
      "clearingState" : "APPROVED",
      "licenseIds" : [ "MIT", "GPL 2+" ]
    } ]
  },
  "_links" : {
    "curies" : [ {
      "href" : "https://sw360.org/docs/{rel}.html",
      "name" : "sw360",
      "templated" : true
    } ]
  }
}
```

