### PR TITLE
chore(maven): segregate war and jar deploy dirs

### DIFF
--- a/backend/licenses-core/pom.xml
+++ b/backend/licenses-core/pom.xml
@@ -18,7 +18,7 @@
         <version>18.99.1</version>
     </parent>
     <properties>
-        <artifact.deploy.dir>${backend.deploy.dir}</artifact.deploy.dir>
+        <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <artifactId>backend-licenses-core</artifactId>

--- a/backend/vulnerabilities-core/pom.xml
+++ b/backend/vulnerabilities-core/pom.xml
@@ -26,7 +26,7 @@
         <finalName>vulnerabilities-core</finalName>
     </build>
     <properties>
-        <artifact.deploy.dir>${backend.deploy.dir}</artifact.deploy.dir>
+        <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <dependencies>

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -73,21 +73,22 @@ sudo ./kc.sh start  --log="console,file" --hostname-strict-backchannel=false --h
 
 ## Build the Backend:
 
-* Build the SW360 backend code using Maven, `mvn clean install -DskipTests`
-* Copy the generated WAR files to the webapps folder of Apache Tomcat, `cp $(find . -name "*.war")  /opt/apache-tomcat-10.x.x/webapps`
+* Build the SW360 backend code using Maven,
+  `mvn clean install -DskipTests -Dbase.deploy.dir=/opt/apache-tomcat-11.x.x/ -Dlistener.deploy.dir=/opt/keycloak-24.x.x/providers -P deploy`
 * Start the Apache Tomcat server.
 
 ## Keycloak Providers and Libraries:
  Providers are used to read users from sw360 db and register users from keycloak to sw360 db
  
-* After building the backend add the below files to providers folder in /opt/keycloak-24.0.2/providers/:
+* After building the backend with deploy profile, following files should be copied and available at `/opt/keycloak-24.0.2/providers/`:
 ```
-sudo cp sw360/keycloak/user-storage-provider/target/sw360-keycloak-user-storage-provider.jar /opt/keycloak-24.0.2/providers/
-sudo cp sw360/keycloak/event-listner/target/sw360-keycloak-event-listener.jar /opt/keycloak-24.0.2/providers
-sudo cp .m2/repository/org/eclipse/sw360/datahandler/18.99.1-SNAPSHOT/datahandler-18.99.1-SNAPSHOT.jar /opt/keycloak-24.0.2/providers/
-sudo cp .m2/repository/org/eclipse/sw360/commonIO/18.99.1/commonIO-18.99.1.jar /opt/keycloak-24.0.2/providers/
-add libthrift-0.19.0.jar file to providers folder
-sudo wget https://repo1.maven.org/maven2/org/apache/httpcomponents/core5/httpcore5/5.2.4/httpcore5-5.2.4.jar
+commonIO-18.99.1.jar
+datahandler-18.99.1.jar
+httpcore5-5.2.5.jar
+libthrift-0.20.0.jar
+spring-security-crypto-6.3.3.jar
+sw360-keycloak-event-listener.jar
+sw360-keycloak-user-storage-provider.jar
 ```
 
 ## Keycloak Admin Console:

--- a/keycloak/event-listeners/pom.xml
+++ b/keycloak/event-listeners/pom.xml
@@ -10,7 +10,6 @@
     <description/>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.sw360</groupId>
     <version>23.0.4</version>
     <artifactId>event-listener</artifactId>
     <packaging>jar</packaging>
@@ -26,6 +25,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <keycloak.provider.version>23.0.4</keycloak.provider.version>
+        <artifact.deploy.dir>${listener.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <dependencies>
@@ -48,14 +48,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.sw360</groupId>
-	    <artifactId>commonIO</artifactId>
+            <artifactId>commonIO</artifactId>
             <version>18.99.1</version>
-	</dependency>
-	<dependency>
-	    <groupId>org.eclipse.sw360</groupId>
-	    <artifactId>datahandler</artifactId>
-        <version>18.99.1</version>
-	</dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>datahandler</artifactId>
+            <version>18.99.1</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
@@ -63,14 +63,14 @@
             <scope>provided</scope>
         </dependency>
 
-	<dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <version>3.5.0.Final</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <finalName>sw360-keycloak-event-listener</finalName>
         <pluginManagement>

--- a/keycloak/pom.xml
+++ b/keycloak/pom.xml
@@ -10,7 +10,6 @@
     <description>Keycloak Providers for Custom User Storage</description>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.sw360</groupId>
     <version>23.0.4</version>
     <artifactId>keycloak</artifactId>
     <packaging>pom</packaging>
@@ -47,6 +46,29 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-deps</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${artifact.deploy.dir}</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <excludeTransitive>true</excludeTransitive>
+                            <excludeGroupIds>org.keycloak,org.jboss.logging,org.jboss.arquillian.graphene,javax.xml.bind,org.projectlombok</excludeGroupIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/keycloak/user-storage-provider/pom.xml
+++ b/keycloak/user-storage-provider/pom.xml
@@ -11,36 +11,37 @@
     <description>User Storage Provider</description>
     <groupId>org.eclipse</groupId>
     <version>1.0.0-SNAPSHOT</version>
-    
+
     <parent>
         <artifactId>keycloak</artifactId>
         <groupId>org.eclipse.sw360</groupId>
         <version>23.0.4</version>
     </parent>
-    
+
     <properties>
-	    <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
-	    <maven.compiler.source>17</maven.compiler.source>
+        <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
+        <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <version.hibernate.javax.persistence>1.0.0.Final</version.hibernate.javax.persistence>
-	    <arquillian-graphene.version>2.5.4</arquillian-graphene.version>
-	    <version.jee.jaxb.api>2.3.1</version.jee.jaxb.api>
-	    <version.keycloak>23.0.4</version.keycloak>
+        <arquillian-graphene.version>2.5.4</arquillian-graphene.version>
+        <version.jee.jaxb.api>2.3.1</version.jee.jaxb.api>
+        <version.keycloak>23.0.4</version.keycloak>
         <spring.security.crypto>6.3.3</spring.security.crypto>
+        <artifact.deploy.dir>${listener.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-	    <scope>provided</scope>
-	    <version>${version.keycloak}</version>
+            <scope>provided</scope>
+            <version>${version.keycloak}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-	    <scope>provided</scope>
-	    <version>${version.keycloak}</version>
+            <scope>provided</scope>
+            <version>${version.keycloak}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -50,8 +51,8 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
-	    <artifactId>jboss-logging</artifactId>
-	    <version>3.5.0.Final</version>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.5.0.Final</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -72,17 +73,22 @@
             <artifactId>spring-security-crypto</artifactId>
             <version>${spring.security.crypto}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>${httpcore5.version}</version>
+        </dependency>
 
         <dependency>
-	    <groupId>org.eclipse.sw360</groupId>
-	    <artifactId>commonIO</artifactId>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>commonIO</artifactId>
             <version>18.99.1</version>
-	</dependency>
-	<dependency>
-	    <groupId>org.eclipse.sw360</groupId>
-	    <artifactId>datahandler</artifactId>
-        <version>18.99.1</version>
-	</dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>datahandler</artifactId>
+            <version>18.99.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <rest.version>2.0.0</rest.version>
     <backend.deploy.dir>${base.deploy.dir}/webapps</backend.deploy.dir>
     <rest.deploy.dir>${base.deploy.dir}/webapps</rest.deploy.dir>
-    <jars.deploy.dir>${base.deploy.dir}</jars.deploy.dir>
+    <jars.deploy.dir/> <!-- Prevent copy of jar files to tomcat/webapps. Used by Docker build -->
     <!-- Build version properties -->
     <java_source.version>21</java_source.version>
     <java_target.version>21</java_target.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <backend.deploy.dir>${base.deploy.dir}/webapps</backend.deploy.dir>
     <rest.deploy.dir>${base.deploy.dir}/webapps</rest.deploy.dir>
     <jars.deploy.dir/> <!-- Prevent copy of jar files to tomcat/webapps. Used by Docker build -->
+    <listener.deploy.dir/>
     <!-- Build version properties -->
     <java_source.version>21</java_source.version>
     <java_target.version>21</java_target.version>


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Since now we do not have OSGi modules, in bare metal install, there is no need to put the jar files. Everything is packages as war and put in tomcat/webapps.

Set the default value of `jars.deploy.dir` to empty to prevent their copy but still allow Docker builds to work as it is passed as parameter to maven.

At the same time, add `listener.deploy.dir` (with default empty value) for copying keycloak related dependencies and jars to its provider directory.

### Suggest Reviewer
@heliocastro @smrutis1

### How To Test?
Install sw360 with `mvn clean install -DskipTests -Dbase.deploy.dir=/opt/apache-tomcat-11.0.0/ -Dlistener.deploy.dir=/opt/keycloak-24.x.x/providers -P deploy` and check if:
1. war files are copied to `/opt/apache-tomcat-11.0.0/webapps`
2. jar files are copied to `/opt/keycloak-24.x.x/providers`