### PR TITLE
fix(rest): Create new endpoint for LicenseType in admin tab

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/licenses.adoc
+++ b/rest/resource-server/src/docs/asciidoc/licenses.adoc
@@ -126,19 +126,57 @@ include::{snippets}/should_document_get_download_license_archive/http-response.a
 
 A `POST` request will upload license file.
 
+[red]#Request parameter#
+|===
+|Parameter |Description
+
+|licenseFile
+|Upload the license file.
+|===
+
 ===== Example request
 include::{snippets}/should_document_upload_license/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_upload_license/http-response.adoc[]
 
+
 [[import-osadl-info]]
 ==== Import osadl information
 
 A `POST` request will import osadl licenses info.
+
+[red]#Request parameter#
+|===
+|Parameter |Description
+
+|licenseFile
+|Import the license file.
+|===
 
 ===== Example request
 include::{snippets}/should_document_import_osadl_info/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_import_osadl_info/http-response.adoc[]
+
+[[add-license-type]]
+==== Create license type
+
+A `POST` request help to create license type.
+
+[red]#Request parameter#
+|===
+|Parameter |Description
+
+|licenseType
+|pass the licenseType name.
+|===
+
+===== Example request
+include::{snippets}/should_document_get_create_license_type/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_create_license_type/http-response.adoc[]
+
+

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -18,6 +18,7 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
@@ -206,7 +207,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
 	    }
        return ResponseEntity.ok(Series.SUCCESSFUL);
      }
-   
+
     @RequestMapping(value = LICENSES_URL + "/import/OSADL", method = RequestMethod.POST)
     public ResponseEntity<RequestSummary> importOsadlInfo() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -216,5 +217,13 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         requestSummary.unsetTotalElements();
         HttpStatus status = HttpStatus.OK;
         return new ResponseEntity<>(requestSummary,status);
+    }
+
+    @RequestMapping(value = LICENSES_URL + "/addLicenseType", method = RequestMethod.POST)
+    public ResponseEntity<RequestStatus> createLicenseType(@RequestParam(value = "licenseType", required = true) String licenseType, HttpServletRequest request) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus requestStatus=licenseService.addLicenseType(sw360User, licenseType, request);
+        HttpStatus status = HttpStatus.OK;
+        return new ResponseEntity<>(requestStatus,status);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -10,7 +10,10 @@
 
 package org.eclipse.sw360.rest.resourceserver.license;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -25,6 +28,7 @@ import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.exporter.LicsExporter;
@@ -34,6 +38,7 @@ import org.eclipse.sw360.importer.LicsImporter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileCopyUtils;
@@ -60,6 +65,7 @@ public class Sw360LicenseService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
     private static String CONTENT_TYPE = "application/zip";
+    LicenseType lType = new LicenseType();
 
     public List<License> getLicenses() throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
@@ -213,11 +219,11 @@ public class Sw360LicenseService {
     }
 
     public void uploadLicense(User sw360User, MultipartFile file, boolean overwriteIfExternalIdMatches, boolean overwriteIfIdMatchesEvenWithoutExternalIdMatch) throws IOException, TException {
-		final HashMap<String, InputStream> inputMap = new HashMap<>();
+        final HashMap<String, InputStream> inputMap = new HashMap<>();
 
-		if (!PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-			throw new HttpMessageNotReadableException("Unable to upload license file. User is not admin");
-		}
+        if (!PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+            throw new HttpMessageNotReadableException("Unable to upload license file. User is not admin");
+        }
         try {
             InputStream inputStream = file.getInputStream();
             ZipTools.extractZipToInputStreamMap(inputStream, inputMap);
@@ -231,6 +237,7 @@ public class Sw360LicenseService {
             }
         }
 	}
+
     public RequestSummary importOsadlInformation(User sw360User) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
@@ -240,4 +247,24 @@ public class Sw360LicenseService {
             throw new HttpMessageNotReadableException("Unable to import All Spdx license. User is not admin");
         }
     }
+
+    public RequestStatus addLicenseType(User sw360User, String licenseType, HttpServletRequest request) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        if (StringUtils.isNotEmpty(licenseType)) {
+             lType.setLicenseType(licenseType);
+        }
+        else {
+              throw new HttpMessageNotReadableException("license type is empty");
+        }
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestStatus status = sw360LicenseClient.addLicenseType(lType, sw360User);
+            } else {
+                throw new HttpMessageNotReadableException("Unable to create License Type. User is not admin");
+            }
+         } catch ( Exception e) {
+                 throw new TException(e.getMessage());
+         }
+         return RequestStatus.SUCCESS;
+     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -11,6 +11,7 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
@@ -96,6 +97,11 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         licenseList.add(license2);
         
         requestSummary.setRequestStatus(RequestStatus.SUCCESS);
+        LicenseType licensetype = new LicenseType();
+        licensetype.setId("1234");
+        licensetype.setLicenseType("wer");
+        licensetype.setLicenseTypeId(123);
+        licensetype.setType("xyz");
 
         given(this.licenseServiceMock.getLicenses()).willReturn(licenseList);
         given(this.licenseServiceMock.getLicenseById(eq(license.getId()))).willReturn(license);
@@ -105,6 +111,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         Mockito.doNothing().when(licenseServiceMock).getDownloadLicenseArchive(any(), any(), any());
         Mockito.doNothing().when(licenseServiceMock).uploadLicense(any(), any(), anyBoolean(), anyBoolean());
         given(this.licenseServiceMock.importOsadlInformation(any())).willReturn(requestSummary);
+        given(this.licenseServiceMock.addLicenseType(any(),any() , any())).willReturn(RequestStatus.SUCCESS);
         obligation1 = new Obligation();
         obligation1.setId("0001");
         obligation1.setTitle("Obligation 1");
@@ -252,15 +259,27 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.multipart("/api/licenses/upload")
                 .file(file)
-                .header("Authorization", "Bearer " + accessToken);
-        this.mockMvc.perform(builder).andExpect(status().isOk());
+                .header("Authorization", "Bearer " + accessToken)
+                .queryParam("licenseFile", "Must need to attach file.");
+        this.mockMvc.perform(builder).andExpect(status().isOk()).andDo(this.documentationHandler.document());
     }
-        		
+
+    @Test   		
     public void should_document_import_osadl_info() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(post("/api/licenses/import/OSADL")
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void should_document_get_create_license_type() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(post("/api/licenses/" + "/addLicenseType")
+                .header("Authorization", "Bearer " + accessToken)
+                .param("licenseType", "wer")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk()).andDo(this.documentationHandler.document());
     }
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2146 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1: Login with Admin user.
Sample URL : http://localhost:8080/resource/api/licenses/addLicenseType

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
