### PR TITLE
fix (rest) : Rest API for component search by Lucene search

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -48,6 +48,23 @@ include::{snippets}/should_document_get_components_with_all_details/curl-request
 ===== Example response
 include::{snippets}/should_document_get_components_with_all_details/http-response.adoc[]
 
+[[resources-components-list-with-lucenesearch]]
+==== Listing by lucene search
+
+A `GET` request will list all of the service's components by lucenesearch.
+
+===== Response structure
+include::{snippets}/should_document_get_components_by_lucene_search/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_components_by_lucene_search/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_components_by_lucene_search/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_components_by_lucene_search/links.adoc[]
+
 [[resources-recent-components-list]]
 ==== Listing recent components
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -323,4 +323,9 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         Set<String> releaseIds = SW360Utils.getReleaseIds(component.getReleases());
         return projectService.countProjectsByReleaseIds(releaseIds);
     }
+
+    public List<Component> refineSearch(Map<String, Set<String>> filterMap, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.refineSearchAccessibleComponents(null, filterMap, sw360User);
+    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -311,6 +311,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         given(this.componentServiceMock.getComponentsForUser(any())).willReturn(componentList);
         given(this.sw360ReportServiceMock.getComponentBuffer(any(),anyBoolean())).willReturn(ByteBuffer.allocate(10000));
         given(this.componentServiceMock.getRecentComponents(any())).willReturn(componentList);
+        given(this.componentServiceMock.refineSearch(any(), any())).willReturn(componentList);
         given(this.componentServiceMock.getComponentSubscriptions(any())).willReturn(componentList);
         given(this.componentServiceMock.getMyComponentsForUser(any())).willReturn(componentList);
         given(this.componentServiceMock.getComponentForUserById(eq("17653524"), any())).willReturn(angularComponent);
@@ -547,6 +548,36 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("page.totalPages").description("Total number of pages"),
                                 fieldWithPath("page.number").description("Number of the current page")
                         )));
+    }
+
+    @Test
+    public void should_document_get_components_by_lucene_search() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/components").header("Authorization", "Bearer " + accessToken)
+                .param("name", angularComponent.getName()).param("luceneSearch", "true").param("sort", "name,desc")
+                .param("page", "0").param("page_entries", "5").accept(MediaTypes.HAL_JSON)).andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        requestParameters(parameterWithName("name").description("name of components"),
+                                parameterWithName("luceneSearch").description("Defines whether luceneSearch is required while searching the component"),
+                                parameterWithName("page").description("Page of components"),
+                                parameterWithName("page_entries").description("Amount of components per page"),
+                                parameterWithName("sort").description("Defines order of the components")),
+                        links(linkWithRel("curies").description("Curies are used for online documentation"),
+                                linkWithRel("first").description("Link to first page"),
+                                linkWithRel("last").description("Link to last page")),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:components.[]id").description("The id of the component"),
+                                subsectionWithPath("_embedded.sw360:components.[]name").description("The name of the component"),
+                                subsectionWithPath("_embedded.sw360:components.[]componentType").description("The component type, possible values are: "+ Arrays.asList(ComponentType.values())),
+                                subsectionWithPath("_embedded.sw360:components.[]visbility").description("The visbility of the component"),
+                                subsectionWithPath("_embedded.sw360:components.[]description").description("The description of the component"),
+                                subsectionWithPath("_embedded.sw360:components").description("An array of <<resources-components, Components resources>>"),
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
+                                fieldWithPath("page").description("Additional paging information"),
+                                fieldWithPath("page.size").description("Number of components per page"),
+                                fieldWithPath("page.totalElements").description("Total number of all existing components"),
+                                fieldWithPath("page.totalPages").description("Total number of pages"),
+                                fieldWithPath("page.number").description("Number of the current page"))));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2195 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Sample URL and response as follows in the screenshot. 

URL : http://localhost:8080/resource/api/components?name=comp&page=0&page_entries=20&luceneSearch=true&sort=name,desc

![image](https://github.com/eclipse-sw360/sw360/assets/121924406/28cf35c0-70e0-4c7b-942f-4766c040b332)



> Have you implemented any additional tests?
No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
