### PR TITLE
fix(rest): Added homepage link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 A software component catalogue application.
 
-SW360 is a Backend server with a REST API to maintain your projects / products and the software components within.
+[SW360](https://eclipse.dev/sw360/) is a Backend server with a REST API to maintain your projects / products and the software components within.
 
 It can manage SPDX files for maintaining the license conditions and maintain
 license information.


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Fixes #798
Added link to the project homepage in Github README.
Followed the style of [Zulip README](https://github.com/zulip/zulip?tab=readme-ov-file#zulip-overview).

