### PR TITLE
fix(api): throw 409 if last moderator

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
@@ -32,8 +32,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.security.InvalidParameterException;
 import java.util.HashMap;
@@ -227,7 +229,8 @@ public class Sw360ModerationRequestService {
             log.error("Error in Moderation ", e);
         }
         if (status == RemoveModeratorRequestStatus.LAST_MODERATOR) {
-            throw new InvalidParameterException("You are the last moderator for this request - " +
+            throw new HttpClientErrorException(HttpStatus.CONFLICT,
+                    "You are the last moderator for this request - " +
                     "you are not allowed to unsubscribe.");
         } else if (status == RemoveModeratorRequestStatus.FAILURE) {
             throw new SW360Exception("Failed to remove from moderator list.");


### PR DESCRIPTION
> Please provide a summary of your changes here.
1. Throw `HttpClientErrorException` instead of `InvalidParameterException` to get correct status code instead of 500.
2. Also, change the status code from 400 to 409 incase the moderator is last moderator.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. Create a moderation request.
2. Use REST API to unassign moderators from the MR.
3. Upon removal of last moderator, endpoint should return status code 409 instead of 500.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR