### PR TITLE
fix(importCDX): Resolve duplicate release creation during SBOM import

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -572,6 +572,8 @@ public class CycloneDxBOMImporter {
 
                 if (CommonUtils.isNotNullEmptyOrWhitespace(compAddSummary.getId())) {
                     comp.setId(compAddSummary.getId());
+                    String existingCompName = getComponetNameById(comp.getId(), user);
+                    comp.setName(existingCompName);
                 } else {
                     // in case of more than 1 duplicate found, then continue and show error message in UI.
                     log.warn("found multiple components: " + comp.getName());
@@ -963,5 +965,10 @@ public class CycloneDxBOMImporter {
             pckg.setLicenseIds(licenses);
         }
         return pckg;
+    }
+
+    public String getComponetNameById(String id, User user) throws SW360Exception {
+        Component comp = componentDatabaseHandler.getComponent(id, user);
+        return comp.getName();
     }
 }


### PR DESCRIPTION
Now during the SBOM import, If we found a component already exists' s in SW360, then we are going to use the existing component name. After this we will search for the release in sw360 that we want to create using the SBOM, and if we found the release we are going to use the same release.

Closes: #2220 