### PR TITLE
feat(moderation): ignore common fields

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -183,7 +183,6 @@ public class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
-                "id",
                 "revision",
                 "attachments",
                 "createdBy",
@@ -2008,6 +2007,7 @@ public class JacksonCustomizations {
                 "setPackageInfoAdditions",
                 "setPackageInfoDeletions",
                 "type",
+                "revision",
                 "moderatorsIterator",
                 "SPDXDocumentAdditions",
                 "SPDXDocumentDeletions",

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
@@ -272,7 +272,6 @@ public class ModerationRequestSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 subsectionWithPath("_embedded.sw360:moderationRequests").description("An array of <<resources-moderationRequest, ModerationRequest>>."),
                                 fieldWithPath("_embedded.sw360:moderationRequests.[]id").description("The id of the moderation request."),
-                                fieldWithPath("_embedded.sw360:moderationRequests.[]revision").description("The revision of the moderation request."),
                                 fieldWithPath("_embedded.sw360:moderationRequests.[]timestamp").description("Timestamp (in unix epoch) when the request was created."),
                                 fieldWithPath("_embedded.sw360:moderationRequests.[]timestampOfDecision").description("Timestamp (in unix epoch) when the decision on the request was made."),
                                 fieldWithPath("_embedded.sw360:moderationRequests.[]documentId").description("The ID of the document for which the moderation request was made."),
@@ -319,7 +318,6 @@ public class ModerationRequestSpecTest extends TestRestDocsSpecBase {
                         ),
                         responseFields(
                                 fieldWithPath("id").description("The id of the moderation request."),
-                                fieldWithPath("revision").description("The revision number of the request."),
                                 fieldWithPath("timestamp").description("Timestamp (in unix epoch) when the request was created."),
                                 fieldWithPath("timestampOfDecision").description("Timestamp (in unix epoch) when the decision on the request was made."),
                                 fieldWithPath("documentId").description("The ID of the document for which the moderation request was made."),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -923,6 +923,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("last").description("Link to last page")
                         ),
                         responseFields(
+                                subsectionWithPath("_embedded.sw360:projects.[]id").description("The id of the project"),
                                 subsectionWithPath("_embedded.sw360:projects.[]name").description("The name of the project"),
                                 subsectionWithPath("_embedded.sw360:projects.[]version").description("The project version"),
                                 subsectionWithPath("_embedded.sw360:projects.[]createdOn").description("The date the project was created"),
@@ -990,6 +991,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("self").description("The <<resources-projects,Projects resource>>")
                         ),
                         responseFields(
+                                fieldWithPath("id").description("The id of the project"),
                                 fieldWithPath("name").description("The name of the project"),
                                 fieldWithPath("version").description("The project version"),
                                 fieldWithPath("createdOn").description("The date the project was created"),
@@ -1669,6 +1671,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("phaseOutSince").description("The project phase-out date")
                         ),
                         responseFields(
+                                fieldWithPath("id").description("The project id"),
                                 fieldWithPath("name").description("The name of the project"),
                                 fieldWithPath("version").description("The project version"),
                                 fieldWithPath("visibility").description("The project visibility, possible values are: " + Arrays.asList(Visibility.values())),
@@ -1729,6 +1732,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("phaseOutSince").description("The project phase-out date")
                         ),
                         responseFields(
+                                fieldWithPath("id").description("The project id"),
                                 fieldWithPath("name").description("The name of the project"),
                                 fieldWithPath("version").description("The project version"),
                                 fieldWithPath("visibility").description("The project visibility, possible values are: " + Arrays.asList(Visibility.values())),
@@ -1778,7 +1782,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
                         fieldWithPath("phaseOutSince").description("The project phase-out date"),
                         fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag.")),
-                responseFields(fieldWithPath("name").description("The name of the project"),
+                responseFields(
+                        fieldWithPath("id").description("The project id"),
+                        fieldWithPath("name").description("The name of the project"),
                         fieldWithPath("version").description("The project version"),
                         fieldWithPath("createdOn").description("The date the project was created"),
                         fieldWithPath("description").description("The project description"),
@@ -2141,6 +2147,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
                         responseFields(
+                                fieldWithPath("id").description("The project id"),
                                 fieldWithPath("name").description("The name of the project"),
                                 fieldWithPath("version").description("The project version"),
                                 fieldWithPath("createdOn").description("The date the project was created"),


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Ignore common fields while returning additions and deletions in a Moderation Request.

Also, ignore the revision field for a moderation request (CouchDB field) but add "id" field to project allowing for easy identification.

Fixes #2417

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Try to create some moderation requests and get them via REST API.
The additions/deletions should not contain any fields which have same value.

### Note
The boolean fields are still there with same value.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
