### PR TITLE
fix(Rest): Adding vcs field in component update api

### DIFF
--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -405,6 +405,7 @@ struct ComponentDTO {
     51: optional string mailinglist,
     52: optional string wiki,
     53: optional string blog,
+    56: optional string vcs,
 }
 
 struct ReleaseLink{

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -46,6 +46,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.getSortedMap;
@@ -147,6 +149,14 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
     public RequestStatus updateComponent(Component component, User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         RequestStatus requestStatus;
+        if (CommonUtils.isNotNullEmptyOrWhitespace(component.getVcs())) {
+	        String urlRegex = "^(https?://)[a-zA-Z0-9+&@#/%?=~_|!:,.;-]*[a-zA-Z0-9+&@#/%=~_|]$";
+	        Pattern urlPattern = Pattern.compile(urlRegex);
+	        Matcher matcher = urlPattern.matcher(component.getVcs());
+	        boolean isValidUrl=matcher.matches();
+	        if(!isValidUrl)
+	        	throw new RuntimeException("sw360 component with name '" + component.getName() + " cannot be updated as vcs url is invalid");
+        }
         if (Sw360ResourceServer.IS_FORCE_UPDATE_ENABLED) {
             requestStatus = sw360ComponentClient.updateComponentWithForceFlag(component, sw360User, true);
         } else {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -120,6 +120,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -675,6 +676,9 @@ public class RestControllerHelper<T> {
         component.setMailinglist(componentDTO.getMailinglist());
         component.setWiki(componentDTO.getWiki());
         component.setBlog(componentDTO.getBlog());
+        if(componentDTO.getVcs()!=null && Objects.nonNull(componentDTO.getVcs())) {
+        	component.setVcs(componentDTO.getVcs().trim());
+        }
 
         return component;
     }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Resolves https://github.com/eclipse-sw360/sw360/issues/2376 
> * Did you add or update any new dependencies that are required for your change?

Depends-on: https://github.com/eclipse-sw360/sw360/pull/2408

Issue: https://github.com/eclipse-sw360/sw360/issues/2376

### Suggest Reviewer
> @ag4ums 

### How To Test?
> Test by passing vcs field in the request body of the patch api to update component  using http://localhost:8080/resource/api/components/{id}
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
