### PR TITLE
fix(UI): Add lang attribute to ReadmeOSS.html for generated license info

### DIFF
--- a/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -6,12 +6,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <style type="text/css">
         * {
-            font-family: Arial;
+            font-family: Arial, sans-serif;
             font-size: 14px;
         }
 
@@ -46,7 +46,7 @@
             padding: 0.7em;
             background: white;
             border-top: 1px solid silver;
-            xborder-right: 1px solid silver;
+            border-right: 1px solid silver;
         }
 
         .inset p {


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Fix XHTML render issues:
* Missing `lang` or `xml:lang` attribute in `<html>`
* Missing font family.
* Unknown attribute `xborder-right`

### How To Test?
Generate LicenseInfo with xhtml format and lint the generated report.