### PR TITLE
fix(rest): Add null check for linkedProject field if it is empty.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -478,7 +478,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 		boolean isTransitive = Boolean.parseBoolean(transitive);
 
 		Map<String, ProjectProjectRelationship> linkedProjects = sw360Proj.getLinkedProjects();
-		List<String> keys = new ArrayList<>(linkedProjects.keySet());
+        List<String> keys = linkedProjects != null ? new ArrayList<>(linkedProjects.keySet()) : new ArrayList<>();
 		List<Project> projects = keys.stream().map(projId -> wrapTException(() -> {
 			final Project sw360Project = projectService.getProjectForUserById(projId, sw360User);
 			return sw360Project;


### PR DESCRIPTION
closes : #2595 

500 internal server error fixed if the project document is missing the **linkedProjects** field.



![image](https://github.com/user-attachments/assets/a35f2d3b-9a6d-49e5-a3f1-ee95e88f28d6)
