### PR TITLE
Revert "feat(CR): Disable Clearing Request creation for the projects which have linked releases without SRC type attachment"

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -3025,22 +3025,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         getReleaseNodes(dependencyNetwork, user);
         return Collections.singletonList(dependencyNetwork);
     }
-    
-    public List<Release> releasesWithoutSRC(String id, User user) throws TException{
-    	ProjectService.Iface projectClient = new ThriftClients().makeProjectClient();
-    	Project project = projectClient.getProjectById(id, user);
-    	List<Release> releasesWithoutSRC = new ArrayList<>();
-    	Map<String, ProjectReleaseRelationship> releaseIdToUsage = project.getReleaseIdToUsage();
-    	List<String> releaseIdsList = new ArrayList<>(releaseIdToUsage.keySet());
-    	List<Release> releaseObjects = getReleaseByIds(releaseIdsList);
-    	for (Release release : releaseObjects) {
-    		Set<Attachment> srcAttachments = getSourceAttachments(release.id);
-            if(srcAttachments.size() == 0){
-                releasesWithoutSRC.add(release);
-            }
-    	}
-    	return releasesWithoutSRC;
-    }
 
     private ReleaseNode getReleaseNodes(ReleaseNode releaseNode, User user) {
         Release releaseById = null;

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -231,15 +231,10 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     // CREATE CLEARING REQUEST //
     /////////////////////////////
 
-    public AddDocumentRequestSummary createClearingRequest(ClearingRequest clearingRequest, User user, String projectUrl) throws TException {
+    public AddDocumentRequestSummary createClearingRequest(ClearingRequest clearingRequest, User user, String projectUrl) throws SW360Exception {
         Project project = getProjectById(clearingRequest.getProjectId(), user);
         AddDocumentRequestSummary requestSummary = new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.FAILURE);
-        int numReleaseWithoutSRC = doAllReleasesHaveSourceAttachment(project.id, user);
-        if(numReleaseWithoutSRC > 0) {
-        	log.error("Failed to create CR as " + numReleaseWithoutSRC + " releases do not have SRC type attachment");
-        	return requestSummary.setMessage("one.or.more.linked.releases.do.not.have.src.type.attachment");
-        }
-        
+
         if (!isWriteActionAllowedOnProject(project, user)) {
             return requestSummary.setMessage("You do not have WRITE access to the project");
         }
@@ -266,11 +261,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             log.error("Cannot create clearing request for closed or private project: " + project.getId());
         }
         return requestSummary.setMessage("Failed to create clearing request");
-    }
-    
-    private int doAllReleasesHaveSourceAttachment(String id, User user) throws TException {
-    	List<Release> releaseWithoutSource = componentDatabaseHandler.releasesWithoutSRC(id, user);
-    	return releaseWithoutSource.size();
     }
 
     private boolean isWriteActionAllowedOnProject(Project project, User user) {

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -198,7 +198,6 @@ clearing.expert=Clearing Expert
 clearing.progress=Clearing Progress
 clearing.report=Clearing Report
 clearing.request=Clearing Request
-one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=Clearing request already present for project
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=Clearing request comments

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -197,7 +197,6 @@ clearing.expert=クリアリングエキスパート
 clearing.progress=クリアリングの進捗
 clearing.report=クリアリングレポート
 clearing.request=クリアリングリクエスト
-one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=プロジェクトに既にクリアリングリクエストが存在しています
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=クリアリングリクエストコメント

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -197,7 +197,6 @@ clearing.expert=Clearing Expert
 clearing.progress=Clearing Progress
 clearing.report=Báo cáo dọn dẹp
 clearing.request=Yêu cầu thanh toán bù trừ
-one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=Clearing request already present for project
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=Clearing request comments

--- a/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
@@ -197,7 +197,6 @@ clearing.expert=明确专家
 clearing.progress=明确进度
 clearing.report=明确报告
 clearing.request=明确请求
-one.or.more.linked.releases.do.not.have.src.type.attachment=One or more linked releases do not have SRC type attachment.
 clearing.request.already.present.for.project=项目的明确请求已经存在
 clearing.request.cannot.be.created.for.project.with.specific.bu.or.closed.or.private.project=Clearing Request cannot be created for project with specific <b>Business unit</b> or <b>CLOSED</b> or <b>PRIVATE</b> project!
 clearing.request.comments=明确请求注释


### PR DESCRIPTION
Reverts eclipse-sw360/sw360#2263

The CR creation should not be blocked if SRS attachment is available, should not check for sources in a COTS component release and only warn (not block creation of CR) if the release is any other clearing state other than NEW and still does not have any source(SRS/SRC) attachment available.

Currently the CR creation feature is not working as expected due to this PR. The above mentioned changes should be considered and a new PR has to be created.
CC: @akshitjoshii 