### PR TITLE
fix(REST): Improve error message handling for CycloneDX sbom import using REST API

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1752,7 +1752,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         if (requestSummary.getRequestStatus() == RequestStatus.FAILURE) {
             return new ResponseEntity<String>(requestSummary.getMessage(), HttpStatus.BAD_REQUEST);
+        }else if(requestSummary.getRequestStatus() == RequestStatus.ACCESS_DENIED){
+            return new ResponseEntity<String>("You do not have sufficient permissions.", HttpStatus.UNAUTHORIZED);
         }
+
         String jsonMessage = requestSummary.getMessage();
         messageMap = new Gson().fromJson(jsonMessage, Map.class);
         projectId = messageMap.get("projectId");
@@ -1761,6 +1764,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             return new ResponseEntity<String>(
                     "A project with same name and version already exists. The projectId is: " + projectId,
                     HttpStatus.CONFLICT);
+        }else if (requestSummary.getRequestStatus() == RequestStatus.FAILED_SANITY_CHECK){
+            return new ResponseEntity<String>(
+                    "Project name or version present in SBOM metadata tag is not same as the current SW360 project!",
+                    HttpStatus.BAD_REQUEST);
         }
 
         Project project = projectService.getProjectForUserById(projectId, sw360User);


### PR DESCRIPTION
Now, if we try to import the SBOM on a already existing project in SW360 and if this SBOM contains different name and version information than the project which is present on SW360, then were handling this case properly in showing the relevant message to the user.
![pr_creation](https://github.com/eclipse-sw360/sw360/assets/141239852/969ef923-8ab7-4453-86e0-a7a3e5689c59)


Closes: #2411