### PR TITLE
fix(Release): Updating the license overview in the summary page

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -902,6 +902,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             JsonNode input = OBJECT_MAPPER.readValue(request.getParameter(SPDX_LICENSE_INFO), JsonNode.class);
             JsonNode licenesIdsNode = input.get(LICENSE_IDS);
             if (null != licenesIdsNode) {
+                release.getMainLicenseIds().clear();
                 if (licenesIdsNode.isArray()) {
                     for (JsonNode objNode : licenesIdsNode) {
                         release.addToMainLicenseIds(objNode.asText());
@@ -912,6 +913,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             }
             licenesIdsNode = input.get("otherLicenseIds");
             if (null != licenesIdsNode) {
+                release.getOtherLicenseIds().clear();
                 if (licenesIdsNode.isArray()) {
                     for (JsonNode objNode : licenesIdsNode) {
                         release.addToOtherLicenseIds(objNode.asText());


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Clearing the existing license info when adding the new license info from a CLI file
> * Which issue is this pull request belonging to and how is it solving it?#2412

