### PR TITLE
fix(importSBOM): Remove the invalid characters appearing in import summary message for invalid packages list

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -224,12 +224,12 @@ public class CycloneDxBOMImporter {
 
                         String packages = messageMap.get(DUPLICATE_PACKAGE);
                         if (CommonUtils.isNotNullEmptyOrWhitespace(packages)) {
-                            duplicatePackages.addAll(Arrays.asList(packages.split(JOINER)));
+                            duplicatePackages.addAll(Arrays.asList(packages.split("\\|\\|")));
                             packages = "";
                         }
                         packages = messageMap.get(INVALID_PACKAGE);
                         if (CommonUtils.isNotNullEmptyOrWhitespace(packages)) {
-                            invalidPackages.addAll(Arrays.asList(packages.split(JOINER)));
+                            invalidPackages.addAll(Arrays.asList(packages.split("\\|\\|")));
                             packages = "";
                         }
                         Project project = projectDatabaseHandler.getProjectById(projId, user);


### PR DESCRIPTION
Now, the CycloneDX import summary message will correctly display the list of invalid packages.
![correct_rezz](https://github.com/eclipse-sw360/sw360/assets/141239852/c9f52bd0-3138-45a7-a6f2-0281879d8314)

closes: #2341 