### PR TITLE
feat(CR): Create a new Clearing Request state Sanity Check to perform sanity check before accepting a project.

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -1291,6 +1291,7 @@ role=Role
 roles=Roles
 sales.and.delivery.channels=Sales and delivery channels
 sap.design.time.repository.(dtr)=SAP Design Time Repository (DTR)
+sanity.check=Sanity Check
 save=Save
 save.configuration=Save configuration
 saved.attachment.usages=Saved attachment usages.

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1287,6 +1287,7 @@ role=役割
 roles=役割
 sales.and.delivery.channels=販売・配送チャネル
 sap.design.time.repository.(dtr)=SAP Design Time Repository (DTR)
+sanity.check=Sanity Check
 save=保存
 save.configuration=設定の保存
 saved.attachment.usages=保存されたアタッチメントの用途

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -1283,6 +1283,7 @@ risks=Những rủi ro
 role=Vai trò
 roles=Những vai trò
 sales.and.delivery.channels=Kênh bán hàng và chuyển giao	
+sanity.check=Sanity Check
 sap.design.time.repository.(dtr)=Kho lưu trữ thời gian thiết kế của SAP (DTR)
 save=Lưu
 save.configuration=Lưu cấu hình

--- a/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
@@ -1279,6 +1279,7 @@ role=角色
 roles=角色
 sales.and.delivery.channels=销售和交付渠道
 sap.design.time.repository.(dtr)=SAP Design Time Repository (DTR)
+sanity.check=Sanity Check
 save=保存
 save.configuration=保存配置
 saved.attachment.usages=保存附件的用途。

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -334,6 +334,7 @@ public class ThriftEnumUtils {
 
     private static final ImmutableMap<ClearingRequestState, String> MAP_CLEARING_REQUEST_STATE_STRING = ImmutableMap.<ClearingRequestState, String>builder()
             .put(ClearingRequestState.NEW, "New")
+            .put(ClearingRequestState.SANITY_CHECK, "Sanity Check")
             .put(ClearingRequestState.ACCEPTED, "Accepted")
             .put(ClearingRequestState.REJECTED, "Rejected")
             .put(ClearingRequestState.IN_QUEUE, "In Queue")

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -234,6 +234,10 @@ struct Release {
     // information from external data sources
     9: optional  map<string, string> externalIds,
     300: optional map<string, string> additionalData,
+    
+    // Urls for the project
+    70: optional string sourceCodeDownloadurl, // URL for download page for this release source code
+    71: optional string binaryDownloadurl, // URL for download page for this release binaries
 
     // Additional informations
     10: optional set<Attachment> attachments,
@@ -270,9 +274,6 @@ struct Release {
     55: optional EccInformation eccInformation,
     56: optional set<string> softwarePlatforms,
 
-    // Urls for the project
-    70: optional string sourceCodeDownloadurl, // URL for download page for this release source code
-    71: optional string binaryDownloadurl, // URL for download page for this release binaries
 
     80: optional map<string, ReleaseRelationship> releaseIdToRelationship,    //id, comment
     81: optional set<string> packageIds,

--- a/libraries/datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/datahandler/src/main/thrift/sw360.thrift
@@ -71,8 +71,9 @@ enum ClearingRequestState {
     IN_QUEUE = 3,
     IN_PROGRESS = 4,
     CLOSED = 5,
-    AWAITING_RESPONSE = 6
-    ON_HOLD = 7
+    AWAITING_RESPONSE = 6,
+    ON_HOLD = 7,
+    SANITY_CHECK = 8
 }
 
 enum ClearingRequestPriority {

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -67,10 +67,12 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
             .add(VERSION)
             .add(MAIN_LICENSE_IDS)
             .add(OTHER_LICENSE_IDS)
+            .add(SOURCE_CODE_DOWNLOADURL)
             .add(CLEARING_STATE)
             .add(ECC_INFORMATION)
             .add(VENDOR)
             .add(EXTERNAL_IDS)
+            .add(ATTACHMENTS)
             .build();
 
    public static final List<EccInformation._Fields> ECC_IGNORE_FIELDS = ImmutableList.<EccInformation._Fields>builder()
@@ -131,6 +133,9 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
         case ECC_INFORMATION:
             EccInformation.metaDataMap.keySet().stream().filter(f -> !ECC_IGNORE_FIELDS.contains(f))
                     .forEach(f -> headers.add("ECC information: " + f.getFieldName()));
+            break;
+        case ATTACHMENTS:
+            headers.add("SRC/SRS Attachments");
             break;
         default:
             headers.add(displayNameFor(field.getFieldName(), nameToDisplayName));


### PR DESCRIPTION

Clearing Request for a project should have a state **Sanity Check** for the clearing team to make sure that the CR for a project is eligible to be accepted. Clearing admin can change the CR state from `New` to `Sanity Check`. They can navigate to the **License Clearing** tab in the project portlet and select **Export Project with linked releases** option.
![Screenshot from 2024-02-19 12-03-43](https://github.com/eclipse-sw360/sw360/assets/142988587/ce20cf0e-118e-46d4-88eb-a01a8dbd88e4)

This will download an excel file containing all previous info with 2 additional columns:
**Source Code Downloadurl** - contains the Source Code Downloadurl for each linked releases 
**SRC/SRS Attachments** - contains the filenames of SRC and SRS type attachments for each linked release.
Clearing Team can go through this data to make sure CR is eligible to be accepted or not.
![MicrosoftTeams-image (1)](https://github.com/eclipse-sw360/sw360/assets/142988587/3f9049c4-e138-43e0-b746-5592d37f6e8a)

Closes: #2287 
