### PR TITLE
feat(REST):fetch releases that are in NEW_CLEARING state and have a SRC/SRS attachment using parameter isNewClearingWithSourceAvailable

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -125,6 +125,25 @@ include::{snippets}/should_document_get_releases_by_name/http-response.adoc[]
 include::{snippets}/should_document_get_releases_by_name/links.adoc[]
 
 
+[[resources-releases-list-by-isNewClearingWithSourceAvailable-filter]]
+==== Listing releases in new clearing state with a source attachment available
+
+A `GET` request will list all the releases in NEW_CLEARING state that have a source attachment available. +
+Please set the request parameter `&isNewClearingWithSourceAvailable=true`.
+
+===== Response structure
+include::{snippets}/should_document_get_releases_by_isNewClearingWithSourceAvailable_filter/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_releases_by_isNewClearingWithSourceAvailable_filter/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_releases_by_isNewClearingWithSourceAvailable_filter/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_releases_by_isNewClearingWithSourceAvailable_filter/links.adoc[]
+
+
 [[resources-releases-get-by-externalids]]
 ==== Listing by external ids
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -311,7 +311,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release2.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
         release2.setComponentId(component.getId());
         release2.setComponentType(ComponentType.OSS);
-        release2.setClearingState(ClearingState.APPROVED);
+        release2.setClearingState(ClearingState.NEW_CLEARING);
         release2.setMainlineState(MainlineState.MAINLINE);
         release2.setExternalIds(release2ExternalIds);
         release2.setLanguages(new HashSet<>(Arrays.asList("C++", "Java")));
@@ -323,6 +323,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release2.setClearingInformation(clearingInfo);
         release2.setCotsDetails(cotsDetails);
         release2.setEccInformation(eccInformation);
+        release2.setAttachments(ImmutableSet.of(att1));
         releaseList.add(release2);
 
         Package package2 = new Package()
@@ -937,6 +938,21 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }
+
+        @Test
+        public void should_document_get_releases_by_isNewClearingWithSourceAvailable_filter() throws Exception {
+            mockMvc.perform(get("/api/releases?isNewClearingWithSourceAvailable=" + true)
+                            .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)).accept(MediaTypes.HAL_JSON))
+                    .andExpect(status().isOk())
+                    .andDo(this.documentationHandler.document(
+                            links(linkWithRel("curies").description("Curies are used for online documentation")),
+                            responseFields(
+                                    subsectionWithPath("_embedded.sw360:releases.[]name").description("The name of the release, optional"),
+                                    subsectionWithPath("_embedded.sw360:releases.[]version").description("The version of the release"),
+                                    subsectionWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
+                                    subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")))
+                    );
+        }
 
     @Test
     public void should_document_trigger_fossology_process() throws Exception {


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

**Description**:
Fetch all the releases that are in NEW_CLEARING state and have a source attachment available by using the `isNewClearingWithSourceAvailable` filter/parameter and setting it to true. This function is useful in determining the candidate releases that can be sent to license scanning tools.

![image](https://github.com/user-attachments/assets/f127d085-ffcf-4d13-bc38-43948b6c9b87)


