### PR TITLE
chore(scorecard): Update permissions on workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,6 +25,9 @@ env:
   COUCHDB_USER: sw360
   COUCHDB_PASSWORD: sw360fossie
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,13 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '55 5 * * *'
+    - cron: "55 5 * * *"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   analyze:
@@ -28,7 +29,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     permissions:
       # required for all workflows
       security-events: write
@@ -44,10 +45,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: java-kotlin
-          build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
-        - language: python
-          build-mode: none
+          - language: java-kotlin
+            build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+          - language: python
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -57,39 +58,39 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -33,7 +33,8 @@ on:
 env:
   REGISTRY: ghcr.io
 
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   sw360_version:
@@ -61,7 +62,6 @@ jobs:
     name: Build SW360 Thrift image
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
       packages: write
 
     steps:
@@ -88,7 +88,6 @@ jobs:
     needs: [sw360_version, thrift_image]
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
       packages: write
 
     steps:
@@ -120,7 +119,6 @@ jobs:
     needs: [sw360_version, binary_image]
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
       packages: write
 
     steps:


### PR DESCRIPTION
Reference on scorecard:

Token-Permissions
Determines if the project's workflows follow the principle of least privilege.

Reason
detected GitHub workflow tokens with excessive permissions

Details
Info: jobLevel 'packages' permission set to 'read': .github/workflows/codeql.yml:37
Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:40
Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:41
Info: jobLevel 'contents' permission set to 'read': .github/workflows/docker_deploy.yml:64
Info: jobLevel 'contents' permission set to 'read': .github/workflows/docker_deploy.yml:91
Info: jobLevel 'contents' permission set to 'read': .github/workflows/docker_deploy.yml:123
Warn: no topLevel permission defined: .github/workflows/build_and_test.yml:1
Warn: no topLevel permission defined: .github/workflows/codeql.yml:1
Warn: topLevel permissions set to 'write-all': .github/workflows/docker_deploy.yml:36