### PR TITLE
feat(rest): Add endpoint to handle updation of clearing requests.

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -277,6 +277,17 @@ public class SW360Utils {
         }
     }
 
+    public static boolean isValidDate(String currRequestedClearingDate, String newRequestedClearingDate, DateTimeFormatter format) {
+        try {
+            LocalDate currLocalDate = LocalDate.parse(currRequestedClearingDate, format);
+            LocalDate requestedLocalDate = LocalDate.parse(newRequestedClearingDate, format);
+
+            return requestedLocalDate.isAfter(currLocalDate);
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+
     public static String printFullname(Release release) {
         if (release == null || isNullOrEmpty(release.getName())) {
             return "New Release";

--- a/rest/resource-server/src/docs/asciidoc/clearingRequests.adoc
+++ b/rest/resource-server/src/docs/asciidoc/clearingRequests.adoc
@@ -115,4 +115,17 @@ include::{snippets}/should_document_add_comment_to_clearingrequest/response-fiel
 include::{snippets}/should_document_add_comment_to_clearingrequest/http-response.adoc[]
 
 
+[[resources-clearingRequest-update]]
+==== Update a clearingRequest
+
+A `PATCH` request is used to update an existing clearingRequest
+
+===== Response structure
+include::{snippets}/should_document_patch_clearingrequest/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_patch_clearingrequest/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_patch_clearingrequest/http-response.adoc[]
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/Sw360ClearingRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/Sw360ClearingRequestService.java
@@ -109,6 +109,17 @@ public class Sw360ClearingRequestService {
         return getClearingRequestById(crId, sw360User);
     }
 
+    public RequestStatus updateClearingRequest(ClearingRequest clearingRequest, User sw360User, String baseUrl, String projectId) throws TException {
+        ModerationService.Iface sw360ModerationClient = getThriftModerationClient();
+        String projectUrl = baseUrl + "/projects/-/project/detail/" + projectId;
 
+        RequestStatus requestStatus;
+        requestStatus = sw360ModerationClient.updateClearingRequest(clearingRequest, sw360User, projectUrl);
+
+        if (requestStatus == RequestStatus.FAILURE) {
+            throw new RuntimeException("Clearing Request with id '" + clearingRequest.getId() + " cannot be updated.");
+        }
+        return requestStatus;
+    }
 
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -659,6 +659,16 @@ public class RestControllerHelper<T> {
         return packageToUpdate;
     }
 
+    public ClearingRequest updateClearingRequest(ClearingRequest crToUpdate, ClearingRequest requestBodyCR) {
+        for(ClearingRequest._Fields field: ClearingRequest._Fields.values()) {
+            Object fieldValue = requestBodyCR.getFieldValue(field);
+            if (fieldValue != null) {
+                crToUpdate.setFieldValue(field, fieldValue);
+            }
+        }
+        return crToUpdate;
+    }
+
     public User updateUserProfile(User userToUpdate, Map<String, Object> requestBodyUser, ImmutableSet<User._Fields> setOfUserProfileFields) {
         for (User._Fields field : setOfUserProfileFields) {
             Object fieldValue = requestBodyUser.get(field.getFieldName());

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ClearingRequestSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ClearingRequestSpecTest.java
@@ -15,9 +15,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.IOException;
@@ -56,6 +60,7 @@ public class ClearingRequestSpecTest extends TestRestDocsSpecBase {
 
     @MockBean
     private Sw360ClearingRequestService clearingRequestServiceMock;
+
     ClearingRequest clearingRequest = new ClearingRequest();
     ClearingRequest cr1 = new ClearingRequest();
     ClearingRequest cr2 = new ClearingRequest();
@@ -63,6 +68,7 @@ public class ClearingRequestSpecTest extends TestRestDocsSpecBase {
 
     @Before
     public void before() throws TException, IOException {
+
         clearingRequest.setId("CR-101");
         clearingRequest.setAgreedClearingDate("12-07-2020");
         clearingRequest.setClearingState(ClearingRequestState.ACCEPTED);
@@ -390,5 +396,49 @@ public class ClearingRequestSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )
                 ));
+    }
+
+    @Test
+    public void should_document_patch_clearingrequest () throws Exception {
+        ClearingRequest updateClearingRequest = new ClearingRequest()
+                .setClearingTeam("clearing.team@sw60.org")
+                .setClearingState(ClearingRequestState.SANITY_CHECK);
+
+        mockMvc.perform(patch("/api/clearingrequest/" + clearingRequest.getId())
+                        .contentType(MediaTypes.HAL_JSON)
+                        .content(this.objectMapper.writeValueAsString(updateClearingRequest))
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        requestFields(
+                                fieldWithPath("clearingTeam").description("The clearing team email id."),
+                                fieldWithPath("clearingState").description("The clearing state of request")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("The id of the clearing request"),
+                                fieldWithPath("agreedClearingDate").description("The agreed clearing date of the request, on / before which CR should be cleared"),
+                                fieldWithPath("clearingState").description("The clearing state of the request. Possible values are: " + Arrays.asList(ClearingRequestState.values())),
+                                fieldWithPath("clearingTeam").description("The clearing team email id."),
+                                fieldWithPath("projectBU").description("The Business Unit / Group of the Project, for which the clearing request is created"),
+                                fieldWithPath("projectId").description("The id of the Project, for which the clearing request is created"),
+                                fieldWithPath("requestedClearingDate").description("The requested clearing date of releases"),
+                                fieldWithPath("requestingUser").description("The user who created the clearing request"),
+                                fieldWithPath("requestingUserComment").description("The comment from the requesting user"),
+                                fieldWithPath("priority").description("The priority of the clearing request. Possible values are: " + Arrays.asList(ClearingRequestPriority.values())),
+                                subsectionWithPath("comments").description("The clearing request comments"),
+                                subsectionWithPath("comments[].text").description("The clearing request comment text"),
+                                subsectionWithPath("comments[].commentedBy").description("The user who added the comment on the clearing request"),
+                                subsectionWithPath("_embedded.sw360:project").description("The Project associated with the ClearingRequest"),
+                                subsectionWithPath("_embedded.clearingTeam").description("Clearing team user detail"),
+                                subsectionWithPath("_embedded.requestingUser").description("Requesting user detail"),
+                                subsectionWithPath("_links").description("Links to other resources"),
+                                fieldWithPath("clearingType").description("The type of clearing, e.g., DEEP"),
+                                fieldWithPath("_embedded.totalRelease").description("Total number of releases"),
+                                fieldWithPath("_embedded.openRelease").description("Number of open releases"),
+                                fieldWithPath("_embedded.lastUpdatedOn").description("Last updated date for the clearing request"),
+                                fieldWithPath("_embedded.createdOn").description("Creation date for the clearing request")
+
+                        )));
     }
 }


### PR DESCRIPTION
### Description
This endpoint is to update a clearing request using id.
![cr_endpoint](https://github.com/eclipse-sw360/sw360/assets/141239852/cbf69abe-16f3-4450-ad2a-4f29fd6f070d)

Closes: #2464 
Closes: #2523
