### PR TITLE
feat(rest): get releases used by vendor

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/vendors.adoc
+++ b/rest/resource-server/src/docs/asciidoc/vendors.adoc
@@ -52,6 +52,22 @@ include::{snippets}/should_document_get_vendor/http-response.adoc[]
 ===== Links
 include::{snippets}/should_document_get_vendor/links.adoc[]
 
+[[resources-vendor-get-releases]]
+==== Get vendor releases
+
+A `GET` request will list the releases used by the vendor.
+
+===== Response structure
+include::{snippets}/should_document_get_vendor_releases/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_vendor_releases/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_vendor_releases/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_vendor_releases/links.adoc[]
 
 [[resources-vendor-create]]
 ==== Creating a vendor

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.apache.thrift.protocol.TSimpleJSONProtocol;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
@@ -21,6 +21,8 @@ import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -29,6 +31,7 @@ import org.springframework.stereotype.Service;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -154,6 +157,10 @@ public class Sw360VendorService {
         return new ThriftClients().makeVendorClient();
     }
 
+    public ComponentService.Iface getThriftComponentClient() throws TTransportException {
+        return new ThriftClients().makeComponentClient();
+    }
+
     public ByteBuffer exportExcel() throws TException {
         List<Vendor> vendors = getAllVendorList();
         VendorService.Iface sw360VendorClient = getThriftVendorClient();
@@ -163,5 +170,11 @@ public class Sw360VendorService {
     private List<Vendor> getAllVendorList() throws TException {
         VendorService.Iface sw360VendorClient = getThriftVendorClient();
         return sw360VendorClient.getAllVendors();
+    }
+
+    public Set<Release> getAllReleaseList(String vendorId) throws TException {
+        ComponentService.Iface componentsClient = getThriftComponentClient();
+        Set<Release> releases = componentsClient.getReleasesByVendorId(vendorId);
+        return releases;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VendorSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VendorSpecTest.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.junit.Before;
@@ -23,10 +24,7 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -84,6 +82,23 @@ public class VendorSpecTest extends TestRestDocsSpecBase {
         vendorList.add(vendor);
         vendorList.add(vendor2);
 
+        Set<Release> releases = new HashSet<>();
+        Release release1 = new Release();
+        release1.setId("12345");
+        release1.setName("Release_1");
+        release1.setVersion("1.0.0");
+        release1.setVendor(vendor);
+
+        Release release2 = new Release();
+        release2.setId("123456");
+        release2.setName("Release_2");
+        release2.setVersion("2.0.0");
+        release2.setVendor(vendor);
+
+        releases.add(release1);
+        releases.add(release2);
+
+        given(this.vendorServiceMock.getAllReleaseList(eq(vendor.getId()))).willReturn(releases);
         given(this.vendorServiceMock.getVendors()).willReturn(vendorList);
         given(this.vendorServiceMock.vendorUpdate(any(), any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.vendorServiceMock.getVendorById(eq(vendor.getId()))).willReturn(vendor);
@@ -139,6 +154,25 @@ public class VendorSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("fullName").description("The full name of the vendor"),
                                 subsectionWithPath("shortName").description("The short name of the vendor, optional"),
                                 subsectionWithPath("url").description("The vendor's home page URL"),
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_vendor_releases() throws Exception {
+        mockMvc.perform(get("/api/vendors/" + vendor.getId() + "/releases")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:releases.[]id").description("Id of the release"),
+                                subsectionWithPath("_embedded.sw360:releases.[]name").description("The name of the release"),
+                                subsectionWithPath("_embedded.sw360:releases.[]version").description("The version of the release"),
+                                subsectionWithPath("_embedded.sw360:releases.[]_links").description("Self <<resources-index-links,Links>> to Release resource\""),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
Closes: #2563 

Description: run the endpoint to get the releases used by the vendor. 
