### PR TITLE
fix(api): provide typeMasks name as Optional type

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
@@ -86,7 +86,7 @@ public class SearchController implements RepresentationModelProcessor<Repository
                             type = "array"
                     )
             )
-            @RequestParam Optional<List<String>> typeMasks,
+            @RequestParam(value = "typeMasks") Optional<List<String>> typeMasks,
             HttpServletRequest request
     ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         log.debug("SearchText = {} typeMasks = {}", searchText, typeMasks);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Provide name for the `typeMasks` parameter in `/search?searchText=hello&typeMasks=document` as it is `Optional` type.

This causes spring to throw following exception:
```
Name for argument of type [java.util.Optional] not specified, and parameter name information not available via reflection. Ensure that the compiler uses the '-parameters' flag.
```

### Suggest Reviewer
@smrutis1 @ag4ums 

### How To Test?
Hit the search endpoint.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
