### PR TITLE
feat(rest): endpoint to get license info header text.

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -973,6 +973,20 @@ include::{snippets}/should_document_get_project_count/response-fields.adoc[]
 ===== Example response
 include::{snippets}/should_document_get_project_count/http-response.adoc[]
 
+[[resources-project-getprojectcount]]
+==== Get license info header text
+
+A `GET` request will get the default license info header text.
+
+===== Example request
+include::{snippets}/should_document_get_license_info_header/curl-request.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_license_info_header/response-fields.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_license_info_header/http-response.adoc[]
+
 [[resources-project-get-summaryadministraion-project]]
 ==== Administration and Summary Info
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2512,6 +2512,25 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     }
 
     @Operation(
+            description = "Get the default license info header text.",
+            tags = {"Projects"}
+    )
+    @RequestMapping(value = PROJECTS_URL + "/licenseInfoHeader", method = RequestMethod.GET)
+    public void getLicenseInfoheaderText(HttpServletResponse response) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        try {
+            response.setContentType("application/json; charset=UTF-8");
+            response.setCharacterEncoding("UTF-8");
+            String licenseHeaderText = projectService.getLicenseInfoHeaderText();
+            JsonObject resultJson = new JsonObject();
+            resultJson.addProperty("licenseInfoHeaderText", licenseHeaderText);
+            response.getWriter().write(resultJson.toString());
+        } catch (IOException e) {
+            throw new SW360Exception(e.getMessage());
+        }
+    }
+
+    @Operation(
             description = "Get license clearing info for a project.",
             tags = {"Projects"}
     )

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1131,6 +1131,13 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return sw360ProjectClient.getMyAccessibleProjectCounts(sw360User);
     }
 
+    public String getLicenseInfoHeaderText() throws TException {
+        ThriftClients thriftClients = new ThriftClients();
+        final LicenseInfoService.Iface licenseClient = thriftClients.makeLicenseInfoClient();
+        String licenseInfoHeaderText = licenseClient.getDefaultLicenseInfoHeaderText(null);
+        return licenseInfoHeaderText;
+    }
+
     /**
      * Import SPDX SBOM using the method on the thrift client.
      * @param user                User uploading the SBOM

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -574,6 +574,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.createClearingRequest(any(),any(),any(),eq(project.getId()))).willReturn(requestSummaryForCR);
         given(this.projectServiceMock.loadPreferredClearingDateLimit()).willReturn(Integer.valueOf(7));
 
+        given(this.projectServiceMock.getLicenseInfoHeaderText()).willReturn("Default License Info Header Text");
         given(this.projectServiceMock.importSPDX(any(),any())).willReturn(requestSummaryForSPDX);
         given(this.projectServiceMock.importCycloneDX(any(),any(),any(),anyBoolean())).willReturn(requestSummaryForCycloneDX);
         given(this.sw360ReportServiceMock.getDocumentName(any(), any())).willReturn(projectName);
@@ -2375,6 +2376,19 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                fieldWithPath("status").description("status of the API. Possible values are `<success|failure>`").optional(),
                                fieldWithPath("count").description("Count of projects for a user.").optional()
                        )));
+    }
+
+    @Test
+    public void should_document_get_license_info_header() throws Exception {
+        this.mockMvc.perform(get("/api/projects/licenseInfoHeader")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON)
+                        .contentType(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("licenseInfoHeaderText").description("default license info header text").optional()
+                        )));
     }
 
     @Test


### PR DESCRIPTION
Closes #2780 

Description:
Endpoint to get the license info header text.

