### PR TITLE
fix(GenerateLicenseInfo): Generate License Info is failing for releases having the same CLX

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -722,15 +722,20 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
             return obligationStatusMap;
         }
 
-        Map<String, LicenseInfoParsingResult> attachmentIdToLicenseMap = licenseResults.stream()
+        Map<String, LicenseInfoParsingResult> attachmentIdToLicenseMap = licenseResults.parallelStream()
                 .filter(LicenseInfoParsingResult::isSetAttachmentContentId)
-                .filter(LicenseInfoParsingResult::isSetLicenseInfo).collect(Collectors.toList()).stream()
-                .collect(Collectors.toMap(LicenseInfoParsingResult::getAttachmentContentId, Function.identity()));
+                .filter(LicenseInfoParsingResult::isSetLicenseInfo)
+                .collect(Collectors.toMap(
+                        LicenseInfoParsingResult::getAttachmentContentId,
+                        Function.identity(),
+                        (existingValue, newValue) -> existingValue
+                ));
 
-        Map<String, ObligationParsingResult> attachmentIdToObligationMap = obligationResults.stream()
-                .filter(ObligationParsingResult::isSetAttachmentContentId).filter(o -> o.getObligationsAtProjectSize() > 0)
-                .collect(Collectors.toList()).stream()
-                .collect(Collectors.toMap(ObligationParsingResult::getAttachmentContentId, Function.identity()));
+        Map<String, ObligationParsingResult> attachmentIdToObligationMap = obligationResults.parallelStream()
+                .filter(ObligationParsingResult::isSetAttachmentContentId)
+                .filter(o -> o.getObligationsAtProjectSize() > 0)
+                .collect(Collectors.toMap(ObligationParsingResult::getAttachmentContentId, Function.identity(),
+                        (existingValue, newValue) -> existingValue));
 
         List<LicenseInfoParsingResult> licenseParsingResults = new ArrayList<LicenseInfoParsingResult>();
         Map<String, String> releaseIdToAcceptedCLI = Maps.newHashMap();


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

**Description:**
1. The "Generate License Info" feature is failing for projects with linked releases having the same CLX attachment.
2. Duplicate releases can exist with version changes like abc 1.0.0 and abc v1.0.0. They have the same CLX attachment(same attachmentContentId). If both of such releases are linked to a project, we get a Duplicate key error due to same attachmentContentId for different release Ids.

![image](https://github.com/user-attachments/assets/22f3b2f5-1f19-4758-bcb9-32c989480688)

![image](https://github.com/user-attachments/assets/61f53141-0164-4c56-83e2-e79d3e4f70f7)
