### PR TITLE
chore(nouveau): catch exception for nouveau query

### DIFF
--- a/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
+++ b/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
@@ -19,6 +19,7 @@ import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.ResponseConverter;
 import com.ibm.cloud.sdk.core.http.ServiceCall;
 import com.ibm.cloud.sdk.core.service.exception.NotFoundException;
+import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
 import com.ibm.cloud.sdk.core.util.Validator;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
@@ -169,7 +170,8 @@ public class LuceneAwareCouchDbConnector {
      * @param query The query to run.
      * @return The result of the query.
      */
-    public NouveauResult queryNouveau(String index, @NotNull NouveauQuery query) {
+    public NouveauResult queryNouveau(String index, @NotNull NouveauQuery query)
+            throws ServiceResponseException {
         return this.database.queryNouveau(index, query).execute().getResult();
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
1. Catch exception thrown by couchdb for nouveau query and log them for easy debugging.
2. Also ignore `@` in the query as it is treated as bad syntax.

Note: If you are using nouveau with old backed, check the error: https://github.com/apache/couchdb/issues/5262

### How To Test?
Deploy the new branch and try a bad query, catalina log should have the response body for the exception.