### PR TITLE
fix(test): enable unauthorized request test

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -29,7 +29,6 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.time.Instant;
@@ -84,7 +83,7 @@ public class RestExceptionHandler {
 
     @Data
     @RequiredArgsConstructor
-    private static class ErrorMessage {
+    public static class ErrorMessage {
 
         @JsonSerialize(using = JsonInstantSerializer.class)
         private Instant timestamp = Instant.now();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/SimpleAuthenticationEntryPoint.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/SimpleAuthenticationEntryPoint.java
@@ -12,14 +12,12 @@ package org.eclipse.sw360.rest.resourceserver.core;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -30,15 +28,12 @@ public class SimpleAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
-        HashMap<String, Object> map = new LinkedHashMap<>();
-        map.put("status", HttpServletResponse.SC_UNAUTHORIZED);
-        map.put("message", authException.getMessage());
-        map.put("timestamp", Calendar.getInstance().getTime().toGMTString());
+        RestExceptionHandler.ErrorMessage message = new RestExceptionHandler.ErrorMessage(authException, HttpStatus.UNAUTHORIZED);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setCharacterEncoding("utf-8");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         ObjectMapper objectMapper = new ObjectMapper();
-        String resBody = objectMapper.writeValueAsString(map);
+        String resBody = objectMapper.writeValueAsString(message);
         PrintWriter printWriter = response.getWriter();
         printWriter.print(resBody);
         printWriter.flush();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -66,14 +66,20 @@ public class ResourceServerConfiguration {
     @Bean
     @Order(1)
     public SecurityFilterChain securityFilterChainRS1(HttpSecurity http) throws Exception {
-        return http.authorizeRequests(auth -> auth.anyRequest().authenticated()).oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(sw360JWTAccessTokenConverter).jwkSetUri(issuerUri))).httpBasic(Customizer.withDefaults()).csrf(csrf -> csrf.disable()).build();
+        SimpleAuthenticationEntryPoint saep = new SimpleAuthenticationEntryPoint();
+        return http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(sw360JWTAccessTokenConverter)
+                        .jwkSetUri(issuerUri)))
+                .httpBasic(Customizer.withDefaults())
+                .exceptionHandling(x -> x.authenticationEntryPoint(saep))
+                .csrf(csrf -> csrf.disable()).build();
     }
 
     @Bean
     @Order(2)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         SimpleAuthenticationEntryPoint saep = new SimpleAuthenticationEntryPoint();
-        return http.addFilterBefore(filter, BasicAuthenticationFilter.class).authorizeRequests(auth -> {
+        return http.addFilterBefore(filter, BasicAuthenticationFilter.class).authorizeHttpRequests(auth -> {
             auth.requestMatchers(HttpMethod.GET, "/health").permitAll();
             auth.requestMatchers(HttpMethod.GET, "/info").hasAuthority("WRITE");
             auth.requestMatchers(HttpMethod.GET, "/api").permitAll();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.rest.resourceserver.configuration.security;
 
 import lombok.RequiredArgsConstructor;
+import org.eclipse.sw360.rest.resourceserver.core.SimpleAuthenticationEntryPoint;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360UserAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -36,12 +37,14 @@ public class Sw360AuthorizationServerConfiguration {
 	@Order(1)
 	@Bean
 	public SecurityFilterChain appSecurtiy(HttpSecurity httpSecurity) throws Exception {
-		httpSecurity.authorizeRequests(
+		SimpleAuthenticationEntryPoint saep = new SimpleAuthenticationEntryPoint();
+		httpSecurity.authorizeHttpRequests(
 				authz -> authz
 				         .requestMatchers(HttpMethod.GET, "/health").permitAll()
 						.requestMatchers(HttpMethod.GET, "/info").permitAll()
 						.anyRequest().authenticated()
-		).httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults());
+		).httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults())
+				.exceptionHandling(x -> x.authenticationEntryPoint(saep));
 		return httpSecurity.csrf(csrf -> csrf.disable()).build();
 	}
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ApiSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ApiSpecTest.java
@@ -13,8 +13,6 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
@@ -78,7 +76,6 @@ public class ApiSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
-    @Ignore
     // SecurityContextHolder.getContext in test filter chain supports no mocking.
     // The authentication object is always null in the test class.
     // As result the test filter automatically authenticates the request
@@ -89,8 +86,10 @@ public class ApiSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isUnauthorized())
                 .andDo(this.documentationHandler.document(
                         responseFields(
-                                fieldWithPath("error").description("The error code, e.g. invalid_token"),
-                                fieldWithPath("error_description").description("The description of invalid token"))));
+                                fieldWithPath("timestamp").description("The timestamp when the error occurred"),
+                                fieldWithPath("status").description("The HTTP status code, e.g. 400"),
+                                fieldWithPath("error").description("The HTTP error code, e.g. Bad Request"),
+                                fieldWithPath("message").description("The error message, e.g. JSON parse error: Unexpected end-of-input: expected close marker for Object"))));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

1. Re-enable the ignored `should_document_error_unauthorized` test.
2. Add the missing exception handler for OAuth2 security filter chain and test cases.
3. Update the authentication exception handler to use classes from `RestExceptionHandler` to get uniform response.

### Suggest Reviewer
@smrutis1

### How To Test?
1. Check if no tests are skipped for resource controller.
2. Check if a proper response body is sent for unauthorized REST API requests.
