### PR TITLE
fix(api): check project modifier before embedding

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2295,11 +2295,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     private void setAdditionalFieldsToHalResource(Project sw360Project, HalResource<Project> userHalResource) throws TException {
         try {
             User projectModifier = restControllerHelper.getUserByEmail(sw360Project.getModifiedBy());
-            if (projectModifier != null) {
+            if (projectModifier != null && projectModifier.getEmail() != null) {
                 restControllerHelper.addEmbeddedUser(userHalResource, projectModifier, "modifiedBy");
             }
             User projectOwner = restControllerHelper.getUserByEmail(sw360Project.getProjectOwner());
-            if (projectOwner != null) {
+            if (projectOwner != null && projectOwner.getEmail() != null) {
                 restControllerHelper.addEmbeddedUser(userHalResource, projectOwner, "projectOwner");
             }
             if (sw360Project.getSecurityResponsibles() == null || sw360Project.getSecurityResponsibles().isEmpty()) {
@@ -2315,7 +2315,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             if (sw360Project.getProjectResponsible() != null) {
                 restControllerHelper.addEmbeddedProjectResponsible(userHalResource,sw360Project.getProjectResponsible());
             }
-        }catch (Exception e) {
+        } catch (Exception e) {
             throw new TException(e.getMessage());
         }
     }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

If a project is not modified, modifier email is null. Check the email before trying to embedd the user object.

### Suggest Reviewer

@smrutis1

### How To Test?
Fetch project summary for a new project using `/resource/api/projects/{id}/summaryAdministration` endpoint.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
