### PR TITLE
fix division by zero for department scheduler

### DIFF
--- a/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleConstants.java
+++ b/backend/src/src-schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleConstants.java
@@ -62,8 +62,9 @@ public class ScheduleConstants {
     public static final String DELETE_ATTACHMENT_OFFSET_PROPERTY_NAME = "schedule.delete.attachment.firstOffset.seconds";
     public static final String DELETE_ATTACHMENT_INTERVAL_PROPERTY_NAME = "schedule.delete.attachment.interval.seconds";
     public static final String DEPARTMENT_OFFSET_PROPERTY_NAME = "schedule.department.firstOffset.seconds";
-    public static final String DEPARTMENT_INTERVAL_PROPERTY_NAME = "schedule.department.interval.seconds";
     public static final String DEPARTMENT_OFFSET_DEFAULT  = "0" ; // default 00:00 am, in seconds
+    public static final String DEPARTMENT_INTERVAL_PROPERTY_NAME = "schedule.department.interval.seconds";
+    public static final String DEPARTMENT_INTERVAL_DEFAULT  = (24*60*60) + "" ; // default 24h, in seconds
 
     // scheduler properties
     public static final ConcurrentHashMap<String, Integer> SYNC_FIRST_RUN_OFFSET_SEC = new ConcurrentHashMap<>();
@@ -143,7 +144,7 @@ public class ScheduleConstants {
         if(! props.containsKey(DEPARTMENT_INTERVAL_PROPERTY_NAME)){
             log.info("Property "+ DEPARTMENT_INTERVAL_PROPERTY_NAME + " not set. Using default value.");
         }
-        String departmentInterval  = props.getProperty(DEPARTMENT_INTERVAL_PROPERTY_NAME, DEPARTMENT_OFFSET_DEFAULT);
+        String departmentInterval  = props.getProperty(DEPARTMENT_INTERVAL_PROPERTY_NAME, DEPARTMENT_INTERVAL_DEFAULT);
         try {
             SYNC_INTERVAL_SEC.put(ThriftClients.IMPORT_DEPARTMENT_SERVICE, Integer.parseInt(departmentInterval));
         } catch (NumberFormatException nfe){


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

The default value for departmentInterval was causing a division by zero in Scheduler.getNextSyncDate
There is a properties file in the final scheduler jat that is supposed to be read, but this seems also to be broken, so  scheduler is falling back to the default value in the code

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
