### PR TITLE
fix(build): add the missing excludeReleaseVersion

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -180,7 +180,9 @@ public class SW360ReportService {
         componentclient.sendExportSpreadsheetSuccessMail(emailURL, email);
     }
 
-    public ByteBuffer getLicenseInfoBuffer(User sw360User, String id, String generatorClassName, String variant, String template, String externalIds) throws TException {
+    public ByteBuffer getLicenseInfoBuffer(User sw360User, String id, String generatorClassName,
+                                           String variant, String template, String externalIds,
+                                           boolean excludeReleaseVersion) throws TException {
         final Project sw360Project = projectService.getProjectForUserById(id, sw360User);
 
         List<ProjectLink> mappedProjectLinks = projectService.createLinkedProjects(sw360Project,
@@ -217,7 +219,7 @@ public class SW360ReportService {
         }
         final LicenseInfoFile licenseInfoFile = licenseInfoService.getLicenseInfoFile(sw360Project, sw360User,
                 outputGeneratorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicensesPerAttachments,
-                externalIds, fileName);
+                externalIds, fileName, excludeReleaseVersion);
         return licenseInfoFile.bufferForGeneratedOutput();
     }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -1333,13 +1333,16 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         .queryParam("withlinkedreleases", "true")
                         .queryParam("mimetype", "xlsx")
                         .queryParam("module", "components")
+                        .queryParam("excludeReleaseVersion", "false")
                         .accept(MediaTypes.HAL_JSON))
              .andExpect(status().isOk())
              .andDo(this.documentationHandler.document(
                      queryParameters(
                              parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
                              parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
-                             parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`")
+                             parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
+                             parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
+                                     + "Possible values are `<true|false>`")
                      )));
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2357,13 +2357,17 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .queryParam("withlinkedreleases", "true")
                 .queryParam("mimetype", "xlsx")
                 .queryParam("module", "projects")
+                .queryParam("excludeReleaseVersion", "false")
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
                         queryParameters(
                                 parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
                                 parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
-                                parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"))
+                                parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
+                                parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
+                                        + "Possible values are `<true|false>`")
+                        )
                 ));
     }
 
@@ -2375,6 +2379,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         .queryParam("mimetype", "xlsx")
                         .queryParam("module", "projects")
                         .queryParam("projectId", project.getId())
+                        .queryParam("excludeReleaseVersion", "false")
                         .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
@@ -2382,8 +2387,10 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
                                 parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
                                 parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
-                                parameterWithName("projectId").description("Id of a project"))
-                        ));
+                                parameterWithName("projectId").description("Id of a project"),
+                                parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
+                                        + "Possible values are `<true|false>`")
+                        )));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Add the missing variable `excludeReleaseVersion` from #2496 in changes from #2442

### Suggest Reviewer
@smrutis1 @afsahsyeda

### How To Test?
Check build logs and REST API test docs.