### PR TITLE
fix(clearingState): making fossology report download configurable.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/common/utils/BackendUtils.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/utils/BackendUtils.java
@@ -20,6 +20,7 @@ public class BackendUtils {
     public static final Boolean MAINLINE_STATE_ENABLED_FOR_USER;
     public static final Boolean IS_BULK_RELEASE_DELETING_ENABLED;
     public static final Boolean IS_FORCE_UPDATE_ENABLED;
+    public static final Boolean DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD;
 
     static {
         loadedProperties = CommonUtils.loadProperties(BackendUtils.class, PROPERTIES_FILE_PATH);
@@ -27,6 +28,7 @@ public class BackendUtils {
         IS_BULK_RELEASE_DELETING_ENABLED = Boolean.parseBoolean(System.getProperty("RunBulkReleaseDeletingTest", loadedProperties.getProperty("bulk.release.deleting.enabled", "false")));
         IS_FORCE_UPDATE_ENABLED = Boolean.parseBoolean(
                 System.getProperty("RunRestForceUpdateTest", loadedProperties.getProperty("rest.force.update.enabled", "false")));
+        DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD = Boolean.parseBoolean(loadedProperties.getProperty("disable.clearing.fossology.report.download", "false"));
     }
 
     protected BackendUtils() {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -225,8 +225,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         long isrCountAfter = evaluateClearingStateForScanAvailable(releaseAfter);
         if (isrCountAfter > 0) {
             releaseAfter.setClearingState(ClearingState.SCAN_AVAILABLE);
-        } else {
-            releaseAfter.setClearingState(ClearingState.NEW_CLEARING);
         }
 
         if (newSecondBestCR.isPresent()) {

--- a/backend/common/src/main/resources/sw360.properties
+++ b/backend/common/src/main/resources/sw360.properties
@@ -131,3 +131,6 @@ auto.set.ecc.status=false
 
 ## This property is used to enable the bulk release deleting feature.
 #bulk.release.deleting.enabled=true
+
+## This property is used to disable the ISR generation in fossology process
+disable.clearing.fossology.report.download=false

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/PermissionUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/PermissionUtils.java
@@ -100,6 +100,10 @@ public class PermissionUtils {
         return user != null && user.isSetUserGroup() && user.getUserGroup() == userGroup;
     }
 
+    public static boolean isUserAtLeastClearingAdminOrExpert(User user) {
+        return isUserAtLeast(UserGroup.CLEARING_ADMIN, user) || isUserAtLeast(UserGroup.CLEARING_EXPERT, user);
+    }
+
     public static boolean isUserAtLeast(UserGroup group, User user) {
         switch (group) {
             case USER:


### PR DESCRIPTION
Issue: #2544 

### How To Test?
To make it configurable, set the variable as true in sw360.properties file.
--> disable.clearing.fossology.report.download=true

After making it configurable, sw360 will now upload the clearing report to fossology for scanning purpose only i.e., it won't generate and download the report back to sw360 as an attachment in release.
As a result it will change the state from Scan Available to Under Clearing.
