### PR TITLE
fix(importCDX): Packages without VCS in SBOM having VCS in SW360 are not getting linked to project

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -260,8 +260,8 @@ public class CycloneDxBOMImporter {
                                             pkgReuseCount++;
                                             Package dupPkg = packageDatabaseHandler.getPackageById(pkgAddSummary.getId());
                                             if (CommonUtils.isNotNullEmptyOrWhitespace(dupPkg.getReleaseId())) {
-                                                if (!CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).containsKey(pkgAddSummary.getId())) {
-                                                    project.putToReleaseIdToUsage(pkgAddSummary.getId(), getDefaultRelation());
+                                                if (!CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).containsKey(dupPkg.getReleaseId())) {
+                                                    project.putToReleaseIdToUsage(dupPkg.getReleaseId(), getDefaultRelation());
                                                 }
                                                 relReuseCount++;
                                             }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
@@ -415,7 +415,7 @@
                                     var cpBtn = $(copyBtn).clone();
                                     $(cpBtn).attr('id', 'copyToClipboard_ics');
                                     statusDiv.append("<div class='alert alert-info'><liferay-ui:message key="list.of.packages.without.vcs.information" />: <b>" + $(invalidCompList).find('li').length +
-                                        "</b> <small>(<liferay-ui:message key="not.linked.to.any.release" />)</small> " + cpBtn[0].outerHTML + " " + invalidCompList[0].outerHTML + "</div>")
+                                        "</b> " + cpBtn[0].outerHTML + " " + invalidCompList[0].outerHTML + "</div>")
                                 }
                                 if (data.dupComp && data.dupComp.length) {
                                     compList = $('<ul/>');

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/importBom.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/importBom.jspf
@@ -371,7 +371,7 @@
                                     var cpBtn = $(copyBtn).clone();
                                     $(cpBtn).attr('id', 'copyToClipboard_ic');
                                     statusDiv.append("<div class='alert alert-info'><liferay-ui:message key="list.of.packages.without.vcs.information" />: <b>" + $(invalidCompList).find('li').length +
-                                            "</b> <small>(<liferay-ui:message key="not.linked.to.any.release" />)</small> " + cpBtn[0].outerHTML + " " + invalidCompList[0].outerHTML + "</div>")
+                                            "</b> " + cpBtn[0].outerHTML + " " + invalidCompList[0].outerHTML + "</div>")
                                 }
                                 if (data.dupComp && data.dupComp.length) {
                                     compList = $('<ul/>');

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -977,7 +977,6 @@ not.applicable=Not Applicable
 not.available=not available
 not.checked=Not Checked
 not.imported=not imported
-not.linked.to.any.release=not linked to any release
 in.analysis=In Analysis
 not.decided.so.far=Not decided so far
 not.loaded.yet=Not loaded yet

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -973,7 +973,6 @@ not.applicable=適用不可
 not.available=利用できない
 not.checked=未チェック
 not.imported=not imported
-not.linked.to.any.release=not linked to any release
 in.analysis=分析中
 not.decided.so.far=今のところ未定
 not.loaded.yet=まだロードされていない

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -976,7 +976,6 @@ not.applicable=Not Applicable
 not.available=Không có sẵn
 not.checked=Chưa được kiểm tra
 not.imported=not imported
-not.linked.to.any.release=not linked to any release
 in.analysis=In Analysis
 not.decided.so.far=Không quyết định cho đến nay
 not.loaded.yet=Not loaded yet

--- a/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_zh.properties
@@ -968,7 +968,6 @@ not.applicable=不适用
 not.available=不可用
 not.checked=未检查
 not.imported=not imported
-not.linked.to.any.release=not linked to any release
 in.analysis=分析中
 not.decided.so.far=目前还没有决定
 not.loaded.yet=尚未加载


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

**Description:**
A package having a clashing state where it does not have a source/VCS in SBOM but is linked to source release in SW360 will now get linked to a project along with its release as expected.

**Note**: Corresponding UI Changes in the Import Status dialog box have not been implemented due to migration to React. 

Closes #2387 
