### PR TITLE
fix(rest): Fix internal server error with 500 status code for link project to projects endpoint.

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -540,7 +540,7 @@ include::{snippets}/should_document_delete_project/http-response.adoc[]
 [[resources-project-link-projects]]
 ==== Link project to the projects
 
-A `POST` request is used to link project to the projects. Please pass an array of project ids as request body.
+A `POST` request is used to link project to the projects. Please pass an array of project ids as request body. The project passed in the url will become the child project of all the projects passed in the request body.
 
 ===== Request structure 1
 Pass an array of project ids as request body.

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -690,9 +690,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         for(String projId: projectIdsInRequestBody) {
             Project proj = projectService.getProjectForUserById(projId, sw360User);
-            Map<String, ProjectProjectRelationship> linkedProject= proj.getLinkedProjects();
+            Map<String, ProjectProjectRelationship> linkedProject = Optional.ofNullable(proj.getLinkedProjects()).orElse(new HashMap<>());
 
-            if (proj.getLinkedProjects().keySet().contains(id)) {
+            if (linkedProject.keySet().contains(id)) {
                 alreadyLinkedIds.add(projId);
                 continue;
             }


### PR DESCRIPTION
Fixes the issue where linking of projects was not possible when projects passed in the request body did not have any linkedProject to them. (couchDB project document did not have a linkedProject object). 

Endpoint : http://localhost:8080/resource/api/projects/{src_project_id}/linkProjects

Request body : array of project ids to be linked.

![image](https://github.com/eclipse-sw360/sw360/assets/142988587/0d045584-0827-4238-acb2-6968ffb2a755)


closes : #2472 