### PR TITLE
fix(importCDX): Add logging for null metadata in sbom.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -816,6 +816,10 @@ public class CycloneDxBOMImporter {
     }
 
     private Project createProject(org.cyclonedx.model.Component compMetadata) {
+        if (compMetadata == null) {
+            log.error("Component metadata is null. Unable to create project.");
+            throw new IllegalArgumentException("Unable to create project due to incorrect metadata");
+        }
         return new Project(CommonUtils.nullToEmptyString(compMetadata.getName()).trim())
                 .setVersion(CommonUtils.nullToEmptyString(compMetadata.getVersion()).trim())
                 .setDescription(CommonUtils.nullToEmptyString(compMetadata.getDescription()).trim()).setType(ThriftEnumUtils.enumToString(ProjectType.PRODUCT))


### PR DESCRIPTION
Added logging while importing SBOMs with wrong/incomplete metadata. Also updated the error msg on UI.

![image](https://github.com/user-attachments/assets/ae653cd6-88ff-43c2-98e3-341b2e5f00df)

closes : #2879