### PR TITLE
fix(doc): fix OpenAPI doc for Search endpoint

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
@@ -71,7 +71,9 @@ public class SearchController implements RepresentationModelProcessor<Repository
 
     @Operation(
             summary = "List all the search results based on the search text and type.",
-            description = "List all the search results based on the search text and type.",
+            description = "List all the search results based on the search text and type.\n\n" +
+                "Note: If `document` is excluded in `typeMasks`, then search will be restricted to " +
+                "Name for Project, Component and Release, Fullname for License, User and Vendor, Title for Obligation",
             tags = {"Search"}
     )
     @RequestMapping(value = SEARCH_URL, method = RequestMethod.GET)
@@ -83,7 +85,7 @@ public class SearchController implements RepresentationModelProcessor<Repository
                     description = "The type of resource.",
                     schema = @Schema(
                             allowableValues = {"project", "component", "license", "release", "obligation", "user",
-                                    "vendor"},
+                                    "vendor", "document"},
                             type = "array"
                     )
             )


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Include documentation for "document" as typeMask in search endpoint which dictates entire document search or only specific fields.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
No issue.
> * Did you add or update any new dependencies that are required for your change?
No new dependency

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Check the OpenAPI doc for search endpoint.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
