### PR TITLE
feat(rest): filter releases for attachment usages page in project

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -683,6 +683,9 @@ include::{snippets}/should_document_get_usedbyresource_for_project/http-response
 
 A `GET` request will display all attachmentUsages of the projects.
 
+===== Request parameter
+include::{snippets}/should_document_get_attachment_usage_for_project/request-parameters.adoc[]
+
 ===== Response structure
 include::{snippets}/should_document_get_attachment_usage_for_project/response-fields.adoc[]
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1505,19 +1505,27 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/{id}/attachmentUsage", method = RequestMethod.GET)
-    public ResponseEntity attachmentUsages(@Parameter(description = "Project ID.") @PathVariable("id") String id,  HttpServletRequest request)
-            throws URISyntaxException, TException {
+    public ResponseEntity attachmentUsages(@Parameter(description = "Project ID.") @PathVariable("id") String id,
+            @Parameter(description = "filtering attachmentUsages")
+            @RequestParam(value = "filter", required = false) String filter,
+            @Parameter(description = "Get the transitive releases.")
+            @RequestParam(value = "transitive", required = true) String transitive)
+            throws TException {
 
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Project sw360Project = projectService.getProjectForUserById(id, sw360User);
-        boolean transitive = true;
-        final Set<String> releaseIds = projectService.getReleaseIds(id, sw360User, transitive);
-        List<Release> releases = releaseIds.stream().map(relId -> wrapTException(() -> {
+        boolean isTransitive = Boolean.parseBoolean(transitive);
+        final Set<String> releaseIds = projectService.getReleaseIds(id, sw360User, isTransitive);
+        List<Release> releases = null;
+        if (filter != null) {
+            releases = filterReleases(sw360User, filter, releaseIds);
+        } else {
+            releases = releaseIds.stream().map(relId -> wrapTException(() -> {
                 final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
                 releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
                 return sw360Release;
-        })).collect(Collectors.toList());
-
+            })).collect(Collectors.toList());
+        }
         List<EntityModel<Release>> releaseList = releases.stream().map(sw360Release -> wrapTException(() -> {
                 final Release embeddedRelease = restControllerHelper.convertToEmbeddedReleaseAttachments(sw360Release);
                 final HalResource<Release> releaseResource = restControllerHelper.addEmbeddedReleaseLinks(embeddedRelease);
@@ -1611,6 +1619,83 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 		}
 		return modifiedList;
 	}
+
+    public List<Release> filterReleases(User sw360User, String filter, Set<String> releaseIds) {
+        List<Release> releasesSrc = new ArrayList<>();
+
+        switch (filter) {
+            case "withSourceAttachment":
+                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
+                    final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
+                    releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
+                    List<Attachment> sourceAttachments = sw360Release.getAttachments().stream()
+                        .filter(attachment -> attachment.getAttachmentType() == AttachmentType.SOURCE || attachment.getAttachmentType() == AttachmentType.SOURCE_SELF)
+                        .collect(Collectors.toList());
+                    Set<Attachment> sourceAttachmentsSet = new HashSet<>(sourceAttachments);
+                    sw360Release.setAttachments(sourceAttachmentsSet);
+                    return sourceAttachmentsSet.isEmpty() ? null : sw360Release;
+                }))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+                break;
+            case "withoutSourceAttachment":
+                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
+                    final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
+                    releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
+                    List<Attachment> withoutSourceAttachments = sw360Release.getAttachments().stream()
+                        .filter(attachment -> attachment.getAttachmentType() != AttachmentType.SOURCE && attachment.getAttachmentType() != AttachmentType.SOURCE_SELF)
+                        .collect(Collectors.toList());
+                    Set<Attachment> withoutSourceAttachmentsSet = new HashSet<>(withoutSourceAttachments);
+                    sw360Release.setAttachments(withoutSourceAttachmentsSet);
+                    return withoutSourceAttachmentsSet.isEmpty() ? null : sw360Release;
+                }))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+                break;
+            case "withoutAttachment":
+                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
+                    final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
+                    releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
+                    return sw360Release.getAttachments().isEmpty() ? sw360Release : null;
+                }))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+                break;
+            case "withAttachment":
+                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
+                    final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
+                    releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
+                    return sw360Release.getAttachments().isEmpty() ? null : sw360Release;
+                }))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+                break;
+            case "withCliAttachment":
+                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
+                    final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
+                    releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
+                    List<Attachment> cliAttachments = sw360Release.getAttachments().stream()
+                        .filter(attachment -> attachment.getAttachmentType() == AttachmentType.COMPONENT_LICENSE_INFO_XML)
+                        .collect(Collectors.toList());
+                    Set<Attachment> cliAttachmentsSet = new HashSet<>(cliAttachments);
+                    sw360Release.setAttachments(cliAttachmentsSet);
+                    return cliAttachmentsSet.isEmpty() ? null : sw360Release;
+                }))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+                break;
+            default:
+                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
+                    final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
+                    releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
+                    return sw360Release;
+                }))
+                .collect(Collectors.toList());
+                break;
+        }
+
+        return releasesSrc;
+    }
 
     private HalResource attachmentUsageReleases(Project sw360Project, List<Map<String, Object>> releases, List<Map<String, Object>> attachmentUsageMap)
             throws TException {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -890,13 +890,20 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     public void should_document_get_attachment_usage_for_project() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(get("/api/projects/" + project.getId() + "/attachmentUsage")
-                .header("Authorization", "Bearer " + accessToken).accept(MediaTypes.HAL_JSON))
+                .header("Authorization", "Bearer " + accessToken)
+                .param("transitive", "true")
+                .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
-                .andDo(this.documentationHandler.document(responseFields(
-                        subsectionWithPath("releaseIdToUsage").description("The relationship between linked releases of the project"),
-                        subsectionWithPath("linkedProjects").description("The linked projects"),
-                        subsectionWithPath("_embedded.sw360:release").description("An array of linked releases"),
-                        subsectionWithPath("_embedded.sw360:attachmentUsages").description("An array of project's attachment usages"))));
+                .andDo(this.documentationHandler.document(
+                        requestParameters(
+                                parameterWithName("transitive").description("Get the transitive releases")
+                        ),
+                        responseFields(
+                                subsectionWithPath("releaseIdToUsage").description("The relationship between linked releases of the project"),
+                                subsectionWithPath("linkedProjects").description("The linked projects"),
+                                subsectionWithPath("_embedded.sw360:release").description("An array of linked releases"),
+                                subsectionWithPath("_embedded.sw360:attachmentUsages").description("An array of project's attachment usages")
+                        )));
     }
 
     @Test


### PR DESCRIPTION
Issue: Closes #2356 

### How To Test?
Run the existing attachment usage endpoint with one of the filter options as parameter.
ex. http://localhost:8080/resource/api/projects/df84ec3a9eba4e67a5b8fcf19c3d099e/attachmentUsage?filter=withSourceAttachment&transitive=true

It will return the releases having source type attachments.
