### PR TITLE
feat(license): Fix Update License when checked field is false

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -159,6 +159,9 @@ public class RestControllerHelper<T> {
     private static final double MIN_CVSS = 0;
     private static final double MAX_CVSS = 10;
     public static final String PAGINATION_PARAM_PAGE_ENTRIES = "page_entries";
+
+    @NonNull
+    private final com.fasterxml.jackson.databind.Module sw360Module;
     public static final ImmutableSet<ProjectReleaseRelationship._Fields> SET_OF_PROJECTRELEASERELATION_FIELDS_TO_IGNORE = ImmutableSet
             .of(ProjectReleaseRelationship._Fields.CREATED_ON, ProjectReleaseRelationship._Fields.CREATED_BY);
 
@@ -667,6 +670,17 @@ public class RestControllerHelper<T> {
             }
         }
         return releaseToUpdate;
+    }
+
+    public License convertLicenseFromRequest(Map<String, Object> reqBodyMap, License licenseUpdate) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.registerModule(sw360Module);
+        License licenseRequestBody = mapper.convertValue(reqBodyMap, License.class);
+        if (null == reqBodyMap.get("checked") && !licenseUpdate.isChecked()) {
+            licenseRequestBody.setChecked(false);
+        }
+        return licenseRequestBody;
     }
 
     private void isLicenseValid(Set<String> licenses) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -148,9 +149,10 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     @RequestMapping(value = LICENSES_URL+ "/{id}", method = RequestMethod.PATCH)
     public ResponseEntity<EntityModel<License>> updateLicense(
             @PathVariable("id") String id,
-            @RequestBody License licenseRequestBody) throws TException {
+            @RequestBody Map<String, Object> reqBodyMap) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         License licenseUpdate = licenseService.getLicenseById(id);
+        License licenseRequestBody = restControllerHelper.convertLicenseFromRequest(reqBodyMap, licenseUpdate);
         if (licenseUpdate.isChecked() && !licenseRequestBody.isChecked()) {
             return new ResponseEntity("Reject license update due to: an already checked license is not allowed to become unchecked again", HttpStatus.METHOD_NOT_ALLOWED);
         }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Issue: #2251

### How To Test?
- Checked ```Apache-2.0``` of license is ```false``` 
- Run command line: 
```
$ curl 'https://sw360.org/api/licenses/Apache-2.0' -i -X PATCH \
    -H 'Content-Type: application/hal+json' \
    -H 'Authorization: BearereyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsic3czNjAtUkVTVC1BUEkiXSwidXNlcl9uYW1lIjoiYWRtaW5Ac3czNjAub3JnIiwic2NvcGUiOlsiYWxsIl0sImV4cCI6MTY5OTQxOTQ0OSwiYXV0aG9yaXRpZXMiOlsiUkVBRCIsIldSSVRFIl0sImp0aSI6ImlyaWwxUDF5Rm1uY2kzaThyNlROWFZJemVvTSIsImNsaWVudF9pZCI6InRydXN0ZWQtc3czNjAtY2xpZW50In0.ggC1M326qKTL6WZhGX-oW-Ti8DGYGNO31g10mFxmgoiT9tIYvZOFnalGBECD5ZcmfHwoFx4_FwU6mjHMgd2FKcsvwRAVKryXOLIWkmno5IVPcHFNuSfMiqVSBQ5Hnl2HrpfGDr1tBmd5Mzg3SeffrPSvZnZNrqKDZmiCbWgx-RYL4PF6UDLk9pXOkfcQLrgjASBF7n4ulcK1z9Na12HFBHDPSheLFZa2sTty9TMt2yREgDlJZXx-Vh-F0YeRW66nau99TI3KqCqYtzoGRhqphVloMgg54-OlX0cyt7F9l3sQ0bo9HW7rkMve8TRlvIr266k4AePE2XMVxapCS-qgIw' \
    -H 'Accept: application/hal+json' \
    -d '{
  "note" : "Apache License",
  "fullName" : "Apache License 4.0"
}'

```

- Response:

```
{
  "externalLicenseLink" : "https://spdx.org/licenses/Apache-2.0.html",
  "note" : "Apache License",
  "externalIds" : {
    "Trove" : "License :: OSI Approved :: Apache Software License",
    "SPDX" : "Apache-2.0"
  },
  "additionalData" : {
    "Key" : "Value"
  },
  "OSIApproved" : "NA",
  "FSFLibre" : "NA",
  "text" : "placeholder for the Apache 2.0 license text",
  "checked" : false,
  "shortName" : "Apache 2.0",
  "fullName" : "Apache License 4.0",
  "_links" : {
    "self" : {
      "href" : "https://sw360.org/api/licenses/Apache-2.0"
    }
  }
}

```

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
