### PR TITLE
feat(rest): Create new Api's to track feedback, reverse svm match and schedule svm sync in schedule tab.

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/schedule.adoc
+++ b/rest/resource-server/src/docs/asciidoc/schedule.adoc
@@ -90,3 +90,102 @@ include::{snippets}/should_document_schedule_cve_search/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_schedule_cve_search/http-response.adoc[]
+
+[[schedule-svmsync]]
+==== Schedule svm sync for user.
+
+A `POST` request will schedule svm sync for user.
+
+===== Example request
+include::{snippets}/should_document_schedule_svm_sync/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_schedule_svm_sync/http-response.adoc[]
+
+[[unschedule-svmSync]]
+==== Cancel schedule svm sync for user.
+
+A `DELETE` request will cancel schedule svm sync for user.
+
+===== Example request
+include::{snippets}/should_document_cancel_schedule_svm_sync/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_cancel_schedule_svm_sync/http-response.adoc[]
+
+[[reverse-svmmatch]]
+==== Svm reverse match for user.
+
+A `POST` request will reverse svm match.
+
+===== Example request
+include::{snippets}/should_document_reverse_svm_match/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_reverse_svm_match/http-response.adoc[]
+
+[[unschedule-reversematch]]
+==== Cancel reverse match for user.
+
+A `DELETE` request will cancel the reverse match.
+
+===== Example request
+include::{snippets}/should_document_cancel_reverse_match/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_cancel_reverse_match/http-response.adoc[]
+
+[[tracking-feedback]]
+==== Tracking feedback for user.
+
+A `POST` request will track the user feedback.
+
+===== Example request
+include::{snippets}/should_document_track_feedback/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_track_feedback/http-response.adoc[]
+
+[[monitoring-listUpdate]]
+==== Monitoring a svm list Update.
+
+A `POST` request will update svm list.
+
+===== Example request
+include::{snippets}/should_document_svm_list_update/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_svm_list_update/http-response.adoc[]
+
+[[cancel-monitoringlist]]
+==== Cancel monitoring svm list and update.
+
+A `DELETE` request will cancel the monitoring svm list and update.
+
+===== Example request
+include::{snippets}/should_document_cancel_monitoring_svm_list/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_cancel_monitoring_svm_list/http-response.adoc[]
+
+[[src-upload]]
+==== Source attachment upload service.
+
+A `POST` request will upload the source attachment.
+
+===== Example request
+include::{snippets}/should_document_src_upload/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_src_upload/http-response.adoc[]
+
+[[cancel-srcupload]]
+==== Cancel source attachment upload service.
+
+A `DELETE` request will cancel the src upload.
+
+===== Example request
+include::{snippets}/should_document_cancel_monitoring_cancel_svm_list/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_cancel_monitoring_cancel_svm_list/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -15,9 +15,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -25,6 +25,8 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,7 +51,6 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
 
     @NonNull
     private Sw360ScheduleService scheduleService;
-
 
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
@@ -88,9 +89,17 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                                     example = "SUCCESS")))
     })
     @PostMapping(SCHEDULE_URL + "/cveService")
-    public ResponseEntity<?> scheduleCve()throws TException {
+    public ResponseEntity<?> scheduleCve() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = scheduleService.scheduleCveSearch(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestSummary, status);
+    }
+        
+    @RequestMapping(value = SCHEDULE_URL + "/scheduleSvmSync", method = RequestMethod.POST)
+    public ResponseEntity<?> scheduleSvmSync()throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary requestSummary = scheduleService.svmSync(sw360User);
         HttpStatus status = HttpStatus.ACCEPTED;
         return new ResponseEntity<>(requestSummary, status);
     }
@@ -107,9 +116,16 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                                     example = "SUCCESS")))
     })
     @PostMapping(SCHEDULE_URL + "/unscheduleCve")
-    public ResponseEntity<?> unscheduleCveSearch()throws TException {
+    public ResponseEntity<?> unscheduleCveSearch() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus requestStatus = scheduleService.cancelCveSearch(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestStatus, status);
+    }
+    @RequestMapping(value = SCHEDULE_URL + "/unscheduleSvmSync", method = RequestMethod.DELETE)
+    public ResponseEntity<?> unscheduleSvmSync() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus requestStatus = scheduleService.cancelSvmSync(sw360User);
         HttpStatus status = HttpStatus.ACCEPTED;
         return new ResponseEntity<>(requestStatus, status);
     }
@@ -126,12 +142,20 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                                     example = "SUCCESS")))
     })
     @PostMapping(SCHEDULE_URL + "/deleteAttachment")
-    public ResponseEntity<?> scheduleDeleteAttachment()throws TException {
+    public ResponseEntity<?> scheduleDeleteAttachment() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = scheduleService.deleteAttachmentService(sw360User);
         HttpStatus status = HttpStatus.ACCEPTED;
         return new ResponseEntity<>(requestSummary, status);
     }
+
+    @RequestMapping(value = SCHEDULE_URL + "/svmReverseMatch", method = RequestMethod.POST)
+    public ResponseEntity<?> svmReverseMatch() throws TException {
+            User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+            RequestSummary requestSummary = scheduleService.scheduleSvmReverseMatch(sw360User);
+            HttpStatus status = HttpStatus.ACCEPTED;
+            return new ResponseEntity<>(requestSummary, status);
+        }
 
     @Operation(
             summary = "Unschedule the attachment deletion service.",
@@ -144,10 +168,19 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                             schema = @Schema(implementation = String.class,
                                     example = "SUCCESS")))
     })
+
     @PostMapping(SCHEDULE_URL + "/unScheduleDeleteAttachment")
     public ResponseEntity<?> unscheduleDeleteAttachment()throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus requestStatus = scheduleService.cancelDeleteAttachment(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestStatus, status);
+    }
+
+    @RequestMapping(value = SCHEDULE_URL + "/unscheduleSvmReverseMatch", method = RequestMethod.DELETE)
+    public ResponseEntity<?> unscheduleSvmReverseMatch()throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus requestStatus = scheduleService.cancelSvmReverseMatch(sw360User);
         HttpStatus status = HttpStatus.ACCEPTED;
         return new ResponseEntity<>(requestStatus, status);
     }
@@ -164,9 +197,33 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                                     example = "SUCCESS")))
     })
     @PostMapping(SCHEDULE_URL + "/cancelAttachmentDeletion")
-    public ResponseEntity<?> attachmentDeleteLocalFS()throws TException {
+    public ResponseEntity<?> attachmentDeleteLocalFS() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus requestStatus = scheduleService.cancelAttachmentDeletionLocalFS(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestStatus, status);
+    }
+
+    @RequestMapping(value = SCHEDULE_URL + "/trackingFeedback", method = RequestMethod.POST)
+    public ResponseEntity<?> svmTrackingFeedback()throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary requestSummary = scheduleService.svmReleaseTrackingFeedback(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestSummary, status);
+    }
+
+    @RequestMapping(value = SCHEDULE_URL + "/monitoringListUpdate", method = RequestMethod.POST)
+    public ResponseEntity<?> monitoringListUpdate()throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary requestSummary = scheduleService.svmMonitoringListUpdate(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestSummary, status);
+    }
+
+    @RequestMapping(value = SCHEDULE_URL + "/cancelMonitoringListUpdate", method = RequestMethod.DELETE)
+    public ResponseEntity<?> cancelMonitoringListUpdate()throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus requestStatus = scheduleService.cancelSvmMonitoringListUpdate(sw360User);
         HttpStatus status = HttpStatus.ACCEPTED;
         return new ResponseEntity<>(requestStatus, status);
     }
@@ -186,6 +243,22 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
     public ResponseEntity<?> cveSearch()throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus requestStatus = scheduleService.triggerCveSearch(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestStatus, status);
+    }
+
+    @RequestMapping(value = SCHEDULE_URL + "/srcUpload", method = RequestMethod.POST)
+    public ResponseEntity<?> srcUpload()throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary requestSummary = scheduleService.triggeSrcUpload(sw360User);
+        HttpStatus status = HttpStatus.ACCEPTED;
+        return new ResponseEntity<>(requestSummary, status);
+    }
+
+    @RequestMapping(value = SCHEDULE_URL + "/cancelSrcUpload", method = RequestMethod.DELETE)
+    public ResponseEntity<?> cancelsrcUpload()throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus requestStatus = scheduleService.unscheduleSrcUpload(sw360User);
         HttpStatus status = HttpStatus.ACCEPTED;
         return new ResponseEntity<>(requestStatus, status);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
@@ -106,6 +106,160 @@ public class Sw360ScheduleService {
     }
 
     public RequestStatus triggerCveSearch(User sw360User) throws TException {
-        return new ThriftClients().makeCvesearchClient().update();
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                ThriftClients thriftClients = new ThriftClients();
+                return thriftClients.makeCvesearchClient().update();
+            } else {
+                throw new AccessDeniedException("User does not have admin access");
+            }
+        } catch (SW360Exception sw360Exp) {
+            if (sw360Exp.getErrorCode() == 403) {
+                throw new AccessDeniedException("User does not have admin access", sw360Exp);
+            } else {
+                throw sw360Exp;
+            }
+        } catch (TException e) {
+            log.error("Error occurred while triggering CVE search: " + e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            log.error("Unexpected error occurred while triggering CVE search: " + e.getMessage());
+            throw new TException("Unexpected error", e);
+        }
+    }
+
+    public RequestSummary svmSync(User sw360User) throws TException {
+        String serviceName = ThriftClients.SVMSYNC_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
+                return requestSummary;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestStatus cancelSvmSync(User sw360User) throws TException {
+        String serviceName = ThriftClients.SVMSYNC_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
+                return requestStatus;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestSummary scheduleSvmReverseMatch(User sw360User) throws TException {
+        String serviceName = ThriftClients.SVMMATCH_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
+                return requestSummary;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestStatus cancelSvmReverseMatch(User sw360User) throws TException {
+        String serviceName = ThriftClients.SVMMATCH_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
+                return requestStatus;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestSummary svmReleaseTrackingFeedback(User sw360User) throws TException {
+        String serviceName = ThriftClients.SVM_TRACKING_FEEDBACK_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);;
+                return requestSummary;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestSummary svmMonitoringListUpdate(User sw360User) throws TException {
+        String serviceName = ThriftClients.SVM_LIST_UPDATE_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
+                return requestSummary;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestStatus cancelSvmMonitoringListUpdate(User sw360User) throws TException {
+        String serviceName = ThriftClients.SVM_LIST_UPDATE_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
+                return requestStatus;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestSummary triggeSrcUpload(User sw360User) throws TException {
+        String serviceName = ThriftClients.SRC_UPLOAD_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
+                return requestSummary;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
+    }
+
+    public RequestStatus unscheduleSrcUpload(User sw360User) throws TException {
+        String serviceName = ThriftClients.SRC_UPLOAD_SERVICE;
+        try {
+            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
+                return requestStatus;
+            } else {
+                throw new AccessDeniedException("User is not admin");
+            }
+        } catch (TException e) {
+            log.error("Error occurred while scheduling service: " + serviceName, e);
+            throw e;
+        }
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
@@ -13,6 +13,9 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -42,7 +45,6 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
     
     @MockBean
     private Sw360ScheduleService scheduleServiceMock;
-    
     private RequestSummary requestSummary = new RequestSummary();
 
     @Before
@@ -60,6 +62,14 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
         given(this.scheduleServiceMock.cancelDeleteAttachment(any())).willReturn(RequestStatus.SUCCESS);
         given(this.scheduleServiceMock.cancelAttachmentDeletionLocalFS(any())).willReturn(RequestStatus.SUCCESS);
         given(this.scheduleServiceMock.triggerCveSearch(any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.cancelSvmSync(any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.cancelSvmReverseMatch(any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.scheduleSvmReverseMatch(any())).willReturn(requestSummary);
+        given(this.scheduleServiceMock.svmReleaseTrackingFeedback(any())).willReturn(requestSummary);
+        given(this.scheduleServiceMock.svmMonitoringListUpdate(any())).willReturn(requestSummary);
+        given(this.scheduleServiceMock.triggeSrcUpload(any())).willReturn(requestSummary);
+        given(this.scheduleServiceMock.cancelSvmMonitoringListUpdate(any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.unscheduleSrcUpload(any())).willReturn(RequestStatus.SUCCESS);
         
     }
 
@@ -74,6 +84,78 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
     @Test
     public void should_document_schedule_cve_service() throws Exception {
         mockMvc.perform(post("/api/schedule/cveService")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_schedule_svm_sync() throws Exception {
+        mockMvc.perform(post("/api/schedule/scheduleSvmSync")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_cancel_schedule_svm_sync() throws Exception {
+        mockMvc.perform(delete("/api/schedule/unscheduleSvmSync")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_reverse_svm_match() throws Exception {
+        mockMvc.perform(post("/api/schedule/svmReverseMatch")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_cancel_reverse_match() throws Exception {
+        mockMvc.perform(delete("/api/schedule/unscheduleSvmReverseMatch")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_track_feedback() throws Exception {
+        mockMvc.perform(post("/api/schedule/trackingFeedback")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_svm_list_update() throws Exception {
+        mockMvc.perform(post("/api/schedule/monitoringListUpdate")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_cancel_monitoring_svm_list() throws Exception {
+        mockMvc.perform(delete("/api/schedule/cancelMonitoringListUpdate")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_src_upload() throws Exception {
+        mockMvc.perform(post("/api/schedule/srcUpload")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_cancel_monitoring_cancel_svm_list() throws Exception {
+        mockMvc.perform(delete("/api/schedule/cancelSrcUpload")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isAccepted());


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #2268 

create new endpoint to schedule svm sync , reverse svm match , track the feedback and cancel services as well.
Note : only admin user can access.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
