### PR TITLE
feat(couchdb): Enable use of latest CouchDB with nouveau

### DIFF
--- a/config/couchdb/nouveau.ini
+++ b/config/couchdb/nouveau.ini
@@ -1,0 +1,3 @@
+[nouveau]
+enable = true
+url = http://couchdb-nouveau:5987

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,17 +22,26 @@ services:
       - etc:/etc/sw360
       - ./config/sw360:/app/sw360/config
 
+  couchdb-nouveau:
+    image: ghcr.io/eclipse-sw360/couchdb:3.4.1-nouveau
+    ports:
+      - "5987:5987"
+      - "5988:5988"
+
   couchdb:
-    image: couchdb:3
+    image: ghcr.io/eclipse-sw360/couchdb:3.4.1
     restart: unless-stopped
     environment:
       - COUCHDB_CREATE_DATABASE=yes
     ports:
       - "5984:5984"
+    depends_on:
+      - couchdb-nouveau
     volumes:
       - couchdb:/opt/couchdb/data
       - ./config/couchdb/sw360_setup.ini:/opt/couchdb/etc/local.d/sw360_setup.ini
       - ./config/couchdb/sw360_log.ini:/opt/couchdb/etc/local.d/sw360_log.ini
+      - ./config/couchdb/nouveau.ini:/opt/couchdb/etc/local.d/nouveau.ini
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://couchdb:5984/_up"]
       interval: 30s

--- a/sw360.code-workspace
+++ b/sw360.code-workspace
@@ -11,6 +11,19 @@
     "java.configuration.updateBuildConfiguration": "automatic",
     "java.format.settings.url": ".vscode/java-formatter.xml",
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
+    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable",
+    "workbench.colorCustomizations": {
+      "commandCenter.border": "#15202b99",
+      "sash.hoverBorder": "#65c89b",
+      "statusBar.background": "#42b883",
+      "statusBar.foreground": "#15202b",
+      "statusBarItem.hoverBackground": "#359268",
+      "statusBarItem.remoteBackground": "#42b883",
+      "statusBarItem.remoteForeground": "#15202b",
+      "titleBar.activeBackground": "#42b883",
+      "titleBar.activeForeground": "#15202b",
+      "titleBar.inactiveBackground": "#42b88399",
+      "titleBar.inactiveForeground": "#15202b99"
+    }
   }
 }


### PR DESCRIPTION
* Uses a image built from [CouchDB Docker repository new 3.4.1 version](https://github.com/apache/couchdb-docker/tree/main/3.4.1-nouveau) as not yet  available in upstream Docker registry.
* Can be pulled from GHCR registry as `ghcr.io/eclipse-sw360/couchdb:3.4.1` and `ghcr.io/eclipse-sw360/couchdb:3.4.1-nouveau`