### PR TITLE
fix(rest): component attachment deletion while updating externalIds

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -358,8 +358,6 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                 attachments.add(restControllerHelper.convertToAttachment(attachmentDTO, user));
             }
             sw360Component.setAttachments(attachments);
-        } else {
-            sw360Component.setAttachments(null);
         }
         RequestStatus updateComponentStatus = componentService.updateComponent(sw360Component, user);
         HalResource<Component> userHalResource = createHalComponent(sw360Component, user);


### PR DESCRIPTION
Issue: #2695 

Description: After these changes, attachment won't get deleted when component's externalIds field is updated through rest.

