### PR TITLE
fix(rest) : Move GenerateLicenseInfoFile rest end point to SW360reportcontroller

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -751,7 +751,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         };
     }
 
-    protected List<ProjectLink> createLinkedProjects(Project project,
+    public List<ProjectLink> createLinkedProjects(Project project,
             Function<ProjectLink, ProjectLink> projectLinkMapper, boolean deep, User user) {
         final Collection<ProjectLink> linkedProjects = SW360Utils
                 .flattenProjectLinkTree(SW360Utils.getLinkedProjects(project, deep, new ThriftClients(), log, user));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2060,15 +2060,17 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     public void should_document_get_download_license_info() throws Exception {
         this.mockMvc.perform(get("/api/projects/" + project.getId()+ "/licenseinfo?generatorClassName=XhtmlGenerator&variant=DISCLOSURE&externalIds=portal-id,main-project-id")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .param("module", "licenseInfo")
+                .param("projectId", project.getId())
+                .param("generatorClassName", "XhtmlGenerator")
+                .param("variant", "DISCLOSURE")
+                .param("externalIds", "portal-id,main-project-id")
                 .accept("application/xhtml+xml"))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler
                         .document(queryParameters(
-                                parameterWithName("generatorClassName")
-                                        .description("All possible values for output generator class names are "
-                                                + Arrays.asList("DocxGenerator", "XhtmlGenerator", "TextGenerator")),
-                                parameterWithName("variant").description("All the possible values for variants are "
-                                        + Arrays.asList(OutputFormatVariant.values())),
+                                parameterWithName("generatorClassName").description("Projects download format. Possible values are `<DocxGenerator|XhtmlGenerator|TextGenerator>`"),
+                                parameterWithName("variant").description("All the possible values for variants are `<REPORT|DISCLOSURE>`"),
                                 parameterWithName("externalIds").description("The external Ids of the project")
                                 )));
     }


### PR DESCRIPTION
<!-- Before filling this issue, please read the wiki (https://eclipse.org/sw360)
and search if the bug do not already exists in the issues (https://github.com//eclipse-sw360/sw360/issues). -->

### Description
Issue reference 
Closes #2441 

#### How to reproduce

Sample test : 
URL : http://localhost:8080/resource/api/reports?module=licenseInfo&projectId=8fef50eafc484e33bb8ebb33618ed56d&generatorClassName=DocxGenerator&variant=DISCLOSURE

Result : 

![image](https://github.com/eclipse-sw360/sw360/assets/121924406/a863cda7-d2d3-4cb0-b2c3-d97eec3983aa)

Can download from rest!


