### PR TITLE
Revert "fix(importCDX): Resolved unnecessary update of component fields"

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -510,11 +510,14 @@ public class CycloneDxBOMImporter {
 
                 // update components specific fields
                 comp = componentDatabaseHandler.getComponent(compAddSummary.getId(), user);
-                if (AddDocumentRequestStatus.SUCCESS.equals(compAddSummary.getRequestStatus()) && (null != bomComp.getType() && null == comp.getCdxComponentType())) {
+                if (null != bomComp.getType() && null == comp.getCdxComponentType()) {
                     comp.setCdxComponentType(getCdxComponentType(bomComp.getType()));
                 }
-                if (AddDocumentRequestStatus.SUCCESS.equals(compAddSummary.getRequestStatus()) && (CommonUtils.isNullEmptyOrWhitespace(comp.getDescription()) && CommonUtils.isNotNullEmptyOrWhitespace(bomComp.getDescription()))) {
-                    comp.setDescription(bomComp.getDescription().trim());
+                StringBuilder description = new StringBuilder();
+                if (CommonUtils.isNullEmptyOrWhitespace(comp.getDescription()) && CommonUtils.isNotNullEmptyOrWhitespace(bomComp.getDescription())) {
+                    description.append(bomComp.getDescription().trim());
+                } else if (CommonUtils.isNotNullEmptyOrWhitespace(bomComp.getDescription())) {
+                    description.append(" || ").append(bomComp.getDescription().trim());
                 }
                 if (CommonUtils.isNotEmpty(comp.getMainLicenseIds())) {
                     comp.getMainLicenseIds().addAll(licenses);
@@ -530,7 +533,7 @@ public class CycloneDxBOMImporter {
                         comp.setWiki(CommonUtils.nullToEmptyString(extRef.getUrl()));
                     }
                 }
-
+                comp.setDescription(description.toString());
                 RequestStatus updateStatus = componentDatabaseHandler.updateComponent(comp, user, true);
                 if (RequestStatus.SUCCESS.equals(updateStatus)) {
                     log.info("updating component successfull: " + comp.getName());
@@ -580,6 +583,7 @@ public class CycloneDxBOMImporter {
 
             Release release = new Release();
             String relName = "";
+            StringBuilder description = new StringBuilder();
             AddDocumentRequestSummary compAddSummary;
             try {
                 Component dupCompByName = componentDatabaseHandler.getComponentByName(comp.getName());
@@ -635,11 +639,13 @@ public class CycloneDxBOMImporter {
 
                     // update components specific fields
                     comp = componentDatabaseHandler.getComponent(compAddSummary.getId(), user);
-                    if (AddDocumentRequestStatus.SUCCESS.equals(compAddSummary.getRequestStatus()) && (null != bomComp.getType() && null == comp.getCdxComponentType())) {
+                    if (null != bomComp.getType() && null == comp.getCdxComponentType()) {
                         comp.setCdxComponentType(getCdxComponentType(bomComp.getType()));
                     }
-                    if (AddDocumentRequestStatus.SUCCESS.equals(compAddSummary.getRequestStatus()) && (CommonUtils.isNullEmptyOrWhitespace(comp.getDescription()) && CommonUtils.isNotNullEmptyOrWhitespace(bomComp.getDescription()))) {
-                        comp.setDescription(bomComp.getDescription().trim());
+                    if (CommonUtils.isNullEmptyOrWhitespace(comp.getDescription()) && CommonUtils.isNotNullEmptyOrWhitespace(bomComp.getDescription())) {
+                        description.append(bomComp.getDescription().trim());
+                    } else if (CommonUtils.isNotNullEmptyOrWhitespace(bomComp.getDescription())) {
+                        description.append(" || ").append(bomComp.getDescription().trim());
                     }
                     if (CommonUtils.isNotEmpty(comp.getMainLicenseIds())) {
                         comp.getMainLicenseIds().addAll(licenses);
@@ -658,6 +664,7 @@ public class CycloneDxBOMImporter {
                         }
                     }
 
+                    comp.setDescription(description.toString());
                     RequestStatus updateStatus = componentDatabaseHandler.updateComponent(comp, user, true);
                     if (RequestStatus.SUCCESS.equals(updateStatus)) {
                         log.info("updating component successfull: " + comp.getName());


### PR DESCRIPTION
Reverts eclipse-sw360/sw360#2138

The component is being updated only if the specific fields are empty which is the expected behavior. This feature prevents the CDX component type from being in the component and also removes the feature of merging different component descriptions using the "||" operator.