### PR TITLE
feat(Project): Add new endpoint for project's license clearing tree view

### DIFF
--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -573,4 +573,8 @@ public class ProjectHandler implements ProjectService.Iface {
         return handler.getLinkedProjectsWithAllReleases(project, deep, user);
     }
 
+    @Override
+    public List<ReleaseLink> getReleaseLinksOfProjectNetWorkByIndexPath(String projectId, List<String> indexPath, User user) throws SW360Exception {
+        return handler.getReleaseLinksOfProjectNetWorkByIndexPath(indexPath, projectId, user);
+    }
 }

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -700,4 +700,10 @@ service ProjectService {
      * is equivalent to `getLinkedProjectsOfProject(getProjectById(id, user))`
      */
     list<ProjectLink> getLinkedProjectsOfProjectWithAllReleases(1: Project project, 2: bool deep, 3: User user);
+
+    /**
+    * get list ReleaseLink in dependency network of project by project id and index path
+    */
+    list<ReleaseLink> getReleaseLinksOfProjectNetWorkByIndexPath(1: string projectId, 2: list<string> indexPath, 3: User user) throws (1: SW360Exception exp);
+
 }

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -1026,3 +1026,38 @@ A `GET` request is used to get list view of a project's dependencies network
 
 ===== Example response
 include::{snippets}/should_document_get_list_view_of_dependencies_network/http-response.adoc[]
+
+[[resources-project-get-linked-resources-in-dependency-network]]
+==== Get linked resources (projects, releases) in dependency network of a project
+
+A `GET` request will get linked resources (projects, releases) in dependency network of a project
+
+===== Request parameters
+include::{snippets}/should_document_get_linked_resources_of_project_in_dependency_network/request-parameters.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_linked_resources_of_project_in_dependency_network/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_linked_resources_of_project_in_dependency_network/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_linked_resources_of_project_in_dependency_network/http-response.adoc[]
+
+[[resources-project-get-indirect-linked-release-of-project-in-dependency-network-by-index-path]]
+
+==== Get indirect linked releases of a project in dependency network by release's index path
+
+A `GET` request will get indirect linked releases of a project in dependency network by release's index path
+
+===== Request parameters
+include::{snippets}/should_document_get_linked_releases_in_dependency_network_by_index_path/request-parameters.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_linked_releases_in_dependency_network_by_index_path/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_linked_releases_in_dependency_network_by_index_path/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_linked_releases_in_dependency_network_by_index_path/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -39,6 +39,7 @@ import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
@@ -124,6 +125,7 @@ public class JacksonCustomizations {
             setMixInAnnotation(ReleaseNode.class, Sw360Module.ReleaseNodeMixin.class);
             setMixInAnnotation(RestrictedResource.class, Sw360Module.RestrictedResourceMixin.class);
             setMixInAnnotation(RestApiToken.class, Sw360Module.RestApiTokenMixin.class);
+            setMixInAnnotation(ProjectLink.class, Sw360Module.ProjectLinkMixin.class);
 
             // Make spring doc aware of the mixin(s)
             SpringDocUtils.getConfig()
@@ -175,7 +177,8 @@ public class JacksonCustomizations {
                     .replaceWithClass(ProjectDTO.class, ProjectDTOMixin.class)
                     .replaceWithClass(EmbeddedProjectDTO.class, EmbeddedProjectDTOMixin.class)
                     .replaceWithClass(ReleaseNode.class, ReleaseNodeMixin.class)
-                    .replaceWithClass(RestrictedResource.class, RestrictedResourceMixin.class);
+                    .replaceWithClass(RestrictedResource.class, RestrictedResourceMixin.class)
+                    .replaceWithClass(ProjectLink.class, ProjectLinkMixin.class);
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -913,11 +916,9 @@ public class JacksonCustomizations {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
                 "nodeId",
+                "layer",
                 "parentNodeId",
-                "componentType",
                 "licenseNames",
-                "comment",
-                "otherLicenseIds",
                 "attachmentsSize",
                 "setName",
                 "setVersion",
@@ -944,8 +945,14 @@ public class JacksonCustomizations {
                 "setLicenseNames",
                 "setAccessible",
                 "setId",
-                "setClearingReport"
-
+                "setClearingReport",
+                "setReleaseWithSameComponent",
+                "setLayer",
+                "setDefaultValue",
+                "setReleaseMainLineState",
+                "setIndex",
+                "setProjectId",
+                "releaseWithSameComponentSize",
         })
         static abstract class ReleaseLinkMixin extends ReleaseLink {
 
@@ -2276,5 +2283,30 @@ public class JacksonCustomizations {
         })
         public abstract static class RestApiTokenMixin extends RestApiToken {
         }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties({
+                "nodeId",
+                "treeLevel",
+                "parentNodeId",
+                "setId",
+                "setName",
+                "setSubprojects",
+                "setNodeId",
+                "setParentNodeId",
+                "setVersion",
+                "setClearingState",
+                "setState",
+                "setProjectType",
+                "setEnableSvm",
+                "linkedReleasesSize",
+                "setRelation",
+                "linkedReleasesIterator",
+                "setLinkedReleases",
+                "subprojectsSize",
+                "subprojectsIterator",
+                "setTreeLevel",
+        })
+        abstract static class ProjectLinkMixin extends ProjectLink {}
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -995,4 +995,21 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             }
         }
     }
+
+    public ProjectLink serveLinkedResourcesOfProjectInDependencyNetwork(String projectId, boolean transitive, User sw360User) throws TException {
+        Project project = getProjectForUserById(projectId, sw360User);
+        final Collection<ProjectLink> linkedProjects = (!transitive)
+                ? SW360Utils.getLinkedProjectsAsFlatList(project, false, new ThriftClients(), log, sw360User)
+                : SW360Utils.getLinkedProjectsWithAllReleasesAsFlatList(project, false, new ThriftClients(), log, sw360User);
+        if (linkedProjects.isEmpty()) {
+            throw new AccessDeniedException(
+                    "Project or its Linked Projects are restricted and / or not accessible");
+        }
+        return new ArrayList<>(linkedProjects).get(0);
+    }
+
+    public List<ReleaseLink> serveLinkedReleasesInDependencyNetworkByIndexPath(String projectId, List<String> indexPath, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.getReleaseLinksOfProjectNetWorkByIndexPath(projectId, indexPath, sw360User);
+    }
 }


### PR DESCRIPTION
### Create new endpoints to serve tree view of dependency network (New GUI)

### Pre-condition:
Turn on feature by adding this property into /etc/sw360/sw360.properties: **enable.flexible.project.release.relationship=true**

Create a new project with dependency network:
- Url: http://localhost:8080/resource/api/projects/network
- Method: POST
- Body: 
```
{
    "name": "Test_PR",
    "dependencyNetwork": [
        {
            "releaseId": "${release_id_1_in_sw360}", // Replace this by an existing release id in sw360
            "releaseRelationship": "CONTAINED",
            "mainlineState": "OPEN",
            "comment": "",
            "createOn": "2024-07-05",
            "createBy": "admin@sw360.org",
            "releaseLink": [
                {
                    "releaseId": "${release_id_2_in_sw360}", // Replace this by an existing release id in sw360 (difference from above)
                    "releaseRelationship": "OPTIONAL",
                    "mainlineState": "MAINLINE",
                    "comment": "",
                    "createOn": "2024-07-05",
                    "createBy": "admin@sw360.org",
                    "releaseLink": []
                }
            ]
        }
    ]
}
```

### How To Test?
_**Replace {project_id} with the id of the project created in the pre-condition**_
#### Endpoint 1: Get directly linked resources of project (listing all directly linked projects and releases of a project)

- Url: http://localhost:8080/resource/api/projects/network/{project_id}/linkedResources
- Method: GET
- Expected output: The response body will be shown in below format:

```
{
    "id": "{project_id}",
    "name": "Test_PR",
    "relation": "UNKNOWN",
    "projectType": "PRODUCT",
    "state": "ACTIVE",
    "clearingState": "OPEN",
    "linkedReleases": [
        {
            "id": "{release_id_1_in_sw360}",
            "vendor": "",
            "name": "{release_1_name}",
            "version": "{release_1_version}",
            "longName": "{release_1_long_name}",
            "releaseRelationship": "CONTAINED",
            "mainlineState": "OPEN",
            "hasSubreleases": true,
            "clearingState": "NEW_CLEARING",
            "attachments": [],
            "componentType": "SERVICE",
            "licenseIds": [],
            "comment": "",
            "otherLicenseIds": [],
            "accessible": true,
            "index": 0,
            "projectId": "{project_id}",
            "releaseMainLineState": "OPEN"
        }
    ],
    "enableSvm": true
}
```

#### Endpoint 2: Get get indirect linked releases of a project in dependency network by release's index path (support fetch data on expand node from GUI)

- Url: http://localhost:8080/resource/api/projects/network/{project_id}/releases?path=0
- Method: GET
- Expected output: The response body will be shown in below format:

```
{
    "_embedded": {
        "sw360:releaseLinks": [
            {
                "id": "{release_id_2_in_sw360}",
                "vendor": "",
                "name": "{release_2_name}",
                "version": "{release_2_version}",
                "longName": "{release_2_long_name}",
                "releaseRelationship": "OPTIONAL",
                "mainlineState": "MAINLINE",
                "hasSubreleases": false,
                "clearingState": "NEW_CLEARING",
                "attachments": [],
                "componentType": "OSS",
                "licenseIds": [],
                "comment": "",
                "otherLicenseIds": [],
                "accessible": true,
                "index": 0,
                "projectId": "6d0c271a16ee457a8b608afc874e1dc9",
                "releaseMainLineState": "OPEN"
            }
        ]
    },
    "_links": {
        "curies": [
            {
                "href": "http://localhost:8080/resource/docs/{rel}.html",
                "name": "sw360",
                "templated": true
            }
        ]
    }
}
```
