### PR TITLE
feat(obl): rest endpoint to update license obligations of project

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -455,6 +455,21 @@ include::{snippets}/should_document_add_obligations_from_license_db/curl-request
 ===== Example response
 include::{snippets}/should_document_add_obligations_from_license_db/http-response.adoc[]
 
+[[resources-project-update-license-obligation-information]]
+==== Update License Obligations for a project
+
+A `PATCH` request will update the license obligations for the given project id.
+
+===== Request structure
+Pass a map having key as Obligation Title and value as Obligation Status and Obligation Comment which you want to update.
+Possible Obligation Status values are [FULFILLED_AND_PARENT_MUST_ALSO_FULFILL, ESCALATED, WILL_BE_FULFILLED_BEFORE_RELEASE, DEFERRED_TO_PARENT_PROJECT, ACKNOWLEDGED_OR_FULFILLED, NOT_APPLICABLE, OPEN]
+
+===== Example request
+include::{snippets}/should_document_update_license_obligations/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_update_license_obligations/http-response.adoc[]
+
 [[resources-project-get-license-clearing-information-information]]
 ==== Project's license clearing count
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2260,21 +2260,25 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     private Map<String, Object> createPaginationMetadata(Pageable pageable, Map<String, ObligationStatusInfo> licenseObligation) {
         List<Map.Entry<String, ObligationStatusInfo>> entries = new ArrayList<>(licenseObligation.entrySet());
-        int pageSize = pageable.getPageSize();
-        int pageNumber = pageable.getPageNumber();
+        boolean isDefaultPaged = pageable != null && pageable.getPageSize() == 20 && pageable.getPageNumber() == 0;
+        boolean isPaged = pageable != null && pageable.isPaged() && !isDefaultPaged;
+        int pageSize = isPaged ? pageable.getPageSize() : entries.size();
+        int pageNumber = isPaged ? pageable.getPageNumber() : 0;
         int start = pageNumber * pageSize;
         int end = Math.min(start + pageSize, entries.size());
-        entries = entries.subList(start, end);
+
+        List<Map.Entry<String, ObligationStatusInfo>> paginatedEntries = entries.subList(start, end);
         int totalPages = (int) Math.ceil((double) licenseObligation.size()/ pageSize);
+
         Map<String, ObligationStatusInfo> paginatedMap = new LinkedHashMap<>();
-        for (Map.Entry<String, ObligationStatusInfo> entry : entries) {
+        for (Map.Entry<String, ObligationStatusInfo> entry : paginatedEntries) {
             paginatedMap.put(entry.getKey(), entry.getValue());
         }
         Map<String, Integer> pagination =  Map.of(
-            "size", pageSize,
-            "totalElements", licenseObligation.size(),
-            "totalPages", totalPages,
-            "number", pageNumber
+                "size", pageSize,
+                "totalElements", licenseObligation.size(),
+                "totalPages", isPaged ? totalPages : 1,
+                "number", pageNumber
         );
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("page", pagination);
@@ -2374,12 +2378,42 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
         }
         selectedLicenseObligation.putAll(obligationStatusMapFromReport);
-        RequestStatus requestStatus= projectService.updateLinkedObligations(sw360Project, sw360User, selectedLicenseObligation);
+        RequestStatus requestStatus= projectService.addLinkedObligations(sw360Project, sw360User, selectedLicenseObligation);
         if (requestStatus == RequestStatus.SUCCESS) {
             return new ResponseEntity<>("License Obligation Added Successfully", HttpStatus.CREATED);
         }
         return new ResponseEntity<>("Failed to add/update obligation for project", HttpStatus.NOT_FOUND);
 	}
+
+    @PreAuthorize("hasAuthority('WRITE')")
+    @Operation(
+            summary = "Update License Obligations ",
+            description = "Pass a map of obligations in request body.",
+            tags = {"Projects"}
+    )
+    @RequestMapping(value = PROJECTS_URL + "/{id}/updateLicenseObligation", method = RequestMethod.PATCH)
+    public ResponseEntity<?> patchLicenseObligations(
+            @Parameter(description = "Project ID.")
+            @PathVariable("id") String id,
+            @Parameter(description = "Map of obligation status info.")
+            @RequestBody Map<String, ObligationStatusInfo> requestBodyObligationStatusInfo
+    ) throws TException {
+        final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        final Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+        ObligationList obligation = new ObligationList();
+        Map<String, ObligationStatusInfo> obligationStatusMap = Maps.newHashMap();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(sw360Project.getLinkedObligationId())) {
+            obligation = projectService.getObligationData(sw360Project.getLinkedObligationId(), sw360User);
+            obligationStatusMap = CommonUtils.nullToEmptyMap(obligation.getLinkedObligationStatus());
+        }
+        Map<String, ObligationStatusInfo> updatedObligationStatusMap = projectService
+                .compareObligationStatusMap(sw360User, obligationStatusMap, requestBodyObligationStatusInfo);
+        RequestStatus updateObligationStatus = projectService.patchLinkedObligations(sw360User, updatedObligationStatusMap, obligation);
+        if (updateObligationStatus == RequestStatus.SUCCESS) {
+            return new ResponseEntity<>("License Obligation Updated Successfully", HttpStatus.CREATED);
+        }
+        return new ResponseEntity<>("Cannot update License Obligation", HttpStatus.CONFLICT);
+    }
 
     @Operation(
             description = "Get summary and administration page of project tab.",

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -480,7 +480,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         Map<String, ObligationStatusInfo> obligationStatusMap = Map.of(obligation.getTitle(), osi);
         
         ObligationList obligationLists = new ObligationList();
-        obligationLists.setProjectId("123456733");
+        obligationLists.setProjectId(project8.getId());
         obligationLists.setId("009");
         obligationLists.setLinkedObligationStatus(obligationStatusMap);
 
@@ -566,7 +566,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.setLicenseInfoWithObligations(eq(obligationStatusMap), eq(releaseIdToAcceptedCLI), any(), any())).willReturn(obligationStatusMap);
         given(this.projectServiceMock.getLicensesFromAttachmentUsage(eq(licenseInfoUsages), any())).willReturn(licensesFromAttachmentUsage);
         given(this.projectServiceMock.getLicenseObligationData(eq(licensesFromAttachmentUsage), any())).willReturn(obligationStatusMap);
-        given(this.projectServiceMock.updateLinkedObligations(any(), any(), eq(obligationStatusMap))).willReturn(RequestStatus.SUCCESS);
+        given(this.projectServiceMock.addLinkedObligations(any(), any(), eq(obligationStatusMap))).willReturn(RequestStatus.SUCCESS);
+        given(this.projectServiceMock.compareObligationStatusMap(any(), any(), any())).willReturn(obligationStatusMap);
+        given(this.projectServiceMock.patchLinkedObligations(any(), any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.projectServiceMock.getProjectForUserById(eq(projectForAtt.getId()), any())).willReturn(projectForAtt);
         given(this.projectServiceMock.getProjectForUserById(eq(SPDXProject.getId()), any())).willReturn(SPDXProject);
         given(this.projectServiceMock.getProjectForUserById(eq(cycloneDXProject.getId()), any())).willReturn(cycloneDXProject);
@@ -894,6 +896,20 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         this.mockMvc.perform(requestBuilder.contentType(MediaTypes.HAL_JSON)
                 .content(this.objectMapper.writeValueAsString(licenseObligationIds))
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))).andExpect(status().isCreated());
+    }
+
+    @Test
+    public void should_document_update_license_obligations() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = patch("/api/projects/" + project8.getId() + "/updateLicenseObligation");
+        ObligationStatusInfo obligationStatusInfo = new ObligationStatusInfo();
+        obligationStatusInfo.setComment("updating comment");
+        obligationStatusInfo.setStatus(ObligationStatus.ESCALATED);
+        Map<String, ObligationStatusInfo> licOblMap = new HashMap<>();
+        licOblMap.put("obligation_title", obligationStatusInfo);
+
+        this.mockMvc.perform(requestBuilder.contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(licOblMap))
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))).andExpect(status().isCreated());
     }
 


### PR DESCRIPTION
Issue: #2475

### Description

Rest endpoint to update license obligations of project.
Pass a map having key as Obligation Title and value as Obligation Status and Obligation Comment which you want to update.

How to test:
run the endpoint to update license obligations: 
http://localhost:8080/resource/api/projects/036452503f984171971de77c8f4de185/updateLicenseObligation

![image](https://github.com/eclipse-sw360/sw360/assets/58290634/89cb7cd2-558e-4d9c-bc46-76ad154bfaf7)


