### PR TITLE
feat(rest): endpoint to get license clearing count for a project

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1295,6 +1295,20 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         return projects;
     }
+    
+    public Project fillClearingStateSummaryIncludingSubprojectsForSingleProject(Project project, User user) {
+        final Map<String, Project> allProjectsIdMap = getRefreshedAllProjectsIdMap();
+
+        Set<String> releaseIdsOfProjectTree = getReleaseIdsOfProjectTree(project, Sets.newHashSet(),
+                allProjectsIdMap, user, null);
+        List<Release> releasesForClearingStateSummary = componentDatabaseHandler
+                .getReleasesForClearingStateSummary(releaseIdsOfProjectTree);
+        final ReleaseClearingStateSummary releaseClearingStateSummary = ReleaseClearingStateSummaryComputer
+                .computeReleaseClearingStateSummary(releasesForClearingStateSummary, project.getClearingTeam());
+
+        project.setReleaseClearingStateSummary(releaseClearingStateSummary);
+        return project;
+    }
 
     /**
      * Synchronization is not really necessary, we could also remove it. Worst case

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -390,6 +390,12 @@ public class ProjectHandler implements ProjectService.Iface {
             throws TException {
         return handler.fillClearingStateSummaryIncludingSubprojects(projects, user);
     }
+    
+    @Override
+    public Project fillClearingStateSummaryIncludingSubprojectsForSingleProject(Project project, User user)
+            throws TException {
+        return handler.fillClearingStateSummaryIncludingSubprojectsForSingleProject(project, user);
+    }
 
     @Override
     public List<ReleaseClearingStatusData> getReleaseClearingStatuses(String projectId, User user) throws SW360Exception {

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -524,6 +524,8 @@ service ProjectService {
      * Visibility of any of the projects in the tree for the given user is currently not considered.
      */
     list<Project> fillClearingStateSummaryIncludingSubprojects(1: list<Project> projects, 2: User user);
+    
+    Project fillClearingStateSummaryIncludingSubprojectsForSingleProject(1: Project project, 2: User user);
 
     /**
     * export all projects to SVM to create/update monitoring lists

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -418,6 +418,16 @@ include::{snippets}/should_document_get_project_releases_ecc_information/http-re
 ===== Links
 include::{snippets}/should_document_get_project_releases_ecc_information/links.adoc[]
 
+[[resources-project-get-license-clearing-information-information]]
+==== Project's license clearing count
+
+A `GET` request will get license clearing count of a project.
+
+===== Example request
+include::{snippets}/should_document_get_license_clearing_information/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_license_clearing_information/http-response.adoc[]
 
 [[resources-projects-create]]
 ==== Creating a project

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -118,6 +118,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStateSummary;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -1849,6 +1850,31 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             resultJson.addProperty("status", "success");
             resultJson.addProperty("count", projectService.getMyAccessibleProjectCounts(sw360User));
             response.getWriter().write(resultJson.toString());
+        } catch (IOException e) {
+            throw new SW360Exception(e.getMessage());
+        }
+    }
+    
+    @Operation(
+            description = "Get license clearing info for a project.",
+            tags = {"Projects"}
+    )
+    @RequestMapping(value = PROJECTS_URL + "/{id}/licenseClearingCount", method = RequestMethod.GET)
+    public void getlicenseClearingCount(HttpServletResponse response ,
+    		@Parameter(description = "Project ID", example = "376521")
+            @PathVariable("id") String id) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+        
+        Project proj = projectService.getClearingInfo(sw360Project, sw360User);
+        ReleaseClearingStateSummary clearingInfo = proj.getReleaseClearingStateSummary();
+        int releaseCount = clearingInfo.newRelease + clearingInfo.sentToClearingTool + clearingInfo.underClearing + clearingInfo.reportAvailable + clearingInfo.scanAvailable + clearingInfo.approved;
+        int approvedCount = clearingInfo.approved;
+        try {
+        	JsonObject row = new JsonObject();
+            row.addProperty("Release Count", releaseCount);
+            row.addProperty("Approved Count", approvedCount);
+            response.getWriter().write(row.toString());
         } catch (IOException e) {
             throw new SW360Exception(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -223,6 +223,11 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             }
         }
     }
+    
+    public Project getClearingInfo(Project sw360Project, User sw360User) throws TException {
+    	ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+    	return sw360ProjectClient.fillClearingStateSummaryIncludingSubprojectsForSingleProject(sw360Project, sw360User);
+    }
 
     public List<Project> searchProjectByName(String name, User sw360User) throws TException {
         final ProjectService.Iface sw360ProjectClient = getThriftProjectClient();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -54,6 +54,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerability
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityCheckStatus;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStateSummary;
 import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
@@ -268,6 +269,15 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project.setDeliveryChannels("Lorem Ipsum");
         project.setVendor(new Vendor());
         project.setRemarksAdditionalRequirements("Lorem Ipsum");
+        ReleaseClearingStateSummary clearingCount = new ReleaseClearingStateSummary();
+        clearingCount.newRelease = 2;
+        clearingCount.sentToClearingTool = 1;
+        clearingCount.underClearing = 0;
+        clearingCount.reportAvailable = 0;
+        clearingCount.scanAvailable = 0;
+        clearingCount.internalUseScanAvailable = 1;
+        clearingCount.approved = 2;
+        project.setReleaseClearingStateSummary(clearingCount);
         linkedReleases.put("3765276512", projectReleaseRelationship);
         project.setReleaseIdToUsage(linkedReleases);
         linkedProjects.put("376570", new ProjectProjectRelationship(ProjectRelationship.CONTAINED).setEnableSvm(true));
@@ -456,6 +466,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(true))).willReturn(releaseIdsTransitive);
         given(this.projectServiceMock.deleteProject(eq(project.getId()), any())).willReturn(RequestStatus.SUCCESS);
         given(this.projectServiceMock.updateProjectReleaseRelationship(any(), any(), any())).willReturn(projectReleaseRelationshipResponseBody);
+        given(this.projectServiceMock.getClearingInfo(eq(project), any())).willReturn(project);
         given(this.projectServiceMock.convertToEmbeddedWithExternalIds(eq(project))).willReturn(
                 new Project("Emerald Web")
                         .setVersion("1.0.2")
@@ -1922,6 +1933,21 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                        responseFields(
                                fieldWithPath("status").description("status of the API. Possible values are `<success|failure>`").optional(),
                                fieldWithPath("count").description("Count of projects for a user.").optional()
+                       )));
+    }
+
+    @Test
+    public void should_document_get_license_clearing_information() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        this.mockMvc.perform(get("/api/projects/" + project.getId()+ "/licenseClearingCount")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON)
+                .contentType(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                       responseFields(
+                               fieldWithPath("Release Count").description("Total count of releases of a project including sub-projects releases"),
+                               fieldWithPath("Approved Count").description("Approved license clearing state releases")
                        )));
     }
 


### PR DESCRIPTION
Issue: closes #2162 

Description: 
This endpoint will give the count of the license clearing count i.e. the data for the highlighted column in project table.

![image](https://github.com/eclipse-sw360/sw360/assets/58290634/cd43dfb9-c615-471c-a7dd-ecc3ec9e9470)

