### PR TITLE
feat(ImportSBOM):Change naming convention of imported components

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
@@ -106,6 +106,10 @@ public class ComponentSummary extends DocumentSummary<Component> {
         copyField(document, copy, Component._Fields.MAIN_LICENSE_IDS);
         copyField(document, copy, Component._Fields.COMPONENT_TYPE);
         copyField(document, copy, Component._Fields.DEFAULT_VENDOR_ID);
+        copyField(document, copy, Component._Fields.VCS);
+        copyField(document, copy, Component._Fields.HOMEPAGE);
+        copyField(document, copy, Component._Fields.EXTERNAL_IDS);
+
 
 
         for (Release release : releases) {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -768,6 +768,16 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     }
 
+    public Component getComponentByName(String name) {
+        Set<String> components = componentRepository.getComponentIdsByName(name,true);
+        if (components != null && components.size() == 1) {
+            Component comp = componentRepository.get(components.iterator().next());
+            return comp;
+        } else {
+            return null;
+        }
+    }
+
     private boolean isDependenciesExistInComponent(Component component) {
         boolean isValidDependentIds = true;
         if (component.isSetReleaseIds()) {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
@@ -424,7 +424,7 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return packageRepository.searchByPackageManager(packageManager);
     }
 
-    private List<Package> getPackageByNameAndVersion(String pkgName, String pkgVersion) {
+    public List<Package> getPackageByNameAndVersion(String pkgName, String pkgVersion) {
         if (isNullEmptyOrWhitespace(pkgName)) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
### Description

Components are being created from the vcs field in a CDX SBOM using the naming convention "manf.name". This has been changed to create the name with only the component name extracted from the vcs, omitting the manufacturer part unless and until there is a name class, which in that case the name would be created as manf/name. 

#### How to reproduce

Import a CDX SBOM

#### Screenshots ( if applicable )

![image](https://github.com/eclipse-sw360/sw360/assets/115608771/d8ae1c57-59a1-4b6b-8f03-f01ab8a5c7be)

