### PR TITLE
chore(templates): Update outdated bug/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,14 +3,9 @@ name: Bug report
 about: Create a report to help us improve
 labels: bug
 ---
-[//]: # (Copyright Siemens AG, 2021. Part of the SW360 Portal Project)
-[//]: # (This program and the accompanying materials are made)
-[//]: # (available under the terms of the Eclipse Public License 2.0)
-[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
-[//]: # (SPDX-License-Identifier: EPL-2.0)
 
-<!-- Before filling this issue, please read the wiki (https://github.com/eclipse/sw360/wiki)
-and search if the bug do not already exists in the issues (https://github.com//eclipse/sw360/issues). -->
+<!-- Before filling this issue, please read the wiki (https://eclipse.org/sw360)
+and search if the bug do not already exists in the issues (https://github.com//eclipse-sw360/sw360/issues). -->
 
 ### Description
 
@@ -20,23 +15,16 @@ Please describe your issue in few words here.
 
 Describe the bug and list the steps you used when the issue occurred.
 
-#### Screenshots
+#### Screenshots ( if applicable )
 
-If applicable, add screenshots to help explain your problem.
+Add screenshots to help explain your problem.
 
 ### Versions
 
-* Last commit id on master:
-* Operating System (lsb_release -a):
-
-### Logs
-
-Any logs (if any) generated in
+* Docker version OR
+* Last commit id on main
 
 #### SW360 logs
 
-Logs generated under /var/log/sw360/sw360.log
-
-#### Tomcat logs
-
-Logs generated under /var/log/tomcat/error.log
+* With docker through `docker logs sw360`
+* From bare metal / vm install system under /var/log/sw360/sw360.log and /var/log/tomcat/error.log

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,14 +3,9 @@ name: Feature request
 about: Request a new feature in sw360
 labels: enhancement
 ---
-[//]: # (Copyright Siemens AG, 2021. Part of the SW360 Portal Project)
-[//]: # (This program and the accompanying materials are made)
-[//]: # (available under the terms of the Eclipse Public License 2.0)
-[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
-[//]: # (SPDX-License-Identifier: EPL-2.0)
 
-<!-- Before filling this issue, please read the Wiki (https://github.com/sw360/wiki)
-and search if the bug do not already exists in the issues (https://github.com/eclipse/sw360/issues). -->
+<!-- Before filling this issue, please read the wiki (https://eclipse.org/sw360)
+and search if the bug do not already exists in the issues (https://github.com//eclipse-sw360/sw360/issues). -->
 
 ### Description
 
@@ -20,6 +15,6 @@ Please describe your situation in few words here.
 
 Describe the steps followed by you and your expected results after following the steps.
 
-#### Screenshots
+#### Screenshots ( if applicable )
 
-If applicable, add screenshots to help explain your problem.
+Add screenshots to help explain your problem.


### PR DESCRIPTION
Some of the data in the bug templating are outdated and mentioning specific information that is no longer valid.
Refactor to match with new docker setups and modern SW360 state

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
