### PR TITLE
feat(version): generate OpenAPI doc version on fly

### DIFF
--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -26,6 +26,11 @@
         <resources>
             <resource>
                 <directory>resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.xml</include>
+                </includes>
             </resource>
         </resources>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     </repository>
   </distributionManagement>
   <properties>
-    <sw360.version>19.0.0</sw360.version>
     <rest.version>2.0.0</rest.version>
     <backend.deploy.dir>${base.deploy.dir}/webapps</backend.deploy.dir>
     <rest.deploy.dir>${base.deploy.dir}/webapps</rest.deploy.dir>
@@ -112,6 +111,7 @@
     <equalsverifier.version>3.19.2</equalsverifier.version>
     <failureaccess.version>1.0.3</failureaccess.version>
     <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
+    <git-commit-id.version>9.0.1</git-commit-id.version>
     <glassfish-jaxb.version>4.0.5</glassfish-jaxb.version>
     <guava.version>33.4.0-jre</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -164,6 +164,7 @@
     <keycloak.version>26.1.4</keycloak.version>
     <spring.security.crypto>6.3.3</spring.security.crypto>
     <org.owasp.encoder.version>1.3.1</org.owasp.encoder.version>
+    <write.properties.file.version>2.0.0</write.properties.file.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -242,9 +242,41 @@
         <finalName>resource</finalName>
         <plugins>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>${git-commit-id.version}</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                    <execution>
+                        <id>validate-the-git-infos</id>
+                        <goals>
+                            <goal>validateRevision</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <validationShouldFailIfNoMatch>false</validationShouldFailIfNoMatch>
+                    <generateGitPropertiesFile>false</generateGitPropertiesFile>
+                    <gitDescribe>
+                        <!--
+                         Run `git describe -tags` to consider lightweight tags
+                         https://github.com/git-commit-id/git-commit-id-maven-plugin/#git-describe-and-a-small-gotcha-with-tags
+                         -->
+                        <tags>true</tags>
+                    </gitDescribe>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.internetitem</groupId>
                 <artifactId>write-properties-file-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>${write.properties.file.version}</version>
                 <executions>
                     <execution>
                         <id>one</id>
@@ -258,6 +290,16 @@
                                 <property>
                                     <name>sw360RestVersion</name>
                                     <value>${rest.version}</value>
+                                </property>
+                                <property>
+                                    <!-- Build version from git-commit-id-maven-plugin -->
+                                    <name>sw360BuildVersion</name>
+                                    <value>${git.build.version}</value>
+                                </property>
+                                <property>
+                                    <!-- Commits between HEAD and latest tag from git-commit-id-maven-plugin -->
+                                    <name>sw360CommitCount</name>
+                                    <value>${git.closest.tag.commit.count}</value>
                                 </property>
                             </properties>
                         </configuration>

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -81,6 +81,8 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     private static final String SW360_PROPERTIES_FILE_PATH = "/sw360.properties";
     private static final String VERSION_INFO_PROPERTIES_FILE = "/restInfo.properties";
     private static final String VERSION_INFO_KEY = "sw360RestVersion";
+    private static final String BUILD_VERSION_KEY = "sw360BuildVersion";
+    private static final String COMMIT_COUNT_KEY = "sw360CommitCount";
     private static final String CURIE_NAMESPACE = "sw360";
     private static final String APPLICATION_ID = "rest";
 
@@ -173,11 +175,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
         Server server = new Server();
         server.setUrl(SERVER_PATH_URL + APPLICATION_NAME + REST_BASE_PATH);
         server.setDescription("Current instance.");
-        Object restVersion = versionInfo.get(VERSION_INFO_KEY);
-        String restVersionString = "1.0.0";
-        if (restVersion != null) {
-            restVersionString = restVersion.toString();
-        }
+        String restVersionString = getRestVersion();
         return new OpenAPI()
                 .components(new Components()
                         .addSecuritySchemes("tokenAuth",
@@ -204,5 +202,28 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
                                                 ))
                                 ))
                 ));
+    }
+
+    /**
+     * Generate version string for REST using git build information.
+     * <ol>
+     *   <li>Check if the build version and commit count exists in properties.</li>
+     *   <li>If the property does not exist, return 1.0.0 as default version.</li>
+     *   <li>Replace the patch version of build version with commit count.</li>
+     *   <li>Return the updated version string.</li>
+     * </ol>
+     * @return Version string for OpenAPI docs.
+     */
+    private String getRestVersion() {
+        Object buildVersion = versionInfo.get(BUILD_VERSION_KEY);
+        Object commitCount = versionInfo.get(COMMIT_COUNT_KEY);
+        String restVersionString = "1.0.0";
+        if (buildVersion != null && commitCount != null) {
+            String[] versionParts = buildVersion.toString().split("\\.");
+            if (versionParts.length == 3) {
+                restVersionString = versionParts[0] + "." + versionParts[1] + "." + commitCount;
+            }
+        }
+        return restVersionString;
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -625,7 +625,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
     @Operation(
             summary = "Delete moderation request.",
             description = "Delete delete moderation request of the service.",
-            tags = {"ModerationRequest"}
+            tags = {"Moderation Requests"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @RequestMapping(value = MODERATION_REQUEST_URL + "/delete", method = RequestMethod.DELETE)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -29,7 +29,6 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -62,13 +61,6 @@ public class ResourceServerConfiguration {
     String issuerUri;
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers("/", "/*/*.html", "/*/*.css", "/*/*.js", "/*.js", "/*.json",
-                "/*/*.json", "/*/*.png", "/*/*.gif", "/*/*.ico", "/*/*.woff/*", "/*/*.ttf", "/*/*.html", "/*/*/*.html",
-                "/*/*.yaml", "/v3/api-docs/**", "/api/health", "/api/info");
-    }
-
-    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
         ApiTokenAuthenticationFilter apiTokenAuthenticationFilter = new ApiTokenAuthenticationFilter(authenticationManager, saep);
         return http
@@ -87,6 +79,9 @@ public class ResourceServerConfiguration {
                     auth.requestMatchers(HttpMethod.DELETE, "/api/**").hasAuthority("WRITE");
                     auth.requestMatchers(HttpMethod.PATCH, "/api/**").hasAuthority("WRITE");
                     auth.requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll();
+                    auth.requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll();
+                    auth.requestMatchers(HttpMethod.GET, "/docs/**").permitAll();
+                    auth.requestMatchers(HttpMethod.GET, "/mkdocs/**").permitAll();
                 })
                 .httpBasic(Customizer.withDefaults())
                 .exceptionHandling(x -> x.authenticationEntryPoint(saep))
@@ -97,7 +92,7 @@ public class ResourceServerConfiguration {
 
 
     @Bean
-    AuthenticationManager authenticationManager() throws Exception {
+    AuthenticationManager authenticationManager() {
         return new ProviderManager(List.of(authProvider, sw360UserAuthenticationProvider));
     }
 

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -56,6 +56,7 @@ spring:
 #logging:
 #  level:
 #    org.springframework.web: DEBUG
+#    org.eclipse.sw360: debug
 
 
 jwt:
@@ -81,14 +82,19 @@ blacklist:
 springdoc:
   api-docs:
     enabled: true
+    path: /v3/api-docs
     security:
       oauth2:
         enabled: true
+    version: openapi_3_1
   swagger-ui:
     enabled: true
+    path: /index.html
     security:
       oauth2:
         enabled: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/hal+json
   paths-to-exclude: /api/**
+  show-actuator: true
+  show-oauth2-endpoints: true

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360XSSRequestWrapper.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360XSSRequestWrapper.java
@@ -83,8 +83,25 @@ public class Sw360XSSRequestWrapper extends HttpServletRequestWrapper {
 
 	@Override
 	public String getHeader(String name) {
+		if (shouldIgnoreHeaderForXSS(name)) {
+			return super.getHeader(name);
+		}
 		String value = super.getHeader(name);
 		return stripXSS(value);
+	}
+
+	private boolean shouldIgnoreHeaderForXSS(String headerName) {
+		// Headers essential for HTTP operations and negotiation
+		return "Range".equalsIgnoreCase(headerName) ||
+				"Accept".equalsIgnoreCase(headerName) ||
+				"Content-Type".equalsIgnoreCase(headerName) ||
+				"Authorization".equalsIgnoreCase(headerName) ||
+				"Content-Length".equalsIgnoreCase(headerName) ||
+				"Host".equalsIgnoreCase(headerName) ||
+				"User-Agent".equalsIgnoreCase(headerName) ||
+				"Referer".equalsIgnoreCase(headerName) ||
+				"Cookie".equalsIgnoreCase(headerName) ||
+				"Set-Cookie".equalsIgnoreCase(headerName);
 	}
 
 	private String stripXSS(String value) {
@@ -109,5 +126,4 @@ public class Sw360XSSRequestWrapper extends HttpServletRequestWrapper {
 			return input;
 		}
 	}
-
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Use `git-commit-id-maven-plugin` plugin to read git properties and generate version for OpenAPI doc on the fly.

The version uses major and minor version from git and number of commits between HEAD and last tag as the patch version.

This helps in providing a reliable way of identifying updates in REST API until we have stable REST API to use custom API version.

### Suggest Reviewer
@heliocastro @hoangnt2 @smrutis1

### How To Test?
Open the OpenAPI docs and check the API version.