### PR TITLE
feat(Component): Add new endpoint that allows user to subscribe and unsubscribe to a component

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -319,6 +319,31 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     }
 
     @Operation(
+            summary = "Toggle user subscription to a component",
+            description = "Subscribes or unsubscribes the user to a specified component based on their current subscription status.",
+            tags = {"Components"}
+    )
+    @RequestMapping(value = COMPONENTS_URL + "/{id}/subscriptions", method = RequestMethod.POST)
+    public ResponseEntity<String> toggleComponentSubscription(
+            @Parameter(description = "The ID of the component.")
+            @PathVariable("id") String componentId
+    ) throws TException {
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        Component componentById = componentService.getComponentForUserById(componentId, user);
+        Set<String> subscribers = componentById.getSubscribers();
+
+        boolean isSubscribed = subscribers.contains(user.getEmail());
+
+        if (isSubscribed) {
+            componentService.unsubscribeComponent(componentId, user);
+            return new ResponseEntity<>("Successfully unsubscribed from the component.", HttpStatus.OK);
+        } else {
+            componentService.subscribeComponent(componentId, user);
+            return new ResponseEntity<>("Successfully subscribed to the component.", HttpStatus.OK);
+        }
+    }
+
+    @Operation(
             summary = "Get components by external ID.",
             description = "Get components by external ID.",
             tags = {"Components"}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -102,6 +102,16 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         return sw360ComponentClient.getSubscribedComponents(sw360User);
     }
 
+    public RequestStatus subscribeComponent(String componentId, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.subscribeComponent(componentId, sw360User);
+    }
+
+    public RequestStatus unsubscribeComponent(String componentId, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.unsubscribeComponent(componentId, sw360User);
+    }
+
     public List<Component> getRecentComponents(User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.getRecentComponentsSummary(5, sw360User);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -34,7 +34,6 @@ import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
 import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
-import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.hamcrest.Matchers;
@@ -1344,5 +1343,13 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                              parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
                                      + "Possible values are `<true|false>`")
                      )));
+    }
+
+    @Test
+    public void should_subscribe_user_to_component() throws Exception {
+        mockMvc.perform(post("/api/components/" + angularComponent.getId() + "/subscriptions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
Add new endpoint that allows user to subscribe and unsubscribe to a component
- If the user **has** previously subscribed to that component, they will **unsubscribe** from that component
- If the user **has not** previously subscribed to that component, they will **subscribe** from that component

### How To Test?
- URL: http://localhost:8080/resource/api/components/{component_id}/subscriptions
- Method: POST
- Response: Status 200

  -  If the user **has** previously subscribed to that component
  ```
  Successfully unsubscribed from the component.
  ```
  
  -  If the user **has not** previously subscribed to that component
  ```
  Successfully subscribed from the component.
  ```


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
