### PR TITLE
fix(Rest): Allowing search for releases using externalIds

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -318,9 +318,12 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             String[] params = queryString.split("&");
             for (String param : params) {
                 String[] keyValue = param.split("=");
-                if (keyValue.length == 2) {
+                if (keyValue.length >= 1) {
                     String key = keyValue[0];
-                    String value = keyValue[1];
+                    String value = "";
+                    if(!(keyValue.length == 1)) {
+                        value = keyValue[1];
+                    }
                     parameters.add(key, value);
                 }
             }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Modified code such that while listing releases by externalIds using key-value pair, value is not required

- Which issue is this pull request belonging to and how is it solving it? (https://github.com/eclipse-sw360/sw360/issues/2207)


### Suggest Reviewer
@ag4ums 

