### PR TITLE
feat: Add logging to identify releases with corrupted attachments during license generation

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -589,7 +589,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                     .filter(parser -> wrapTException(() -> parser.isApplicableTo(attachment, user, release))).collect(Collectors.toList());
 
             if (applicableParsers.size() == 0) {
-                LOGGER.warn("No applicable parser has been found for the attachment selected for license information");
+                LOGGER.warn("No applicable parser has been found for the attachment selected for license information " + attachmentContentId);
                 return assignReleaseToLicenseInfoParsingResult(
                         assignFileNameToLicenseInfoParsingResult(
                                 noSourceParsingResult("No applicable parser has been found for the attachment"), attachment.getFilename()),

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
@@ -112,6 +112,7 @@ public class SPDXParser extends LicenseInfoParser {
         } catch (SAXException e) {
             String msg = "failed to parse attachment=" + attachmentContent.getFilename() + " with id="
                     + attachmentContent.getId();
+            log.error(msg, e);
             throw new SW360Exception(msg);
         }
     }


### PR DESCRIPTION
**Description:**
When generating license information for a project, some releases may contain attachments (e.g., ISR, CLX files) that are in a corrupted format. These corrupted attachments prevent the successful generation of the license information for the entire project. However, identifying which specific release has the corrupted attachment is challenging.

**Solution:** Adding log statements to the license generation process can help identify specific release(s) with corrupted attachments, such as ISR or CLX files. By logging details when an attachment processing fails, we can quickly pinpoint which release is causing the issue