### PR TITLE
feat(REST): Exclude release version from license info

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -127,6 +127,16 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
             Map<String, Map<String, Boolean>> releaseIdsToSelectedAttachmentIds,
             Map<String, Set<LicenseNameWithText>> excludedLicensesPerAttachment, String externalIds, String fileName)
             throws TException {
+        return getLicenseInfoFileWithoutReleaseVersion(project, user, outputGenerator,
+                releaseIdsToSelectedAttachmentIds, excludedLicensesPerAttachment, externalIds, fileName, false);
+    }
+
+    @Override
+    public LicenseInfoFile getLicenseInfoFileWithoutReleaseVersion(Project project, User user, String outputGenerator,
+            Map<String, Map<String, Boolean>> releaseIdsToSelectedAttachmentIds,
+            Map<String, Set<LicenseNameWithText>> excludedLicensesPerAttachment, String externalIds, String fileName,
+            boolean excludeReleaseVersion)
+            throws TException {
         assertNotNull(project);
         assertNotNull(user);
         assertNotNull(outputGenerator);
@@ -170,7 +180,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         }
 
         Object output = generator.generateOutputFile(projectLicenseInfoResults, project, obligationsResults, user,
-                filteredExtIdMap, obligationsStatusInfoMap, fileName);
+                filteredExtIdMap, obligationsStatusInfoMap, fileName, excludeReleaseVersion);
         if (output instanceof byte[]) {
             licenseInfoFile.setGeneratedOutput((byte[]) output);
         } else if (output instanceof String) {
@@ -182,6 +192,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         return licenseInfoFile;
     }
 
+    @Override
     public Map<String, Map<String, String>> evaluateAttachments(String releaseId, User user) throws TException {
         Release release = componentDatabaseHandler.getRelease(releaseId, user);
         Map<Attachment, LicenseInfoParsingResult> parsedResults = new HashMap<Attachment, LicenseInfoParsingResult>();
@@ -619,7 +630,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     }
 
     @Override
-    public LicenseObligationsStatusInfo getProjectObligationStatus(Map<String, ObligationStatusInfo> obligationStatusMap, List<LicenseInfoParsingResult> licenseResults, 
+    public LicenseObligationsStatusInfo getProjectObligationStatus(Map<String, ObligationStatusInfo> obligationStatusMap, List<LicenseInfoParsingResult> licenseResults,
             Map<String, String> excludedReleaseIdToAcceptedCLI) {
 
         Map<String, ObligationStatusInfo> filteredObligationStatusMap = obligationStatusMap.isEmpty()

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/JsonGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/JsonGenerator.java
@@ -37,8 +37,9 @@ public class JsonGenerator extends OutputGenerator<String> {
     }
 
     @Override
-    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String, String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception {
+    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project,
+            Collection<ObligationParsingResult> obligationResults, User user, Map<String, String> externalIds,
+            Map<String, ObligationStatusInfo> obligationsStatus, String fileName, boolean excludeReleaseVersion) throws SW360Exception {
         return "";
-        
     }
 }

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/TextGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/TextGenerator.java
@@ -37,7 +37,10 @@ public class TextGenerator extends OutputGenerator<String> {
     }
 
     @Override
-    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception {
+    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project,
+            Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds,
+            Map<String, ObligationStatusInfo> obligationsStatus, String fileName,
+            boolean excludeReleaseVersion) throws SW360Exception {
         String projectName = project.getName();
         String projectVersion = project.getVersion();
         String licenseInfoHeaderText = project.getLicenseInfoHeaderText();
@@ -45,14 +48,19 @@ public class TextGenerator extends OutputGenerator<String> {
 
         switch (getOutputVariant()) {
             case DISCLOSURE:
-                return generateDisclosure(projectLicenseInfoResults, projectName + " " + projectVersion, licenseInfoHeaderText, obligationsText, externalIds);
+                return generateDisclosure(projectLicenseInfoResults, projectName + " " + projectVersion,
+                        licenseInfoHeaderText, obligationsText, externalIds, excludeReleaseVersion);
             default:
                 throw new IllegalArgumentException("Unknown generator variant type: " + getOutputVariant());
         }
     }
-    private String generateDisclosure(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectTitle, String licenseInfoHeaderText, String obligationsText, Map<String, String> externalIds) {
+
+    private String generateDisclosure(Collection<LicenseInfoParsingResult> projectLicenseInfoResults,
+            String projectTitle, String licenseInfoHeaderText, String obligationsText,
+            Map<String, String> externalIds, boolean excludeReleaseVersion) {
         try {
-            return renderTemplateWithDefaultValues(projectLicenseInfoResults, TXT_TEMPLATE_FILE, projectTitle, licenseInfoHeaderText, obligationsText, externalIds);
+            return renderTemplateWithDefaultValues(projectLicenseInfoResults, TXT_TEMPLATE_FILE, projectTitle,
+                    licenseInfoHeaderText, obligationsText, externalIds, excludeReleaseVersion);
         } catch (Exception e) {
             LOGGER.error("Could not generate text licenseinfo file for project " + projectTitle, e);
             return "License information could not be generated.\nAn exception occurred: " + e.toString();

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -38,7 +38,9 @@ public class XhtmlGenerator extends OutputGenerator<String> {
     }
 
     @Override
-    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception {
+    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project,
+            Collection<ObligationParsingResult> obligationResults, User user, Map<String, String> externalIds,
+            Map<String, ObligationStatusInfo> obligationsStatus, String fileName, boolean excludeReleaseVersion) throws SW360Exception {
         String projectName = project.getName();
         String projectVersion = project.getVersion();
         String licenseInfoHeaderText = project.getLicenseInfoHeaderText();
@@ -46,15 +48,19 @@ public class XhtmlGenerator extends OutputGenerator<String> {
 
         switch (getOutputVariant()) {
             case DISCLOSURE:
-                return generateDisclosure(projectLicenseInfoResults, projectName + " " + projectVersion, licenseInfoHeaderText, obligationsText, externalIds);
+                return generateDisclosure(projectLicenseInfoResults, projectName + " " + projectVersion, licenseInfoHeaderText, obligationsText, externalIds, excludeReleaseVersion);
             default:
                 throw new IllegalArgumentException("Unknown generator variant type: " + getOutputVariant());
         }
     }
 
-    private String generateDisclosure(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, String projectTitle, String licenseInfoHeaderText, String obligationsText, Map<String, String> externalIds) {
+    private String generateDisclosure(Collection<LicenseInfoParsingResult> projectLicenseInfoResults,
+            String projectTitle, String licenseInfoHeaderText, String obligationsText, Map<String, String> externalIds,
+            boolean excludeReleaseVersion) {
         try {
-            return renderTemplateWithDefaultValues(projectLicenseInfoResults, XHTML_TEMPLATE_FILE, projectTitle, convertHeaderTextToHTML(licenseInfoHeaderText), convertHeaderTextToHTML(obligationsText), externalIds);
+            return renderTemplateWithDefaultValues(projectLicenseInfoResults, XHTML_TEMPLATE_FILE, projectTitle,
+                    convertHeaderTextToHTML(licenseInfoHeaderText), convertHeaderTextToHTML(obligationsText),
+                    externalIds, excludeReleaseVersion);
         } catch (Exception e) {
             LOGGER.error("Could not generate xhtml license info file for project " + projectTitle, e);
             return "License information could not be generated.\nAn exception occured: " + e.toString();

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -136,10 +136,10 @@ public class XhtmlGeneratorTest {
         Map<String, String> externalIds = Collections.emptyMap();
         Map<String, ObligationStatusInfo> obligationsStatus = Collections.emptyMap();
 
-        xmlString = xhtmlGenerator.generateOutputFile(lipresults, p, obligationResults, null, externalIds, obligationsStatus, "");
-        xmlString2 = xhtmlGenerator.generateOutputFile(lipresults2, p, obligationResults, null, externalIds, obligationsStatus, "");
-        xmlString3 = xhtmlGenerator.generateOutputFile(lipresults3, p, obligationResults, null, externalIds, obligationsStatus, "");
-        xmlStringEmpty = xhtmlGenerator.generateOutputFile(lipresultsEmpty, p, obligationResults, null, externalIds, obligationsStatus, "");
+        xmlString = xhtmlGenerator.generateOutputFile(lipresults, p, obligationResults, null, externalIds, obligationsStatus, "", false);
+        xmlString2 = xhtmlGenerator.generateOutputFile(lipresults2, p, obligationResults, null, externalIds, obligationsStatus, "", false);
+        xmlString3 = xhtmlGenerator.generateOutputFile(lipresults3, p, obligationResults, null, externalIds, obligationsStatus, "", false);
+        xmlStringEmpty = xhtmlGenerator.generateOutputFile(lipresultsEmpty, p, obligationResults, null, externalIds, obligationsStatus, "", false);
 
         generateDocumentsFromXml();
     }

--- a/libraries/datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/datahandler/src/main/thrift/licenseinfo.thrift
@@ -145,6 +145,17 @@ service LicenseInfoService {
     LicenseInfoFile getLicenseInfoFile(1: Project project, 2: User user, 3: string outputGeneratorClassName, 4: map<string, map<string, bool>> releaseIdsToSelectedAttachmentIds, 5: map<string, set<LicenseNameWithText>> excludedLicensesPerAttachment, 6: string externalIds, 7: string fileName);
 
     /**
+     * Get copyright and license information file of linked releases of the project and its sub-projects (recursively)
+     * If excludeReleaseVersion is true, the release version will be excluded from the license file
+     * Output format as specified by outputType
+     */
+    LicenseInfoFile getLicenseInfoFileWithoutReleaseVersion(1: Project project, 2: User user, 3: string outputGeneratorClassName,
+    4: map<string, map<string, bool>> releaseIdsToSelectedAttachmentIds,
+    5: map<string, set<LicenseNameWithText>> excludedLicensesPerAttachment, 6: string externalIds, 7: string fileName,
+    8: bool excludeReleaseVersion);
+
+
+    /**
       * returns all available output types
       */
     list<OutputFormatInfo> getPossibleOutputFormats();

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -701,7 +701,7 @@ include::{snippets}/should_document_get_download_license_info/http-response.adoc
 [[resources-project-get-download-licenseinfo-with-all-attachments]]
 ==== Download License Info with all attachments
 
-A `GET` request is used to download the project's license information. The resulting file will include findings from either the CLX or ISR attachment of a linked release.
+A `GET` request is used to download the project's license information. The resulting file will include findings from the CLX, and if not available, the ISR attachment of a linked release.
 
 ===== Request parameter
 include::{snippets}/should_document_get_download_license_info_with_all_attachemnts/request-parameters.adoc[]
@@ -711,6 +711,20 @@ include::{snippets}/should_document_get_download_license_info_with_all_attachemn
 
 ===== Example response
 include::{snippets}/should_document_get_download_license_info_with_all_attachemnts/http-response.adoc[]
+
+[[resources-project-get-download-licenseinfo-without-release-version]]
+==== Download License Info without component versions
+
+A `GET` request is used to download license info for the project. If the `excludeReleaseVersion` parameter is set to true, the component versions will be omitted from the output file.
+
+===== Request parameter
+include::{snippets}/should_document_get_download_license_info_without_release_version/request-parameters.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_download_license_info_without_release_version/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_download_license_info_without_release_version/http-response.adoc[]
 
 [[resources-project-usedby-list]]
 ==== Resources using the project

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
@@ -50,10 +50,17 @@ public class Sw360LicenseInfoService {
 
     public LicenseInfoFile getLicenseInfoFile(Project project, User sw360User, String generatorClassNameWithVariant,
             Map<String, Map<String, Boolean>> selectedReleaseAndAttachmentIds,
-            Map<String, Set<LicenseNameWithText>> excludedLicenses, String externalIds, String fileName) {
+            Map<String, Set<LicenseNameWithText>> excludedLicenses, String externalIds, String fileName,
+            boolean excludeReleaseVersion) {
         try {
             LicenseInfoService.Iface sw360LicenseInfoClient = getThriftLicenseInfoClient();
-            return sw360LicenseInfoClient.getLicenseInfoFile(project, sw360User, generatorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicenses, externalIds, fileName);
+            if (excludeReleaseVersion) {
+                return sw360LicenseInfoClient.getLicenseInfoFileWithoutReleaseVersion(project, sw360User,
+                        generatorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicenses, externalIds,
+                        fileName, excludeReleaseVersion);
+            }
+            return sw360LicenseInfoClient.getLicenseInfoFile(project, sw360User, generatorClassNameWithVariant,
+                    selectedReleaseAndAttachmentIds, excludedLicenses, externalIds, fileName);
         } catch (TException e) {
             throw new RuntimeException(e);
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1370,6 +1370,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "template", required = false) String template,
             @Parameter(description = "Generate license info including all attachments of the linked releases")
             @RequestParam(value = "includeAllAttachments", required = false ) boolean includeAllAttachments,
+            @Parameter(description = "Exclude release version from the license info file")
+            @RequestParam(value = "excludeReleaseVersion", required = false, defaultValue = "false") boolean excludeReleaseVersion,
             HttpServletResponse response
     ) throws TException, IOException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -1448,7 +1450,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         final LicenseInfoFile licenseInfoFile = licenseInfoService.getLicenseInfoFile(sw360Project, sw360User,
                 outputGeneratorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicensesPerAttachments,
-                externalIds, fileName);
+                externalIds, fileName, excludeReleaseVersion);
         byte[] byteContent = licenseInfoFile.bufferForGeneratedOutput().array();
         response.setContentType(outputFormatInfo.getMimeType());
         response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -709,7 +709,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         LicenseInfoFile licenseInfoFile = new LicenseInfoFile();
         licenseInfoFile.setGeneratedOutput(new byte[0]);
         given(this.licenseInfoMockService.getLicenseInfoFile(any(), any(), any(), any(),
-                any(),any(), any())).willReturn(licenseInfoFile);
+                any(),any(), any(), eq(false))).willReturn(licenseInfoFile);
+        given(this.licenseInfoMockService.getLicenseInfoFile(any(), any(), any(), any(),
+                any(),any(), any(), eq(true))).willReturn(licenseInfoFile);
 
         Source ownerSrc1 = Source.releaseId("9988776655");
         Source usedBySrc = Source.projectId(project.getId());
@@ -2070,6 +2072,24 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("variant").description("All the possible values for variants are "
                                         + Arrays.asList(OutputFormatVariant.values())),
                                 parameterWithName("externalIds").description("The external Ids of the project")
+                                )));
+    }
+    
+    @Test
+    public void should_document_get_download_license_info_without_release_version() throws Exception {
+        this.mockMvc.perform(get("/api/projects/" + project.getId()+ "/licenseinfo?generatorClassName=XhtmlGenerator&variant=DISCLOSURE&excludeReleaseVersion=true")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept("application/xhtml+xml"))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler
+                        .document(queryParameters(
+                                parameterWithName("generatorClassName")
+                                        .description("All possible values for output generator class names are "
+                                                + Arrays.asList("DocxGenerator", "XhtmlGenerator", "TextGenerator")),
+                                parameterWithName("variant").description("All the possible values for variants are "
+                                        + Arrays.asList(OutputFormatVariant.values())),
+                                parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
+                                		+ "Possible values are `<true|false>`")
                                 )));
     }
 


### PR DESCRIPTION


### Description

Parameter "excludeReleaseVersion" for endpoint /projects/{id}/licenseinfo that excludes release version information from the license info document when set to true.
 Works for variant "DISCLOSURE" only.
