### PR TITLE
feat(rest): standardize POST response to include created entity ID

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -643,7 +643,6 @@ public class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties(value = {
-                "id",
                 "revision",
                 "type",
                 "licenseIdsSize",

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/PackageSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/PackageSpecTest.java
@@ -236,6 +236,7 @@ public class PackageSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("last").description("Link to last page")
                         ),
                         responseFields(
+                                fieldWithPath("_embedded.sw360:packages.[]id").description("The id of the package"),
                                 fieldWithPath("_embedded.sw360:packages.[]name").description("The name of the package"),
                                 fieldWithPath("_embedded.sw360:packages.[]version").description("The version of the package"),
                                 fieldWithPath("_embedded.sw360:packages.[]packageType").description("The package type, possible values are: " + Arrays.asList(CycloneDxComponentType.values())),
@@ -270,6 +271,7 @@ public class PackageSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("self").description("The <<resources-packages,Packages resource>>")
                         ),
                         responseFields(
+                                fieldWithPath("id").description("The id of the package"),
                                 fieldWithPath("name").description("The name of the package"),
                                 fieldWithPath("version").description("The version of the package"),
                                 fieldWithPath("packageType").description("The package type, possible values are: " + Arrays.asList(CycloneDxComponentType.values())),
@@ -403,6 +405,7 @@ public class PackageSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("description").description("Description of the package")
                         ),
                         responseFields(
+                                fieldWithPath("id").description("The id of the package"),
                                 fieldWithPath("name").description("The name of the package"),
                                 fieldWithPath("version").description("The version of the package"),
                                 fieldWithPath("packageType").description("The package type, possible values are: " + Arrays.asList(CycloneDxComponentType.values())),
@@ -437,6 +440,7 @@ public class PackageSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("description").description("Description of the package")
                         ),
                         responseFields(
+                                fieldWithPath("id").description("The id of the package"),
                                 fieldWithPath("name").description("The name of the package"),
                                 fieldWithPath("version").description("The version of the package"),
                                 fieldWithPath("packageType").description("The package type, possible values are: " + Arrays.asList(CycloneDxComponentType.values())),


### PR DESCRIPTION
This pull request addresses an issue where the package creation endpoint previously did not return the ID of the newly created package upon successful execution of a POST request.