### PR TITLE
feat(api): postpone moderation request action

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationPatch.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationPatch.java
@@ -13,9 +13,14 @@
 
 package org.eclipse.sw360.rest.resourceserver.moderationrequest;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Input for PATCH request on moderation request to accept/reject it.
  */
+@Setter
+@Getter
 public class ModerationPatch {
     private ModerationAction action;
     private String comment;
@@ -25,22 +30,6 @@ public class ModerationPatch {
         this.comment = null;
     }
 
-    public ModerationAction getAction() {
-        return action;
-    }
-
-    public void setAction(ModerationAction action) {
-        this.action = action;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
     /**
      * Actions which can be performed on the moderation request
      */
@@ -48,6 +37,7 @@ public class ModerationPatch {
         ACCEPT,
         REJECT,
         UNASSIGN,
-        ASSIGN
+        ASSIGN,
+        POSTPONE
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -206,7 +206,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
 
     @Operation(
             summary = "Action on moderation request.",
-            description = "Accept or reject the moderation request, save the comment by the reviewer and send email " +
+            description = "Perform actions on the moderation request, save the comment by the reviewer and send email " +
                     "notifications.",
             tags = {"Moderation Requests"},
             responses = {@ApiResponse(
@@ -255,6 +255,9 @@ public class ModerationRequestController implements RepresentationModelProcessor
                 break;
             case ASSIGN:
                 moderationStatus = sw360ModerationRequestService.assignRequest(moderationRequest, sw360User);
+                break;
+            case POSTPONE:
+                moderationStatus = sw360ModerationRequestService.postponeRequest(moderationRequest, patch.getComment());
                 break;
             default:
                 throw new HttpClientErrorException(HttpStatus.BAD_REQUEST,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
@@ -377,6 +377,23 @@ public class Sw360ModerationRequestService {
     }
 
     /**
+     * Update the moderation request with the new comment when POSTPONE action
+     * is performed and update its state to INPROGRESS.
+     *
+     * @param request          Moderation request to postpone
+     * @param moderatorComment Comment from moderator
+     * @return Current status of the moderation request
+     * @throws TException Exception in case of error.
+     */
+    public ModerationState postponeRequest(@NotNull ModerationRequest request,
+                                           String moderatorComment) throws TException {
+        request.setModerationState(ModerationState.INPROGRESS);
+        request.setCommentDecisionModerator(moderatorComment);
+        getThriftModerationClient().updateModerationRequest(request);
+        return ModerationState.INPROGRESS;
+    }
+
+    /**
      * Remove the user from moderator list of the moderation request.
      *
      * @param request  Moderation request to edit
@@ -424,7 +441,7 @@ public class Sw360ModerationRequestService {
     /**
      * Get open critical CR count by user department
      *
-     * @param department Department of user
+     * @param group Department of user
      * @return Count of open critical CRs
      * @throws TException Throws exception in case of errors.
      */


### PR DESCRIPTION
### Description

Update `PATCH` endpoint for `ModerationRequestController` to accept `POSTPONE` as an action from user.

### How to test

When the user clicks on "Postpone Request" button from new UI, the moderation request can be patched with `action: POSTPONE` and new comment updated on the MR.

Closes #2467