### PR TITLE
feat(rest) : Remove mail-request parameter and read from config file while downloading reports.

### DIFF
--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -124,8 +124,10 @@ textForRejectedClearingRequest= your clearing request with id: %s for the projec
 enable.sw360.change.log=false
 sw360changelog.output.path=sw360changelog/sw360changelog
 auto.set.ecc.status=false
-send.project.spreadsheet.export.to.mail.enabled=false
-send.component.spreadsheet.export.to.mail.enabled=false
+
+##This property is used to enable mail request for projects/components report.
+#send.project.spreadsheet.export.to.mail.enabled=false
+#send.component.spreadsheet.export.to.mail.enabled=false
 
 ## This property is used to enable the bulk release deleting feature.
 #bulk.release.deleting.enabled=true

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -123,6 +123,8 @@ public class SW360Constants {
     public static final String SRC_ATTACHMENT_UPLOADER_EMAIL;
     public static final String SRC_ATTACHMENT_DOWNLOAD_LOCATION;
     public static final String PREFERRED_CLEARING_DATE_LIMIT;
+    public static final Boolean MAIL_REQUEST_FOR_PROJECT_REPORT;
+    public static final Boolean MAIL_REQUEST_FOR_COMPONENT_REPORT;
 
     /**
      * Hashmap containing the name field for each type.
@@ -228,6 +230,8 @@ public class SW360Constants {
         SRC_ATTACHMENT_UPLOADER_EMAIL = props.getProperty("source.code.attachment.uploader.email", "");
         SRC_ATTACHMENT_DOWNLOAD_LOCATION = props.getProperty("src.attachment.download.location", "");
         PREFERRED_CLEARING_DATE_LIMIT =  props.getProperty("preferred.clearing.date.limit","");
+        MAIL_REQUEST_FOR_PROJECT_REPORT = Boolean.parseBoolean(props.getProperty("send.project.spreadsheet.export.to.mail.enabled", "false"));
+        MAIL_REQUEST_FOR_COMPONENT_REPORT = Boolean.parseBoolean(props.getProperty("send.component.spreadsheet.export.to.mail.enabled", "false"));
     }
 
     private static Map.Entry<String, String> pair(TFieldIdEnum field, String displayName){

--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -560,20 +560,3 @@ include::{snippets}/should_document_get_component_report/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_get_component_report/http-response.adoc[]
-
-[[resources-components-download-report-mail_req]]
-==== Downloading component report with mail request
-
-A `GET` request help to download the components report with mail request.
-
-===== Request parameter
-include::{snippets}/should_document_get_component_report_with_mail_req/request-parameters.adoc[]
-
-===== Response structure
-include::{snippets}/should_document_get_component_report_with_mail_req/response-fields.adoc[]
-
-===== Example request
-include::{snippets}/should_document_get_component_report_with_mail_req/curl-request.adoc[]
-
-===== Example response
-include::{snippets}/should_document_get_component_report_with_mail_req/http-response.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -851,27 +851,10 @@ include::{snippets}/should_document_create_summary_administration/http-response.
 [[resources-projects-download-report]]
 ==== Downloading project report
 
-A `GET` request help to download the projects report with mail request false.
-
-===== Request parameter
-include::{snippets}/should_document_get_project_report_without_mail_req/request-parameters.adoc[]
-
-===== Example request
-include::{snippets}/should_document_get_project_report_without_mail_req/curl-request.adoc[]
-
-===== Example response
-include::{snippets}/should_document_get_project_report_without_mail_req/http-response.adoc[]
-
-[[resources-projects-download-report-mail-request]]
-==== Downloading project report with mail request
-
-A `GET` request help to download the projects report with mail request true.
+A `GET` request help to download the projects report.
 
 ===== Request parameter
 include::{snippets}/should_document_get_project_report/request-parameters.adoc[]
-
-===== Response structure
-include::{snippets}/should_document_get_project_report/response-fields.adoc[]
 
 ===== Example request
 include::{snippets}/should_document_get_project_report/curl-request.adoc[]
@@ -932,28 +915,10 @@ include::{snippets}/should_document_update_project_with_network/http-response.ad
 [[resources-projects-download-licenseclearing-report]]
 ==== Downloading project license clearing report
 
-A `GET` request help to download the projects report with mail request false.
-
-===== Request parameter
-include::{snippets}/should_document_get_project_licenseclearing_spreadsheet_without_mail_req/request-parameters.adoc[]
-
-===== Example request
-include::{snippets}/should_document_get_project_licenseclearing_spreadsheet_without_mail_req/curl-request.adoc[]
-
-===== Example response
-include::{snippets}/should_document_get_project_licenseclearing_spreadsheet_without_mail_req/http-response.adoc[]
-
-
-[[resources-projects-download-licenseclearing-report-mail-request]]
-==== Downloading project license clearing report with mail request
-
-A `GET` request help to download the projects report with mail request true.
+A `GET` request help to download project license clearing report.
 
 ===== Request parameter
 include::{snippets}/should_document_get_project_licenseclearing_spreadsheet/request-parameters.adoc[]
-
-===== Response structure
-include::{snippets}/should_document_get_project_licenseclearing_spreadsheet/response-fields.adoc[]
 
 ===== Example request
 include::{snippets}/should_document_get_project_licenseclearing_spreadsheet/curl-request.adoc[]
@@ -977,3 +942,4 @@ include::{snippets}/should_document_create_clearing_request/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_create_clearing_request/http-response.adoc[]
+

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -22,6 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -79,8 +82,6 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "withlinkedreleases", required = false, defaultValue = "false") boolean withLinkedReleases,
             @Parameter(description = "Report download format.", schema = @Schema(allowableValues = {"xls", "xlsx"}))
             @RequestParam(value = "mimetype", required = false, defaultValue = "xlsx") String mimeType,
-            @Parameter(description = "Downloading project report required mail link.")
-            @RequestParam(value = "mailrequest", required = false, defaultValue = "false") boolean mailRequest,
             @Parameter(description = "Project id.")
             @RequestParam(value = "projectId", required = false) String projectId,
             @Parameter(description = "Module name.", schema = @Schema(allowableValues = {PROJECTS, COMPONENTS}))
@@ -93,17 +94,19 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         try {
             if (validateMimeType(mimeType)) {
                 switch (module) {
-                    case PROJECTS:
-                        getProjectReports(withLinkedReleases, mailRequest, response, request, sw360User, module, projectId);
-                        break;
-                    case COMPONENTS:
-                        getComponentsReports(withLinkedReleases, mailRequest, response, request, sw360User, module);
-                        break;
-                    case LICENSES:
-                        getLicensesReports(response, sw360User, module);
-                        break;
-                    default:
-                        break;
+                case PROJECTS:
+                    getProjectReports(withLinkedReleases, SW360Constants.MAIL_REQUEST_FOR_PROJECT_REPORT, response,
+                            request, sw360User, module, projectId);
+                    break;
+                case COMPONENTS:
+                    getComponentsReports(withLinkedReleases, SW360Constants.MAIL_REQUEST_FOR_COMPONENT_REPORT, response,
+                            request, sw360User, module);
+                    break;
+                case LICENSES:
+                    getLicensesReports(response, sw360User, module);
+                    break;
+                default:
+                    break;
                 }
             } else {
                 throw new TException("Error : Mimetype either should be : xls/xlsx");
@@ -119,7 +122,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             if (mailRequest) {
                 sw360ReportService.getUploadedProjectPath(sw360User, withLinkedReleases,getBaseUrl(request), projectId);
                 JsonObject responseJson = new JsonObject();
-                responseJson.addProperty("response", "Project report download link will get send to the end user.");
+                responseJson.addProperty("response", "The downloaded report link will be send to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
                 downloadExcelReport(withLinkedReleases, response, sw360User, module, projectId);
@@ -210,6 +213,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     )
     @GetMapping(value = REPORTS_URL + "/download")
     public void downloadExcel(
+            HttpServletRequest request,
             HttpServletResponse response,
             @Parameter(description = "Module name.", schema = @Schema(allowableValues = {PROJECTS, COMPONENTS}))
             @RequestParam(value = "module", required = true) String module,
@@ -218,9 +222,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @Parameter(description = "Extended by releases.")
             @RequestParam(value = "extendedByReleases", required = false, defaultValue = "false") boolean extendedByReleases
     ) throws TException {
-        final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        User user = restControllerHelper.getUserByEmail(sw360User.getEmail());
-        String fileConstant = module+"-%s.xlsx";
+        final User user = restControllerHelper.getUserByEmail(request.getParameter("user"));
         try {
             ByteBuffer buffer = null;
             switch (module) {
@@ -239,9 +241,16 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             if (null == buffer) {
                 throw new TException("No data available for the user " + user.getEmail());
             }
-            String filename = String.format(fileConstant, SW360Utils.getCreatedOn());
+            String fileName;
+            if(module.equals(LICENSES)) {
+                fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
+            } else if(module.equals(PROJECTS)) {
+                fileName = sw360ReportService.getDocumentName(user, request.getParameter("projectId"));
+            }else {
+                fileName = sw360ReportService.getDocumentName(user, null);
+            }
             response.setContentType(CONTENT_TYPE);
-            response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
+            response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", fileName));
             copyDataStreamToResponse(response, buffer);
         } catch (Exception e) {
             throw new TException(e.getMessage());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -96,6 +96,7 @@ public class ResourceServerConfiguration extends WebSecurityConfigurerAdapter im
                 .antMatchers(HttpMethod.GET, "/health").permitAll()
                 .antMatchers(HttpMethod.GET, "/info").hasAuthority("WRITE")
                 .antMatchers(HttpMethod.GET, "/api").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/reports/download").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/**").hasAuthority("READ")
                 .antMatchers(HttpMethod.POST, "/api/**").hasAuthority("WRITE")
                 .antMatchers(HttpMethod.PUT, "/api/**").hasAuthority("WRITE")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -1355,7 +1355,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         .header("Authorization", "Bearer " + accessToken)
                         .param("withlinkedreleases", "true")
                         .param("mimetype", "xlsx")
-                        .param("mailrequest", "false")
                         .param("module", "components")
                         .accept(MediaTypes.HAL_JSON))
              .andExpect(status().isOk())
@@ -1363,31 +1362,8 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                      requestParameters(
                              parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
                              parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
-                             parameterWithName("mailrequest").description("Downloading project report requirted mail link. Possible values are `<true|false>`"),
                              parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`")
                      )));
     }
 
-    @Test
-    public void should_document_get_component_report_with_mail_req() throws Exception{
-        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(get("/api/reports")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .param("withlinkedreleases", "true")
-                        .param("mimetype", "xlsx")
-                        .param("mailrequest", "true")
-                        .param("module", "components")
-                        .accept(MediaTypes.HAL_JSON))
-             .andExpect(status().isOk())
-             .andDo(this.documentationHandler.document(
-                     requestParameters(
-                             parameterWithName("withlinkedreleases").description("components with linked releases. Possible values are `<true|false>`"),
-                             parameterWithName("mimetype").description("components download format. Possible values are `<xls|xlsx>`"),
-                             parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
-                             parameterWithName("mailrequest").description("Downloading components report requirted mail link. Possible values are `<true|false>`")
-                     ),responseFields(
-                             subsectionWithPath("response").description("The response message displayed").optional()
-                             )
-                     ));
-    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -541,6 +541,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         RequestSummary requestSummaryForCycloneDX = new RequestSummary();
         requestSummaryForCycloneDX.setMessage("{\"projectId\":\"" + cycloneDXProject.getId() + "\"}");
+        
+        String projectName="project_name_version_createdOn.xlsx";
 
         AddDocumentRequestSummary requestSummaryForCR = new AddDocumentRequestSummary();
         requestSummaryForCR.setMessage("Clearing request created successfully");
@@ -552,6 +554,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         given(this.projectServiceMock.importSPDX(any(),any())).willReturn(requestSummaryForSPDX);
         given(this.projectServiceMock.importCycloneDX(any(),any(),any())).willReturn(requestSummaryForCycloneDX);
+        given(this.sw360ReportServiceMock.getDocumentName(any(), any())).willReturn(projectName);
         given(this.sw360ReportServiceMock.getProjectBuffer(any(),anyBoolean(),any())).willReturn(ByteBuffer.allocate(10000));
         given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(projectList);
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), any())).willReturn(project);
@@ -2270,46 +2273,21 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
-    public void should_document_get_project_report() throws Exception{
+    public void should_document_get_project_report() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(get("/api/reports")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .param("withlinkedreleases", "true")
-                        .param("mimetype", "xlsx")
-                        .param("mailrequest", "true")
-                        .param("module", "projects")
-                        .accept(MediaTypes.HAL_JSON))
+        mockMvc.perform(get("/api/reports").
+                header("Authorization", "Bearer " + accessToken)
+                .param("withlinkedreleases", "true")
+                .param("mimetype", "xlsx")
+                .param("module", "projects")
+                .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        requestParameters(
-                                parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
-                                parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
-                                parameterWithName("mailrequest").description("Downloading project report requirted mail link. Possible values are `<true|false>`"),
-                                parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`")
-                        ),responseFields(
-                                subsectionWithPath("response").description("The response message displayed").optional()
-                                )
-                        ));
-    }
-
-    @Test
-    public void should_document_get_project_report_without_mail_req() throws Exception {
-        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(get("/api/reports")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .param("withlinkedreleases", "true")
-                        .param("mimetype", "xlsx")
-                        .param("mailrequest", "false")
-                        .param("module", "projects")
-                        .accept("application/xhtml+xml"))
-                .andExpect(status().isOk())
-                .andDo(this.documentationHandler.document(
-                        requestParameters(
-                                parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
-                                parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
-                                parameterWithName("mailrequest").description("Downloading project report requirted mail link. Possible values are `<true|false>`"),
-                                parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`")
-                        )));
+                      requestParameters(
+                        parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
+                        parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
+                        parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"))
+                      ));
     }
 
     @Test
@@ -2319,7 +2297,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         .header("Authorization", "Bearer " + accessToken)
                         .param("withlinkedreleases", "true")
                         .param("mimetype", "xlsx")
-                        .param("mailrequest", "true")
                         .param("module", "projects")
                         .param("projectId", project.getId())
                         .accept(MediaTypes.HAL_JSON))
@@ -2328,35 +2305,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         requestParameters(
                                 parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
                                 parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
-                                parameterWithName("mailrequest").description("Downloading project report requirted mail link. Possible values are `<true|false>`"),
                                 parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
-                                parameterWithName("projectId").description("Id of a project")
-                        ),responseFields(
-                                subsectionWithPath("response").description("The response message displayed").optional()
-                                )
+                                parameterWithName("projectId").description("Id of a project"))
                         ));
-    }
-
-    @Test
-    public void should_document_get_project_licenseclearing_spreadsheet_without_mail_req() throws Exception{
-        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(get("/api/reports")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .param("withlinkedreleases", "true")
-                        .param("mimetype", "xlsx")
-                        .param("mailrequest", "false")
-                        .param("module", "projects")
-                        .param("projectId", project.getId())
-                        .accept("application/xhtml+xml"))
-                .andExpect(status().isOk())
-                .andDo(this.documentationHandler.document(
-                        requestParameters(
-                                parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
-                                parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
-                                parameterWithName("mailrequest").description("Downloading project report requirted mail link. Possible values are `<true|false>`"),
-                                parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
-                                parameterWithName("projectId").description("Id of a project")
-                        )));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 
Closes #2256 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
URL : 
http://localhost:8080/resource/api/reports?withlinkedreleases=false&module=projects&projectId=bf1570a235414de486eb1043d4b0c0a8

Response : 
After send and download report should get downloaded.


> Have you implemented any additional tests?
No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
