### PR TITLE
fix(rest) : Add licenseInfoHeaderText in summaryAdministration api response

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2949,6 +2949,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     ) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+        if(sw360Project.getLicenseInfoHeaderText().isEmpty()){
+            sw360Project.setLicenseInfoHeaderText(projectService.getLicenseInfoHeaderText());
+        }
         Map<String, String> sortedExternalURLs = CommonUtils.getSortedMap(sw360Project.getExternalUrls(), true);
         sw360Project.setExternalUrls(sortedExternalURLs);
         sw360Project.setReleaseIdToUsage(null);
@@ -2961,7 +2964,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         sw360Project.unsetReleaseIdToUsage();
         sw360Project.unsetProjectResponsible();
         sw360Project.unsetSecurityResponsibles();
-        sw360Project.unsetLicenseInfoHeaderText();
 
         return new ResponseEntity<>(userHalResource, HttpStatus.OK);
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2451,6 +2451,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
                                 fieldWithPath("phaseOutSince").description("The project phase-out date"),
                                 fieldWithPath("clearingRequestId").description("Clearing Request id associated with project."),
+                                fieldWithPath("licenseInfoHeaderText").description("LicenseInfoHeaderText associated with project."),
                                 subsectionWithPath("externalUrls").description("A place to store additional data used by external URLs"),
                                 subsectionWithPath("_embedded.createdBy").description("The user who created this project"),
                                 subsectionWithPath("_embedded.projectResponsible").description("The project responsible displayed").type(JsonFieldType.OBJECT).optional(),


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Adding licenseInfoHeaderText parameter in summaryAdministration api response.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
Closes : #2867  

### How To Test?
API end point :  projects/{projectId}/summaryAdministration .

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
