### PR TITLE
fix(REST):GET Component endpoint failing for names with space

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -129,7 +129,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
         Map<String, String> params = parseQueryString(queryString);
 
         if (name != null && !name.isEmpty()) {
-            allComponents.addAll(componentService.searchComponentByName(params.get("name")));
+            allComponents.addAll(componentService.searchComponentByName(params.get("name").replace("%20"," ")));
         } else {
             allComponents.addAll(componentService.getComponentsForUser(sw360User));
         }


### PR DESCRIPTION
Signed-off-by: afsahsyeda <afsah.syeda@siemens-healhtineers.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Space character and "+" character in names is getting converted to "%20". This issue has been fixed by replacing "%20" to " " before searching for the component in the repository.

Closes #2115 

