### PR TITLE
feat(rest): Add size parameter to clearing request.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -250,6 +250,11 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         if (!(ProjectClearingState.CLOSED.equals(project.getClearingState()) || Visibility.PRIVATE.equals(project.getVisbility()))) {
             clearingRequest.setProjectBU(project.getBusinessUnit());
+            Project projectWithInfo = fillClearingStateSummaryIncludingSubprojectsForSingleProject(project, user);
+            int initialOpenReleases = SW360Utils.getOpenReleaseCount(projectWithInfo.releaseClearingStateSummary);
+            ClearingRequestSize initialSize = SW360Utils.determineCRSize(initialOpenReleases);
+            clearingRequest.setClearingSize(initialSize);
+            log.info(initialOpenReleases + " open releases found for project: " + project.getId() + "and initial size is: " + initialSize);
             String crId = moderator.createClearingRequest(clearingRequest, user);
             if (CommonUtils.isNotNullEmptyOrWhitespace(crId)) {
                 project.setClearingRequestId(crId);

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RemoveModeratorRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.ClearingRequestSize;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
@@ -356,6 +357,14 @@ public class ModerationHandler implements ModerationService.Iface {
         assertUser(user);
 
         handler.updateClearingRequestForChangeInProjectBU(crId, businessUnit, user);
+    }
+
+    @Override
+    public void updateClearingRequestForChangeInClearingSize(String crId, ClearingRequestSize size) throws TException {
+        assertId(crId);
+        assertNotNull(size);
+
+        handler.updateClearingRequestForChangeInClearingSize(crId, size);
     }
 
     @Override

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -30,6 +30,7 @@ import org.eclipse.sw360.datahandler.db.spdx.packageinfo.SpdxPackageInfoDatabase
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestEmailTemplate;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
+import org.eclipse.sw360.datahandler.thrift.ClearingRequestSize;
 import org.eclipse.sw360.datahandler.thrift.Comment;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -315,6 +316,15 @@ public class ModerationDatabaseHandler {
         try {
             ClearingRequest clearingRequest = clearingRequestRepository.get(crId);
             clearingRequest.setProjectBU(businessUnit);
+            clearingRequestRepository.update(clearingRequest);
+        } catch (Exception e) {
+            log.error("Failed to update CR-ID: %s with error: %s", crId, e.getMessage());
+        }
+    }
+    public void updateClearingRequestForChangeInClearingSize(String crId, ClearingRequestSize size) {
+        try{
+            ClearingRequest clearingRequest = clearingRequestRepository.get(crId);
+            clearingRequest.setClearingSize(size);
             clearingRequestRepository.update(clearingRequest);
         } catch (Exception e) {
             log.error("Failed to update CR-ID: %s with error: %s", crId, e.getMessage());

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -755,6 +755,27 @@ public class SW360Utils {
         return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 
+    public static ClearingRequestSize determineCRSize(int totalReleaseCount) {
+        if (totalReleaseCount <= CLEARING_REQUEST_SIZE_MAP.get(ClearingRequestSize.VERY_SMALL)) {
+            return ClearingRequestSize.VERY_SMALL;
+        } else if (totalReleaseCount <= CLEARING_REQUEST_SIZE_MAP.get(ClearingRequestSize.SMALL)) {
+            return ClearingRequestSize.SMALL;
+        } else if (totalReleaseCount <= CLEARING_REQUEST_SIZE_MAP.get(ClearingRequestSize.MEDIUM)) {
+            return ClearingRequestSize.MEDIUM;
+        } else if (totalReleaseCount <= CLEARING_REQUEST_SIZE_MAP.get(ClearingRequestSize.LARGE)) {
+            return ClearingRequestSize.LARGE;
+        } else {
+            return ClearingRequestSize.VERY_LARGE;
+        }
+    }
+
+    public static final HashMap<ClearingRequestSize, Integer> CLEARING_REQUEST_SIZE_MAP = new HashMap<>() {{
+        put(ClearingRequestSize.VERY_SMALL, 20);
+        put(ClearingRequestSize.SMALL, 50);
+        put(ClearingRequestSize.MEDIUM, 75);
+        put(ClearingRequestSize.LARGE, 150);
+    }};
+
     /**
      * Assumes that the process exists.
      */

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -363,6 +363,15 @@ public class ThriftEnumUtils {
             ClearingRequestType.HIGH, "High ISR"
     );
 
+    private static final ImmutableMap<ClearingRequestSize, String> MAP_CLEARING_REQUEST_SIZE_STRING = ImmutableMap.of(
+            ClearingRequestSize.VERY_SMALL, "Very Small",
+            ClearingRequestSize.SMALL, "Small",
+            ClearingRequestSize.MEDIUM, "Medium",
+            ClearingRequestSize.LARGE, "Large",
+            ClearingRequestSize.VERY_LARGE, "Very Large"
+    );
+
+
     private static final ImmutableMap<UserAccess, String> MAP_USER_ACCESS_STRING = ImmutableMap.<UserAccess, String>builder()
             .put(UserAccess.READ, "Read")
             .put(UserAccess.READ_WRITE, "Read and Write")
@@ -456,6 +465,7 @@ public class ThriftEnumUtils {
             .put(PackageManager.class, MAP_PACKAGE_MANAGER_STRING)
             .put(CycloneDxComponentType.class, MAP_CYCLONE_DX_COMPONENT_TYPE_STRING)
             .put(ClearingRequestType.class, MAP_CLEARING_REQUEST_TYPE_STRING)
+            .put(ClearingRequestSize.class, MAP_CLEARING_REQUEST_SIZE_STRING)
             .build();
 
     public static String enumToString(TEnum value) {

--- a/libraries/datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/datahandler/src/main/thrift/moderation.thrift
@@ -34,6 +34,7 @@ typedef licenses.License License
 typedef licenses.Obligation Obligation
 typedef components.ComponentType ComponentType
 typedef projects.ClearingRequest ClearingRequest
+typedef sw360.ClearingRequestSize ClearingSize
 typedef spdxdocument.SPDXDocument SPDXDocument
 typedef documentcreationinformation.DocumentCreationInformation DocumentCreationInformation
 typedef packageinformation.PackageInformation PackageInformation
@@ -313,6 +314,11 @@ service ModerationService {
      * update clearing request if project's BU is changed
      **/
     oneway void updateClearingRequestForChangeInProjectBU(1: string crId, 2: string businessUnit, 3: User user);
+
+    /**
+     * update clearing request if project's BU is changed
+     **/
+    oneway  void updateClearingRequestForChangeInClearingSize(1: string crId, 2: ClearingSize size);
 
     /**
      * get clearing request by Id for view/read

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -30,6 +30,7 @@ typedef sw360.SW360Exception SW360Exception
 typedef sw360.ClearingRequestState ClearingState
 typedef sw360.ClearingRequestPriority ClearingPriority
 typedef sw360.ClearingRequestType ClearingType
+typedef sw360.ClearingRequestSize ClearingSize
 typedef sw360.Comment Comment
 typedef sw360.PaginationData PaginationData
 typedef components.Release Release
@@ -247,7 +248,8 @@ struct ClearingRequest {
     17: optional i64 modifiedOn,
     18: optional list<i64> reOpenOn,
     19: optional ClearingPriority priority,
-    20: optional ClearingType clearingType
+    20: optional ClearingType clearingType,
+    21: optional ClearingSize clearingSize
 }
 
 struct ProjectDTO{

--- a/libraries/datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/datahandler/src/main/thrift/sw360.thrift
@@ -89,6 +89,14 @@ enum ClearingRequestType {
     HIGH = 1
 }
 
+enum ClearingRequestSize{
+    VERY_SMALL = 0,
+    SMALL = 1,
+    MEDIUM = 2,
+    LARGE = 3,
+    VERY_LARGE = 4
+}
+
 enum Visibility {
     PRIVATE = 0,
     ME_AND_MODERATORS = 1,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -140,6 +140,8 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             try{
                 Project project = projectService.getProjectForUserById(clearingRequest.getProjectId(), sw360User);
                 Project projectWithClearingInfo = projectService.getClearingInfo(project, sw360User);
+                ClearingRequest updatedCR = restControllerHelper.updateCRSize(clearingRequest, projectWithClearingInfo, sw360User);
+                halClearingRequest = new HalResource<>(updatedCR);
                 restControllerHelper.addEmbeddedReleaseDetails(halClearingRequest, projectWithClearingInfo);
                 restControllerHelper.addEmbeddedProject(halClearingRequest, project, true);
             }catch (Exception e){

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/Sw360ClearingRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/Sw360ClearingRequestService.java
@@ -16,6 +16,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.thrift.ClearingRequestSize;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
 import org.eclipse.sw360.datahandler.thrift.Comment;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
@@ -122,4 +123,11 @@ public class Sw360ClearingRequestService {
         return requestStatus;
     }
 
+    public void updateClearingRequestForChangeInClearingSize(String crId, ClearingRequestSize size) throws TException{
+        try {
+            getThriftModerationClient().updateClearingRequestForChangeInClearingSize(crId, size);
+        } catch (SW360Exception e) {
+            log.error("Error updating clearing request for change in clearing size: " + e.getMessage());
+        }
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -1890,7 +1890,8 @@ public class JacksonCustomizations {
                 "modifiedOn",
                 "commentsSize",
                 "setPriority",
-                "setClearingType"
+                "setClearingType",
+                "setClearingSize"
         })
         @JsonRootName(value = "clearingRequest")
         public static abstract class ClearingRequestMixin extends ClearingRequest {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3264,7 +3264,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         if (reqBodyMap.get("dependencyNetwork") != null) {
             try {
                 addOrPatchDependencyNetworkToProject(duplicatedProject, reqBodyMap, ProjectOperation.CREATE);
-            } catch (JsonProcessingException | NoSuchElementException | InvalidPropertiesFormatException e) {
+            } catch (JsonProcessingException | NoSuchElementException e) {
                 log.error(e.getMessage());
                 return ResponseEntity.badRequest().body(e.getMessage());
             }


### PR DESCRIPTION
Add a new field **size** to the clearing request which determines the size of the clearing request based on the number of **open releases** in the project for which the CR is created. 

Size based on the table below : 
1- 20 = **Very Small**
21- 50 = **Small**
50-75 = **Medium**
75-150 = **Large**
150 and above = **Very large**

The CR size should be dynamic. if release are uploaded after CR creation, it should reflect in the `CR Size`.

![image](https://github.com/user-attachments/assets/42b7c502-6de2-4fcc-9e32-cab523037a6d)
