### PR TITLE
Feat(User): Create new endpoints to Create/Revoke/List rest API token for users

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/users.adoc
+++ b/rest/resource-server/src/docs/asciidoc/users.adoc
@@ -100,3 +100,40 @@ include::{snippets}/should_document_update_user_profile/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_update_user_profile/http-response.adoc[]
+
+[[resources-user-token-get]]
+==== List all of rest api tokens of current user.
+
+A `GET` request will list all of rest api tokens of current user.
+
+===== Response structure
+include::{snippets}/should_document_list_all_user_tokens/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_list_all_user_tokens/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_list_all_user_tokens/http-response.adoc[]
+
+
+[[resources-user-token-create]]
+==== Create a new rest api token for current user.
+
+A `POST` request will create a new rest api token for current user.
+
+===== Example request
+include::{snippets}/should_document_create_user_token/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_create_user_token/http-response.adoc[]
+
+[[resources-user-token-delete]]
+==== Delete rest api token for current user by token's name.
+
+A `DELETE` request will delete rest api token for current user by token's name
+
+===== Example request
+include::{snippets}/should_document_revoke_user_token/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_revoke_user_token/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -61,6 +61,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     public static final String API_TOKEN_HASH_SALT;
     public static final String API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
     public static final String API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS;
+    public static final UserGroup API_WRITE_ACCESS_USERGROUP;
     public static final Set<String> DOMAIN;
     public static final String REPORT_FILENAME_MAPPING;
     public static final String JWKS_ISSUER_URL;
@@ -80,6 +81,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
         API_TOKEN_MAX_VALIDITY_READ_IN_DAYS = props.getProperty("rest.apitoken.read.validity.days", "90");
         API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS = props.getProperty("rest.apitoken.write.validity.days", "30");
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
+        API_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", UserGroup.ADMIN.name()));
         DOMAIN = CommonUtils.splitToSet(props.getProperty("domain",
                 "Application Software, Documentation, Embedded Software, Hardware, Test and Diagnostics"));
         REPORT_FILENAME_MAPPING = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templatemapping", "");

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -44,6 +44,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectDTO;
 import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
+import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
@@ -119,6 +120,7 @@ public class JacksonCustomizations {
             setMixInAnnotation(EmbeddedProjectDTO.class, Sw360Module.EmbeddedProjectDTOMixin.class);
             setMixInAnnotation(ReleaseNode.class, Sw360Module.ReleaseNodeMixin.class);
             setMixInAnnotation(RestrictedResource.class, Sw360Module.RestrictedResourceMixin.class);
+            setMixInAnnotation(RestApiToken.class, Sw360Module.RestApiTokenMixin.class);
 
             // Make spring doc aware of the mixin(s)
             SpringDocUtils.getConfig()
@@ -2211,6 +2213,20 @@ public class JacksonCustomizations {
                 "setComponents"
         })
         public abstract static class RestrictedResourceMixin extends RestrictedResource {
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties({
+                "setName",
+                "setCreatedOn",
+                "setToken",
+                "setNumberOfDaysValid",
+                "authoritiesIterator",
+                "authoritiesSize",
+                "setAuthorities",
+                "token"
+        })
+        public abstract static class RestApiTokenMixin extends RestApiToken {
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?:
1. Create endpoint to list all user's tokens.
2. Create endpoint to create new user's token.
3. Create endpoint to revoke user's token by its name.

### How To Test?
**1. Endpoint to list all user's tokens**

#### Procedure:
- Send GET request to http://localhost:8080/resource/api/users/tokens
#### Expected:
- Response will list all Rest API token of the requesting user. (Status code 200).

**2. Endpoint to create new user's token**

#### Procedure:
- Send POST request to http://localhost:8080/resource/api/users/tokens with request body:

```
{
  "name" : "MyToken3",
  "expirationDate" : "2023-12-29",
  "authorities" : ["READ", "WRITE"]
}
```

#### Expected:
- Response will contain created token. (Status code 201).
- A new Rest API token will be created for requesting user.
- You can use this created token to authenticate API request by setting Authorization header in this format: **Token {created_token}**


**3. Endpoint to revoke user's token by name**

#### Procedure:
- Send DELETE request to http://localhost:8080/resource/api/users/tokens?name={token_name}:

#### Expected:
- Token will be revoked from requesting user.


Refer to user Rest API doc (http://localhost:8080/resource/docs/api-guide.html#resources-users) for more information.
