### PR TITLE
fix(Project): Import SPDX as dependency network

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -2837,7 +2837,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
             try (final InputStream inputStream = attachmentStreamConnector.unsafeGetAttachmentStream(attachmentContent)) {
                 final SpdxBOMImporterSink spdxBOMImporterSink = new SpdxBOMImporterSink(user, null, this);
                 final SpdxBOMImporter spdxBOMImporter = new SpdxBOMImporter(spdxBOMImporterSink);
-                return spdxBOMImporter.importSpdxBOMAsRelease(inputStream, attachmentContent);
+                return spdxBOMImporter.importSpdxBOMAsRelease(inputStream, attachmentContent, user);
             }
         } catch (IOException e) {
             throw new SW360Exception(e.getMessage());

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1839,7 +1839,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             try (final InputStream inputStream = attachmentStreamConnector.unsafeGetAttachmentStream(attachmentContent)) {
                 final SpdxBOMImporterSink spdxBOMImporterSink = new SpdxBOMImporterSink(user, this, componentDatabaseHandler);
                 final SpdxBOMImporter spdxBOMImporter = new SpdxBOMImporter(spdxBOMImporterSink);
-                return spdxBOMImporter.importSpdxBOMAsProject(inputStream, attachmentContent);
+                return spdxBOMImporter.importSpdxBOMAsProject(inputStream, attachmentContent, user);
             }
         } catch (IOException e) {
             throw new SW360Exception(e.getMessage());

--- a/backend/common/src/test/java/org/eclipse/sw360/spdx/SpdxBOMImporterTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/spdx/SpdxBOMImporterTest.java
@@ -14,6 +14,7 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,9 @@ public class SpdxBOMImporterTest {
     private SpdxBOMImporterSink spdxBOMImporterSink;
 
     private SpdxBOMImporter spdxBOMImporter;
+
+    @Mock
+    private User user;
 
     @Before
     public void before() throws Exception {
@@ -75,7 +79,7 @@ public class SpdxBOMImporterTest {
 
     @Test
     public void testProject() throws  Exception {
-        final RequestSummary requestSummary = spdxBOMImporter.importSpdxBOMAsProject(inputStream, attachmentContent);
+        final RequestSummary requestSummary = spdxBOMImporter.importSpdxBOMAsProject(inputStream, attachmentContent, user);
         assertNotNull(requestSummary);
 
         verify(spdxBOMImporterSink, times(1)).addProject(ArgumentMatchers.any());
@@ -85,7 +89,7 @@ public class SpdxBOMImporterTest {
 
     @Test
     public void testRelease() throws  Exception {
-        final RequestSummary requestSummary = spdxBOMImporter.importSpdxBOMAsRelease(inputStream, attachmentContent);
+        final RequestSummary requestSummary = spdxBOMImporter.importSpdxBOMAsRelease(inputStream, attachmentContent, user);
         assertNotNull(requestSummary);
 
         verify(spdxBOMImporterSink, times(4)).addComponent(ArgumentMatchers.any());


### PR DESCRIPTION
Issue #2364 (Import SPDX function not working when `enable.flexible.project.release.relationship=true` is enabled)

This PR allows to import SDPX as project's dependency network

### Pre-condition:
Add configuration: `enable.flexible.project.release.relationship=true` to `/etc/sw360/sw360.properties`

### How To Test?
1. Go to Project Page then select import SBOM (SPDX):

![image](https://github.com/eclipse-sw360/sw360/assets/94659621/00e6bf3f-f5e5-4b6c-968b-34eb9ed250b7)

2. Import following file (Unzip this zip file to get SPDX example file) [SPDX_Example.spdx.zip](https://github.com/eclipse-sw360/sw360/files/14612031/SPDX_Example.spdx.zip):

![image](https://github.com/eclipse-sw360/sw360/assets/94659621/a2f78d7f-beac-472c-a553-0b29d895029b)

3. Click **Upload & Import** button, then a new project with name **Project3** will be created:

![image](https://github.com/eclipse-sw360/sw360/assets/94659621/3526792b-33a0-47d1-a888-89b62f019138)

4. Select **License Clearing** tab the tree view will show as below:

![image](https://github.com/eclipse-sw360/sw360/assets/94659621/81d61936-20c4-48bf-b94a-e4d572e4f7f6)
