### PR TITLE
fix(cloudant): fix structure of elemMatch query

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -785,7 +785,7 @@ public class DatabaseConnectorCloudant {
      * @return New selector
      */
     public static @NotNull Map<String, Object> elemMatch(String field, String value) {
-        return Collections.singletonMap("$elemMatch",
-                eq(field, value));
+        return Collections.singletonMap(field,
+                eq("$elemMatch", value));
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Fix structure of `elemMatch`. The position of operator and field was wrong in the structure.

Current:
```json
{
  "$elemMatch": {
    "field": {
      "$eq": "value"
    }
  }
}
```

Correct:
```json
{
  "field": {
    "$elemMatch": {
      "$eq": "value"
    }
  }
}
```

See: http://localhost:5984/_utils/docs/api/database/find.html#find-elemmatch

### How To Test?
Fetch data which uses this filter:
1. Fetch moderation request list
2. Fetch projects
3. Fetch projects with moderator filter