### PR TITLE
fix(script): Fix incorrect numbering for migration scripts

### DIFF
--- a/scripts/migrations/059_repair_broken_releasevulnerability.py
+++ b/scripts/migrations/059_repair_broken_releasevulnerability.py
@@ -148,7 +148,7 @@ def verify_if_the_relations_exists(release_id, vulnerability_id, result_rows):
 
 
 def run():
-    log_file = open("054_repair_broken_release_vulnerability.log", 'w')
+    log_file = open("059_repair_broken_release_vulnerability.log", 'w')
     print('\nGetting all releases having external Ids')
 
     start_time = time.time()
@@ -188,7 +188,7 @@ def run():
 
     log_file.close()
     print('\n\n------------------------------------------')
-    print('Please check log file "054_repair_broken_release_vulnerability.log" in this directory for details')
+    print('Please check log file "059_repair_broken_release_vulnerability.log" in this directory for details')
     print('------------------------------------------')
 
 

--- a/scripts/migrations/060_migrate_project_dependency_network.py
+++ b/scripts/migrations/060_migrate_project_dependency_network.py
@@ -115,12 +115,12 @@ def run():
 # --------------------------------
 
 def writeLog():
-    logFile = open('056_migrate_project_dependency_network.log', 'w')
+    logFile = open('060_migrate_project_dependency_network.log', 'w')
     json.dump(log, logFile, indent = 4, sort_keys = True)
     logFile.close()
     print ('\n')
     print ('------------------------------------------')
-    print ('Please check log file "056_migrate_project_dependency_network.log" in this directory for details')
+    print ('Please check log file "060_migrate_project_dependency_network.log" in this directory for details')
     print ('------------------------------------------')
 
 

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -108,11 +108,11 @@ To migrate it is recommended to do this in the following order:
 
 ### 17.0.0 -> 17.0.1
 
-- `054_repair_broken_releasevulnerability.py`
+- `059_repair_broken_releasevulnerability.py`
 
 ### 17.0.1 -> 18.0.0
 
-- `056_migrate_project_dependency_network.py`
+- `060_migrate_project_dependency_network.py`
 
 ## Optional usage
 - `009_overwrite_release_name_with_component_name.py`


### PR DESCRIPTION
### Issue:
The numbering of migration scripts is duplicated: duplicate 054 and 056 files

### Fix:

- **Renumbering scripts:**
     056_migrate_project_dependency_network.py -> 060_migrate_project_dependency_network.py
     054_repair_broken_releasevulnerability.py -> 059_repair_broken_releasevulnerability.py

-  **Correct file name in README.md file** 
 
 

