### PR TITLE
fix(rest): error handling when user dont have sufficient import permission

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1518,6 +1518,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             if (requestSummary.getRequestStatus() == RequestStatus.FAILURE) {
                 return new ResponseEntity<String>(requestSummary.getMessage(), HttpStatus.BAD_REQUEST);
             }
+            else if(requestSummary.getRequestStatus() == RequestStatus.ACCESS_DENIED){
+                return new ResponseEntity<String>("You do not have sufficient permissions.", HttpStatus.UNAUTHORIZED);
+            }
+
             String jsonMessage = requestSummary.getMessage();
             messageMap = new Gson().fromJson(jsonMessage, Map.class);
             projectId = messageMap.get("projectId");


### PR DESCRIPTION
Additional, if else condition has been added in code to handle the case when user try to import the SBOM and lacks import permission.

![import_error](https://github.com/eclipse-sw360/sw360/assets/141239852/228c546e-d41d-4db4-bd0b-aab9fd8925ab)

Closes: #2126 
