### PR TITLE
fix(importCDX) : Fix package's linked release updation when an SBOM is imported

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -646,10 +646,12 @@ public class CycloneDxBOMImporter {
                             pkg.setId(pkgAddSummary.getId());
                             if (AddDocumentRequestStatus.DUPLICATE.equals(pkgAddSummary.getRequestStatus())) {
                                 Package dupPkg = packageDatabaseHandler.getPackageById(pkg.getId());
-                                if (!release.getId().equals(dupPkg.getReleaseId())) {
-                                    log.error("Release Id of Package from BOM: '%s' and Database: '%s' is not equal!", release.getId(), dupPkg.getReleaseId());
-                                    dupPkg.setReleaseId(release.getId());
+                                String dupPkgReleaseId = dupPkg.getReleaseId();
+                                String releaseId = release.getId();
+                                if (!releaseId.equals(dupPkgReleaseId) && CommonUtils.isNullEmptyOrWhitespace(dupPkgReleaseId)) {
+                                    dupPkg.setReleaseId(releaseId);
                                     packageDatabaseHandler.updatePackage(dupPkg, user);
+                                    log.error("Release Id of Package from BOM: '%s' and Database: '%s' is not equal!", releaseId, dupPkgReleaseId);
                                 }
                                 pkgReuseCount++;
                             } else {


### PR DESCRIPTION
closes #2428
Now when an SBOM is imported containing a duplicate pkg, the existing pkg's linked release would not be modified. 
For example : 
If this an SBOM that contains a duplicate pkg but different VCS : 
![akshitPR1](https://github.com/eclipse-sw360/sw360/assets/142988587/e71bae2a-5221-45cf-afc7-c8b3beae7a95)
 
The existing pkg : **chartjs.chartjs-color-string (0.6.0)** along with it's release is linked to the project along with the new release that is created from the SBOM. 

![2024-04-30 14_35_10-SW360_NEW  Running  - Oracle VM VirtualBox](https://github.com/eclipse-sw360/sw360/assets/142988587/29fe0c53-d28c-472f-a181-4f992e2f606d)

![2024-04-30 14_38_00-SW360_NEW  Running  - Oracle VM VirtualBox](https://github.com/eclipse-sw360/sw360/assets/142988587/091deb2c-2944-4f30-be38-948c53f48ce2)
 
With this change the projects that were using the particular pkg won't be affected and there won't be an inconsistency in them.