### PR TITLE
docs(api): add OpenAPI docs for releases

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -257,6 +257,20 @@ include::{snippets}/should_document_get_release_attachment_bundle/curl-request.a
 ===== Example response
 include::{snippets}/should_document_get_release_attachment_bundle/http-response.adoc[]
 
+[[resources-release-external-id]]
+==== Get releases by external IDs
+
+A `GET` request will allow you to get releases by external IDs.
+Put the external ID as query parameter and its value as parameter's value.
+
+===== Example request
+
+include::{snippets}/should_document_get_releases_by_externalIds/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_releases_by_externalIds/http-response.adoc[]
+
 [[resources-release-attachment-delete]]
 ==== Delete attachments
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

1. Add OpenAPI docs for `/releases` endpoints.
2. Add the missing AsciiDoc for getting releases by external ID.
3. Replace deprecated exception `HttpMessageNotReadableException` with `HttpClientErrorException`.

Continuation of https://github.com/eclipse-sw360/sw360/pull/2071

### Suggest Reviewer
@heliocastro
@KoukiHama
@ag4ums

### How To Test?
* The Swagger UI for the API should be available at http://localhost:8080/resource/api/swagger-ui/index.html
  * Read the documentation for the endpoints.
* OpenAPI JSON file should be available at http://localhost:8080/resource/api-docs

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR