### PR TITLE
fix: Remove wrong placed copyrights on commit template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-[//]: # (Copyright Bosch.IO GmbH 2020)
 [//]: # (This program and the accompanying materials are made)
 [//]: # (available under the terms of the Eclipse Public License 2.0)
 [//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)


### PR DESCRIPTION
PR's should not be assigned to a single company or a single project or owner.