### PR TITLE
feat(obligation): endpoint to list license obligations from license db.

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -421,6 +421,20 @@ include::{snippets}/should_document_get_project_releases_ecc_information/http-re
 ===== Links
 include::{snippets}/should_document_get_project_releases_ecc_information/links.adoc[]
 
+[[resources-project-get-license-obligation-information]]
+==== Listing obligations from licenseDB
+
+A `GET` request will get all license obligations from licenseDB.
+
+===== Response structure
+include::{snippets}/should_document_get_obligations_from_license_db/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_obligations_from_license_db/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_obligations_from_license_db/http-response.adoc[]
+
 [[resources-project-get-license-clearing-information-information]]
 ==== Project's license clearing count
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -37,6 +37,7 @@ import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
+import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
@@ -106,6 +107,7 @@ public class JacksonCustomizations {
             setMixInAnnotation(ClearingRequest.class, Sw360Module.ClearingRequestMixin.class);
             setMixInAnnotation(Comment.class, Sw360Module.CommentMixin.class);
             setMixInAnnotation(ProjectReleaseRelationship.class, Sw360Module.ProjectReleaseRelationshipMixin.class);
+            setMixInAnnotation(ObligationStatusInfo.class, Sw360Module.ObligationStatusInfoMixin.class);
             setMixInAnnotation(ReleaseVulnerabilityRelation.class, Sw360Module.ReleaseVulnerabilityRelationMixin.class);
             setMixInAnnotation(VerificationStateInfo.class, Sw360Module.VerificationStateInfoMixin.class);
             setMixInAnnotation(ProjectProjectRelationship.class, Sw360Module.ProjectProjectRelationshipMixin.class);
@@ -156,6 +158,7 @@ public class JacksonCustomizations {
                     .replaceWithClass(ClearingRequest.class, ClearingRequestMixin.class)
                     .replaceWithClass(Comment.class, CommentMixin.class)
                     .replaceWithClass(ProjectReleaseRelationship.class, ProjectReleaseRelationshipMixin.class)
+                    .replaceWithClass(ObligationStatusInfo.class, ObligationStatusInfoMixin.class)
                     .replaceWithClass(ReleaseVulnerabilityRelation.class, ReleaseVulnerabilityRelationMixin.class)
                     .replaceWithClass(VerificationStateInfo.class, VerificationStateInfoMixin.class)
                     .replaceWithClass(ProjectProjectRelationship.class, ProjectProjectRelationshipMixin.class)
@@ -1808,6 +1811,29 @@ public class JacksonCustomizations {
                 "setSpdxId"
         })
         public static abstract class ProjectReleaseRelationshipMixin extends ProjectReleaseRelationship {
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties({
+                "setComment",
+                "setText",
+                "setObligationType",
+                "setObligationLevel",
+                "setModifiedBy",
+                "setModifiedOn",
+                "setId",
+                "setStatus",
+                "setAction",
+                "setLicenseIds",
+                "setReleaseIdToAcceptedCLI",
+                "releaseIdToAcceptedCLISize",
+                "releasesSize",
+                "releasesIterator",
+                "setReleases",
+                "licenseIdsSize",
+                "licenseIdsIterator"
+        })
+        public static abstract class ObligationStatusInfoMixin extends ObligationStatusInfo {
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
Issue: Closes #2275 

Description: get license obligations for the project from license database.

Steps to test:
- create a release and a project to which the release will be linked
- add a CLX attachment to release, having status checked/accepted
- in attachment usages of project enable the license info checkbox for the release(having attachment)
- run the new endpoint to get the list of obligations from the license database
