### PR TITLE
fix(UI): Moderation Request for releases does not show any changes issue fix

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/editRelease.jsp
@@ -69,6 +69,9 @@
 <c:set var="hasWritePermissions" value="${release.permissions[WRITE]}"/>
 <%@include file="/html/utils/includes/logError.jspf" %>
 
+<%! String objBeforeEdit=""; %>
+<%! String objAfterEdit=""; %>
+
 <core_rt:if test="${empty attributeNotFoundException}">
     <div class="container" style="display: none;">
         <div class="row">
@@ -241,6 +244,7 @@
         autocomplete.prepareForMultipleHits('programminglanguages', ${programmingLanguages});
         autocomplete.prepareForMultipleHits('op_systems', ${operatingSystemsAutoC});
         autocomplete.prepareForMultipleHits('platformsTB', ${platformsAutoC});
+
         $('#formSubmit').click(
             function() {
                 if (("${addMode}" == "false") && ("${isSpdxDocument }" == "true")) {
@@ -279,7 +283,13 @@
                 $(document).find(".checkedComment input").attr("disabled", false);
                 <core_rt:choose>
                     <core_rt:when test="${addMode || release.permissions[WRITE]}">
-                        $('#releaseEditForm').submit();
+                    objAfterEdit = $('#releaseEditForm').serialize();
+                    if(JSON.stringify(objAfterEdit) == JSON.stringify(objBeforeEdit)){
+                    	var $dialog;
+                    	$dialog = dialog.info('Warning','<div>No data changes were made</div>');
+                    	return;
+                    }
+                     $('#releaseEditForm').submit();
                     </core_rt:when>
                     <core_rt:otherwise>
                         showCommentDialog();
@@ -367,10 +377,19 @@
             $('#<%=Release._Fields.VENDOR_ID.toString()%>').val(beforeComma.trim());
             $('#<%=Release._Fields.VENDOR_ID.toString()%>Display').val(afterComma.trim());
         }
+        
+        function setObjBeforeEdit(){
+        	objBeforeEdit = $('#releaseEditForm').serialize();
+        }
 
         $("#clearVendor").click(function() {
             $('#<%=Release._Fields.VENDOR_ID.toString()%>').val("");
             $('#<%=Release._Fields.VENDOR_ID.toString()%>Display').val("").attr("placeholder", "Click to set vendor");
         });
+        
+        $(document).ready(function () {
+        	setTimeout(setObjBeforeEdit, 3000);
+        });
+        
     });
 </script>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

Closes #2368 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Steps : 

1. Create a moderation request of any release
2. next time onwards keep submit to create a moderation request of the same without any changes
3. It will keep create the moderation request in old code
4. This issue is fixed with this Validation PR
5. It should not allow if no changes made while creating a moderation request of any release.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
