### PR TITLE
fix(rest): add requestClosedOn field in get clearingRequest_by_id endpoint.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -120,7 +120,9 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
         restControllerHelper.addEmbeddedUser(halClearingRequest, requestingUser, "requestingUser");
         User clearingTeam = restControllerHelper.getUserByEmail(clearingRequest.getClearingTeam());
         restControllerHelper.addEmbeddedUser(halClearingRequest, clearingTeam, "clearingTeam");
-
+        if(clearingRequest.getClearingState().equals(ClearingRequestState.CLOSED) || clearingRequest.getClearingState().equals(ClearingRequestState.REJECTED)){
+            restControllerHelper.addEmbeddedTimestampOfDecision(halClearingRequest,clearingRequest.getTimestampOfDecision());
+        }
         return halClearingRequest;
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -108,15 +108,10 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -1508,6 +1503,14 @@ public class RestControllerHelper<T> {
             HalResource<License> licenseHalResource = addEmbeddedLicense(licenseId);
             halRelease.addEmbeddedResource("sw360:otherLicenses", licenseHalResource);
         }
+    }
+
+    public void addEmbeddedTimestampOfDecision(HalResource<ClearingRequest> halClearingRequest, long timestampOfDecision) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+                .withLocale(Locale.ENGLISH)
+                .withZone(ZoneId.systemDefault());
+        String humanReadableDate = formatter.format(Instant.ofEpochMilli(timestampOfDecision));
+        halClearingRequest.addEmbeddedResource("requestClosedOn", humanReadableDate);
     }
 
     public String getBaseUrl(HttpServletRequest request) {


### PR DESCRIPTION
If a clearing request has been REJECTED or CLOSED, "requestClosedOn" field will be added in the get clearingById endpoint response body.


http://localhost:8080/resource/api/clearingrequest/{crId}



![image](https://github.com/user-attachments/assets/c1059b0c-598f-434f-9ee5-885318ae2cb8)
