### PR TITLE
fix(report): refactor /reports endpoint

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -133,9 +133,7 @@ public class SW360Constants {
     public static final String COMPONENTS = "components";
     public static final String PROJECTS = "projects";
     public static final String LICENSES = "licenses";
-    public static final String REPORTS_URL = "/reports";
     public static final String PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO = "projectReleaseSpreadSheetWithEcc";
-    public static final String CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
     /**
      * Hashmap containing the name field for each type.

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2557,7 +2557,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             description = "Get license obligations data from license database.",
-            tags = {"Project"}
+            tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/{id}/licenseDbObligations", method = RequestMethod.GET)
 	public ResponseEntity<?> getLicObligations(Pageable pageable,
@@ -2647,7 +2647,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             description = "Get license obligation data of project tab.",
-            tags = {"Project"}
+            tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/{id}/licenseObligations", method = RequestMethod.GET)
 	public ResponseEntity<HalResource> getLicenseObligations(Pageable pageable,
@@ -2686,7 +2686,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             description = "Get obligation data of project tab.",
-            tags = {"Project"}
+            tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/{id}/obligation", method = RequestMethod.GET)
     public ResponseEntity<HalResource> getObligations(Pageable pageable,
@@ -3203,7 +3203,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             description = "Get linked releases information in project's dependency network.",
-            tags = {"Project"}
+            tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/network/{id}/linkedReleases", method = RequestMethod.GET)
     public ResponseEntity<?> getLinkedReleasesInNetwork(
@@ -3219,7 +3219,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             description = "Get linked releases information of linked projects.",
-            tags = {"Project"}
+            tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/{id}/subProjects/releases", method = RequestMethod.GET)
     public ResponseEntity<?> getLinkedReleasesOfLinkedProjects(
@@ -3236,7 +3236,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             description = "Compare dependency network with default network (relationships between releases).",
-            tags = {"Project"}
+            tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/network/compareDefaultNetwork", method = RequestMethod.POST)
     public ResponseEntity<?> compareDependencyNetworkWithDefaultNetwork(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -83,7 +83,11 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "mimetype", required = false, defaultValue = "xlsx") String mimeType,
             @Parameter(description = "Project id.")
             @RequestParam(value = "projectId", required = false) String projectId,
-            @Parameter(description = "Module name.", schema = @Schema(allowableValues = {SW360Constants.PROJECTS, SW360Constants.COMPONENTS, SW360Constants.LICENSES, LICENSES_RESOURCE_BUNDLE, SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO}))
+            @Parameter(description = "Module name.", schema = @Schema(allowableValues = {
+                    SW360Constants.PROJECTS, SW360Constants.COMPONENTS, SW360Constants.LICENSES,
+                    LICENSE_INFO, LICENSES_RESOURCE_BUNDLE, SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO,
+                    EXPORT_CREATE_PROJ_CLEARING_REPORT
+            }))
             @RequestParam(value = "module", required = true) String module,
             @Parameter(description = "Exclude release version from the license info file")
             @RequestParam(value = "excludeReleaseVersion", required = false, defaultValue = "false") boolean excludeReleaseVersion,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -1,15 +1,16 @@
 /*
-SPDX-FileCopyrightText: © 2023 Siemens AG
+SPDX-FileCopyrightText: © 2023-2024 Siemens AG
 SPDX-License-Identifier: EPL-2.0
 */
 
 package org.eclipse.sw360.rest.resourceserver.report;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.CONTENT_TYPE_OPENXML_SPREADSHEET;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,15 +22,19 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,41 +51,34 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
 public class SW360ReportController implements RepresentationModelProcessor<RepositoryLinksResource> {
+    public static final String REPORTS_URL = "/reports";
+    private static final Logger log = LogManager.getLogger(SW360ReportController.class);
     private static final String LICENSE_INFO = "licenseInfo";
     private static final String LICENSES_RESOURCE_BUNDLE = "licenseResourceBundle";
     private static final String ZIP_CONTENT_TYPE = "application/zip";
-    private ByteBuffer defaultByteBufferVal = null;
     private static final String EXPORT_CREATE_PROJ_CLEARING_REPORT = "exportCreateProjectClearingReport";
-
-    public static final String REPORTS_URL = "/reports";
-
-    private static final String CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-
+    private static final List<String> GENERATOR_MODULES = List.of(LICENSE_INFO, EXPORT_CREATE_PROJ_CLEARING_REPORT);
     @NonNull
     private final RestControllerHelper restControllerHelper;
-
     @NonNull
     private final SW360ReportService sw360ReportService;
+    private final ByteBuffer defaultByteBufferVal = ByteBuffer.wrap(new byte[0]);
 
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
-        resource.add(linkTo(SW360ReportController.class).slash("api/" + SW360Constants.REPORTS_URL).withRel("reports"));
+        resource.add(linkTo(SW360ReportController.class).slash("api/" + REPORTS_URL).withRel("reports"));
         return resource;
     }
-
-    private final List<String> mimeTypeList = Arrays.asList("xls", "xlsx");
 
     @Operation(
             summary = "Generate the reports.",
             description = "Generate the reports.",
             tags = {"Reports"}
     )
-    @GetMapping(value = SW360Constants.REPORTS_URL)
+    @GetMapping(value = REPORTS_URL)
     public void getProjectReport(
             @Parameter(description = "Projects with linked releases.")
             @RequestParam(value = "withlinkedreleases", required = false, defaultValue = "false") boolean withLinkedReleases,
-            @Parameter(description = "Report download format.", schema = @Schema(allowableValues = {"xls", "xlsx"}))
-            @RequestParam(value = "mimetype", required = false, defaultValue = "xlsx") String mimeType,
             @Parameter(description = "Project id.")
             @RequestParam(value = "projectId", required = false) String projectId,
             @Parameter(description = "Module name.", schema = @Schema(allowableValues = {
@@ -91,136 +89,198 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "module", required = true) String module,
             @Parameter(description = "Exclude release version from the license info file")
             @RequestParam(value = "excludeReleaseVersion", required = false, defaultValue = "false") boolean excludeReleaseVersion,
+            @Parameter(description = "Output generator class. Required for modules [" + LICENSE_INFO + ", " + EXPORT_CREATE_PROJ_CLEARING_REPORT + "]",
+                    schema = @Schema(type = "string", allowableValues = {"DocxGenerator", "XhtmlGenerator", "TextGenerator"}))
+            @RequestParam(value = "generatorClassName", required = false) String generatorClassName,
+            @Parameter(description = "Variant of the report. Required for modules [" + LICENSE_INFO + ", " + EXPORT_CREATE_PROJ_CLEARING_REPORT + "]",
+                    schema = @Schema(implementation = OutputFormatVariant.class))
+            @RequestParam(value = "variant", required = false) String variant,
+            @Parameter(description = "Template for generating report. Can be supplied with modules [" + LICENSE_INFO + ", " + EXPORT_CREATE_PROJ_CLEARING_REPORT + "]")
+            @RequestParam(value = "template", required = false, defaultValue = "") String template,
+            @Parameter(description = "The external Ids of the project. Can be supplied with modules [" + LICENSE_INFO + ", " + EXPORT_CREATE_PROJ_CLEARING_REPORT + "]", example = "376577")
+            @RequestParam(value = "externalIds", required = false, defaultValue = "") String externalIds,
+            @Parameter(description = "Generate report for only current project or with Sub projects. Can be supplied with modules [" + LICENSE_INFO + ", " + EXPORT_CREATE_PROJ_CLEARING_REPORT + "]")
+            @RequestParam(value = "withSubProject", required = false, defaultValue = "false") boolean withSubProject,
             HttpServletRequest request,
             HttpServletResponse response
     ) throws TException {
-
+        if (GENERATOR_MODULES.contains(module) && (isNullOrEmpty(generatorClassName) || isNullOrEmpty(variant))) {
+            throw new HttpMessageNotReadableException("Error : GeneratorClassName and Variant is required for module " + module);
+        }
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        String baseUrl = getBaseUrl(request);
         try {
-            if (validateMimeType(mimeType)) {
-                switch (module) {
+            switch (module) {
                 case SW360Constants.PROJECTS:
-                    getProjectReports(withLinkedReleases, response,
-                            request, sw360User, module, projectId, excludeReleaseVersion);
+                    getProjectReports(withLinkedReleases, response, sw360User, module, projectId,
+                            excludeReleaseVersion, baseUrl, generatorClassName, variant, template, externalIds);
                     break;
                 case SW360Constants.COMPONENTS:
-                    getComponentsReports(withLinkedReleases, SW360Constants.MAIL_REQUEST_FOR_COMPONENT_REPORT, response,
-                            request, sw360User, module, excludeReleaseVersion);
+                    getComponentsReports(withLinkedReleases, response, sw360User, module, excludeReleaseVersion,
+                            baseUrl, generatorClassName, variant, template, externalIds);
                     break;
                 case SW360Constants.LICENSES:
-                    getLicensesReports(request, response, sw360User, module, excludeReleaseVersion);
+                    getLicensesReports(response, sw360User, module, excludeReleaseVersion, generatorClassName, variant,
+                            template, externalIds);
                     break;
                 case LICENSE_INFO:
-                    getLicensesInfoReports(request, response, sw360User, module, projectId, excludeReleaseVersion);
+                    getLicensesInfoReports(response, sw360User, module, projectId, excludeReleaseVersion,
+                            generatorClassName, variant, template, externalIds, withSubProject);
                     break;
                 case LICENSES_RESOURCE_BUNDLE:
-                    getLicenseResourceBundleReports(projectId, request, response, sw360User, module, excludeReleaseVersion);
+                    getLicenseResourceBundleReports(projectId, response, sw360User, module, generatorClassName, variant,
+                            template, externalIds, excludeReleaseVersion, withSubProject);
                     break;
                 case SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO:
-                    getProjectReleaseWithEccSpreadSheet(response, sw360User, module, projectId, request, excludeReleaseVersion);
+                    getProjectReleaseWithEccSpreadSheet(response, sw360User, module, projectId, excludeReleaseVersion,
+                            generatorClassName, variant, template, externalIds);
                     break;
                 case EXPORT_CREATE_PROJ_CLEARING_REPORT:
-                    exportProjectCreateClearingRequest(request, response, sw360User, module, projectId, excludeReleaseVersion);
+                    exportProjectCreateClearingRequest(response, sw360User, module, projectId, excludeReleaseVersion,
+                            generatorClassName, variant, template, externalIds);
                     break;
                 default:
                     break;
-                }
-            } else {
-                throw new TException("Error : Mimetype either should be : xls/xlsx");
             }
         } catch (Exception e) {
             throw new TException(e.getMessage());
         }
     }
 
-    private void getProjectReports(boolean withLinkedReleases, HttpServletResponse response,
-            HttpServletRequest request, User sw360User, String module, String projectId, boolean excludeReleaseVersion) throws TException {
+    private void getProjectReports(
+            boolean withLinkedReleases, HttpServletResponse response, User sw360User, String module, String projectId,
+            boolean excludeReleaseVersion, String baseUrl, String generatorClassName, String variant, String template,
+            String externalIds
+    ) throws TException {
         try {
             if (SW360Constants.MAIL_REQUEST_FOR_PROJECT_REPORT) {
-                sw360ReportService.getUploadedProjectPath(sw360User, withLinkedReleases,getBaseUrl(request), projectId);
+                sw360ReportService.getUploadedProjectPath(sw360User, withLinkedReleases, baseUrl, projectId);
                 JsonObject responseJson = new JsonObject();
                 responseJson.addProperty("response", "The downloaded report link will be send to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
-                downloadExcelReport(withLinkedReleases, request, response, sw360User, module, projectId, excludeReleaseVersion, defaultByteBufferVal);
+                downloadExcelReport(withLinkedReleases, response, sw360User, module, projectId, excludeReleaseVersion,
+                        defaultByteBufferVal, generatorClassName, variant, template, externalIds);
             }
         } catch (Exception e) {
+            log.error(e);
             throw new TException(e.getMessage());
         }
     }
 
-    private void getComponentsReports(boolean withLinkedReleases, boolean mailRequest, HttpServletResponse response,
-            HttpServletRequest request, User sw360User, String module, boolean excludeReleaseVersion) throws TException {
+    private void getComponentsReports(
+            boolean withLinkedReleases, HttpServletResponse response, User sw360User, String module,
+            boolean excludeReleaseVersion, String baseUrl, String generatorClassName, String variant, String template,
+            String externalIds
+    ) throws TException {
         try {
-            if (mailRequest) {
-                sw360ReportService.getUploadedComponentPath(sw360User, withLinkedReleases, getBaseUrl(request));
+            if (SW360Constants.MAIL_REQUEST_FOR_COMPONENT_REPORT) {
+                sw360ReportService.getUploadedComponentPath(sw360User, withLinkedReleases, baseUrl);
                 JsonObject responseJson = new JsonObject();
                 responseJson.addProperty("response", "Component report download link will get send to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
-                downloadExcelReport(withLinkedReleases, request, response, sw360User, module, null, excludeReleaseVersion, defaultByteBufferVal);
+                downloadExcelReport(withLinkedReleases, response, sw360User, module, null, excludeReleaseVersion,
+                        defaultByteBufferVal, generatorClassName, variant, template, externalIds);
             }
         } catch (Exception e) {
+            log.error(e);
             throw new TException(e.getMessage());
         }
     }
 
-    private void getLicensesReports(HttpServletRequest request, HttpServletResponse response,
-                                    User sw360User, String module, boolean excludeReleaseVersion) throws TException {
+    private void getLicensesReports(
+            HttpServletResponse response, User sw360User, String module, boolean excludeReleaseVersion,
+            String generatorClassName, String variant, String template, String externalIds
+    ) throws TException {
         try {
-            downloadExcelReport(false, request, response, sw360User, module, null, excludeReleaseVersion, defaultByteBufferVal);
+            downloadExcelReport(false, response, sw360User, module, null, excludeReleaseVersion,
+                    defaultByteBufferVal, generatorClassName, variant, template, externalIds);
+        } catch (Exception e) {
+            log.error(e);
+            throw new TException(e.getMessage());
+        }
+    }
+
+    private void getLicensesInfoReports(
+            HttpServletResponse response, User sw360User, String module, String projectId,
+            boolean excludeReleaseVersion, String generatorClassName, String variant, String template,
+            String externalIds, boolean withSubProject
+    ) throws TException {
+        // TODO: use `withSubProject` while generating LicenseInfo report.
+        try {
+            downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
+                    defaultByteBufferVal, generatorClassName, variant, template, externalIds);
+        } catch (Exception e) {
+            log.error(e);
+            throw new TException(e.getMessage());
+        }
+    }
+
+    private void getProjectReleaseWithEccSpreadSheet(
+            HttpServletResponse response, User sw360User, String module, String projectId,
+            boolean excludeReleaseVersion, String generatorClassName, String variant, String template,
+            String externalIds
+    ) throws TException {
+        try {
+            downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
+                    defaultByteBufferVal, generatorClassName, variant, template, externalIds);
         } catch (Exception e) {
             throw new TException(e.getMessage());
         }
     }
 
-    private void getLicensesInfoReports(HttpServletRequest request, HttpServletResponse response, User sw360User,
-                                        String module, String projectId, boolean excludeReleaseVersion) throws TException {
+    private void exportProjectCreateClearingRequest(
+            HttpServletResponse response, User sw360User, String module, String projectId,
+            boolean excludeReleaseVersion, String generatorClassName, String variant, String template,
+            String externalIds
+    ) throws TException {
         try {
-            downloadExcelReport(false, request, response, sw360User, module, projectId, excludeReleaseVersion, defaultByteBufferVal);
-        }catch (Exception e) {
+            downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
+                    defaultByteBufferVal, generatorClassName, variant, template, externalIds);
+        } catch (Exception e) {
+            log.error(e);
             throw new TException(e.getMessage());
         }
     }
 
-    private void exportProjectCreateClearingRequest(HttpServletRequest request, HttpServletResponse response, User sw360User,
-                                                    String module, String projectId, boolean excludeReleaseVersion) throws TException {
-        try {
-            downloadExcelReport(false, request, response, sw360User, module, projectId, excludeReleaseVersion, defaultByteBufferVal);
-        }catch (Exception e) {
-            throw new TException(e.getMessage());
-        }
-    }
-
-    private void downloadExcelReport(boolean withLinkedReleases, HttpServletRequest request,
-                                     HttpServletResponse response, User user, String module,
-                                     String projectId, boolean excludeReleaseVersion, ByteBuffer buffer)
-            throws TException {
+    private void downloadExcelReport(
+            boolean withLinkedReleases, HttpServletResponse response, User user, String module, String projectId,
+            boolean excludeReleaseVersion, ByteBuffer buffer, String generatorClassName, String variant,
+            String template, String externalIds
+    ) throws TException {
         try {
             ByteBuffer buff = null;
+            String fileName = sw360ReportService.getDocumentName(user, null, module);
+            response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
+
             switch (module) {
                 case SW360Constants.PROJECTS:
                     buff = sw360ReportService.getProjectBuffer(user, withLinkedReleases, projectId);
+                    fileName = sw360ReportService.getDocumentName(user, projectId, module);
                     break;
                 case SW360Constants.COMPONENTS:
                     buff = sw360ReportService.getComponentBuffer(user, withLinkedReleases);
                     break;
                 case SW360Constants.LICENSES:
                     buff = sw360ReportService.getLicenseBuffer();
+                    fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
                     break;
                 case LICENSES_RESOURCE_BUNDLE:
                     buff = buffer;
+                    response.setContentType(ZIP_CONTENT_TYPE);
+                    fileName = sw360ReportService.getSourceCodeBundleName(projectId, user);
                     break;
                 case LICENSE_INFO:
                 case EXPORT_CREATE_PROJ_CLEARING_REPORT:
-                    final String generatorClassName = request.getParameter("generatorClassName");
-                    final String variant = request.getParameter("variant");
-                    final String template = request.getParameter("template");
-                    final String externalIds = request.getParameter("externalIds");
-                    buff = sw360ReportService.getLicenseInfoBuffer(user, projectId, generatorClassName, variant, template, externalIds, excludeReleaseVersion);
+                    buff = sw360ReportService.getLicenseInfoBuffer(user, projectId, generatorClassName, variant,
+                            template, externalIds, excludeReleaseVersion);
+                    fileName = sw360ReportService.getGenericLicInfoFileName(user, projectId, generatorClassName,
+                            variant);
                     break;
                 case SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO:
                     buff = sw360ReportService.getProjectReleaseSpreadSheetWithEcc(user, projectId);
+                    fileName = sw360ReportService.getDocumentName(user, projectId, module);
                     break;
                 default:
                     break;
@@ -228,32 +288,22 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             if (null == buff) {
                 throw new TException("No data available for the user " + user.getEmail());
             }
-            response.setContentType(SW360Constants.CONTENT_TYPE);
-            String fileName;
-            if (module.equals(SW360Constants.LICENSES)) {
-                fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
-            } else if (module.equals(LICENSES_RESOURCE_BUNDLE)) {
-                response.setContentType(ZIP_CONTENT_TYPE);
-                fileName = sw360ReportService.getSourceCodeBundleName(projectId, user);
-            } else if(module.equals(LICENSE_INFO) || module.equals(EXPORT_CREATE_PROJ_CLEARING_REPORT)) {
-                fileName = sw360ReportService.getGenericLicInfoFileName(request, user);
-            } else if ( module.equals(SW360Constants.PROJECTS) || module.equals(SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO) ) {
-                fileName = sw360ReportService.getDocumentName(user, projectId, module);
-            } else {
-                fileName = sw360ReportService.getDocumentName(user, null, module);
-            }
             response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", fileName));
             copyDataStreamToResponse(response, buff);
         } catch (Exception e) {
+            log.error(e);
             throw new TException(e.getMessage());
         }
     }
 
-    private void getLicenseResourceBundleReports(String projectId, HttpServletRequest request,
-                                                 HttpServletResponse response, User sw360User, String module, boolean excludeReleaseVersion) throws TException {
+    private void getLicenseResourceBundleReports(
+            String projectId, HttpServletResponse response, User sw360User, String module, String generatorClassName,
+            String variant, String template, String externalIds, boolean excludeReleaseVersion, boolean withSubProject
+    ) throws TException {
         try {
-            ByteBuffer buffer = sw360ReportService.downloadSourceCodeBundle(projectId, request, sw360User);
-            downloadExcelReport(false, request, response, sw360User, module, projectId, excludeReleaseVersion, buffer);
+            ByteBuffer buffer = sw360ReportService.downloadSourceCodeBundle(projectId, sw360User, withSubProject);
+            downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
+                    buffer, generatorClassName, variant, template, externalIds);
         } catch (Exception e) {
             throw new TException(e.getMessage());
         }
@@ -263,10 +313,6 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         FileCopyUtils.copy(buffer.array(), response.getOutputStream());
     }
 
-    private boolean validateMimeType(String mimeType) {
-        return mimeTypeList.contains(mimeType);
-    }
-
     @Operation(
             summary = "Download reports.",
             description = "Download reports.",
@@ -274,11 +320,11 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             responses = {@ApiResponse(
                     responseCode = "200",
                     description = "Generated report.",
-                    content = @Content(mediaType = SW360Constants.CONTENT_TYPE,
+                    content = @Content(mediaType = CONTENT_TYPE_OPENXML_SPREADSHEET,
                             schema = @Schema(type = "string", format = "binary"))
             )}
     )
-    @GetMapping(value = SW360Constants.REPORTS_URL + "/download")
+    @GetMapping(value = REPORTS_URL + "/download")
     public void downloadExcel(
             HttpServletRequest request,
             HttpServletResponse response,
@@ -292,15 +338,18 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         final User user = restControllerHelper.getUserByEmail(request.getParameter("user"));
         try {
             ByteBuffer buffer = null;
+            String fileName = sw360ReportService.getDocumentName(user, null, module);
             switch (module) {
                 case SW360Constants.PROJECTS:
                     buffer = sw360ReportService.getReportStreamFromURl(user, extendedByReleases, token);
+                    fileName = sw360ReportService.getDocumentName(user, request.getParameter("projectId"), module);
                     break;
                 case SW360Constants.COMPONENTS:
                     buffer = sw360ReportService.getComponentReportStreamFromURl(user, extendedByReleases, token);
                     break;
                 case SW360Constants.LICENSES:
                     buffer = sw360ReportService.getLicenseReportStreamFromURl(token);
+                    fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
                     break;
                 default:
                     break;
@@ -308,17 +357,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             if (null == buffer) {
                 throw new TException("No data available for the user " + user.getEmail());
             }
-            String fileName;
-            if(module.equals(SW360Constants.LICENSES)) {
-                fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
-            } else if(module.equals(SW360Constants.PROJECTS) || module.equals(SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO)) {
-                fileName = sw360ReportService.getDocumentName(user, request.getParameter("projectId"), module);
-            } else if(module.equals(LICENSE_INFO)) {
-                fileName = sw360ReportService.getGenericLicInfoFileName(request, user);
-            } else {
-                fileName = sw360ReportService.getDocumentName(user, null, module);
-            }
-            response.setContentType(SW360Constants.CONTENT_TYPE);
+            response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
             response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", fileName));
             copyDataStreamToResponse(response, buffer);
         } catch (Exception e) {
@@ -331,14 +370,5 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         String uri = request.getRequestURI();
         String ctx = request.getContextPath();
         return url.substring(0, url.length() - uri.length() + ctx.length()) + "/";
-    }
-
-    private void getProjectReleaseWithEccSpreadSheet(HttpServletResponse response, User sw360User, String module,
-            String projectId, HttpServletRequest request, boolean excludeReleaseVersion) throws TException {
-        try {
-            downloadExcelReport(false, request, response, sw360User, module, projectId, excludeReleaseVersion, defaultByteBufferVal);
-        } catch (Exception e) {
-            throw new TException(e.getMessage());
-        }
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.List;
 import jakarta.servlet.http.HttpServletResponse;
 
+import static org.eclipse.sw360.datahandler.common.SW360Constants.CONTENT_TYPE_OPENXML_SPREADSHEET;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @BasePathAwareController
@@ -256,7 +257,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Vendor spreadsheet.",
                     content = {
-                            @Content(mediaType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+                            @Content(mediaType = CONTENT_TYPE_OPENXML_SPREADSHEET)
                     })
     })
     @PreAuthorize("hasAuthority('WRITE')")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -1330,7 +1330,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(get("/api/reports")
                         .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                         .queryParam("withlinkedreleases", "true")
-                        .queryParam("mimetype", "xlsx")
                         .queryParam("module", "components")
                         .queryParam("excludeReleaseVersion", "false")
                         .accept(MediaTypes.HAL_JSON))
@@ -1338,7 +1337,6 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
              .andDo(this.documentationHandler.document(
                      queryParameters(
                              parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
-                             parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
                              parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
                              parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
                                      + "Possible values are `<true|false>`")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -588,7 +588,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.getProjectForUserById(eq(project6.getId()), any())).willReturn(project6);
         given(this.projectServiceMock.getProjectForUserById(eq(project7.getId()), any())).willReturn(project7);
         given(this.projectServiceMock.getProjectForUserById(eq(project8.getId()), any())).willReturn(project8);
-        given(this.sw360ReportServiceMock.downloadSourceCodeBundle(any(), any(), any())).willReturn(ByteBuffer.allocate(10000));
+        given(this.sw360ReportServiceMock.downloadSourceCodeBundle(any(), any(), anyBoolean())).willReturn(ByteBuffer.allocate(10000));
         given(this.sw360ReportServiceMock.getLicenseInfoBuffer(any(), any(), any(), any(), any(), any(), anyBoolean())).willReturn(ByteBuffer.allocate(10000));
         given(this.sw360ReportServiceMock.getSourceCodeBundleName(any(), any())).willReturn("SourceCodeBundle-ProjectName");
         given(this.projectServiceMock.getLicenseInfoAttachmentUsage(eq(project8.getId()))).willReturn(licenseInfoUsages);
@@ -2162,7 +2162,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("externalIds").description("The external Ids of the project")
                                 )));
     }
-    
+
     @Test
     public void should_document_get_download_license_info_without_release_version() throws Exception {
         this.mockMvc.perform(get("/api/projects/" + project.getId()+ "/licenseinfo?generatorClassName=XhtmlGenerator&variant=DISCLOSURE&excludeReleaseVersion=true")
@@ -2465,7 +2465,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(get("/api/reports").
                 header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .queryParam("withlinkedreleases", "true")
-                .queryParam("mimetype", "xlsx")
                 .queryParam("module", "projects")
                 .queryParam("excludeReleaseVersion", "false")
                 .accept(MediaTypes.HAL_JSON))
@@ -2473,7 +2472,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .andDo(this.documentationHandler.document(
                         queryParameters(
                                 parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
-                                parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
                                 parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
                                 parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
                                         + "Possible values are `<true|false>`")
@@ -2486,7 +2484,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(get("/api/reports")
                         .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                         .queryParam("withlinkedreleases", "true")
-                        .queryParam("mimetype", "xlsx")
                         .queryParam("module", "projects")
                         .queryParam("projectId", project.getId())
                         .queryParam("excludeReleaseVersion", "false")
@@ -2495,7 +2492,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .andDo(this.documentationHandler.document(
                         queryParameters(
                                 parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
-                                parameterWithName("mimetype").description("Projects download format. Possible values are `<xls|xlsx>`"),
                                 parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
                                 parameterWithName("projectId").description("Id of a project"),
                                 parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
@@ -3038,11 +3034,11 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     public void should_document_get_resource_source_bundle() throws Exception {
         mockMvc.perform(get("/api/reports").header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .param("module", "licenseResourceBundle").param("projectId", project.getId())
-                .param("isAllAttachmentSelected", "true").accept(MediaTypes.HAL_JSON)).andExpect(status().isOk())
+                .param("withSubProject", "true").accept(MediaTypes.HAL_JSON)).andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(queryParameters(
                         parameterWithName("projectId").description("Project id"),
-                        parameterWithName("isAllAttachmentSelected").description(
-                                "All attachment selected to download source code bundle. Possible values are `<true|false>`"),
+                        parameterWithName("withSubProject").description(
+                                "Use subprojects as well to download source code bundle. Possible values are `<true|false>`"),
                         parameterWithName("module").description(
                                 "module represent the type oa document. Possible values are `<licenseResourceBundle>`"))));
     }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

1. Fix OpenAPI docs for the `/reports` endpoint.
2. Refactor `/reports` endpoint to expose all hidden parameters.
3. Modify source bundle to use attachment usage to generate bundle.
4. Do not update attachment usage based on report generation. Should be changed with `/attachmentUsage` endpoint only.

### Suggest Reviewer
@keerthi-bl

### How To Test?
Generate different reports with `/reports` endpoint to check all parameters.