### PR TITLE
fix(REST): Patch Release is causing the clearing state to be updated to NEW even if a Clearing is existing

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1152,12 +1152,13 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
                 copyFields(actual, release, immutableFields);
 
-                autosetReleaseClearingState(release, actual);
                 if (hasChangesInEccFields) {
                     autosetEccUpdaterInfo(release, user);
                 }
+
                 release.setAttachments(
                         getAllAttachmentsToKeep(toSource(actual), actual.getAttachments(), release.getAttachments()));
+                autosetReleaseClearingState(release, actual);
 
                 List<ChangeLogs> referenceDocLogList = new LinkedList<>();
                 Set<Attachment> attachmentsAfter = release.getAttachments();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -441,6 +441,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         sw360Release = this.restControllerHelper.updateRelease(sw360Release, updateRelease);
         releaseService.setComponentNameAsReleaseName(sw360Release, user);
         RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, user);
+        sw360Release = releaseService.getReleaseForUserById(id, user);
         HalResource<Release> halRelease = createHalReleaseResource(sw360Release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

**Description:**
1. The new clearing state of a release was not being rendered after a successful PATCH. It was rereferring to the older clearing state.
2. If an empty array of attachments was passed in the request body, the clearing state of the release would get updated to NEW while an approved CLX/CRT was still present. 

**These issues are fixed by**

-  Fetching the updated release before creating a HalResource out of it.
-  Setting the new clearing state _after_ the approved attachments are retained.


### How To Test?
1. Pass an empty array of attachments and try to PATCH while the release has approved CRT/CLX attachments. The attachments would be retained and clearing state will still be "APPROVED". (would be NEW_CLEARING before the fix)
2. Remove the approval from both all the attachments and then pass an empty array of attachments and PATCH the release. In this case, all the attachments would be removed and clearing state would change to NEW_CLEARING. ( would still be APPROVED before the fix)
![image](https://github.com/user-attachments/assets/52bf7ef2-c056-4847-81a5-ac20703aea9c)
