### PR TITLE
fix(docker): Remove deletion that invalidate image

### DIFF
--- a/.github/actions/clean_up_package_registry/clean_up_package_registry.py
+++ b/.github/actions/clean_up_package_registry/clean_up_package_registry.py
@@ -22,7 +22,7 @@ from rich import print
 """
 
 dry_run: bool = True if os.getenv("INPUT_DRY_RUN") == "true" else False
-keep = int(os.getenv("INPUT_KEEP"))
+keep = int(os.getenv("INPUT_KEEP")) if os.getenv("INPUT_KEEP") else 5
 org = os.getenv("GITHUB_REPOSITORY_OWNER")
 packages = os.getenv("INPUT_PACKAGES").split("\n")
 token = os.getenv("INPUT_TOKEN")

--- a/.github/workflows/clean_up_package_registry.yml
+++ b/.github/workflows/clean_up_package_registry.yml
@@ -26,8 +26,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           packages: |-
-            sw360/thrift
-            sw360/clucene
-            sw360/base
-            sw360/binaries
             sw360


### PR DESCRIPTION
A logic flaw due to a lack of information was also introduced when the cleanup packages workflow was introduced.
Images on ghcr do not contain the layers info in their API, which leads to being unable to restrict the deletion of nonchanged layers for a long time.
This is especially valid for base, clucene, and thrift layers. The unattended removal of old layers makes the main image (sw360) not reachable with the error of manifest unknown.

Reference issue: https://github.com/eclipse-sw360/sw360/issues/2240