### PR TITLE
fix(deps): Deprecate old commmons-lang library

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -22,7 +22,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.common.utils.BackendUtils;
 import org.eclipse.sw360.components.summary.SummaryType;
@@ -1319,7 +1319,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         return projects;
     }
-    
+
     public Project fillClearingStateSummaryIncludingSubprojectsForSingleProject(Project project, User user) {
         final Map<String, Project> allProjectsIdMap = getRefreshedAllProjectsIdMap();
 

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -25,7 +25,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.fossology.config.FossologyRestConfig;
 import org.eclipse.sw360.fossology.rest.FossologyRestClient;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,7 +159,7 @@ public class FossologyHandler implements FossologyService.Iface {
 
         FossologyUtils.ensureOrderOfProcessSteps(fossologyProcess);
 
-        ExternalToolProcessStep furthestStep = fossologyProcess.getProcessSteps().get(fossologyProcess.getProcessSteps().size() - 1); 
+        ExternalToolProcessStep furthestStep = fossologyProcess.getProcessSteps().get(fossologyProcess.getProcessSteps().size() - 1);
         if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(furthestStep.getStepName())) {
             handleUploadStep(componentClient, release, user, fossologyProcess, sourceAttachment, uploadDescription);
         } else if (FossologyUtils.FOSSOLOGY_STEP_NAME_SCAN.equals(furthestStep.getStepName())) {

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.fossology.config.FossologyRestConfig;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/licenseinfo/pom.xml
+++ b/backend/licenseinfo/pom.xml
@@ -7,8 +7,8 @@
   ~
   ~ SPDX-License-Identifier: EPL-2.0
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -20,7 +20,9 @@
     <artifactId>backend-licenseinfo</artifactId>
     <packaging>war</packaging>
     <name>backend-licenseinfo</name>
-    <build><finalName>licenseinfo</finalName></build>
+    <build>
+        <finalName>licenseinfo</finalName>
+    </build>
     <properties>
         <artifact.deploy.dir>${backend.deploy.dir}</artifact.deploy.dir>
     </properties>
@@ -30,6 +32,10 @@
             <groupId>org.eclipse.sw360</groupId>
             <artifactId>backend-common</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -40,7 +40,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.licenseinfo.outputGenerators.*;
 import org.eclipse.sw360.licenseinfo.parsers.*;
 import org.eclipse.sw360.licenseinfo.util.LicenseNameWithTextUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -12,7 +12,7 @@
 
 package org.eclipse.sw360.licenseinfo.outputGenerators;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.xwpf.usermodel.*;
 import org.apache.xmlbeans.XmlException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -12,7 +12,7 @@
 
 package org.eclipse.sw360.licenseinfo.outputGenerators;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
@@ -68,7 +68,7 @@ public class XhtmlGenerator extends OutputGenerator<String> {
     }
 
     private String convertHeaderTextToHTML(String headerText) {
-        String html = StringEscapeUtils.escapeHtml(headerText);
+        String html = StringEscapeUtils.escapeHtml4(headerText);
         html = html.replace("\n", "<br>");
         return html;
     }

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -10,7 +10,7 @@
 package org.eclipse.sw360.licenseinfo.parsers;
 
 import com.google.common.collect.Sets;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,7 +88,7 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
     }
 
     protected static String normalizeEscapedXhtml(Node node) {
-        return StringEscapeUtils.unescapeHtml(StringEscapeUtils.unescapeXml(node.getTextContent().trim()));
+        return StringEscapeUtils.unescapeHtml4(StringEscapeUtils.unescapeXml(node.getTextContent().trim()));
     }
 
     protected static String normalizeSpace(Node node) {

--- a/backend/search/src/main/java/org/eclipse/sw360/search/db/SearchDocument.java
+++ b/backend/search/src/main/java/org/eclipse/sw360/search/db/SearchDocument.java
@@ -10,7 +10,7 @@
 package org.eclipse.sw360.search.db;
 
 import org.eclipse.sw360.datahandler.common.SW360Constants;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/VMComponentHandler.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/VMComponentHandler.java
@@ -18,7 +18,7 @@ import org.eclipse.sw360.vmcomponents.process.VMProcessHandler;
 
 import org.eclipse.sw360.datahandler.thrift.vmcomponents.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/common/SVMMapper.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/common/SVMMapper.java
@@ -6,7 +6,7 @@ package org.eclipse.sw360.vmcomponents.common;
 
 import com.google.common.base.Joiner;
 import org.eclipse.sw360.datahandler.thrift.vmcomponents.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/db/VMDatabaseHandler.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/db/VMDatabaseHandler.java
@@ -8,7 +8,7 @@ import com.ibm.cloud.cloudant.v1.Cloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.thrift.vmcomponents.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TBase;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandler.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandler.java
@@ -7,7 +7,7 @@ package org.eclipse.sw360.vmcomponents.handler;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TBase;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/process/VMProcessHandler.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/process/VMProcessHandler.java
@@ -6,7 +6,7 @@ package org.eclipse.sw360.vmcomponents.process;
 
 import org.eclipse.sw360.datahandler.thrift.vmcomponents.VMComponent;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TBase;
 import org.eclipse.sw360.datahandler.common.SW360Utils;

--- a/backend/vmcomponents/src/test/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandlerTest.java
+++ b/backend/vmcomponents/src/test/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandlerTest.java
@@ -7,7 +7,7 @@ package org.eclipse.sw360.vmcomponents.handler;
 import org.eclipse.sw360.datahandler.thrift.vmcomponents.*;
 import org.eclipse.sw360.vmcomponents.AbstractJSONMockTest;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.TestUtils;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;

--- a/backend/vulnerabilities-core/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
+++ b/backend/vulnerabilities-core/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
@@ -22,7 +22,7 @@ import org.eclipse.sw360.datahandler.thrift.VerificationStateInfo;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.vulnerabilities.common.VulnerabilityMapper;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TBase;

--- a/backend/vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
+++ b/backend/vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
@@ -34,7 +34,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.vulnerabilities.common.VulnerabilityMapper;
 import org.eclipse.sw360.vulnerabilities.db.VulnerabilityDatabaseHandler;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissionsTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissionsTest.java
@@ -12,7 +12,7 @@ package org.eclipse.sw360.datahandler.permissions;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libraries/nouveau-handler/pom.xml
+++ b/libraries/nouveau-handler/pom.xml
@@ -162,28 +162,18 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>cloudant</artifactId>
-            <version>${cloudantsdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>26.0.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
     <jgiven.version>2.0.1</jgiven.version>
     <jose4j.version>0.9.6</jose4j.version>
     <json.version>20240303</json.version>
+    <joda-time.version>2.13.0</joda-time.version>
     <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
     <junit.version>4.13.2</junit.version>
     <log4j2.version>2.24.3</log4j2.version>
@@ -626,6 +627,11 @@
         <type>pom</type>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>${joda-time.version}</version>
+    </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.sw360.rest.authserver.security;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 import jakarta.annotation.PostConstruct;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -165,6 +165,10 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
@@ -200,7 +204,6 @@
             <artifactId>springdoc-openapi-starter-common</artifactId>
             <version>${springdoc-openapi-stater-common.version}</version>
         </dependency>
-
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -46,8 +46,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
-import org.apache.commons.lang.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -22,8 +21,8 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
@@ -91,28 +90,25 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     @NonNull
     private final RestControllerHelper restControllerHelper;
 
-    private static final ImmutableSet<User._Fields> setOfUserProfileFields = ImmutableSet.<User._Fields>builder()
-            .add(User._Fields.WANTS_MAIL_NOTIFICATION)
-            .add(User._Fields.NOTIFICATION_PREFERENCES).build();
+    private static final ImmutableSet<User._Fields> setOfUserProfileFields =
+            ImmutableSet.<User._Fields>builder().add(User._Fields.WANTS_MAIL_NOTIFICATION)
+                    .add(User._Fields.NOTIFICATION_PREFERENCES).build();
 
-    @Operation(
-            summary = "List all of the service's users.",
-            description = "List all of the service's users.",
-            tags = {"Users"}
-    )
+    @Operation(summary = "List all of the service's users.",
+            description = "List all of the service's users.", tags = {"Users"})
     @RequestMapping(value = USERS_URL, method = RequestMethod.GET)
-    public ResponseEntity<CollectionModel<EntityModel<User>>> getUsers(
-            Pageable pageable,
+    public ResponseEntity<CollectionModel<EntityModel<User>>> getUsers(Pageable pageable,
             HttpServletRequest request,
-            @Parameter(description = "fullName of the users")
-            @RequestParam(value = "givenname", required = false) String givenname,
+            @Parameter(description = "fullName of the users") @RequestParam(value = "givenname",
+                    required = false) String givenname,
             @RequestParam(value = "email", required = false) String email,
-            @Parameter(description = "luceneSearch parameter to filter the users.")
-            @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
+            @Parameter(description = "luceneSearch parameter to filter the users.") @RequestParam(
+                    value = "luceneSearch", required = false) boolean luceneSearch,
             @RequestParam(value = "lastname", required = false) String lastname,
             @RequestParam(value = "department", required = false) String department,
-            @RequestParam(value = "usergroup", required = false) UserGroup usergroup
-    ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
+            @RequestParam(value = "usergroup", required = false) UserGroup usergroup)
+            throws TException, URISyntaxException, PaginationParameterException,
+            ResourceClassNotFoundException {
         PaginationResult<User> paginationResult = null;
         List<User> sw360Users = new ArrayList<>();
         boolean isSearchByName = givenname != null && !givenname.isEmpty();
@@ -124,13 +120,15 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             Map<String, Set<String>> filterMap = new HashMap<>();
             if (CommonUtils.isNotNullEmptyOrWhitespace(givenname)) {
                 Set<String> values = CommonUtils.splitToSet(givenname);
-                values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
+                values = values.stream()
+                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
                         .collect(Collectors.toSet());
                 filterMap.put(User._Fields.GIVENNAME.getFieldName(), values);
             }
             if (CommonUtils.isNotNullEmptyOrWhitespace(email)) {
                 Set<String> values = CommonUtils.splitToSet(email);
-                values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
+                values = values.stream()
+                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
                         .collect(Collectors.toSet());
                 filterMap.put(User._Fields.EMAIL.getFieldName(), values);
             }
@@ -142,15 +140,16 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
                 Set<String> values = CommonUtils.splitToSet(usergroup.toString());
                 filterMap.put(User._Fields.USER_GROUP.getFieldName(), values);
             }
-           if (CommonUtils.isNotNullEmptyOrWhitespace(lastname)) {
-             Set<String> values = CommonUtils.splitToSet(lastname);
-              values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
+            if (CommonUtils.isNotNullEmptyOrWhitespace(lastname)) {
+                Set<String> values = CommonUtils.splitToSet(lastname);
+                values = values.stream()
+                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
                         .collect(Collectors.toSet());
                 filterMap.put(User._Fields.LASTNAME.getFieldName(), values);
             }
             List<User> userByGivenName = userService.refineSearch(filterMap);
-            paginationResult = restControllerHelper.createPaginationResult(request, pageable, userByGivenName,
-                    SW360Constants.TYPE_USER);
+            paginationResult = restControllerHelper.createPaginationResult(request, pageable,
+                    userByGivenName, SW360Constants.TYPE_USER);
         } else {
             if (isSearchByName) {
                 sw360Users.addAll(userService.searchUserByName(givenname));
@@ -163,8 +162,8 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             } else {
                 sw360Users = userService.getAllUsers();
             }
-            paginationResult = restControllerHelper.createPaginationResult(request, pageable, sw360Users,
-                    SW360Constants.TYPE_USER);
+            paginationResult = restControllerHelper.createPaginationResult(request, pageable,
+                    sw360Users, SW360Constants.TYPE_USER);
         }
         List<EntityModel<User>> userResources = new ArrayList<>();
         for (User sw360User : paginationResult.getResources()) {
@@ -186,16 +185,11 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
 
     // '/users/{xyz}' searches by email, as opposed to by id, as is customary,
     // for compatibility with older version of the REST API
-    @Operation(
-            summary = "Get a single user.",
-            description = "Get a single user by email.",
-            tags = {"Users"}
-    )
+    @Operation(summary = "Get a single user.", description = "Get a single user by email.",
+            tags = {"Users"})
     @RequestMapping(value = USERS_URL + "/{email:.+}", method = RequestMethod.GET)
-    public ResponseEntity<EntityModel<User>> getUserByEmail(
-            @Parameter(description = "The email of the user to be retrieved.")
-            @PathVariable("email") String email
-    ) {
+    public ResponseEntity<EntityModel<User>> getUserByEmail(@Parameter(
+            description = "The email of the user to be retrieved.") @PathVariable("email") String email) {
         String decodedEmail;
         try {
             decodedEmail = URLDecoder.decode(email, "UTF-8");
@@ -208,51 +202,40 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         return new ResponseEntity<>(halResource, HttpStatus.OK);
     }
 
-    // unusual URL mapping for compatibility with older version of the REST API (see getUserByEmail())
-    @Operation(
-            summary = "Get a single user.",
-            description = "Get a single user by id.",
-            tags = {"Users"}
-    )
+    // unusual URL mapping for compatibility with older version of the REST API (see
+    // getUserByEmail())
+    @Operation(summary = "Get a single user.", description = "Get a single user by id.",
+            tags = {"Users"})
     @RequestMapping(value = USERS_URL + "/byid/{id:.+}", method = RequestMethod.GET)
-    public ResponseEntity<EntityModel<User>> getUser(
-            @Parameter(description = "The id of the user to be retrieved.")
-            @PathVariable("id") String id
-    ) {
+    public ResponseEntity<EntityModel<User>> getUser(@Parameter(
+            description = "The id of the user to be retrieved.") @PathVariable("id") String id) {
         User sw360User = userService.getUser(id);
         HalResource<User> halResource = createHalUser(sw360User);
         return new ResponseEntity<>(halResource, HttpStatus.OK);
     }
 
-    @Operation(
-            summary = "Create a new user.",
-            description = "Create a user (not in Liferay).",
-            tags = {"Users"}
-    )
+    @Operation(summary = "Create a new user.", description = "Create a user (not in Liferay).",
+            tags = {"Users"})
     @PostMapping(value = USERS_URL)
     public ResponseEntity<EntityModel<User>> createUser(
-            @Parameter(description = "The user to be created.")
-            @RequestBody User user
-    ) throws TException {
-        if(CommonUtils.isNullEmptyOrWhitespace(user.getPassword())) {
-            throw new HttpMessageNotReadableException("Password can not be null or empty or whitespace!");
+            @Parameter(description = "The user to be created.") @RequestBody User user)
+            throws TException {
+        if (CommonUtils.isNullEmptyOrWhitespace(user.getPassword())) {
+            throw new HttpMessageNotReadableException(
+                    "Password can not be null or empty or whitespace!");
         }
         String encodedPassword = passwordEncoder.encode(user.getPassword());
         user.setPassword(encodedPassword);
         User createdUser = userService.addUser(user);
         HalResource<User> halResource = createHalUser(createdUser);
-        URI location = ServletUriComponentsBuilder
-                .fromCurrentRequest().path("/{id}")
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}")
                 .buildAndExpand(createdUser.getId()).toUri();
 
         return ResponseEntity.created(location).body(halResource);
     }
 
-    @Operation(
-            summary = "Get current user's profile.",
-            description = "Get current user's profile.",
-            tags = {"Users"}
-    )
+    @Operation(summary = "Get current user's profile.", description = "Get current user's profile.",
+            tags = {"Users"})
     @GetMapping(value = USERS_URL + "/profile")
     public ResponseEntity<HalResource<User>> getUserProfile() {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -260,58 +243,49 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         return ResponseEntity.ok(halUserResource);
     }
 
-    @Operation(
-            summary = "Update user's profile.",
-            description = "Update user's profile.",
-            tags = {"Users"}
-    )
+    @Operation(summary = "Update user's profile.", description = "Update user's profile.",
+            tags = {"Users"})
     @PatchMapping(value = USERS_URL + "/profile")
     public ResponseEntity<HalResource<User>> updateUserProfile(
-            @Parameter(description = "Updated user profile",
-                    schema = @Schema(example = """
-                            {
-                                "wantsMailNotification": true,
-                                "notificationPreferences": {
-                                    "releaseCONTRIBUTORS": true,
-                                    "componentCREATED_BY": false,
-                                    "releaseCREATED_BY": false,
-                                    "moderationREQUESTING_USER": false,
-                                    "projectPROJECT_OWNER": true,
-                                    "moderationMODERATORS": false,
-                                    "releaseSUBSCRIBERS": true,
-                                    "componentMODERATORS": true,
-                                    "projectMODERATORS": false,
-                                    "projectROLES": false,
-                                    "releaseROLES": true,
-                                    "componentROLES": true,
-                                    "projectLEAD_ARCHITECT": false,
-                                    "componentCOMPONENT_OWNER": true,
-                                    "projectSECURITY_RESPONSIBLES": true,
-                                    "clearingREQUESTING_USER": true,
-                                    "projectCONTRIBUTORS": true,
-                                    "componentSUBSCRIBERS": true,
-                                    "projectPROJECT_RESPONSIBLE": false,
-                                    "releaseMODERATORS": false
-                                }
-                            }
-                            """))
-            @RequestBody Map<String, Object> userProfile
-    ) throws TException {
+            @Parameter(description = "Updated user profile", schema = @Schema(example = """
+                    {
+                        "wantsMailNotification": true,
+                        "notificationPreferences": {
+                            "releaseCONTRIBUTORS": true,
+                            "componentCREATED_BY": false,
+                            "releaseCREATED_BY": false,
+                            "moderationREQUESTING_USER": false,
+                            "projectPROJECT_OWNER": true,
+                            "moderationMODERATORS": false,
+                            "releaseSUBSCRIBERS": true,
+                            "componentMODERATORS": true,
+                            "projectMODERATORS": false,
+                            "projectROLES": false,
+                            "releaseROLES": true,
+                            "componentROLES": true,
+                            "projectLEAD_ARCHITECT": false,
+                            "componentCOMPONENT_OWNER": true,
+                            "projectSECURITY_RESPONSIBLES": true,
+                            "clearingREQUESTING_USER": true,
+                            "projectCONTRIBUTORS": true,
+                            "componentSUBSCRIBERS": true,
+                            "projectPROJECT_RESPONSIBLE": false,
+                            "releaseMODERATORS": false
+                        }
+                    }
+                    """)) @RequestBody Map<String, Object> userProfile) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        sw360User = restControllerHelper.updateUserProfile(sw360User, userProfile, setOfUserProfileFields);
+        sw360User = restControllerHelper.updateUserProfile(sw360User, userProfile,
+                setOfUserProfileFields);
         userService.updateUser(sw360User);
         HalResource<User> halUserResource = new HalResource<>(sw360User);
         return ResponseEntity.ok(halUserResource);
     }
 
-    @Operation(
-            summary = "List all of rest api tokens.",
+    @Operation(summary = "List all of rest api tokens.",
             description = "List all of rest api tokens of current user.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "List of tokens.")
-            },
-            tags = {"Users"}
-    )
+            responses = {@ApiResponse(responseCode = "200", description = "List of tokens.")},
+            tags = {"Users"})
     @RequestMapping(value = USERS_URL + "/tokens", method = RequestMethod.GET)
     public ResponseEntity<CollectionModel<EntityModel<RestApiToken>>> getUserRestApiTokens() {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -321,26 +295,22 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             return new ResponseEntity<>(CollectionModel.of(Collections.emptyList()), HttpStatus.OK);
         }
 
-        List<EntityModel<RestApiToken>> restApiResources = restApiTokens.stream()
-                .map(EntityModel::of)
-                .collect(Collectors.toList());
+        List<EntityModel<RestApiToken>> restApiResources =
+                restApiTokens.stream().map(EntityModel::of).collect(Collectors.toList());
         return new ResponseEntity<>(CollectionModel.of(restApiResources), HttpStatus.OK);
     }
 
-    @Operation(
-            summary = "Create rest api token.",
+    @Operation(summary = "Create rest api token.",
             description = "Create rest api token for current user.",
             responses = {
                     @ApiResponse(responseCode = "201", description = "Create token successfully."),
-                    @ApiResponse(responseCode = "500", description = "Create token failure.")
-            },
-            tags = {"Users"}
-    )
+                    @ApiResponse(responseCode = "500", description = "Create token failure.")},
+            tags = {"Users"})
     @RequestMapping(value = USERS_URL + "/tokens", method = RequestMethod.POST)
     public ResponseEntity<String> createUserRestApiToken(
-            @Parameter(description = "Token request", schema = @Schema(implementation = RestApiToken.class))
-            @RequestBody Map<String, Object> requestBody
-    ) throws TException {
+            @Parameter(description = "Token request", schema = @Schema(
+                    implementation = RestApiToken.class)) @RequestBody Map<String, Object> requestBody)
+            throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RestApiToken restApiToken = userService.convertToRestApiToken(requestBody, sw360User);
         String token = RandomStringUtils.random(20, true, true);
@@ -351,24 +321,23 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         return new ResponseEntity<>(token, HttpStatus.CREATED);
     }
 
-    @Operation(
-            summary = "Delete rest api token.",
+    @Operation(summary = "Delete rest api token.",
             description = "Delete rest api token by name for current user.",
             responses = {
                     @ApiResponse(responseCode = "204", description = "Revoke token successfully."),
-                    @ApiResponse(responseCode = "404", description = "Token name not found.")
-            },
-            tags = {"Users"}
-    )
+                    @ApiResponse(responseCode = "404", description = "Token name not found.")},
+            tags = {"Users"})
     @RequestMapping(value = USERS_URL + "/tokens", method = RequestMethod.DELETE)
     public ResponseEntity<String> revokeUserRestApiToken(
-            @Parameter(description = "Name of token to be revoked.", example = "MyToken")
-            @RequestParam("name") String tokenName
-    ) throws TException {
+            @Parameter(description = "Name of token to be revoked.",
+                    example = "MyToken") @RequestParam("name") String tokenName)
+            throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
         if (!userService.isTokenNameExisted(sw360User, tokenName)) {
-            return new ResponseEntity<>("Token not found: " + StringEscapeUtils.escapeHtml(tokenName), HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(
+                    "Token not found: " + StringEscapeUtils.escapeHtml4(tokenName),
+                    HttpStatus.NOT_FOUND);
         }
 
         sw360User.getRestApiTokens().removeIf(t -> t.getName().equals(tokenName));
@@ -386,26 +355,16 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         return new HalResource<>(sw360User);
     }
 
-    @Operation(
-            summary = "Fetch group list of a user.",
-            description = "Fetch the list of group for a particular user.",
-            tags = {"Users"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "User and its groups.",
-                    content = {
-                            @Content(mediaType = "application/json",
-                                    examples = @ExampleObject(
-                                            value = """
-                                    {
-                                        "primaryGrpList": ["DEPARTMENT"],
-                                        "secondaryGrpList": ["DEPARTMENT1","DEPARTMENT2"]
-                                    }
-                                    """
-                                    ))
-                    }
-            )
-    })
+    @Operation(summary = "Fetch group list of a user.",
+            description = "Fetch the list of group for a particular user.", tags = {"Users"})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "User and its groups.",
+            content = {
+                    @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                                "primaryGrpList": ["DEPARTMENT"],
+                                "secondaryGrpList": ["DEPARTMENT1","DEPARTMENT2"]
+                            }
+                            """))})})
     @RequestMapping(value = USERS_URL + "/groupList", method = RequestMethod.GET)
     public ResponseEntity<Map<String, List<String>>> getGroupList() {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -416,7 +375,8 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         if (mainDepartment != null && !mainDepartment.isEmpty()) {
             primaryGrpList.add(mainDepartment);
         }
-        Map<String, Set<UserGroup>> secondaryDepartmentsAndRoles = sw360User.getSecondaryDepartmentsAndRoles();
+        Map<String, Set<UserGroup>> secondaryDepartmentsAndRoles =
+                sw360User.getSecondaryDepartmentsAndRoles();
         if (secondaryDepartmentsAndRoles != null) {
             secondaryGrpList.addAll(secondaryDepartmentsAndRoles.keySet());
         }


### PR DESCRIPTION
Old apache-commons-lang was puled down by nouveau-handler, and misleading outdated code in different sources.
All code now is adjusted to commons-lang3 or commons-text where needed.
