### PR TITLE
feat(Release): Add new endpoint for release subscription

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -1529,6 +1529,29 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
     }
 
+    @Operation(
+            summary = "Handle release subcription for requesting user.",
+            description = "Handle release subcription for requesting user.",
+            tags = {"Releases"}
+    )
+    @PreAuthorize("hasAuthority('WRITE')")
+    @PostMapping(value = RELEASES_URL + "/{id}/subscriptions")
+    public ResponseEntity<String> handleReleaseSubscriptions(
+            @Parameter(description = "The ID of the release.")
+            @PathVariable("id") String releaseId
+    ) throws TException {
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        Release releaseById = releaseService.getReleaseForUserById(releaseId, user);
+        Set<String> subscribers = releaseById.getSubscribers();
+        if (subscribers.contains(user.getEmail())) {
+            releaseService.unsubscribeRelease(user, releaseId);
+            return new ResponseEntity<>("Release has been unsubscribed", HttpStatus.OK);
+        } else {
+            releaseService.subscribeRelease(user, releaseId);
+            return new ResponseEntity<>("Release has been subscribed", HttpStatus.OK);
+        }
+    }
+
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(ReleaseController.class).slash("api" + RELEASES_URL).withRel("releases"));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -786,4 +786,24 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         parentRelease.setReleaseIdToRelationship(releaseRelationshipMap);
         return sw360ComponentClient.getCyclicLinkedReleasePath(parentRelease, sw360User);
     }
+
+    /**
+     * Subscribe release
+     * @param releaseId              Release ID
+     * @throws TException            TException
+     */
+    public void subscribeRelease(User user, String releaseId) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        sw360ComponentClient.subscribeRelease(releaseId, user);
+    }
+
+    /**
+     * Unsubscribe release
+     * @param releaseId              Release ID
+     * @throws TException            TException
+     */
+    public void unsubscribeRelease(User user, String releaseId) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        sw360ComponentClient.unsubscribeRelease(releaseId, user);
+    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -1481,4 +1481,13 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                         .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isMultiStatus());
     }
+
+    @Test
+    public void should_user_subscribe_release() throws Exception {
+        mockMvc.perform(post("/api/releases/" + release.getId() + "/subscriptions")
+                        .contentType(MediaTypes.HAL_JSON)
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
Add new endpoint that allows user to subscribe and unsubscribe to a release
- If the user **has** previously subscribed to that release, they will **unsubscribe** from that release
- If the user **has not** previously subscribed to that release, they will **subscribe** from that release

### How To Test?
- URL: http://localhost:8080/resource/api/releases/{release_id}/subscriptions
- Method: POST
- Response: Status 200

  -  If the user **has** previously subscribed to that release
  ```
  Release has been unsubscribed
  ```
  
  -  If the user **has not** previously subscribed to that release
  ```
  Release has been subscribed
  ```