### PR TITLE
fix(servlet): complete migration javax to jakarta

### DIFF
--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -58,6 +58,10 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
         </dependency>
-        
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${jakarta.activation-api.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/backend/common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
@@ -22,9 +22,9 @@ import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
-import javax.mail.*;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.*;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.IllegalFormatException;
@@ -37,7 +37,7 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhit
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 
 /**
- * Provides the possiblity to send mail from SW360
+ * Provides the possibility to send mail from SW360
  *
  * @author birgit.heydenreich@tngtech.com
  */

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentServlet.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentServlet.java
@@ -14,7 +14,6 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.eclipse.sw360.projects.Sw360ThriftServlet;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 
 /**
  * Thrift Servlet instantiation

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
@@ -103,7 +103,6 @@ public class FossologyRestClient {
         this.restConfig = restConfig;
 
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setBufferRequestBody(false);
         restTemplate.setRequestFactory(requestFactory);
         this.restTemplate = restTemplate;
     }

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -116,9 +116,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-            <version>1.5.0-b01</version>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <version>${jakarta.mail-api.version}</version>
         </dependency>
     </dependencies>
 

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectServlet.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectServlet.java
@@ -13,8 +13,6 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.apache.thrift.protocol.TCompactProtocol;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-
 
 /**
  * Thrift Servlet instantiation
@@ -24,7 +22,7 @@ import java.net.MalformedURLException;
  */
 public class ProjectServlet extends Sw360ThriftServlet {
 
-    public ProjectServlet() throws MalformedURLException, IOException {
+    public ProjectServlet() throws IOException {
         // Create a service processor using the provided handler
         super(new ProjectService.Processor<>(new ProjectHandler()), new TCompactProtocol.Factory());
     }

--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -107,9 +107,9 @@
             <artifactId>wiremock-jre8</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/clients/http-support/pom.xml
+++ b/clients/http-support/pom.xml
@@ -79,9 +79,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -398,7 +398,7 @@ public class DatabaseConnectorCloudant {
                     .db(this.dbName)
                     .ddoc(type.getSimpleName())
                     .view(viewName)
-                    .keys(Arrays.asList(keys))
+                    .keys(Collections.singletonList(keys))
                     .includeDocs(false)
                     .group(true)
                     .reduce(true)

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -229,7 +229,7 @@ public class DatabaseRepositoryCloudantClient<T> {
 
     public Set<String> queryForIdsAsComplexValue(String queryName, String... keys) {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, queryName)
-                .keys(Arrays.asList(keys)).build();
+                .keys(Collections.singletonList(keys)).build();
         return queryForIds(query);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <!-- Build version properties -->
     <java_source.version>21</java_source.version>
     <java_target.version>21</java_target.version>
+    <java_release.version>21</java_release.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -114,8 +115,9 @@
     <httpcore5.version>5.2.5</httpcore5.version>
     <jakarta-xml-bind.version>4.0.2</jakarta-xml-bind.version>
     <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
-    <javax-activation.version>1.1.1</javax-activation.version>
-    <javax-annotation.version>1.3.2</javax-annotation.version>
+    <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+    <jakarta.activation-api.version>2.0.1</jakarta.activation-api.version>
+    <jakarta.mail-api.version>2.0.1</jakarta.mail-api.version>
     <jaxen.version>2.0.0</jaxen.version>
     <jcip-annotations.version>1.0</jcip-annotations.version>
     <jcraft.version>0.1.54</jcraft.version>
@@ -195,11 +197,10 @@
         <artifactId>packageurl-java</artifactId>
         <version>${package-url.version}</version>
       </dependency>
-      <!-- javax.annotation: java 11 compatibility -->
       <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>${javax-annotation.version}</version>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>${jakarta.annotation-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -351,9 +352,9 @@
         <version>${httpclient5.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>${jakarta.activation-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
@@ -661,6 +662,7 @@
         <configuration>
           <source>${java_source.version}</source>
           <target>${java_target.version}</target>
+          <release>${java_release.version}</release>
           <parameters>true</parameters>
         </configuration>
       </plugin>

--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -110,8 +110,9 @@
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.restdocs</groupId>

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
@@ -11,7 +11,7 @@ package org.eclipse.sw360.rest.authserver.security.customheaderauth;
 
 import java.io.IOException;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -169,14 +169,9 @@
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>${javax-annotation.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>${javax-activation.version}</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security.oauth.boot</groupId>

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/Sw360DatabaseSanitationService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/Sw360DatabaseSanitationService.java
@@ -18,8 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -33,7 +31,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
@@ -44,7 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class Sw360DatabaseSanitationService {
-    private static final Logger log = LogManager.getLogger(Sw360DatabaseSanitationService.class);
 
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
@@ -81,7 +77,7 @@ public class Sw360DatabaseSanitationService {
             } else if (sw360Exp.getErrorCode() == 204) {
                 throw new SW360Exception(sw360Exp.getMessage()).setErrorCode(204);
             } else {
-                log.error("No dulicate ids found: " + sw360Exp.getMessage());
+                log.error("No duplicate ids found: {}", sw360Exp.getMessage());
             }
             throw sw360Exp;
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -77,7 +77,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -35,15 +35,12 @@ import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
 import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -51,14 +48,9 @@ import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileCopyUtils;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
-import com.google.common.collect.Sets;
-
-import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyString;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
-import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -83,8 +75,6 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
     @NonNull
     private final Sw360ProjectService projectService;
     private final Sw360LicenseService licenseService;
-
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     private static FossologyService.Iface fossologyClient;
     private static final String RESPONSE_STATUS_VALUE_COMPLETED = "Completed";

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
@@ -12,14 +12,12 @@ package org.eclipse.sw360.rest.resourceserver.vendor;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TCompactProtocol;
-import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
@@ -131,9 +129,7 @@ public class Sw360VendorService {
     }
 
     private VendorService.Iface getThriftVendorClient() throws TTransportException {
-        THttpClient thriftClient = new THttpClient(thriftServerUrl + "/vendors/thrift");
-        TProtocol protocol = new TCompactProtocol(thriftClient);
-        return new VendorService.Client(protocol);
+        return new ThriftClients().makeVendorClient();
     }
 
     public ByteBuffer exportExcel() throws TException {


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Replace all `javax.*` dependencies with `jakarta.*` dependencies as Tomcat 11 completes the migration and servlets refuse to load.

Did not migrate to latest jakarta-mail `2.1.3` as it throws error "No provider of jakarta.mail.util.StreamProvider was found". `2.0.1` is the latest version which works.

Also, fix some compile warnings from Java 11.

### Suggest Reviewer
@heliocastro

### How To Test?
Setup new backend with Java 21+ and Apache Tomcat 11.