### PR TITLE
feat(docker): Add option to specify cvesearch.host at build time

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -4,7 +4,7 @@
 
 [Building](#building)
 
-[Running the Image](#running-the-image)
+[Running the Image](#running-the-image-first-time)
 
 [Extra Configurations](#configurations)
 
@@ -17,8 +17,16 @@
     Build is done by the script:
 
     ```sh
-    docker_build.sh
+    ./docker_build.sh
     ```
+
+    If you want to specify [CVE-Search](https://github.com/cve-search/cve-search) host at build time, run as follows:
+    ```sh
+    ./docker_build.sh --cvesearch-host <HOST_URL>
+    ```
+    The `<HOST_URL>` above should be `http://<YOUR_SERVER_HOST>:<PORT>` style, 
+    or it can be https://cvepremium.circl.lu for testing purposes only.
+
 
     The script will build multiple intermediary images.
     Subsequent builds will only build the differences

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -14,6 +14,33 @@
 # (execution of docker run cmd) starts couchdb and tomcat.
 # -----------------------------------------------------------------------------
 
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --cvesearch-host)
+            shift
+            cvesearch_host="$1"
+            ;;
+        *)
+            other_args+=("$1")  # store other arguments
+            ;;
+    esac
+    shift
+done
+
+# Validate the --cvesearch-host value is a URL
+if [ ! -z "$cvesearch_host" ]; then
+    if [[ $cvesearch_host =~ ^https?:// ]]; then
+        sed -i "s@cvesearch.host=.*@cvesearch.host=$cvesearch_host@g"\
+            ./backend/src/src-cvesearch/src/main/resources/cvesearch.properties
+    else
+        echo "Warning: CVE Search host is not a URL: $cvesearch_host"
+    fi
+fi
+
+set -- "${other_args[@]}"  # restore other arguments
+
+
 set -e -o pipefail
 
 # Source the version


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Hello, community. 

I am a new contributor for sw360. When I tried to build sw360 by `docker-compose`, I found the issue that I couldn't set the CVE Search server. So I added an option for a docker build script.

This option's input changes the `cvesearch.properties`.
This is a very minor update, however users can it without changing manually.

* Add `--cvesearch-host` option for `docker_build.sh`.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
#### Build
For doing test this option, you can use your own CVE server, however you can also use public server (https://cvepremium.circl.lu/)
* Run `./docker_build.sh --cvesearch-host https://cvepremium.circl.lu/`
* Setup according to [README_DOCKER](https://github.com/eclipse-sw360/sw360/blob/main/README_DOCKER.md)

#### Login
* Login SW360 with admin user

#### Add a vulnerable component
* Create Component named "libfoo"
* Go to "Components > libfoo > Release Overview > Edit Component > Create Release"
* Enter "cpe:/o:redhat:enterprise_linux:7.3" in "CPE ID", and "1" in "Version".
* Click "Update Release"

![libfoo](https://github.com/eclipse-sw360/sw360/assets/66460638/c5e281a4-eda9-413f-a497-ca6cee3dbd7a)

#### Run CVE Searching
* Go to "Vulnerabilities" and confirm that there are no vulnerability records
* Go to "Admin > Schedule"
* Click "CVE Search"
![schedule](https://github.com/eclipse-sw360/sw360/assets/66460638/dd61bca2-3b8c-4f72-991e-554133bec714)


#### Confirm the results
* In terminal, `cd` to SW360's directory
* Run `grep SUCCESS <(docker compose logs)`  to check if the connection was successful
* In web GUI, Go to "Vulnerabilities" and confirm that there are some vulnerability records

![success](https://github.com/eclipse-sw360/sw360/assets/66460638/8d6f0f7b-ce05-47b6-9296-a842ea84c9d0)


![vuln](https://github.com/eclipse-sw360/sw360/assets/66460638/d2012d6c-696c-4d73-a0bc-5f221d3147a1)

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
