### PR TITLE
fix(Release): Add embedded other licenses in release response

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -1430,4 +1430,11 @@ public class RestControllerHelper<T> {
         if(sw360User!=null)
             addEmbeddedUser(userHalResource, sw360User, resource);
     }
+
+    public void addEmbeddedOtherLicenses(HalResource<Release> halRelease, Set<String> licenseIds) {
+        for (String licenseId : licenseIds) {
+            HalResource<License> licenseHalResource = addEmbeddedLicense(licenseId);
+            halRelease.addEmbeddedResource("sw360:otherLicenses", licenseHalResource);
+        }
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -1416,6 +1416,9 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                 restControllerHelper.addEmbeddedLicenses(halRelease, release.getMainLicenseIds());
                 release.setMainLicenseIds(null);
             }
+            if (release.getOtherLicenseIds() != null) {
+                restControllerHelper.addEmbeddedOtherLicenses(halRelease, release.getOtherLicenseIds());
+            }
             Set<String> packageIds = release.getPackageIds();
 
             if (packageIds != null) {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -446,6 +446,20 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         given(this.licenseServiceMock.getLicenseById("ML2")).willReturn(
                 new License("Main license 2 name").setText("Main license 2 Text")
                         .setShortname("ML2").setId("ML2"));
+
+        given(this.licenseServiceMock.getLicenseById("MIT")).willReturn(
+                new License("MIT").setText("MIT")
+                        .setShortname("MIT").setId("MIT"));
+        given(this.licenseServiceMock.getLicenseById("BSD-3-Clause")).willReturn(
+                new License("BSD-3-Clause").setText("BSD-3-Clause")
+                        .setShortname("BSD-3-Clause").setId("BSD-3-Clause"));
+        given(this.licenseServiceMock.getLicenseById("OL1")).willReturn(
+                new License("Other license 1 name").setText("Other license 1 Text")
+                        .setShortname("OL1").setId("OL1"));
+        given(this.licenseServiceMock.getLicenseById("OL2")).willReturn(
+                new License("Other license 2 name").setText("Other license 2 Text")
+                        .setShortname("OL2").setId("OL2"));
+
         ExternalToolProcess fossologyProcess = new ExternalToolProcess();
         fossologyProcess.setAttachmentId("5345ab789");
         fossologyProcess.setAttachmentHash("535434657567");
@@ -776,6 +790,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:createdBy").description("A release createdBy with email and link to their <<resources-user-get,User resource>>"),
                                 subsectionWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),
                                 subsectionWithPath("_embedded.sw360:cotsDetail").description("Cots detail information of release has component type = COTS "),
+                                subsectionWithPath("_embedded.sw360:otherLicenses").description("An array of all other release's licenses and link to their <<resources-license-get,License resource>>"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }
@@ -1123,6 +1138,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("softwarePlatforms").description("The software platforms of the component"),
                         subsectionWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                         subsectionWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),
+                        subsectionWithPath("_embedded.sw360:otherLicenses").description("An array of all other release's licenses and link to their <<resources-license-get,License resource>>"),
                         subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                 )
         );
@@ -1265,6 +1281,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("softwarePlatforms").description("The software platforms of the component"),
                                 subsectionWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                                 subsectionWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),
+                                subsectionWithPath("_embedded.sw360:otherLicenses").description("An array of all other release's licenses and link to their <<resources-license-get,License resource>>"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
### Issue:
- Other licenses information is not be presented in release's response


### How To Test?
##### Pre-condition:
Release must have at least one license in other licenses field

##### Procedure:
Send GET request to get single release: http://localhost:8080/resource/api/releases/{release_id}

##### Expected:
Response will contain other licenses of release in embedded field with the format:

```
 "sw360:otherLicenses" : [ {
      "OSIApproved" : "NA",
      "FSFLibre" : "NA",
      "checked" : true,
      "shortName" : "BSD-3-Clause",
      "fullName" : "BSD-3-Clause",
      "_links" : {
        "self" : {
          "href" : "https://sw360.org/api/licenses/BSD-3-Clause"
        }
      }
    }, {
      "OSIApproved" : "NA",
      "FSFLibre" : "NA",
      "checked" : true,
      "shortName" : "MIT",
      "fullName" : "MIT",
      "_links" : {
        "self" : {
          "href" : "https://sw360.org/api/licenses/MIT"
        }
      }
    } ]
  }
```
