### PR TITLE
fix(importCDX):Improve error message when PURL is invalid

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -632,8 +632,9 @@ public class CycloneDxBOMImporter {
                         log.info("updating component successfull: " + comp.getName());
                     }
 
+                    releaseRelationMap.putIfAbsent(release.getId(), getDefaultRelation());
                     Package pkg = createPackage(bomComp, release, licenses);
-                    String pkgName = SW360Utils.getVersionedName(pkg.getName(), pkg.getVersion());
+                    String pkgName = pkg == null ? SW360Utils.getVersionedName(bomComp.getName(), bomComp.getVersion()) : SW360Utils.getVersionedName(pkg.getName(), pkg.getVersion());
                     if (pkg == null || CommonUtils.isNullEmptyOrWhitespace(pkg.getName()) || CommonUtils.isNullEmptyOrWhitespace(pkg.getVersion())
                             || CommonUtils.isNullEmptyOrWhitespace(pkg.getPurl())) {
                         invalidPackages.add(pkgName);
@@ -667,7 +668,6 @@ public class CycloneDxBOMImporter {
                             continue;
                         }
                         project.addToPackageIds(pkg.getId());
-                        releaseRelationMap.putIfAbsent(release.getId(), getDefaultRelation());
                     } catch (SW360Exception e) {
                         log.error("An error occured while creating/adding package from SBOM: " + e.getMessage());
                         continue;


### PR DESCRIPTION
Currently, when an import fails due to an invalid PURL (Package URL) present in the SBOM, the error message lacked details about the failed component and gives a null exception. Now the components having malformed PURL are listed for the users to know where it failed.

Closes : #2451 

Before : 
![image](https://github.com/eclipse-sw360/sw360/assets/142988587/58890e0d-c2b5-4c9f-a7e7-ecdc1b8d745d)

Now we get info of the failed component : 
![image](https://github.com/eclipse-sw360/sw360/assets/142988587/bbabf856-33d1-470a-8ab9-92a3e72674d4)
