### PR TITLE
fix(openapi)!: add health endpoint to openapi

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -10,10 +10,17 @@
 
 package org.eclipse.sw360.rest.resourceserver;
 
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
@@ -25,6 +32,7 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationFilter;
 import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -45,7 +53,26 @@ import java.util.*;
 @Import(Sw360CORSFilter.class)
 public class Sw360ResourceServer extends SpringBootServletInitializer {
 
-    private static final String REST_BASE_PATH = "/api";
+    public static final String REST_BASE_PATH = "/api";
+    public static final String EXAMPLE_HEALTH_RESPONSE = """
+            {
+              "status": "UP",
+              "components": {
+                "SW360Rest": {
+                  "status": "UP",
+                  "details": {
+                    "Rest State": {
+                      "isDbReachable": true,
+                      "isThriftReachable": true
+                    }
+                  }
+                },
+                "ping": {
+                  "status": "UP"
+                }
+              }
+            }
+            """;
 
     @Value("${spring.data.rest.default-page-size:10}")
     private int defaultPageSize;
@@ -168,6 +195,18 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
                 .info(new Info().title("SW360 API").license(new License().name("EPL-2.0")
                                 .url("https://github.com/eclipse-sw360/sw360/blob/main/LICENSE"))
                         .version(restVersionString))
-                .servers(List.of(server));
+                .servers(List.of(server))
+                .path("/health", new PathItem().get(
+                        new Operation().tags(Collections.singletonList("Health"))
+                                .summary("Health endpoint").operationId("health")
+                                .responses(new ApiResponses().addApiResponse("200",
+                                        new ApiResponse().description("OK")
+                                                .content(new Content()
+                                                        .addMediaType("application/json", new MediaType()
+                                                                .example(EXAMPLE_HEALTH_RESPONSE)
+                                                                .schema(new Schema<Health>())
+                                                ))
+                                ))
+                ));
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -60,7 +60,9 @@ public class ResourceServerConfiguration {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("/", "/*/*.html", "/*/*.css", "/*/*.js", "/*.js", "/*.json", "/*/*.json", "/*/*.png", "/*/*.gif", "/*/*.ico", "/*/*.woff/*", "/*/*.ttf", "/*/*.html", "/*/*/*.html", "/*/*.yaml", "/v3/api-docs/**");
+        return (web) -> web.ignoring().requestMatchers("/", "/*/*.html", "/*/*.css", "/*/*.js", "/*.js", "/*.json",
+                "/*/*.json", "/*/*.png", "/*/*.gif", "/*/*.ico", "/*/*.woff/*", "/*/*.ttf", "/*/*.html", "/*/*/*.html",
+                "/*/*.yaml", "/v3/api-docs/**", "/api/health", "/api/info");
     }
 
     @Bean
@@ -80,8 +82,8 @@ public class ResourceServerConfiguration {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         SimpleAuthenticationEntryPoint saep = new SimpleAuthenticationEntryPoint();
         return http.addFilterBefore(filter, BasicAuthenticationFilter.class).authorizeHttpRequests(auth -> {
-            auth.requestMatchers(HttpMethod.GET, "/health").permitAll();
-            auth.requestMatchers(HttpMethod.GET, "/info").hasAuthority("WRITE");
+            auth.requestMatchers(HttpMethod.GET, "/api/health").permitAll();
+            auth.requestMatchers(HttpMethod.GET, "/api/info").hasAuthority("WRITE");
             auth.requestMatchers(HttpMethod.GET, "/api").permitAll();
             auth.requestMatchers(HttpMethod.GET, "/api/reports/download").permitAll();
             auth.requestMatchers(HttpMethod.GET, "/api/**").hasAuthority("READ");

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -20,6 +20,9 @@ management:
       base-path: /
       exposure:
         include: health,info
+      path-mapping:
+        health: /api/health
+        info: /api/info
   endpoint:
     health:
       show-details: always
@@ -28,6 +31,11 @@ management:
       enabled: true
   security:
     enabled: true
+  health:
+    diskspace:
+      enabled: true    # Disable to hide sensitive system information
+    ping:
+      enabled: true
 
 spring:
   application:

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/SW360RestHealthIndicatorTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/SW360RestHealthIndicatorTest.java
@@ -71,7 +71,7 @@ public class SW360RestHealthIndicatorTest {
      */
     private ResponseEntity<Map> getMapResponseEntityForHealthEndpointRequest(String endpoint) {
         return this.testRestTemplate.getForEntity(
-                "http://localhost:" + this.port + endpoint, Map.class);
+                "http://localhost:" + this.port + Sw360ResourceServer.REST_BASE_PATH + endpoint, Map.class);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
@@ -40,8 +40,8 @@ public class Sw360AuthorizationServerConfiguration {
 		SimpleAuthenticationEntryPoint saep = new SimpleAuthenticationEntryPoint();
 		httpSecurity.authorizeHttpRequests(
 				authz -> authz
-				         .requestMatchers(HttpMethod.GET, "/health").permitAll()
-						.requestMatchers(HttpMethod.GET, "/info").permitAll()
+						.requestMatchers(HttpMethod.GET, "/api/health").permitAll()
+						.requestMatchers(HttpMethod.GET, "/api/info").permitAll()
 						.anyRequest().authenticated()
 		).httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults())
 				.exceptionHandling(x -> x.authenticationEntryPoint(saep));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/HealthSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/HealthSpecTest.java
@@ -43,7 +43,7 @@ public class HealthSpecTest extends TestRestDocsSpecBase{
         given(this.restHealthIndicatorMock.health()).willReturn(spring_health);
 
 
-        mockMvc.perform(get("/health")
+        mockMvc.perform(get("/api/health")
                     .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
@@ -72,7 +72,7 @@ public class HealthSpecTest extends TestRestDocsSpecBase{
                 .build();
         given(this.restHealthIndicatorMock.health()).willReturn(spring_health_down);
 
-        mockMvc.perform(get("/health")
+        mockMvc.perform(get("/api/health")
                     .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().is2xxSuccessful())
                 .andDo(this.documentationHandler.document(

--- a/rest/resource-server/src/test/resources/application.yml
+++ b/rest/resource-server/src/test/resources/application.yml
@@ -1,21 +1,9 @@
 #SPDX-FileCopyrightText: © 2024 Siemens AG
 #SPDX-License-Identifier: EPL-2.0
 
-spring:
-  profiles:
-    active: SECURITY_MOCK
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: http://localhost:8080/authorization/oauth2/jwks
-          jwk-set-uri: http://localhost:8080/authorization/oauth2/jwks
-  application:
-    name: resource
+server:
   servlet:
-    multipart:
-      max-file-size: 500MB
-      max-request-size: 600MB
+    context-path: /
 
 management:
   endpoints:
@@ -23,6 +11,9 @@ management:
       base-path: /
       exposure:
         include: health,info
+      path-mapping:
+        health: /api/health
+        info: /api/info
   endpoint:
     health:
       show-details: always
@@ -31,9 +22,27 @@ management:
       enabled: true
   security:
     enabled: true
-server:
+  health:
+    diskspace:
+      enabled: true    # Disable to hide sensitive system information
+    ping:
+      enabled: true
+
+spring:
+  profiles:
+    active: SECURITY_MOCK
+  application:
+    name: resource
   servlet:
-    context-path: /
+    multipart:
+      max-file-size: 500MB
+      max-request-size: 600MB
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:8080/authorization/oauth2/jwks
+          jwk-set-uri: http://localhost:8080/authorization/oauth2/jwks
 
 #logging:
 #  level:


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Add the missing docs for `/health` endpoint in OpenAPI docs. To make the changes work with Swagger UI, the `/health` endpoint had to be moved making it a breaking change.

**BREAKING CHANGE:** Move the health endpoint from `/resource/health` to `/resource/api/health` for OpenAPI documentations to be easy to use.

### Suggest Reviewer

### How To Test?
Check OpenAPI docs for the health endpoint.