### PR TITLE
fix(rest): Unable to import the data for SPDX and OSADL.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -254,11 +254,15 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/import/SPDX", method = RequestMethod.POST)
+    @RequestMapping(value = LICENSES_URL + "/import/SPDX", method = RequestMethod.GET)
     public ResponseEntity importSPDX() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        licenseService.importSpdxInformation(sw360User);
-        return new ResponseEntity<>(HttpStatus.OK);
+        RequestSummary requestSummary = licenseService.importSpdxInformation(sw360User);
+        requestSummary.setMessage("SPDX license has imported successfully");
+        requestSummary.unsetTotalAffectedElements();
+        requestSummary.unsetTotalElements();
+        HttpStatus status = HttpStatus.OK;
+        return new ResponseEntity<>(requestSummary,status);
     }
 
     @Operation(
@@ -309,7 +313,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "Import OSADL information.",
             tags = {"Licenses"}
     )
-    @RequestMapping(value = LICENSES_URL + "/import/OSADL", method = RequestMethod.POST)
+    @RequestMapping(value = LICENSES_URL + "/import/OSADL", method = RequestMethod.GET)
     public ResponseEntity<RequestSummary> importOsadlInfo() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary=licenseService.importOsadlInformation(sw360User);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -193,10 +193,11 @@ public class Sw360LicenseService {
         TProtocol protocol = new TCompactProtocol(thriftClient);
         return new LicenseService.Client(protocol);
     }
-    public void importSpdxInformation(User sw360User) throws TException {
+    public RequestSummary importSpdxInformation(User sw360User) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             RequestSummary allSPDXLicenseStatus = sw360LicenseClient.importAllSpdxLicenses(sw360User);
+            return allSPDXLicenseStatus;
         } else {
             throw new HttpMessageNotReadableException("Unable to import All Spdx license. User is not admin");
         }
@@ -258,7 +259,7 @@ public class Sw360LicenseService {
 
     public RequestSummary importOsadlInformation(User sw360User) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
-        if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+        if (sw360LicenseClient != null && PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             RequestSummary osdlLicenseStatus = sw360LicenseClient.importAllOSADLLicenses(sw360User);
             return osdlLicenseStatus;
         } else {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -121,7 +121,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         given(this.licenseServiceMock.updateLicense(any(),any())).willReturn(RequestStatus.SUCCESS);
         Mockito.doNothing().when(licenseServiceMock).deleteLicenseById(any(), any());
         Mockito.doNothing().when(licenseServiceMock).deleteAllLicenseInfo(any());
-        Mockito.doNothing().when(licenseServiceMock).importSpdxInformation(any());
+        given(this.licenseServiceMock.importSpdxInformation(any())).willReturn(requestSummary);
         Mockito.doNothing().when(licenseServiceMock).getDownloadLicenseArchive(any(), any(), any());
         Mockito.doNothing().when(licenseServiceMock).uploadLicense(any(), any(), anyBoolean(), anyBoolean());
         given(this.licenseServiceMock.importOsadlInformation(any())).willReturn(requestSummary);
@@ -319,7 +319,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
     @Test
     public void should_document_import_spdx_info() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(post("/api/licenses/" + "/import/SPDX")
+        mockMvc.perform(get("/api/licenses/" + "/import/SPDX")
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk());
@@ -339,7 +339,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
     @Test   		
     public void should_document_import_osadl_info() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(post("/api/licenses/import/OSADL")
+        mockMvc.perform(get("/api/licenses/import/OSADL")
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk());


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2232 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
http://localhost:8080/resource/api/licenses/import/SPDX   And   /OSADL

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
