### PR TITLE
feat(rest): endpoint to get obligations depending upon obligation level

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -508,6 +508,23 @@ include::{snippets}/should_document_get_license_obligations/curl-request.adoc[]
 ===== Example response
 include::{snippets}/should_document_get_license_obligations/http-response.adoc[]
 
+[[resources-project-get-project-page-obligations-information]]
+==== List project page obligations
+
+A `GET` request will list obligations of a project depending upon the type of obigation level.
+
+===== Request parameter
+include::{snippets}/should_document_get_project_page_obligations/query-parameters.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_project_page_obligations/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_project_page_obligations/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_project_page_obligations/http-response.adoc[]
+
 [[resources-projects-create]]
 ==== Creating a project
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2445,7 +2445,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         );
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("page", pagination);
-        responseBody.put("licenseObligations", paginatedMap);
+        responseBody.put("obligations", paginatedMap);
         return responseBody;
     }
 
@@ -2484,6 +2484,62 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
 
         Map<String, Object> responseBody = createPaginationMetadata(pageable, obligationStatusMap);
+        HalResource<Map<String, Object>> halObligation = new HalResource<>(responseBody);
+        return new ResponseEntity<>(halObligation, HttpStatus.OK);
+    }
+
+    @Operation(
+            description = "Get obligation data of project tab.",
+            tags = {"Project"}
+    )
+    @RequestMapping(value = PROJECTS_URL + "/{id}/obligation", method = RequestMethod.GET)
+    public ResponseEntity<HalResource> getObligations(Pageable pageable,
+                                                             @Parameter(description = "Project ID.") @PathVariable("id") String id,
+                                                             @Parameter(description = "Obligation Level",
+                                                                        schema = @Schema(allowableValues = {"license", "project", "organization", "component"}))
+                                                             @RequestParam(value = "obligationLevel", required = true) String oblLevel)
+            throws TException {
+        final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        final Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+        final Map<String, String> releaseIdToAcceptedCLI = Maps.newHashMap();
+        List<Release> releases = new ArrayList<>();;
+        ObligationList obligation = new ObligationList();
+        Map<String, ObligationStatusInfo> obligationStatusMap = Maps.newHashMap();
+        Map<String, ObligationStatusInfo> oblData = Maps.newHashMap();
+        Map<String, ObligationStatusInfo> filterData = Maps.newHashMap();
+
+        List<String> releaseIds = new ArrayList<>(sw360Project.getReleaseIdToUsage().keySet());
+        for (final String releaseId : releaseIds) {
+            Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
+            if (sw360Release.getAttachmentsSize() > 0) {
+                releases.add(sw360Release);
+            }
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(sw360Project.getLinkedObligationId())) {
+            obligation = projectService.getObligationData(sw360Project.getLinkedObligationId(), sw360User);
+            obligationStatusMap = CommonUtils.nullToEmptyMap(obligation.getLinkedObligationStatus());
+            oblData = projectService.setObligationsFromAdminSection(sw360User, obligationStatusMap, sw360Project, oblLevel);
+        } else {
+            oblData = projectService.setObligationsFromAdminSection(sw360User, new HashMap(), sw360Project, oblLevel);
+        }
+
+        if (oblLevel.equalsIgnoreCase("License")) {
+            for (Map.Entry<String, ObligationStatusInfo> entry : obligationStatusMap.entrySet()) {
+                String key = entry.getKey();
+                if (!key.equals("compObl") && !key.equals("projectObl") && !key.equals("orgObl")) {
+                    filterData.put(key, entry.getValue());
+                }
+            }
+            releaseIdToAcceptedCLI.putAll(SW360Utils.getReleaseIdtoAcceptedCLIMappings(filterData));
+            oblData = projectService.setLicenseInfoWithObligations(filterData, releaseIdToAcceptedCLI, releases, sw360User);
+            for (Map.Entry<String, ObligationStatusInfo> entry : oblData.entrySet()) {
+                ObligationStatusInfo statusInfo = entry.getValue();
+                Set<Release> limitedSet = releaseService.getReleasesForUserByIds(statusInfo.getReleaseIdToAcceptedCLI().keySet());
+                statusInfo.setReleases(limitedSet);
+            }
+        }
+
+        Map<String, Object> responseBody = createPaginationMetadata(pageable, oblData);
         HalResource<Map<String, Object>> halObligation = new HalResource<>(responseBody);
         return new ResponseEntity<>(halObligation, HttpStatus.OK);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -25,6 +25,8 @@ import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.common.WrappedException.WrappedTException;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
@@ -435,6 +437,28 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public ObligationList getObligationData(String linkedObligationId, User user) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         return sw360ProjectClient.getLinkedObligations(linkedObligationId, user);
+    }
+
+    public Map<String, ObligationStatusInfo> setObligationsFromAdminSection(User user, Map<String, ObligationStatusInfo> obligationStatusMap,
+                                                                            Project project, String oblLevel) throws TException {
+        List<Obligation> obligations = SW360Utils.getObligations();
+        Map<String, ObligationStatusInfo> updatedObligationStatusMap = Maps.newHashMap();
+        ThriftClients thriftClients = new ThriftClients();
+        ComponentService.Iface componentClient = thriftClients.makeComponentClient();
+
+        if (oblLevel.equalsIgnoreCase("Project")) {
+            updatedObligationStatusMap = SW360Utils.getProjectComponentOrganisationLicenseObligationToDisplay(
+                    obligationStatusMap, obligations, ObligationLevel.PROJECT_OBLIGATION, true);
+            return updatedObligationStatusMap;
+        } else if (oblLevel.equalsIgnoreCase("Organization")) {
+            updatedObligationStatusMap = SW360Utils.getProjectComponentOrganisationLicenseObligationToDisplay(
+                    obligationStatusMap, obligations, ObligationLevel.ORGANISATION_OBLIGATION, true);
+            return updatedObligationStatusMap;
+        } else if (oblLevel.equalsIgnoreCase("Component")) {
+            updatedObligationStatusMap = SW360Utils.getProjectComponentOrganisationLicenseObligationToDisplay(
+                    obligationStatusMap, obligations, ObligationLevel.COMPONENT_OBLIGATION, true);
+            return updatedObligationStatusMap;
+        } return updatedObligationStatusMap;
     }
 
     public Map<String, ObligationStatusInfo> setLicenseInfoWithObligations(Map<String, ObligationStatusInfo> obligationStatusMap, Map<String, String> releaseIdToAcceptedCLI,

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -478,6 +478,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         osi.setStatus(ObligationStatus.OPEN);
         osi.setObligationType(obligation.getObligationType());
         Map<String, ObligationStatusInfo> obligationStatusMap = Map.of(obligation.getTitle(), osi);
+        Map<String, ObligationStatusInfo> obligationStatusMapFromAdminSection = new HashMap<>();
 
         ObligationList obligationLists = new ObligationList();
         obligationLists.setProjectId(project8.getId());
@@ -563,6 +564,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.getProjectForUserById(eq(project8.getId()), any())).willReturn(project8);
         given(this.projectServiceMock.getLicenseInfoAttachmentUsage(eq(project8.getId()))).willReturn(licenseInfoUsages);
         given(this.projectServiceMock.getObligationData(eq(project8.getLinkedObligationId()), any())).willReturn(obligationLists);
+        given(this.projectServiceMock.setObligationsFromAdminSection(any(), any(), any(), any())).willReturn(obligationStatusMapFromAdminSection);
         given(this.projectServiceMock.setLicenseInfoWithObligations(eq(obligationStatusMap), eq(releaseIdToAcceptedCLI), any(), any())).willReturn(obligationStatusMap);
         given(this.projectServiceMock.getLicensesFromAttachmentUsage(eq(licenseInfoUsages), any())).willReturn(licensesFromAttachmentUsage);
         given(this.projectServiceMock.getLicenseObligationData(eq(licensesFromAttachmentUsage), any())).willReturn(obligationStatusMap);
@@ -876,12 +878,12 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("page_entries").description("Amount of projects per page")
                         ),
                         responseFields(
-                                subsectionWithPath("licenseObligations.obligation_title").description("Title of license obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.text").description("Text of license obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.licenseIds[]").description("List of licenseIds"),
-                                subsectionWithPath("licenseObligations.obligation_title.id").description("Id of the obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.releaseIdToAcceptedCLI").description("Releases having accepted attachments"),
-                                subsectionWithPath("licenseObligations.obligation_title.obligationType").description("Type of the obligation"),
+                                subsectionWithPath("obligations.obligation_title").description("Title of license obligation"),
+                                subsectionWithPath("obligations.obligation_title.text").description("Text of license obligation"),
+                                subsectionWithPath("obligations.obligation_title.licenseIds[]").description("List of licenseIds"),
+                                subsectionWithPath("obligations.obligation_title.id").description("Id of the obligation"),
+                                subsectionWithPath("obligations.obligation_title.releaseIdToAcceptedCLI").description("Releases having accepted attachments"),
+                                subsectionWithPath("obligations.obligation_title.obligationType").description("Type of the obligation"),
                                 fieldWithPath("page").description("Additional paging information"),
                                 fieldWithPath("page.size").description("Number of obligations per page"),
                                 fieldWithPath("page.totalElements").description("Total number of all license obligations"),
@@ -1126,14 +1128,46 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("page_entries").description("Amount of projects per page")
                         ),
                         responseFields(
-                                subsectionWithPath("licenseObligations.obligation_title").description("Title of license obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.text").description("Text of license obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.releaseIdToAcceptedCLI").description("Release Ids having accepted attachments"),
-                                subsectionWithPath("licenseObligations.obligation_title.licenseIds[]").description("List of licenseIds"),
-                                subsectionWithPath("licenseObligations.obligation_title.comment").description("Comment on the obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.status").description("Status of the obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.id").description("Id of the obligation"),
-                                subsectionWithPath("licenseObligations.obligation_title.obligationType").description("Type of the obligation"),
+                                subsectionWithPath("obligations.obligation_title").description("Title of license obligation"),
+                                subsectionWithPath("obligations.obligation_title.text").description("Text of license obligation"),
+                                subsectionWithPath("obligations.obligation_title.releaseIdToAcceptedCLI").description("Release Ids having accepted attachments"),
+                                subsectionWithPath("obligations.obligation_title.licenseIds[]").description("List of licenseIds"),
+                                subsectionWithPath("obligations.obligation_title.comment").description("Comment on the obligation"),
+                                subsectionWithPath("obligations.obligation_title.status").description("Status of the obligation"),
+                                subsectionWithPath("obligations.obligation_title.id").description("Id of the obligation"),
+                                subsectionWithPath("obligations.obligation_title.obligationType").description("Type of the obligation"),
+                                fieldWithPath("page").description("Additional paging information"),
+                                fieldWithPath("page.size").description("Number of obligations per page"),
+                                fieldWithPath("page.totalElements").description("Total number of all license obligations"),
+                                fieldWithPath("page.totalPages").description("Total number of pages"),
+                                fieldWithPath("page.number").description("Number of the current page")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_project_page_obligations() throws Exception {
+        mockMvc.perform(get("/api/projects/" + project8.getId() + "/obligation")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .param("obligationLevel", "License")
+                        .param("page", "0")
+                        .param("page_entries", "5")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("obligationLevel").description("Possible values are: [LICENSE, PROJECT, COMPONENT or ORGANIZATION]"),
+                                parameterWithName("page").description("Page of projects"),
+                                parameterWithName("page_entries").description("Amount of projects per page")
+                        ),
+                        responseFields(
+                                subsectionWithPath("obligations.obligation_title").description("Title of license obligation"),
+                                subsectionWithPath("obligations.obligation_title.text").description("Text of license obligation"),
+                                subsectionWithPath("obligations.obligation_title.releaseIdToAcceptedCLI").description("Release Ids having accepted attachments"),
+                                subsectionWithPath("obligations.obligation_title.licenseIds[]").description("List of licenseIds"),
+                                subsectionWithPath("obligations.obligation_title.comment").description("Comment on the obligation"),
+                                subsectionWithPath("obligations.obligation_title.status").description("Status of the obligation"),
+                                subsectionWithPath("obligations.obligation_title.id").description("Id of the obligation"),
+                                subsectionWithPath("obligations.obligation_title.obligationType").description("Type of the obligation"),
                                 fieldWithPath("page").description("Additional paging information"),
                                 fieldWithPath("page.size").description("Number of obligations per page"),
                                 fieldWithPath("page.totalElements").description("Total number of all license obligations"),


### PR DESCRIPTION
Issue: #2610 

Description: endpoint to get obligations depending upon obligation level (Possible values are: License, Project, Component, Organization). 
