### PR TITLE
feat(importCDX): Add functionality to configure release creation when importing SBOM to an existing project

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1853,6 +1853,10 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     public RequestSummary importCycloneDxFromAttachmentContent(User user, String attachmentContentId, String projectId) throws SW360Exception {
+        return importCycloneDxFromAttachmentContent(user, attachmentContentId, projectId, false);
+    }
+
+    public RequestSummary importCycloneDxFromAttachmentContent(User user, String attachmentContentId, String projectId, boolean doNotReplacePackageAndRelease) throws SW360Exception {
         final AttachmentContent attachmentContent = attachmentConnector.getAttachmentContent(attachmentContentId);
         final Duration timeout = Duration.durationOf(30, TimeUnit.SECONDS);
         try {
@@ -1861,7 +1865,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                     .unsafeGetAttachmentStream(attachmentContent)) {
                 final CycloneDxBOMImporter cycloneDxBOMImporter = new CycloneDxBOMImporter(this,
                         componentDatabaseHandler, packageDatabaseHandler, attachmentConnector, user);
-                return cycloneDxBOMImporter.importFromBOM(inputStream, attachmentContent, projectId, user);
+                return cycloneDxBOMImporter.importFromBOM(inputStream, attachmentContent, projectId, user, doNotReplacePackageAndRelease);
             }
         } catch (IOException e) {
             log.error("Error while importing / parsing CycloneDX SBOM! ", e);

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -274,6 +274,13 @@ public class ProjectHandler implements ProjectService.Iface {
     }
 
     @Override
+    public RequestSummary importCycloneDxFromAttachmentContentWithReplacePackageAndReleaseFlag(User user, String attachmentContentId, String projectId, boolean doNotReplacePackageAndRelease) throws SW360Exception {
+        assertId(attachmentContentId);
+        assertUser(user);
+        return handler.importCycloneDxFromAttachmentContent(user, attachmentContentId, projectId, doNotReplacePackageAndRelease);
+    }
+
+    @Override
     public RequestSummary exportCycloneDxSbom(String projectId, String bomType, boolean includeSubProjReleases, User user) throws SW360Exception {
         assertId(projectId);
         assertUser(user);

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -611,6 +611,12 @@ service ProjectService {
     RequestSummary importCycloneDxFromAttachmentContent(1: User user, 2: string attachmentContentId, 3: string projectId) throws (1: SW360Exception exp);
 
     /**
+    * Parse a CycloneDx SBoM file (XML or JSON) during re-import on a project and write the information to SW360 as Project / Component / Release / Package
+    * with replaceReleaseAndPackageFlag
+    */
+    RequestSummary importCycloneDxFromAttachmentContentWithReplacePackageAndReleaseFlag(1: User user, 2: string attachmentContentId, 3: string projectId, 4: bool doNotReplacePackageAndRelease) throws (1: SW360Exception exp);
+
+    /**
      * Export a CycloneDx SBoM file (XML or JSON) for a Project
      */
     RequestSummary exportCycloneDxSbom(1: string projectId, 2: string bomType, 3: bool includeSubProjReleases, 4: User user) throws (1: SW360Exception exp);

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -899,7 +899,15 @@ include::{snippets}/should_document_import_cyclonedx/http-response.adoc[]
 [[resources-import-sbom-on-project]]
 ==== Import SBOM on project
 
-A `POST` request is used to import a SBOM on a project. Currently only CycloneDX(.xml/.json) files are supported.
+A `POST` request is used to import a SBOM on a project. The project’s releases and packages will be replaced with the latest data from the SBOM. Currently only CycloneDX(.xml/.json) files are supported.
+
+[red]#Request parameter#
+|===
+|Parameter |Description
+
+|doNotReplacePackageAndRelease
+|When importing an SBOM into an existing project, the project’s releases and packages will be replaced with the latest data from the SBOM. Use the parameter `doNotReplacePackageAndRelease=true` to import new data without replacing the existing releases and packages.
+|===
 
 [red]#Request body#
 |===

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2010,7 +2010,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
             projectId = requestSummary.getMessage();
         } else {
-            requestSummary = projectService.importCycloneDX(sw360User, attachment.getAttachmentContentId(), "");
+            requestSummary = projectService.importCycloneDX(sw360User, attachment.getAttachmentContentId(), "", true);
 
             if (requestSummary.getRequestStatus() == RequestStatus.FAILURE) {
                 return new ResponseEntity<String>(requestSummary.getMessage(), HttpStatus.BAD_REQUEST);
@@ -2064,7 +2064,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable(value = "id", required = true) String id,
             @Parameter(description = "SBOM file")
-            @RequestBody MultipartFile file
+            @RequestBody MultipartFile file,
+            @Parameter(description = "Don't overwrite existing project releases and packages while re-importing SBOM")
+            @RequestParam(value = "doNotReplacePackageAndRelease", required = false) boolean doNotReplacePackageAndRelease
     ) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Attachment attachment = null;
@@ -2079,7 +2081,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             throw new RuntimeException("failed to upload attachment", e);
         }
 
-        requestSummary = projectService.importCycloneDX(sw360User, attachment.getAttachmentContentId(), id);
+        requestSummary = projectService.importCycloneDX(sw360User, attachment.getAttachmentContentId(), id, doNotReplacePackageAndRelease);
 
         if (requestSummary.getRequestStatus() == RequestStatus.FAILURE) {
             return new ResponseEntity<String>(requestSummary.getMessage(), HttpStatus.BAD_REQUEST);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1103,9 +1103,9 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
      * @return RequestSummary
      * @throws TException
      */
-    public RequestSummary importCycloneDX(User user, String attachmentContentId, String projectId) throws TException {
+    public RequestSummary importCycloneDX(User user, String attachmentContentId, String projectId, boolean doNotReplacePackageAndRelease) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        return sw360ProjectClient.importCycloneDxFromAttachmentContent(user, attachmentContentId, CommonUtils.nullToEmptyString(projectId));
+        return sw360ProjectClient.importCycloneDxFromAttachmentContentWithReplacePackageAndReleaseFlag(user, attachmentContentId, CommonUtils.nullToEmptyString(projectId), doNotReplacePackageAndRelease);
     }
 
     /**

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -573,7 +573,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.loadPreferredClearingDateLimit()).willReturn(Integer.valueOf(7));
 
         given(this.projectServiceMock.importSPDX(any(),any())).willReturn(requestSummaryForSPDX);
-        given(this.projectServiceMock.importCycloneDX(any(),any(),any())).willReturn(requestSummaryForCycloneDX);
+        given(this.projectServiceMock.importCycloneDX(any(),any(),any(),anyBoolean())).willReturn(requestSummaryForCycloneDX);
         given(this.sw360ReportServiceMock.getDocumentName(any(), any())).willReturn(projectName);
         given(this.sw360ReportServiceMock.getProjectBuffer(any(),anyBoolean(),any())).willReturn(ByteBuffer.allocate(10000));
         given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(projectList);
@@ -2456,6 +2456,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.post("/api/projects/"+project.getId()+"/import/SBOM")
                 .content(file.getBytes())
                 .contentType(MediaType.MULTIPART_FORM_DATA)
+                .queryParam("doNotReplacePackageAndRelease", "false")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword));
         this.mockMvc.perform(builder).andExpect(status().isOk()).andDo(this.documentationHandler.document());
     }


### PR DESCRIPTION
This PR introduces the feature that allows users to configure release creation when importing CycloneDX SBOM to an existing project.

closes: #2435