### PR TITLE
feat(rest): saveUsages in project page

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -729,6 +729,30 @@ include::{snippets}/should_document_get_attachment_usage_for_project/curl-reques
 ===== Example response
 include::{snippets}/should_document_get_attachment_usage_for_project/http-response.adoc[]
 
+[[resources-project-save-attachmentUsages]]
+==== Save attachmentUsages of the project
+
+A `POST` request is used to save attachmentUsages of the project. Please pass a Map<String, List<String>> having string as key and list<string> as value in request body.
+
+===== Request structure 1
+Pass a Map<String, List<String>> in request body.
+
+Keys can be selected, deselected, selectedConcludedUsages or deselectedConcludedUsages.
+
+Format of String inside list varies according to the usageFields (sourcePackage, licenseInfo, manuallySet) :
+
+for `sourcePackage`, releaseId_sourcePakage_attachmentContentId
+
+for `licenseInfo`, projectId-releaseId_licenseInfo_attachmentContentId (for directly linked project) OR projectPath-releaseId_licenseInfo_attachmentContentId (for nested projects)
+
+for `manuallySet`, releaseId_manuallySet_attachmentContentId
+
+===== Example request 1
+include::{snippets}/should_document_save_usages/curl-request.adoc[]
+
+===== Example response 1
+include::{snippets}/should_document_save_usages/http-response.adoc[]
+
 [[resources-project-get-project-vulnerabilities]]
 ==== Listing project vulnerabilities
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -34,11 +34,8 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
-import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
-import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
-import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
+import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
@@ -63,6 +60,7 @@ import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -104,6 +102,7 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.arrayToList;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.getSortedMap;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyList;
@@ -155,6 +154,177 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             }
         }
     }
+
+    public boolean validate(List<String> changedUsages, User sw360User, Sw360ReleaseService releaseService, Set<String> totalReleaseIds) throws TException {
+		for (String data : changedUsages) {
+			String releaseId;
+			String usageData;
+			String attachmentContentId;
+			String[] parts = data.split("-");
+			if (parts.length > 1) {
+				String[] components = parts[1].split("_");
+	            releaseId = components[0];
+	            usageData = components[1];
+	            attachmentContentId = components[2];
+			}
+			else {
+				String[] components = data.split("_");
+	            releaseId = components[0];
+	            usageData = components[1];
+	            attachmentContentId = components[2];
+			}
+			boolean relPresent = totalReleaseIds.contains(releaseId);
+			if (!relPresent) {
+				return false;
+			}
+            Release release = releaseService.getReleaseForUserById(releaseId, sw360User);
+            Set<Attachment> attachments = release.getAttachments();
+            if (usageData.equals("sourcePackage")) {
+                for (Attachment attach : attachments) {
+                    if (attach.getAttachmentContentId().equals(attachmentContentId) && (attach.getAttachmentType() != AttachmentType.SOURCE && attach.getAttachmentType() != AttachmentType.SOURCE_SELF)) {
+                        return false;
+                    }
+                }
+            }
+            if (usageData.equals("licenseInfo")) {
+                for (Attachment attach : attachments) {
+                    if (attach.getAttachmentContentId().equals(attachmentContentId) && (attach.getAttachmentType() != AttachmentType.COMPONENT_LICENSE_INFO_COMBINED && attach.getAttachmentType() != AttachmentType.COMPONENT_LICENSE_INFO_XML)) {
+                        return false;
+                    }
+                }
+            }
+        } return true;
+    }
+
+    public List<String> savedUsages(List<AttachmentUsage> allUsagesByProject) {
+        List<String> selectedData = new ArrayList<>();
+        for (AttachmentUsage usage : allUsagesByProject) {
+            if (usage.getUsageData().getSetField().equals(UsageData._Fields.LICENSE_INFO)) {
+                StringBuilder result = new StringBuilder();
+                result.append(usage.getUsageData().getLicenseInfo().getProjectPath())
+                      .append("-")
+                      .append(usage.getOwner().getReleaseId())
+                      .append("_")
+                      .append(usage.getUsageData().getSetField().getFieldName())
+                      .append("_")
+                      .append(usage.getAttachmentContentId());
+                String stringResult = result.toString();
+                selectedData.add(stringResult);
+            }
+            else {
+                StringBuilder result = new StringBuilder();
+                result.append(usage.getOwner().getReleaseId())
+                      .append("_")
+                      .append(usage.getUsageData().getSetField().getFieldName())
+                      .append("_")
+                      .append(usage.getAttachmentContentId());
+                String stringResult = result.toString();
+                selectedData.add(stringResult);
+            }
+        }
+        System.out.println("Resulting string: " + selectedData);
+        return selectedData;
+    }
+
+    public List<AttachmentUsage> deselectedAttachmentUsagesFromRequest(List<String> deselectedUsages, List<String> selectedUsages, List<String> deselectedConcludedUsages, List<String> selectedConcludedUsages, String id) {
+        return makeAttachmentUsagesFromParameters(deselectedUsages, selectedUsages, deselectedConcludedUsages, selectedConcludedUsages,  Sets::difference, true, id);
+    }
+
+    public List<AttachmentUsage> selectedAttachmentUsagesFromRequest(List<String> deselectedUsages, List<String> selectedUsages, List<String> deselectedConcludedUsages, List<String> selectedConcludedUsages, String id) {
+        return makeAttachmentUsagesFromParameters(deselectedUsages, selectedUsages, deselectedConcludedUsages, selectedConcludedUsages, Sets::intersection, false, id);
+    }
+
+    private static List<AttachmentUsage> makeAttachmentUsagesFromParameters(List<String> deselectedUsages, List<String> selectedUsage,
+            List<String> deselectedConcludedUsages, List<String> selectedConcludedUsages,
+            BiFunction<Set<String>, Set<String>, Set<String>> computeUsagesFromCheckboxes, boolean deselectUsage, String projectId) {
+        Set<String> selectedUsages = new HashSet<>(selectedUsage);
+        Set<String> changedUsages = new HashSet<>(deselectedUsages);
+        Set<String> changedIncludeConludedLicenses = new HashSet<>(deselectedConcludedUsages);
+        changedUsages = Sets.union(changedUsages, new HashSet(changedIncludeConludedLicenses));
+        List<String> includeConludedLicenses = new ArrayList<>(selectedConcludedUsages);
+        Set<String> usagesSubset = computeUsagesFromCheckboxes.apply(changedUsages, selectedUsages);
+        if (deselectUsage) {
+            usagesSubset = Sets.union(usagesSubset, new HashSet(changedIncludeConludedLicenses));
+        }
+        return usagesSubset.stream()
+                .map(s -> parseAttachmentUsageFromString(projectId, s, includeConludedLicenses))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private static AttachmentUsage parseAttachmentUsageFromString(String projectId, String s, List<String> includeConludedLicense) {
+        String[] split = s.split("_");
+        if (split.length != 3) {
+            log.warn(String.format("cannot parse attachment usage from %s for project id %s", s, projectId));
+            return null;
+        }
+
+        String releaseId = split[0];
+        String type = split[1];
+        String attachmentContentId = split[2];
+        String projectPath = null;
+        if (UsageData._Fields.findByName(type).equals(UsageData._Fields.LICENSE_INFO)) {
+            String[] projectPath_releaseId = split[0].split("-");
+            if (projectPath_releaseId.length == 2) {
+                releaseId = projectPath_releaseId[1];
+                projectPath = projectPath_releaseId[0];
+            }
+        }
+
+        AttachmentUsage usage = new AttachmentUsage(Source.releaseId(releaseId), attachmentContentId, Source.projectId(projectId));
+        final UsageData usageData;
+        switch (UsageData._Fields.findByName(type)) {
+            case LICENSE_INFO:
+                LicenseInfoUsage licenseInfoUsage = new LicenseInfoUsage(Collections.emptySet());
+                licenseInfoUsage.setIncludeConcludedLicense(includeConludedLicense.contains(s));
+                if (projectPath != null) {
+                    licenseInfoUsage.setProjectPath(projectPath);
+                }
+                usageData = UsageData.licenseInfo(licenseInfoUsage);
+                break;
+            case SOURCE_PACKAGE:
+                usageData = UsageData.sourcePackage(new SourcePackageUsage());
+                break;
+            case MANUALLY_SET:
+                usageData = UsageData.manuallySet(new ManuallySetUsage());
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected UsageData type: " + type);
+        }
+        usage.setUsageData(usageData);
+        return usage;
+    }
+
+    /**
+     * Here, "equivalent" means an AttachmentUsage should replace another one in the DB, not that they are equal.
+     * I.e, they have the same attachmentContentId, owner, usedBy, and same UsageData type.
+     */
+    @NotNull
+    public Predicate<AttachmentUsage> isUsageEquivalent(AttachmentUsage usage) {
+        return equivalentUsage -> usage.getAttachmentContentId().equals(equivalentUsage.getAttachmentContentId()) &&
+                usage.getOwner().equals(equivalentUsage.getOwner()) &&
+                usage.getUsedBy().equals(equivalentUsage.getUsedBy()) &&
+                usage.getUsageData().getSetField().equals(equivalentUsage.getUsageData().getSetField());
+    }
+
+    public void deleteAttachmentUsages(List<AttachmentUsage> usagesToDelete) throws TException {
+        ThriftClients thriftClients = new ThriftClients();
+        AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
+        attachmentClient.deleteAttachmentUsages(usagesToDelete);
+	}
+
+	public void makeAttachmentUsages(List<AttachmentUsage> usagesToCreate) throws TException {
+		ThriftClients thriftClients = new ThriftClients();
+		AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
+		attachmentClient.makeAttachmentUsages(usagesToCreate);
+	}
+
+	public List<AttachmentUsage> getUsedAttachments(Source usedBy, Object object) throws TException {
+		ThriftClients thriftClients = new ThriftClients();
+		AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
+		List<AttachmentUsage> allUsagesByProjectAfterCleanUp = attachmentClient.getUsedAttachments(usedBy, null);
+		return allUsagesByProjectAfterCleanUp;
+	}
 
     public String getCyclicLinkedProjectPath(Project project, User user) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -28,13 +28,7 @@ import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestPriority;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
-import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
-import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
-import org.eclipse.sw360.datahandler.thrift.attachments.LicenseInfoUsage;
-import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
+import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
@@ -366,6 +360,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         projectList.add(project2);
 
         Map<String, ProjectReleaseRelationship> linkedReleases2 = new HashMap<>();
+        Map<String, ProjectReleaseRelationship> linkedReleases3 = new HashMap<>();
+        Map<String, ProjectReleaseRelationship> linkedReleases4 = new HashMap<>();
         Map<String, ProjectProjectRelationship> linkedProjects2 = new HashMap<>();
         Map<String, ProjectProjectRelationship> linkedProjects3 = new HashMap<>();
         Project project4 = new Project();
@@ -412,7 +408,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project7.setClearingState(ProjectClearingState.OPEN);
         project7.setSecurityResponsibles(new HashSet<>(Arrays.asList("securityresponsible1@sw360.org", "securityresponsible2@sw360.org")));
 
-        Map<String, ProjectReleaseRelationship> linkedReleases3 = new HashMap<>();
         Set<Attachment> attachmentSet = new HashSet<Attachment>();
         List<Obligation> obligationList = new ArrayList<>();
         Set<String> licenseIds2 = new HashSet<>();
@@ -492,6 +487,32 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         release5.setVersion("2.3.1");
         release5.setCreatedOn("2016-12-28");
 
+        Project project9 = new Project();
+        project9.setId("0000007");
+        project9.setName("attachUsages");
+        project9.setVersion("2");
+        project9.setCreatedBy(testUserId);
+        project9.setProjectType(ProjectType.PRODUCT);
+        project9.setState(ProjectState.ACTIVE);
+        project9.setClearingState(ProjectClearingState.OPEN);
+        linkedReleases4.put("00000071", projectReleaseRelationship);
+        project9.setReleaseIdToUsage(linkedReleases4);
+
+        Release release9 = new Release();
+        release9.setId("00000071");
+        release9.setName("docker");
+        release9.setCpeid("cpe:/a:Google:Angular:2.3.1:");
+        release9.setReleaseDate("2024-03-17");
+        release9.setVersion("2");
+        release9.setCreatedOn("2024-03-28");
+        release9.setAttachments(setOfAttachment);
+
+        List<AttachmentUsage> attachmentUsageNewList = new ArrayList<>();
+        List<AttachmentUsage> deselectedUsagesFromRequest = new ArrayList<>();
+        List<AttachmentUsage> selectedUsagesFromRequest = new ArrayList<>();
+        List<String> selectedUsages = Arrays.asList("00000071_sourcePackage_1234");
+
+        Set<String> releaseIds2 = new HashSet<>(Collections.singletonList("00000071"));
         Set<String> releaseIds = new HashSet<>(Collections.singletonList("3765276512"));
         Set<String> releaseIdsTransitive = new HashSet<>(Arrays.asList("3765276512", "5578999"));
 
@@ -569,6 +590,11 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.addLinkedObligations(any(), any(), eq(obligationStatusMap))).willReturn(RequestStatus.SUCCESS);
         given(this.projectServiceMock.compareObligationStatusMap(any(), any(), any())).willReturn(obligationStatusMap);
         given(this.projectServiceMock.patchLinkedObligations(any(), any(), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.projectServiceMock.getProjectForUserById(eq(project9.getId()), any())).willReturn(project9);
+        given(this.projectServiceMock.getUsedAttachments(any(), any())).willReturn(attachmentUsageNewList);
+        given(this.projectServiceMock.validate(any(), any(), any(), any())).willReturn(true);
+        given(this.projectServiceMock.deselectedAttachmentUsagesFromRequest(any(), eq(selectedUsages), any(), any(), any())).willReturn(deselectedUsagesFromRequest);
+        given(this.projectServiceMock.selectedAttachmentUsagesFromRequest(any(), eq(selectedUsages), any(), any(), any())).willReturn(selectedUsagesFromRequest);
         given(this.projectServiceMock.getProjectForUserById(eq(projectForAtt.getId()), any())).willReturn(projectForAtt);
         given(this.projectServiceMock.getProjectForUserById(eq(SPDXProject.getId()), any())).willReturn(SPDXProject);
         given(this.projectServiceMock.getProjectForUserById(eq(cycloneDXProject.getId()), any())).willReturn(cycloneDXProject);
@@ -579,6 +605,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.searchProjectByGroup(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.refineSearch(any(), any())).willReturn(projectListByName);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(false))).willReturn(releaseIds);
+        given(this.projectServiceMock.getReleaseIds(eq(project9.getId()), any(), eq(true))).willReturn(releaseIds2);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(true))).willReturn(releaseIdsTransitive);
         given(this.projectServiceMock.deleteProject(eq(project.getId()), any())).willReturn(RequestStatus.SUCCESS);
         given(this.projectServiceMock.updateProjectReleaseRelationship(any(), any(), any())).willReturn(projectReleaseRelationshipResponseBody);
@@ -1952,6 +1979,21 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 fieldWithPath("Message regarding successfully linked project(s)").description("project linked to respective project ids").optional()
                         )));
+    }
+
+    @Test
+    public void should_document_save_usages() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = post("/api/projects/" + "0000007" + "/saveAttachmentUsages");
+        Map<String, List<String>> usages = Map.of(
+            "selected", new ArrayList<>(List.of("00000071_sourcePackage_1234")),
+            "deselected", new ArrayList<>(List.of()),
+            "selectedConcludedUsages", new ArrayList<>(List.of()),
+            "deselectedConcludedUsages", new ArrayList<>(List.of()));
+
+        this.mockMvc.perform(requestBuilder.contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(usages))
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)))
+                .andExpect(status().isCreated());
     }
 
     @Test


### PR DESCRIPTION
Issue: Closes #2371

Description: this new endpoint is used to save attachmnetUsages for the project.

How to test:
Pass Map< String, List< String >> in request body.
String can be of 4 types:
- selected : release attachmentUsage that you want to save/check
- deselected : release attachmentUsage that you want to delete/uncheck
- selectedConcludedUsages : release attachmentUsage that you want to save/check of type license info's conclusion checkbox only
- deselectedConcludedUsages:  release attachmentUsage that you want to delete/uncheck of type license info's conclusion checkbox only

Format of String inside list varies according to the usageFields (sourcePackage, licenseInfo, manuallySet) :
- for `sourcePackage`, releaseId_sourcePakage_attachmentContentId
- for `licenseInfo`, projectId-releaseId_licenseInfo_attachmentContentId (for directly linked project) OR projectPath-releaseId_licenseInfo_attachmentContentId (for nested projects)
- for `manuallySet`, releaseId_manuallySet_attachmentContentId

Example:
{"selected": ["4427a8e723ad405db63f75170ef240a2_sourcePackage_5c5d6f54ac6a4b33bcd3c5d3a8fefc43", "value2"],
 "deselected": ["de213309ba0842ac8a7251bf27ea8f36_manuallySet_eec66c3465f64f0292dfc2564215c681", "value2"],
 "selectedConcludedUsages": ["de213309ba0842ac8a7251bf27ea8f36_licenseInfo_eec66c3465f64f0292dfc2564215c681"],"
 "deselectedConcludedUsages":
 ["ade213309ba0842ac8a7251bf27ea8f36_licenseInfo_aeec66c3465f64f0292dfc2564215c681"]}
