### PR TITLE
feat(CR): Disable Clearing Request creation for the projects which have linked releases without SRC type attachment

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -3025,6 +3025,22 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         getReleaseNodes(dependencyNetwork, user);
         return Collections.singletonList(dependencyNetwork);
     }
+    
+    public List<Release> releasesWithoutSRC(String id, User user) throws TException{
+    	ProjectService.Iface projectClient = new ThriftClients().makeProjectClient();
+    	Project project = projectClient.getProjectById(id, user);
+    	List<Release> releasesWithoutSRC = new ArrayList<>();
+    	Map<String, ProjectReleaseRelationship> releaseIdToUsage = project.getReleaseIdToUsage();
+    	List<String> releaseIdsList = new ArrayList<>(releaseIdToUsage.keySet());
+    	List<Release> releaseObjects = getReleaseByIds(releaseIdsList);
+    	for (Release release : releaseObjects) {
+    		Set<Attachment> srcAttachments = getSourceAttachments(release.id);
+            if(srcAttachments.size() == 0){
+                releasesWithoutSRC.add(release);
+            }
+    	}
+    	return releasesWithoutSRC;
+    }
 
     private ReleaseNode getReleaseNodes(ReleaseNode releaseNode, User user) {
         Release releaseById = null;

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -198,6 +198,7 @@ clearing.expert=Clearing Expert
 clearing.progress=Clearing Progress
 clearing.report=Clearing Report
 clearing.request=Clearing Request
+one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=Clearing request already present for project
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=Clearing request comments

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -197,6 +197,7 @@ clearing.expert=クリアリングエキスパート
 clearing.progress=クリアリングの進捗
 clearing.report=クリアリングレポート
 clearing.request=クリアリングリクエスト
+one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=プロジェクトに既にクリアリングリクエストが存在しています
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=クリアリングリクエストコメント

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -197,6 +197,7 @@ clearing.expert=Clearing Expert
 clearing.progress=Clearing Progress
 clearing.report=Báo cáo dọn dẹp
 clearing.request=Yêu cầu thanh toán bù trừ
+one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=Clearing request already present for project
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=Clearing request comments

--- a/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
@@ -197,6 +197,7 @@ clearing.expert=明确专家
 clearing.progress=明确进度
 clearing.report=明确报告
 clearing.request=明确请求
+one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=项目的明确请求已经存在
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=明确请求注释


### PR DESCRIPTION
Clearing Request will not be created if a project has 1 or more linked releases that do not have **SRC** type attachment, 

Issue: #2259 
Closes: #2259 


### How To Test?
> Create a CR for a project.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
![Capture](https://github.com/eclipse-sw360/sw360/assets/142988587/fb313b82-a2dc-4c7c-b4e7-bb5166b197d9)

