### PR TITLE
feat(api): complete advance search for components

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -317,8 +317,14 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return "[" + dateToNouveauDouble(dates[0]) + RANGE_TO + dateToNouveauDouble(dates[1]) + "]";
     }
 
+    /**
+     * Parse dates from String in (yyyy-MM-dd) format to Nouveau format (yyyyMMdd) which is used as a double in queries.
+     * @param date Date to convert
+     * @return Parsed date for Nouveau
+     * @throws ParseException If input date cannot be parsed
+     * @see #dateToNouveauFormat(Date)
+     */
     public static @NotNull String dateToNouveauDouble(String date) throws ParseException {
-        SimpleDateFormat outputFormatter = new SimpleDateFormat("yyyyMMdd");
         SimpleDateFormat inputFormatterDate = new SimpleDateFormat("yyyy-MM-dd");
         Date parsedDate;
         try {
@@ -328,6 +334,17 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         } catch (Exception e) {
             throw new ParseException("Date format not recognized", 0);
         }
-        return outputFormatter.format(parsedDate.getTime());
+        return dateToNouveauFormat(parsedDate);
+    }
+
+    /**
+     * Convert a java.util.Date object to Nouveau format (yyyyMMdd) which is used as a double in queries.
+     * @param date Date to convert
+     * @return Parsed date for Nouveau
+     * @see #dateToNouveauDouble(String)
+     */
+    public static @NotNull String dateToNouveauFormat(Date date) {
+        SimpleDateFormat outputFormatter = new SimpleDateFormat("yyyyMMdd");
+        return outputFormatter.format(date.getTime());
     }
 }

--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -122,6 +122,26 @@ include::{snippets}/should_document_get_components_by_name/http-response.adoc[]
 include::{snippets}/should_document_get_components_by_name/links.adoc[]
 
 
+[[resources-components-list-by-type-and-createdon]]
+==== Filtering with more fields
+
+A `GET` request to fetch filtered list of service components.
+
+Note : send query parameter's value in encoded format. (Reference: `https://datatracker.ietf.org/doc/html/rfc3986`)
+
+===== Response structure
+include::{snippets}/should_document_get_components_by_type_and_created_on/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_components_by_type_and_created_on/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_components_by_type_and_created_on/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_components_by_type_and_created_on/links.adoc[]
+
+
 [[resources-components-list-by-type]]
 ==== Listing by type
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.component;
 
+import com.google.common.collect.Sets;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -1163,9 +1164,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                         && !fieldValue.toString().equalsIgnoreCase(filterSet.iterator().next())) {
                     return false;
                 } else if (fieldValue instanceof Set) {
-                    Set<String> fieldValueSet = (Set<String>) fieldValue;
-                    fieldValueSet.retainAll(filterSet);
-                    if (fieldValueSet.isEmpty()) {
+                    if (Sets.intersection(filterSet, (Set<String>) fieldValue).isEmpty()) {
                         return false;
                     }
                 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -912,6 +912,47 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_document_get_components_by_type_and_created_on() throws Exception {
+        mockMvc.perform(get("/api/components")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .queryParam("componentType", angularComponent.getComponentType().toString())
+                        .queryParam("createdOn", angularComponent.getCreatedOn())
+                        .queryParam("categories", "javascript, sql")
+                        .queryParam("luceneSearch", "false")
+                        .queryParam("page", "0")
+                        .queryParam("page_entries", "5")
+                        .queryParam("sort", "name,desc")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("componentType").description("Filter for type"),
+                                parameterWithName("createdOn").description("Filter for component creation date"),
+                                parameterWithName("categories").description("Filter for categories"),
+                                parameterWithName("luceneSearch").description("Filter with exact match or lucene match."),
+                                parameterWithName("page").description("Page of components"),
+                                parameterWithName("page_entries").description("Amount of components per page"),
+                                parameterWithName("sort").description("Defines order of the components")
+                        ),
+                        links(
+                                linkWithRel("curies").description("Curies are used for online documentation"),
+                                linkWithRel("first").description("Link to first page"),
+                                linkWithRel("last").description("Link to last page")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:components.[]name").description("The name of the component"),
+                                subsectionWithPath("_embedded.sw360:components.[]componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
+                                subsectionWithPath("_embedded.sw360:components").description("An array of <<resources-components, Components resources>>"),
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
+                                fieldWithPath("page").description("Additional paging information"),
+                                fieldWithPath("page.size").description("Number of components per page"),
+                                fieldWithPath("page.totalElements").description("Total number of all existing components"),
+                                fieldWithPath("page.totalPages").description("Total number of pages"),
+                                fieldWithPath("page.number").description("Number of the current page")
+                        )));
+    }
+
+    @Test
     public void should_document_update_component() throws Exception {
         ComponentDTO updateComponent = new ComponentDTO();
         AttachmentDTO attachmentDTO = new AttachmentDTO("1231231255", "spring-mvc-4.3.4.RELEASE.jar");


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Add all advance search parameters for `/components` endpoint.

Closes #2842

### Suggest Reviewer

### How To Test?
1. Test all combinations of the filter.
2. Test with lucene as true and false.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
