### PR TITLE
feat(Import CDX): Handle redirection of VCS URLs in SBOM

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -12,7 +12,10 @@ package org.eclipse.sw360.cyclonedx;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.Predicate;
@@ -104,8 +107,11 @@ public class CycloneDxBOMImporter {
     private static final String INVALID_PACKAGE = "invalidPkg";
     private static final String PROJECT_ID = "projectId";
     private static final String PROJECT_NAME = "projectName";
+    private static final String REDIRECTED_VCS = "redirectedVCS";
     private static final boolean IS_PACKAGE_PORTLET_ENABLED = SW360Constants.IS_PACKAGE_PORTLET_ENABLED;
     private static final Predicate<ExternalReference.Type> typeFilter = type -> ExternalReference.Type.VCS.equals(type);
+
+    private Set<String> redirectedUrls = new HashSet<>();
 
     private final ProjectDatabaseHandler projectDatabaseHandler;
     private final ComponentDatabaseHandler componentDatabaseHandler;
@@ -148,6 +154,7 @@ public class CycloneDxBOMImporter {
                         .map(ExternalReference::getUrl)
                         .map(url -> sanitizeVCS(url.toLowerCase()))
                         .filter(url -> CommonUtils.isValidUrl(url))
+                        .map(url -> getFinalURL(url))
                         .map(url -> new AbstractMap.SimpleEntry<>(url, comp)))
                 .collect(Collectors.groupingBy(e -> e.getKey(),
                         Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
@@ -288,6 +295,7 @@ public class CycloneDxBOMImporter {
                         // all components does not have VCS, so return & show appropriate error in UI
                         messageMap.put(INVALID_COMPONENT, String.join(JOINER, componentsWithoutVcs));
                         messageMap.put(INVALID_PACKAGE, String.join(JOINER, invalidPackages));
+                        messageMap.put(REDIRECTED_VCS, String.join(JOINER, this.redirectedUrls));
                         messageMap.put(DUPLICATE_PACKAGE, String.join(JOINER, duplicatePackages));
                         messageMap.put(SW360Constants.MESSAGE,
                                 String.format("VCS information is missing for <b>%s</b> / <b>%s</b> Components!",
@@ -703,6 +711,7 @@ public class CycloneDxBOMImporter {
         messageMap.put(DUPLICATE_RELEASE, String.join(JOINER, duplicateReleases));
         messageMap.put(DUPLICATE_PACKAGE, String.join(JOINER, duplicatePackages));
         messageMap.put(INVALID_RELEASE, String.join(JOINER, invalidReleases));
+        messageMap.put(REDIRECTED_VCS, String.join(JOINER, this.redirectedUrls));
         messageMap.put(INVALID_PACKAGE, String.join(JOINER, invalidPackages));
         messageMap.put(PROJECT_ID, project.getId());
         messageMap.put(PROJECT_NAME, SW360Utils.getVersionedName(project.getName(), project.getVersion()));
@@ -1079,5 +1088,62 @@ public class CycloneDxBOMImporter {
             }
         }
         return false;
+    }
+
+    public String getFinalURL(String urlString) {
+        URL url;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            log.error("Invalid URL format: {}", e.getMessage());
+            return urlString;
+        }
+
+        int redirectCount = 0;
+
+        while (redirectCount < SW360Constants.VCS_REDIRECTION_LIMIT) {
+            try {
+                HttpURLConnection connection = openConnection(url);
+                int status = connection.getResponseCode();
+
+                if (status == HttpURLConnection.HTTP_MOVED_PERM || status == 308) {
+                    String newUrl = connection.getHeaderField("Location");
+                    connection.disconnect();
+
+                    // Resolve relative URLs
+                    url = new URL(url, newUrl);
+
+                    if (!"https".equalsIgnoreCase(url.getProtocol())) {
+                        log.error("Insecure redirection to non-HTTPS URL: {}", url);
+                        return urlString;
+                    }
+
+                    redirectCount++;
+                    this.redirectedUrls.add(urlString);
+                } else {
+                    connection.disconnect();
+                    break;
+                }
+            } catch (IOException e) {
+                log.error("Error during redirection handling: {}", e.getMessage());
+                return urlString;
+            }
+        }
+
+        if (redirectCount == 0 || redirectCount == SW360Constants.VCS_REDIRECTION_LIMIT) {
+            if (redirectCount == SW360Constants.VCS_REDIRECTION_LIMIT) {
+                log.error("Exceeded maximum redirect limit. Returning original URL.");
+            }
+            return urlString;
+        }
+        return sanitizeVCS(url.toString());
+    }
+
+    private static HttpURLConnection openConnection(URL url) throws IOException{
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setInstanceFollowRedirects(false);
+        connection.setConnectTimeout(SW360Constants.VCS_REDIRECTION_TIMEOUT_LIMIT);
+        connection.setReadTimeout(SW360Constants.VCS_REDIRECTION_TIMEOUT_LIMIT);
+        return connection;
     }
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -117,6 +117,8 @@ public class SW360Constants {
     public static final String DATA_HANDLER_POM_FILE_PATH;
     public static final UserGroup PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE;
     public static final boolean IS_PACKAGE_PORTLET_ENABLED;
+    public static final Integer VCS_REDIRECTION_LIMIT;
+    public static final Integer VCS_REDIRECTION_TIMEOUT_LIMIT;
     public static final String TOOL_NAME;
     public static final String TOOL_VENDOR;
     public static final UserGroup SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE;
@@ -226,6 +228,8 @@ public class SW360Constants {
         DATA_HANDLER_POM_FILE_PATH = props.getProperty("datahandler.pom.file.path", "/META-INF/maven/org.eclipse.sw360/datahandler/pom.xml");
         PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE = UserGroup.valueOf(props.getProperty("package.portlet.write.access.usergroup", UserGroup.USER.name()));
         IS_PACKAGE_PORTLET_ENABLED = Boolean.parseBoolean(props.getProperty("package.portlet.enabled", "true"));
+        VCS_REDIRECTION_LIMIT = Integer.parseInt(props.getProperty("vcs.redirection.limit","5"));
+        VCS_REDIRECTION_TIMEOUT_LIMIT = Integer.parseInt(props.getProperty("vcs.redirection.timeout.limit","5000"));
         TOOL_NAME = props.getProperty("sw360.tool.name", "SW360");
         TOOL_VENDOR = props.getProperty("sw360.tool.vendor", "Eclipse Foundation");
         SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE = UserGroup.valueOf(props.getProperty("sbom.import.export.access.usergroup", UserGroup.USER.name()));


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

**Description**:

- Certain VCS URLs in the imported SBOM redirect to different URLS.
- The URLS they are redirecting to might already exist in SW360, leading to duplicate creation of components.
- This redirection is now handled during import where each each valid VCS is checked for redirection. If the VCS redirects, the final URL it redirects to is considered as the actual VCS of the component.
- The maximum number of redirect attempts and connection timeout can be configured in the sw360.properties file. The default value has been set to 5 and 5000 m/s respectively.

### How To Test?
Include VCS URLs that would get redirected in your SBOM. Few examples:
https://github.com/davidtheclark/cosmiconfig
https://github.com/isaacs/abbrev-js
https://github.com/angular/material2
https://github.com/reacttraining/react-router

