### PR TITLE
fix(Project): Fix bug Expand Next Level and Collapse All button are hidden when click on sort icon

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/dependencyNetwork.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/dependencyNetwork.jsp
@@ -76,7 +76,7 @@
                 <tr>
                     <th style="width:36%; cursor: pointer" class="sort">
                         <div id="expandAllWarning" class="alert alert-warning alert-dismissible mb-0 p-2" style="display:none">
-                            <button type="button" class="close pb-3" data-dismiss="alert">�</button>
+                            <button type="button" class="close pb-3" data-dismiss="alert">x</button>
                              <liferay-ui:message key="all.the.levels.are.expanded" />
                         </div>
                         <div class="row px-2">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/expandCollapse.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/expandCollapse.js
@@ -12,11 +12,15 @@ define('modules/expandCollapse', [ 'jquery' ], function($) {
         toggleIcon: function toggleIcon(element){
 
             if (element.closest('thead').hasClass('collapsed')) {
-                element.find("div").eq(3).children().css('display', 'none');
-                element.find("div").eq(2).children().css('display', 'inline');
+                element.find('.lexicon-icon-caret-bottom').hide();
+                element.find('.lexicon-icon-caret-bottom').parent().hide();
+                element.find('.lexicon-icon-caret-top').show();
+                element.find('.lexicon-icon-caret-top').parent().show();
             }else{
-                element.find("div").eq(3).children().css('display', 'inline');
-                element.find("div").eq(2).children().css('display', 'none');
+                element.find('.lexicon-icon-caret-bottom').show();
+                element.find('.lexicon-icon-caret-bottom').parent().show();
+                element.find('.lexicon-icon-caret-top').hide();
+                element.find('.lexicon-icon-caret-top').parent().hide();
             }
         }
     }


### PR DESCRIPTION
Issue: #2390

### Description:
- This PR will reduce effect of expandCollapse.js file, which is used to toggle collapse, expand icon. Then the issue will be solved
- Fix bug close icon is shown incorrectly (should be "x" icon)
![expected1](https://github.com/eclipse-sw360/sw360/assets/94659621/59df0c91-8127-4cca-8915-72e46800f04f)


### How To Test?
Refer to Issue: #2390

### Additional check:
Ensure that the collapse, expand icon are toggled correctly in Project, Release, Component, Package detail tabs
![expected](https://github.com/eclipse-sw360/sw360/assets/94659621/15cfbb47-701d-4caa-8c6c-db003defac0b)



### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
