### PR TITLE
fix(Attachment): Make get attachment endpoints consistent, allow to update project/component/release with attachment data

### DIFF
--- a/backend/attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
+++ b/backend/attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
@@ -252,4 +252,11 @@ public class AttachmentHandler implements AttachmentService.Iface {
     public RequestStatus deleteOldAttachmentFromFileSystem() throws TException {
         return handler.deleteOldAttachmentFromFileSystem();
     }
+
+    @Override
+    public AttachmentContent getAttachmentContentById(String attachmentContentId) throws TException {
+        assertNotEmpty(attachmentContentId);
+        assertNotNull(attachmentContentId);
+        return handler.getAttachmentContentById(attachmentContentId);
+    }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
@@ -276,4 +276,8 @@ public class AttachmentDatabaseHandler {
     public RequestStatus deleteOldAttachmentFromFileSystem() throws TException {
         return DatabaseHandlerUtil.deleteOldAttachmentFromFileSystem();
     }
+
+    public AttachmentContent getAttachmentContentById(String attachmentContentId) {
+        return attachmentContentRepository.get(attachmentContentId);
+    }
 }

--- a/libraries/datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/datahandler/src/main/thrift/attachments.thrift
@@ -71,35 +71,11 @@ struct Attachment {
     20: optional set<string> uploadHistory, // just for importing data by now
     21: optional CheckStatus checkStatus; // simple status of checks
     22: optional string superAttachmentId,
-    23: optional string superAttachmentFilename
-}
-
-struct AttachmentDTO {
-    // WILL NOT BE SAVED IN DB, only for api
-    // General information
-    1: required string attachmentContentId,
-    5: required string filename,
-    6: optional string sha1,
-
-    10: optional AttachmentType attachmentType,
-
-    11: optional string createdBy,
-    12: optional string createdTeam,
-    13: optional string createdComment,
-    14: optional string createdOn,
-    15: optional string checkedBy,
-    16: optional string checkedTeam,
-    17: optional string checkedComment,
-    18: optional string checkedOn,
-
-    20: optional set<string> uploadHistory,
-    21: optional CheckStatus checkStatus;
-    22: optional string superAttachmentId,
     23: optional string superAttachmentFilename,
-    24: optional UsageAttachment usageAttachment;
+    24: optional ProjectAttachmentUsage projectAttachmentUsage, // for view data only, will not be saved in DB
 }
 
-struct UsageAttachment {
+struct ProjectAttachmentUsage {
     // WILL NOT BE SAVED IN DB, only for api
     // General information
     1: optional string id,
@@ -361,4 +337,6 @@ service AttachmentService {
      * calls deleteAttachmentAndDirectory for identifying the file and delete
      */
     RequestStatus deleteOldAttachmentFromFileSystem();
+
+    AttachmentContent getAttachmentContentById(1: string attachmentContentId);
 }

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -374,7 +374,7 @@ struct ComponentDTO {
     6: optional string description,
 
     // Additional informations
-    10: optional set<AttachmentDTO> attachmentDTOs,
+    10: optional set<Attachment> attachments,
     11: optional string createdOn, // Creation date YYYY-MM-dd
     12: optional ComponentType componentType,
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentDTO;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
@@ -127,7 +126,7 @@ public class AttachmentController implements RepresentationModelProcessor<Reposi
             tags = {"Attachments"}
     )
     @RequestMapping(value = ATTACHMENTS_URL , method = RequestMethod.POST, consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<List<AttachmentDTO>> createAttachment(
+    public ResponseEntity<CollectionModel<EntityModel<Attachment>>> createAttachment(
             @Parameter(description = "List of files to attach",
                     schema = @Schema(
                             type = "string",
@@ -141,12 +140,13 @@ public class AttachmentController implements RepresentationModelProcessor<Reposi
             throw new RuntimeException("You must select at least one file for uploading");
         }
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        List<AttachmentDTO> attachmentDTOs = new ArrayList<>();
+        List<EntityModel<Attachment>> attachments = new ArrayList<>();
         for (MultipartFile file: files) {
-            AttachmentDTO attachmentDTO = restControllerHelper.convertAttachmentToAttachmentDTO(attachmentService.addAttachment(file, sw360User),null);
-            attachmentDTOs.add(attachmentDTO);
+            Attachment attachment = attachmentService.addAttachment(file, sw360User);
+            attachments.add(EntityModel.of(attachment));
         }
-        return new ResponseEntity<>(attachmentDTOs, HttpStatus.OK);
+        CollectionModel<EntityModel<Attachment>> attachmentsResponse = CollectionModel.of(attachments);
+        return new ResponseEntity<>(attachmentsResponse, HttpStatus.OK);
     }
 
     private HalResource<Attachment> createHalAttachment(AttachmentInfo attachmentInfo, User sw360User) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -166,6 +166,8 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
         } else if (requestStatus == RequestStatus.NAMINGERROR) {
             throw new HttpMessageNotReadableException("Component name field cannot be empty or contain only whitespace character");
+        } else if (requestStatus == RequestStatus.DUPLICATE_ATTACHMENT) {
+            throw new RuntimeException("Multiple attachments with same name or content cannot be present in attachment list.");
         } else if (requestStatus != RequestStatus.SUCCESS && requestStatus != RequestStatus.SENT_TO_MODERATOR) {
             throw new RuntimeException("sw360 component with name '" + component.getName() + " cannot be updated.");
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -24,9 +24,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentDTO;
+import org.eclipse.sw360.datahandler.thrift.attachments.ProjectAttachmentUsage;
 import org.eclipse.sw360.datahandler.thrift.attachments.ProjectUsage;
-import org.eclipse.sw360.datahandler.thrift.attachments.UsageAttachment;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangedFields;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ReferenceDocData;
@@ -111,8 +110,7 @@ public class JacksonCustomizations {
             setMixInAnnotation(ReleaseLink.class, Sw360Module.ReleaseLinkMixin.class);
             setMixInAnnotation(ClearingReport.class, Sw360Module.ClearingReportMixin.class);
             setMixInAnnotation(Attachment.class, Sw360Module.AttachmentMixin.class);
-            setMixInAnnotation(AttachmentDTO.class, Sw360Module.AttachmentDTOMixin.class);
-            setMixInAnnotation(UsageAttachment.class, Sw360Module.UsageAttachmentMixin.class);
+            setMixInAnnotation(ProjectAttachmentUsage.class, Sw360Module.ProjectAttachmentUsageMixin.class);
             setMixInAnnotation(ProjectUsage.class, Sw360Module.ProjectUsageMixin.class);
             setMixInAnnotation(Vendor.class, Sw360Module.VendorMixin.class);
             setMixInAnnotation(License.class, Sw360Module.LicenseMixin.class);
@@ -165,8 +163,7 @@ public class JacksonCustomizations {
                     .replaceWithClass(ReleaseLink.class, ReleaseLinkMixin.class)
                     .replaceWithClass(ClearingReport.class, ClearingReportMixin.class)
                     .replaceWithClass(Attachment.class, AttachmentMixin.class)
-                    .replaceWithClass(AttachmentDTO.class, AttachmentDTOMixin.class)
-                    .replaceWithClass(UsageAttachment.class, UsageAttachmentMixin.class)
+                    .replaceWithClass(ProjectAttachmentUsage.class, ProjectAttachmentUsageMixin.class)
                     .replaceWithClass(ProjectUsage.class, ProjectUsageMixin.class)
                     .replaceWithClass(Vendor.class, VendorMixin.class)
                     .replaceWithClass(License.class, LicenseMixin.class)
@@ -698,7 +695,6 @@ public class JacksonCustomizations {
                 "id",
                 "type",
                 "revision",
-                "attachments",
                 "createdBy",
                 "releases",
                 "wikipedia",
@@ -1271,7 +1267,6 @@ public class JacksonCustomizations {
         }
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
-                "attachmentContentId",
                 "setAttachmentContentId",
                 "setAttachmentType",
                 "setCreatedComment",
@@ -1306,34 +1301,10 @@ public class JacksonCustomizations {
                 "uploadHistoryIsSet",
                 "checkStatusIsSet",
                 "superAttachmentIdIsSet",
-                "superAttachmentFilenameIsSet"
+                "superAttachmentFilenameIsSet",
+                "setProjectAttachmentUsage"
         })
         static abstract class AttachmentMixin extends Attachment {
-        }
-
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        @JsonIgnoreProperties({
-                "setAttachmentContentId",
-                "setFilename",
-                "setSha1",
-                "setAttachmentType",
-                "setCreatedBy",
-                "setCreatedTeam",
-                "setCreatedComment",
-                "setCreatedOn",
-                "setCheckedBy",
-                "setCheckedTeam",
-                "setCheckedComment",
-                "setCheckedOn",
-                "uploadHistorySize",
-                "uploadHistoryIterator",
-                "setUploadHistory",
-                "setCheckStatus",
-                "setSuperAttachmentId",
-                "setSuperAttachmentFilename",
-                "setUsageAttachment"
-        })
-        static abstract class AttachmentDTOMixin extends AttachmentDTO {
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1353,7 +1324,7 @@ public class JacksonCustomizations {
                 "projectUsagesIterator",
                 "setProjectUsages",
         })
-        static abstract class UsageAttachmentMixin extends UsageAttachment {
+        static abstract class ProjectAttachmentUsageMixin extends ProjectAttachmentUsage {
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -35,9 +35,8 @@ import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentDTO;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
-import org.eclipse.sw360.datahandler.thrift.attachments.UsageAttachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.ProjectAttachmentUsage;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
@@ -103,6 +102,9 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
+import static org.eclipse.sw360.datahandler.common.WrappedException.wrapSW360Exception;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -762,6 +764,7 @@ public class RestControllerHelper<T> {
         component.setMailinglist(componentDTO.getMailinglist());
         component.setWiki(componentDTO.getWiki());
         component.setBlog(componentDTO.getBlog());
+        component.setAttachments(componentDTO.getAttachments());
 
         return component;
     }
@@ -1108,50 +1111,6 @@ public class RestControllerHelper<T> {
         attachment.setCheckedOn(null);
         attachment.setCheckedTeam(null);
         attachment.setCheckedComment(null);
-        return attachment;
-    }
-
-    public AttachmentDTO convertAttachmentToAttachmentDTO(Attachment attachment, UsageAttachment usage) {
-        AttachmentDTO attachmentDTO = new AttachmentDTO();
-        attachmentDTO.setAttachmentContentId(attachment.getAttachmentContentId());
-        attachmentDTO.setFilename(attachment.getFilename());
-        attachmentDTO.setSha1(attachment.getSha1());
-        attachmentDTO.setAttachmentType(attachment.getAttachmentType());
-        attachmentDTO.setCreatedBy(attachment.getCreatedBy());
-        attachmentDTO.setCreatedTeam(attachment.getCreatedTeam());
-        attachmentDTO.setCreatedComment(attachment.getCreatedComment());
-        attachmentDTO.setCreatedOn(attachment.getCreatedOn());
-        attachmentDTO.setCheckedBy(attachment.getCheckedBy());
-        attachmentDTO.setCheckedTeam(attachment.getCheckedTeam());
-        attachmentDTO.setCheckedComment(attachment.getCheckedComment());
-        attachmentDTO.setCheckedOn(attachment.getCheckedOn());
-        attachmentDTO.setCheckStatus(attachment.getCheckStatus());
-        attachmentDTO.setSuperAttachmentId(attachment.getSuperAttachmentId());
-        attachmentDTO.setSuperAttachmentFilename(attachment.getSuperAttachmentFilename());
-        attachmentDTO.setUsageAttachment(usage);
-
-        return attachmentDTO;
-    }
-
-    public Attachment convertToAttachment(AttachmentDTO attachmentDTO, User user) {
-        Attachment attachment = new Attachment();
-        attachment.setAttachmentContentId(attachmentDTO.getAttachmentContentId());
-        attachment.setFilename(attachmentDTO.getFilename());
-        attachment.setSha1(attachmentDTO.getSha1());
-        attachment.setAttachmentType(attachmentDTO.getAttachmentType());
-        attachment.setCreatedBy(attachmentDTO.getCreatedBy());
-        attachment.setCreatedTeam(attachmentDTO.getCreatedTeam());
-        attachment.setCreatedComment(attachmentDTO.getCreatedComment());
-        attachment.setCreatedOn(attachmentDTO.getCreatedOn());
-        if (CheckStatus.NOTCHECKED != attachmentDTO.getCheckStatus()) {
-            attachment.setCheckedComment(attachmentDTO.getCheckedComment());
-            attachment.setCheckedBy(user.getEmail());
-            attachment.setCheckedTeam(user.getDepartment());
-            attachment.setCheckedOn(SW360Utils.getCreatedOn());
-        }
-        attachment.setCheckStatus(attachmentDTO.getCheckStatus());
-        attachment.setSuperAttachmentId(attachmentDTO.getSuperAttachmentId());
-        attachment.setSuperAttachmentFilename(attachmentDTO.getSuperAttachmentFilename());
         return attachment;
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -286,6 +286,8 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         } else if (requestStatus == RequestStatus.NAMINGERROR) {
             throw new HttpMessageNotReadableException(
                     "Release name and version field cannot be empty or contain only whitespace character");
+        } else if (requestStatus == RequestStatus.DUPLICATE_ATTACHMENT) {
+            throw new RuntimeException("Multiple attachments with same name or content cannot be present in attachment list.");
         } else if (requestStatus != RequestStatus.SUCCESS && requestStatus != RequestStatus.SENT_TO_MODERATOR) {
             throw new RuntimeException(
                     "sw360 release with name '" + SW360Utils.printName(release) + " cannot be updated.");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
@@ -142,6 +142,7 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("Curies are used for online documentation")
                         ),
                         responseFields(
+                                fieldWithPath("attachmentContentId").description("The attachment content id"),
                                 fieldWithPath("filename").description("The filename of the attachment"),
                                 fieldWithPath("sha1").description("The attachment's file contents sha1 hash"),
                                 fieldWithPath("attachmentType").description("The attachment type, possible values are " + Arrays.asList(AttachmentType.values())),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -231,28 +231,28 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         componentList.add(angularTargetComponent);
         componentListByName.add(angularComponent);
 
-        AttachmentDTO attachmentDTO = new AttachmentDTO();
-        attachmentDTO.setAttachmentContentId("");
-        attachmentDTO.setFilename(attachment.getFilename());
-        attachmentDTO.setSha1(attachment.getSha1());
-        attachmentDTO.setAttachmentType(AttachmentType.BINARY_SELF);
-        attachmentDTO.setCreatedBy("admin@sw360.org");
-        attachmentDTO.setCreatedTeam("Clearing Team 1");
-        attachmentDTO.setCreatedComment("please check asap");
-        attachmentDTO.setCreatedOn("2016-12-18");
-        attachmentDTO.setCheckedTeam("Clearing Team 2");
-        attachmentDTO.setCheckedComment("everything looks good");
-        attachmentDTO.setCheckedOn("2016-12-18");
-        attachmentDTO.setCheckStatus(CheckStatus.ACCEPTED);
+        Attachment attachmentWithUsage = new Attachment();
+        attachmentWithUsage.setAttachmentContentId("");
+        attachmentWithUsage.setFilename(attachment.getFilename());
+        attachmentWithUsage.setSha1(attachment.getSha1());
+        attachmentWithUsage.setAttachmentType(AttachmentType.BINARY_SELF);
+        attachmentWithUsage.setCreatedBy("admin@sw360.org");
+        attachmentWithUsage.setCreatedTeam("Clearing Team 1");
+        attachmentWithUsage.setCreatedComment("please check asap");
+        attachmentWithUsage.setCreatedOn("2016-12-18");
+        attachmentWithUsage.setCheckedTeam("Clearing Team 2");
+        attachmentWithUsage.setCheckedComment("everything looks good");
+        attachmentWithUsage.setCheckedOn("2016-12-18");
+        attachmentWithUsage.setCheckStatus(CheckStatus.ACCEPTED);
 
-        UsageAttachment usageAttachment = new UsageAttachment();
+        ProjectAttachmentUsage usageAttachment = new ProjectAttachmentUsage();
         usageAttachment.setVisible(0);
         usageAttachment.setRestricted(0);
 
-        attachmentDTO.setUsageAttachment(usageAttachment);
-        List<EntityModel<AttachmentDTO>> atEntityModels = new ArrayList<>();
-        atEntityModels.add(EntityModel.of(attachmentDTO));
-        given(this.attachmentServiceMock.getAttachmentDTOResourcesFromList(any(), any(), any())).willReturn(CollectionModel.of(atEntityModels));
+        attachmentWithUsage.setProjectAttachmentUsage(usageAttachment);
+        List<EntityModel<Attachment>> atEntityModels = new ArrayList<>();
+        atEntityModels.add(EntityModel.of(attachmentWithUsage));
+        given(this.attachmentServiceMock.getAttachmentResourcesFromList(any(), any(), any())).willReturn(CollectionModel.of(atEntityModels));
 
         Component springComponent = new Component();
         Map<String, String> springComponentExternalIds = new HashMap<>();
@@ -636,6 +636,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:components.[]_embedded.createdBy.wantsMailNotification").description("Does user want to be notified via mail?").optional(),
                                 subsectionWithPath("_embedded.sw360:components.[]_embedded.createdBy.deactivated").description("The user is activated or deactivated").optional(),
                                 subsectionWithPath("_embedded.sw360:components.[]_embedded.createdBy._links").description("Self <<resources-index-links,Links>> to Component resource").optional(),
+                                subsectionWithPath("_embedded.sw360:components.[]_embedded.sw360:attachments.[]attachmentContentId").description("Attachment content id").optional(),
                                 subsectionWithPath("_embedded.sw360:components.[]_embedded.sw360:attachments.[]filename").description("Attached file name").optional(),
                                 subsectionWithPath("_embedded.sw360:components.[]_embedded.sw360:attachments.[]sha1").description("The attachment sha1 value").optional(),
                                 subsectionWithPath("_embedded.sw360:components.[]_embedded.sw360:attachments.[]_links").description("Self <<resources-index-links,Links>> to Component resource").optional(),
@@ -955,11 +956,11 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
     @Test
     public void should_document_update_component() throws Exception {
         ComponentDTO updateComponent = new ComponentDTO();
-        AttachmentDTO attachmentDTO = new AttachmentDTO("1231231255", "spring-mvc-4.3.4.RELEASE.jar");
-        Set<AttachmentDTO> attachmentDTOS = new HashSet<>();
-        attachmentDTOS.add(attachmentDTO);
+        Attachment attachment = new Attachment("1231231255", "spring-mvc-4.3.4.RELEASE.jar");
+        Set<Attachment> attachments = new HashSet<>();
+        attachments.add(attachment);
         updateComponent.setName("Updated Component");
-        updateComponent.setAttachmentDTOs(attachmentDTOS);
+        updateComponent.setAttachments(attachments);
 
         mockMvc.perform(patch("/api/components/17653524")
                 .contentType(MediaTypes.HAL_JSON)
@@ -1088,20 +1089,19 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
                         responseFields(
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes").description("An array of <<resources-attachment, Attachments resources>>"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]attachmentContentId").description("The attachment attachmentContentId"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]filename").description("The attachment filename"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]sha1").description("The attachment sha1"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]attachmentType").description("The attachment attachmentType"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]createdBy").description("The attachment createdBy"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]createdTeam").description("The attachment createdTeam"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]createdComment").description("The attachment createdComment"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]createdOn").description("The attachment createdOn"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]checkedComment").description("The attachment checkedComment"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]checkStatus").description("The attachment checkStatus"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]usageAttachment").description("The usages in project"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]usageAttachment.visible").description("The visible usages in project"),
-                                subsectionWithPath("_embedded.sw360:attachmentDTOes.[]usageAttachment.restricted").description("The restricted usages in project"),
+                                subsectionWithPath("_embedded.sw360:attachments").description("An array of <<resources-attachment, Attachments resources>>"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]filename").description("The attachment filename"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]sha1").description("The attachment sha1"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]attachmentType").description("The attachment attachmentType"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]createdBy").description("The attachment createdBy"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]createdTeam").description("The attachment createdTeam"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]createdComment").description("The attachment createdComment"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]createdOn").description("The attachment createdOn"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]checkedComment").description("The attachment checkedComment"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]checkStatus").description("The attachment checkStatus"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]projectAttachmentUsage").description("The usages in project"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]projectAttachmentUsage.visible").description("The visible usages in project"),
+                                subsectionWithPath("_embedded.sw360:attachments.[]projectAttachmentUsage.restricted").description("The restricted usages in project"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }
@@ -1124,6 +1124,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("checkStatus").description("The checkStatus of Attachment. Possible Values are: "+Arrays.asList(CheckStatus.values())),
                         fieldWithPath("checkedComment").description("The checked Comment of Attachment")),
                 responseFields(
+                        fieldWithPath("attachmentContentId").description("The attachment content id"),
                         fieldWithPath("filename").description("The attachment filename"),
                         fieldWithPath("sha1").description("The attachment sha1 value"),
                         fieldWithPath("attachmentType").description("The type of attachment. Possible Values are: "+Arrays.asList(AttachmentType.values())),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -856,6 +856,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.vulnerabilityMockService.updateProjectVulnerabilityRating(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.projectServiceMock.getReleasesFromProjectIds(any(), anyBoolean(), any(), any())).willReturn(Set.of(rel));
         given(this.projectServiceMock.getLinkedReleasesOfSubProjects(any(), any())).willReturn(List.of(release, release2));
+        given(this.attachmentServiceMock.getAttachmentResourcesFromList(any(), any(), any())).willReturn(CollectionModel.of(attachmentResources));
     }
 
     @Test
@@ -1779,6 +1780,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("checkStatus").description("The checkStatus of Attachment. Possible Values are: "+Arrays.asList(CheckStatus.values())),
                         fieldWithPath("checkedComment").description("The checked Comment of Attachment")),
                 responseFields(
+                        fieldWithPath("attachmentContentId").description("The attachment content id"),
                         fieldWithPath("filename").description("The attachment filename"),
                         fieldWithPath("sha1").description("The attachment sha1 value"),
                         fieldWithPath("attachmentType").description("The type of attachment. Possible Values are: "+Arrays.asList(AttachmentType.values())),


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Issue:
1. Currently, there are two formats when fetching attachments for a project, component, or release
- For **projects** and **releases**:
```json
{
    "_embedded": {
          "sw360:attachments": [....]
    }
}
```
- For **components**:
```json
{
    "_embedded": {
         "sw360:attachmentDTOes": [....]
    }
}
```
2. Additionally, project/release attachments cannot be updated when calling the patch project/release endpoint.


## => These two issues make it difficult for us to create a common component for listing and editing attachments in the new front-end

### This PR does:

1. Make get attachment endpoints response format consistent
2. Allow patching a project/component/release with attachment data (in a consistent way)
3. Remove **AttachmentDTO** class

### How To Test?

#### 1.Make get attachment endpoints response format consistent

- **Method**: GET
- **Url**:
        - Project attachments: http://{ip}:8080/resource/api/projects/{project_id}/attachments
        - Component attachments: http://{ip}:8080/resource/api/components/{component_id}/attachments
        - Release attachments: http://{ip}:8080/resource/api/releases/{release_id}/attachments

 - **Expected output**:
  ```json
  {
      "_embedded": {
            "sw360:attachments": [....]
      }
  }
  ```

#### 2.Update project/component/response

- **Method**: PATCH
- **Url**:
        - Update project : http://{ip}:8080/resource/api/projects/{project_id}/
        - Update component: http://{ip}:8080/resource/api/components/{component_id}/attachments
        - Update release: http://{ip}:8080/resource/api/releases/{release_id}/attachments

 - **Body**:
  ```json
  {
      "attachments": [
           {
            "attachmentContentId": "${attachment_content_id}",
            "filename": "${file_name}",
            "attachmentType": "SOURCE",
            "createdBy": "admin@sw360.org",
            "createdTeam": "DEPARTMENT1",
            "createdComment": "",
            "createdOn": "2025-02-06",
            "checkedBy": "admin@sw360.org"
         }
      ]
  }
  ```
 - **Expected output**: Update success with status code = 200
