### PR TITLE
fix(rest): Update search API to return 200 status with empty results array when no match found

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
@@ -102,6 +102,8 @@ public class SearchController implements RepresentationModelProcessor<Repository
         CollectionModel resources = null;
         if (CommonUtils.isNotEmpty(searchResources)) {
             resources = restControllerHelper.generatePagesResource(paginationResult, searchResources);
+        }else{
+            resources = restControllerHelper.emptyPageResource(SearchResult.class, paginationResult);
         }
 
         HttpStatus status = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;


### PR DESCRIPTION
### Description
This PR updates the search API to return a 200 status code with an empty results array when no matches are found.
![aftest](https://github.com/eclipse-sw360/sw360/assets/141239852/a81e275d-ed4c-4fdf-bf5a-708c0b1e362c)

