### PR TITLE
docs(api): add OpenAPI docs for /vulnerabilities

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -257,6 +257,20 @@ include::{snippets}/should_document_get_release_attachment_bundle/curl-request.a
 ===== Example response
 include::{snippets}/should_document_get_release_attachment_bundle/http-response.adoc[]
 
+[[resources-release-external-id]]
+==== Get releases by external IDs
+
+A `GET` request will allow you to get releases by external IDs.
+Put the external ID as query parameter and its value as parameter's value.
+
+===== Example request
+
+include::{snippets}/should_document_get_releases_by_externalIds/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/should_document_get_releases_by_externalIds/http-response.adoc[]
+
 [[resources-release-attachment-delete]]
 ==== Delete attachments
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -139,6 +139,7 @@ public class JacksonCustomizations {
                     .replaceWithClass(Vulnerability.class, VulnerabilityMixin.class)
                     .replaceWithClass(VulnerabilityState.class, VulnerabilityStateMixin.class)
                     .replaceWithClass(ReleaseVulnerabilityRelationDTO.class, ReleaseVulnerabilityRelationDTOMixin.class)
+                    .replaceWithClass(VendorAdvisory.class, VendorAdvisoryMixin.class)
                     .replaceWithClass(VulnerabilityDTO.class, VulnerabilityDTOMixin.class)
                     .replaceWithClass(VulnerabilityApiDTO.class, VulnerabilityApiDTOMixin.class)
                     .replaceWithClass(EccInformation.class, EccInformationMixin.class)
@@ -1474,7 +1475,34 @@ public class JacksonCustomizations {
                 "setAccess",
                 "accessSize",
                 "releasesSize",
-                "setReleases"
+                "setReleases",
+                "descriptionIsSet",
+                "idIsSet",
+                "revisionIsSet",
+                "typeIsSet",
+                "releasesIsSet",
+                "externalIdIsSet",
+                "titleIsSet",
+                "publishDateIsSet",
+                "lastExternalUpdateIsSet",
+                "priorityIsSet",
+                "actionIsSet",
+                "impactIsSet",
+                "legalNoticeIsSet",
+                "cveReferencesIsSet",
+                "referencesIsSet",
+                "lastUpdateDateIsSet",
+                "priorityTextIsSet",
+                "assignedExtComponentIdsIsSet",
+                "vendorAdvisoriesIsSet",
+                "extendedDescriptionIsSet",
+                "cvssIsSet",
+                "isSetCvssIsSet",
+                "cvssTimeIsSet",
+                "vulnerableConfigurationIsSet",
+                "accessIsSet",
+                "cweIsSet",
+                "cveFurtherMetaDataPerSourceIsSet"
         })
         public static abstract class VulnerabilityApiDTOMixin extends VulnerabilityApiDTO {
             @Override
@@ -1803,7 +1831,13 @@ public class JacksonCustomizations {
                 "setName",
                 "setVendor",
                 "setUrl",
-                "type"
+                "type",
+                "urlIsSet",
+                "nameIsSet",
+                "idIsSet",
+                "revisionIsSet",
+                "typeIsSet",
+                "vendorIsSet"
         })
         public static abstract class VendorAdvisoryMixin extends VendorAdvisory {
         }
@@ -1876,7 +1910,15 @@ public class JacksonCustomizations {
                 "setMatchedBy",
                 "setUsedNeedle",
                 "setReleaseId",
-                "setSpdxId"
+                "setSpdxId",
+                "idIsSet",
+                "revisionIsSet",
+                "typeIsSet",
+                "releaseIdIsSet",
+                "matchedByIsSet",
+                "usedNeedleIsSet",
+                "vulnerabilityIdIsSet",
+                "verificationStateInfoIsSet"
         })
         public static abstract class ReleaseVulnerabilityRelationMixin extends ReleaseVulnerabilityRelation {
         }
@@ -1886,7 +1928,11 @@ public class JacksonCustomizations {
                 "setCheckedBy",
                 "setCheckedOn",
                 "setComment",
-                "setVerificationState"
+                "setVerificationState",
+                "checkedByIsSet",
+                "checkedOnIsSet",
+                "commentIsSet",
+                "verificationStateIsSet"
         })
         public static abstract class VerificationStateInfoMixin extends VerificationStateInfo {
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -11,6 +11,12 @@
  */
 package org.eclipse.sw360.rest.resourceserver.vulnerability;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,19 +31,16 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import javax.websocket.server.PathParam;
 import javax.servlet.http.HttpServletRequest;
 
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
-import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.permissions.DocumentPermissions;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
-import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
@@ -65,14 +68,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.ArrayList;
@@ -81,13 +78,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 
-import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @BasePathAwareController
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RestController
+@SecurityRequirement(name = "tokenAuth")
 public class VulnerabilityController implements RepresentationModelProcessor<RepositoryLinksResource> {
     static final String VULNERABILITIES_URL = "/vulnerabilities";
 
@@ -96,15 +94,20 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
 
     @NonNull
     private final RestControllerHelper restControllerHelper;
-    
+
     @NonNull
     private Sw360ReleaseService releaseService;
 
-    @RequestMapping(value = VULNERABILITIES_URL)
+    @Operation(
+            summary = "List all of the service's vulnerabilities.",
+            description = "List all of the service's vulnerabilities.",
+            tags = {"Vulnerabilities"}
+    )
+    @GetMapping(value = VULNERABILITIES_URL)
     public ResponseEntity<CollectionModel<EntityModel<VulnerabilityApiDTO>>> getVulnerabilities(
             Pageable pageable,
             HttpServletRequest request
-            ) throws TException, URISyntaxException, PaginationParameterException,  ResourceClassNotFoundException {
+    ) throws URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         List<Vulnerability> vulnerabilities = vulnerabilityService.getVulnerabilities(user);
 
@@ -118,7 +121,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         }
 
         CollectionModel<EntityModel<VulnerabilityApiDTO>> resources;
-        if (vulnerabilities.size() == 0) {
+        if (vulnerabilities.isEmpty()) {
             resources = restControllerHelper.emptyPageResource(Vulnerability.class, paginationResult);
         } else {
             resources = restControllerHelper.generatePagesResource(paginationResult, vulnResources);
@@ -126,12 +129,18 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
 
         HttpStatus status = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
         return new ResponseEntity<>(resources, status);
-
     }
 
-    @RequestMapping(VULNERABILITIES_URL + "/{id}")
+    @Operation(
+            summary = "Get a vulnerability by the external ID.",
+            description = "Get a vulnerability by the external ID.",
+            tags = {"Vulnerabilities"}
+    )
+    @GetMapping(VULNERABILITIES_URL + "/{id}")
     public ResponseEntity<HalResource<VulnerabilityApiDTO>> getVulnerability(
-            @PathVariable("id") String id) {
+            @Parameter(description = "The external ID of the vulnerability to be retrieved.")
+            @PathVariable("id") String id
+    ) {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Vulnerability vulnerability = vulnerabilityService.getVulnerabilityByExternalId(id, user);
         Set<Release> releaseList = getReleaseRelationsInfo(vulnerability, user);
@@ -143,21 +152,39 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     }
 
     @PreAuthorize("hasAuthority('WRITE')")
+    @Operation(
+            summary = "Create a new vulnerability.",
+            description = "Create a new vulnerability.",
+            tags = {"Vulnerabilities"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            content = @Content(mediaType = "application/hal+json",
+                                    schema = @Schema(implementation = VulnerabilityApiDTO.class)),
+                            description = "Redirection to the created vulnerability."
+                    )
+            }
+    )
     @PostMapping(VULNERABILITIES_URL)
-    public ResponseEntity createVulnerability(@RequestBody Map<String, Object> vulnerabilityAsMap) {
+    public ResponseEntity createVulnerability(
+            @Parameter(description = "The vulnerability to be created.",
+                    schema = @Schema(implementation = VulnerabilityApiDTO.class)
+            )
+            @RequestBody Map<String, Object> vulnerabilityAsMap
+    ) {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         ObjectMapper mapper = vulnerabilityService.getObjectMapper();
         VulnerabilityApiDTO vulnerabilityApiDTO = mapper.convertValue(vulnerabilityAsMap, VulnerabilityApiDTO.class);
         String externalId = vulnerabilityApiDTO.getExternalId();
         if (CommonUtils.isNullEmptyOrWhitespace(externalId)) {
-            throw new HttpMessageNotReadableException("External Id should not be null or empty");
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "External Id should not be null or empty");
         }
 
         try {
             vulnerabilityService.getVulnerabilityByExternalId(externalId, user);
-            throw new HttpMessageNotReadableException("Conflict Vulnerability with same external id already exists.");
-        } catch (ResourceNotFoundException e) {
-
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Conflict Vulnerability with same external id " +
+                    "already exists.");
+        } catch (ResourceNotFoundException ignored) {
         }
         Vulnerability vulnerability = new Vulnerability(externalId);
         restControllerHelper.setDataForVulnerability(vulnerabilityApiDTO, vulnerability);
@@ -171,17 +198,36 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     }
 
     @PreAuthorize("hasAuthority('WRITE')")
+    @Operation(
+            summary = "Update a vulnerability.",
+            description = "Update a vulnerability.",
+            tags = {"Vulnerabilities"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            content = @Content(mediaType = "application/hal+json",
+                                    schema = @Schema(implementation = VulnerabilityApiDTO.class)),
+                            description = "Redirection to the created vulnerability."
+                    )
+            }
+    )
     @PatchMapping(VULNERABILITIES_URL + "/{externalId}")
-    public ResponseEntity updateVulnerability(@PathVariable String externalId,
-            @RequestBody Map<String, Object> vulnerabilityAsMap) {
+    public ResponseEntity updateVulnerability(
+            @Parameter(description = "The external ID of the vulnerability to be updated.")
+            @PathVariable String externalId,
+            @Parameter(description = "The updated vulnerability.",
+                    schema = @Schema(implementation = VulnerabilityApiDTO.class)
+            )
+            @RequestBody Map<String, Object> vulnerabilityAsMap
+    ) {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         ObjectMapper mapper = vulnerabilityService.getObjectMapper();
         VulnerabilityApiDTO vulnerabilityApiDTO = mapper.convertValue(vulnerabilityAsMap, VulnerabilityApiDTO.class);
         if (CommonUtils.isNullEmptyOrWhitespace(externalId)) {
-            throw new HttpMessageNotReadableException("External Id should not be null or empty");
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "External Id should not be null or empty");
         }
         if (!externalId.equals(vulnerabilityApiDTO.getExternalId())) {
-            throw new HttpMessageNotReadableException("External Id is not correct");
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "External Id is not correct");
         }
         Vulnerability vulnerability = new Vulnerability(externalId);
         restControllerHelper.setDataForVulnerability(vulnerabilityApiDTO, vulnerability);
@@ -197,8 +243,25 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     }
 
     @PreAuthorize("hasAuthority('WRITE')")
+    @Operation(
+            summary = "Delete a vulnerability.",
+            description = "Delete a vulnerability.",
+            tags = {"Vulnerabilities"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "207",
+                            content = @Content(mediaType = "application/hal+json",
+                                    schema = @Schema(type = "array",
+                                            implementation = MultiStatus.class)),
+                            description = "External ID and status."
+                    )
+            }
+    )
     @DeleteMapping(VULNERABILITIES_URL + "/{externalId}")
-    public ResponseEntity deleteVulnerability(@PathVariable String externalId) {
+    public ResponseEntity deleteVulnerability(
+            @Parameter(description = "The external ID of the vulnerability to be deleted.")
+            @PathVariable String externalId
+    ) {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         List<MultiStatus> results = new ArrayList<>();
         if (CommonUtils.isNullEmptyOrWhitespace(externalId)) {
@@ -229,7 +292,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
                     }
                 });
 
-                if (releasesInRelation.size() == 0) {
+                if (releasesInRelation.isEmpty()) {
                     vulnerabilityService.createUpdateDeleteVulnerability(vulnerabilityWithReleaseRelations.getVulnerability(),
                             user, VulnerabilityOperation.DELETE);
                 } else {
@@ -260,13 +323,30 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     }
 
     @PreAuthorize("hasAuthority('WRITE')")
+    @Operation(
+            summary = "Create a new vulnerability to release relation.",
+            description = "Create a new vulnerability to release relation.",
+            tags = {"Vulnerabilities"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(mediaType = "application/hal+json",
+                                    schema = @Schema(implementation = ReleaseVulnerabilityRelation.class)),
+                            description = "Updated relation information."
+                    )
+            }
+    )
     @PostMapping(value = VULNERABILITIES_URL + "/{externalId}/releaseVulnerabilityRelation")
-    public ResponseEntity postVulnearbilitytoReleases(@PathVariable String externalId,
-            @RequestBody ReleaseVulnerabilityRelation releaseVulnerabilityRelation) throws TException {
+    public ResponseEntity postVulnearbilitytoReleases(
+            @Parameter(description = "The external ID of the vulnerability to be linked to a release.")
+            @PathVariable String externalId,
+            @Parameter(description = "The release to be linked to a vulnerability.")
+            @RequestBody ReleaseVulnerabilityRelation releaseVulnerabilityRelation
+    ) throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         String releaseId = releaseVulnerabilityRelation.getReleaseId();
         if (CommonUtils.isNullEmptyOrWhitespace(externalId) || CommonUtils.isNullEmptyOrWhitespace(releaseId)) {
-            throw new HttpMessageNotReadableException("External Id or Release Id should not be null or empty");
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "External Id or Release Id should not be null or empty");
         }
         VulnerabilityWithReleaseRelations vulnerabilityWithReleaseRelations = vulnerabilityService
                 .getVulnerabilityWithReleaseRelations(externalId, user);
@@ -274,7 +354,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         Release releaseForUserById = releaseService.getReleaseForUserById(releaseId, user);
         DocumentPermissions<Release> permissions = makePermission(releaseForUserById, user);
         if (!permissions.isActionAllowed(RequestedAction.WRITE)) {
-            throw new AccessDeniedException("User doesnot have write access to release : " + releaseId);
+            throw new AccessDeniedException("User does not have write access to release : " + releaseId);
         }
 
         long count = 0;
@@ -289,18 +369,35 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             vulnerabilityService.createUpdateDeleteVulnerabilityReleaseRelation(releaseVulnerabilityRelation, user,
                     VulnerabilityOperation.CREATE);
         } else {
-            throw new HttpMessageNotReadableException("Vulnerability Release Relation already exists");
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Vulnerability Release Relation already exists");
         }
         return ResponseEntity.ok().body(releaseVulnerabilityRelation);
     }
 
     @PreAuthorize("hasAuthority('WRITE')")
+    @Operation(
+            summary = "Delete a release vulnerability relation.",
+            description = "Delete a release vulnerability relation.",
+            tags = {"Vulnerabilities"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(mediaType = "application/hal+json",
+                                    schema = @Schema(implementation = ReleaseVulnerabilityRelation.class)),
+                            description = "Updated relation information."
+                    )
+            }
+    )
     @DeleteMapping(value = VULNERABILITIES_URL + "/{externalId}/release/{releaseId}")
-    public ResponseEntity deleteVulnearbilitytoReleasesRealtion(@PathVariable(value = "externalId") String externalId,
-            @PathVariable(value = "releaseId") String releaseId) throws TException {
+    public ResponseEntity deleteVulnearbilitytoReleasesRealtion(
+            @Parameter(description = "The external ID of the vulnerability.")
+            @PathVariable(value = "externalId") String externalId,
+            @Parameter(description = "The release to be unlinked.")
+            @PathVariable(value = "releaseId") String releaseId
+    ) throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         List<MultiStatus> results = new ArrayList<>();
-        String resourceId = new StringBuilder(externalId).append(" - ").append(releaseId).toString();
+        String resourceId = externalId + " - " + releaseId;
 
         if (CommonUtils.isNullEmptyOrWhitespace(externalId) || CommonUtils.isNullEmptyOrWhitespace(releaseId)) {
             results.add(new MultiStatus(resourceId, HttpStatus.BAD_REQUEST));
@@ -385,8 +482,34 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         return releaseList;
     }
 
+    @Operation(
+            summary = "Get vulnerability tracking status for project.",
+            description = "Get vulnerability tracking status for project.",
+            tags = {"Vulnerabilities"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(type = "array",
+                                            example = "[\n" +
+                                                    "{\n" +
+                                                    "  \"releaseId\": \"123\",\n" +
+                                                    "  \"name\": \"releaseName\",\n" +
+                                                    "  \"projectOrigin\": \"projectOrigin\",\n" +
+                                                    "  \"svmTrackingStatus\": \"svmComponentId\",\n" +
+                                                    "  \"shortStatus\": \"svmShortStatus\",\n" +
+                                                    "  \"type\": \"OSS\"\n" +
+                                                    "}\n" +
+                                                    "]"
+                                    ))
+                    )
+            }
+    )
     @GetMapping(value = VULNERABILITIES_URL + "/trackingStatus" + "/{projectId}")
-    public ResponseEntity<List<Map<String, String>>> getVulnerabilitiesTrackingStatus(@PathVariable("projectId") String projectId) throws TException {
+    public ResponseEntity<List<Map<String, String>>> getVulnerabilitiesTrackingStatus(
+            @Parameter(description = "The ID of the project to be retrieved.")
+            @PathVariable("projectId") String projectId
+    ) throws TException {
         List<Map<String, String>> result = new ArrayList<>();
         try {
             User user = restControllerHelper.getSw360UserFromAuthentication();


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

1. Add OpenAPI docs for `/vulnerabilities` endpoints.
2. Replace deprecated exception `HttpMessageNotReadableException` with `HttpClientErrorException`.

Continuation of https://github.com/eclipse-sw360/sw360/pull/2071

### Suggest Reviewer
@heliocastro
@KoukiHama
@ag4ums

### How To Test?
* The Swagger UI for the API should be available at http://localhost:8080/resource/api/swagger-ui/index.html
  * Read the documentation for the endpoints.
* OpenAPI JSON file should be available at http://localhost:8080/resource/api-docs

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

**Note:** To be merged after #2200