### PR TITLE
feat(rest): Added parameter for exporting linked package information along with release info.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -2129,7 +2129,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return repository.searchByType(type, user);
     }
 
-	public ByteBuffer getReportDataStream(User user, boolean extendedByReleases, String projectId) throws TException {
+	public ByteBuffer getReportDataStream(User user, boolean extendedByReleases, String projectId, boolean extendedByPackages) throws TException {
 	    List<Project> projectList = null;
         try {
             if (!isNullOrEmpty(projectId)) {
@@ -2137,7 +2137,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }else {
                 projectList =  getAccessibleProjectsSummary(user);
             }
-            ProjectExporter exporter = getProjectExporterObject(projectList, user, extendedByReleases);
+            ProjectExporter exporter = getProjectExporterObject(projectList, user, extendedByReleases, extendedByPackages);
             InputStream stream = exporter.makeExcelExport(projectList);
             return ByteBuffer.wrap(IOUtils.toByteArray(stream));
           }catch (IOException e) {
@@ -2145,14 +2145,14 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
        }
      }
 
-    private ProjectExporter getProjectExporterObject(List<Project> documents, User user, boolean extendedByReleases) throws SW360Exception {
+    private ProjectExporter getProjectExporterObject(List<Project> documents, User user, boolean extendedByReleases, boolean extendedByPackages) throws SW360Exception {
     	ThriftClients thriftClients = new ThriftClients();
-    	return new ProjectExporter(thriftClients.makeComponentClient(),
+        return extendedByPackages ? new ProjectExporter(thriftClients.makeComponentClient(), thriftClients.makePackageClient(), thriftClients.makeProjectClient(), user, documents, true) : new ProjectExporter(thriftClients.makeComponentClient(),
                 thriftClients.makeProjectClient(), user, documents, extendedByReleases);
     }
 
     public String getReportInEmail(User user,
-			boolean extendedByReleases, String projectId) throws TException {
+			boolean extendedByReleases, String projectId, boolean extendedByPackages) throws TException {
         List<Project> projectList = null;
         try {
             if (!isNullOrEmpty(projectId)) {
@@ -2160,7 +2160,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }else {
                 projectList = getAccessibleProjectsSummary(user);
             }
-            ProjectExporter exporter = getProjectExporterObject(projectList, user, extendedByReleases);
+            ProjectExporter exporter = getProjectExporterObject(projectList, user, extendedByReleases, extendedByPackages);
             return exporter.makeExcelExportForProject(projectList, user);
           }catch (IOException | TException e) {
              throw new SW360Exception(e.getMessage());
@@ -2178,9 +2178,9 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
          return getProjectsById(linkedProjectIds, user);
      }
 
-     public ByteBuffer downloadExcel(User user, boolean extendedByReleases, String token) throws SW360Exception {
+     public ByteBuffer downloadExcel(User user, boolean extendedByReleases, boolean extendedByPackages, String token) throws SW360Exception {
         ThriftClients thriftClients = new ThriftClients();
-        ProjectExporter exporter = new ProjectExporter(thriftClients.makeComponentClient(),
+         ProjectExporter exporter = extendedByPackages ? new ProjectExporter(thriftClients.makeComponentClient(),thriftClients.makePackageClient(),thriftClients.makeProjectClient(),user,extendedByPackages) : new ProjectExporter(thriftClients.makeComponentClient(),
 				thriftClients.makeProjectClient(), user, extendedByReleases);
 		try {
 			InputStream stream = exporter.downloadExcelSheet(token);

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -556,21 +556,21 @@ public class ProjectHandler implements ProjectService.Iface {
     }
 
     @Override
-    public ByteBuffer downloadExcel(User user, boolean extendedByReleases, String token)
+    public ByteBuffer downloadExcel(User user, boolean extendedByReleases, boolean extendedByPackages,  String token)
             throws TException {
-        return handler.downloadExcel(user, extendedByReleases,token);
+        return handler.downloadExcel(user, extendedByReleases, extendedByPackages, token);
     }
 
 	@Override
-	public ByteBuffer getReportDataStream(User user, boolean extendedByReleases, String projectId)
+	public ByteBuffer getReportDataStream(User user, boolean extendedByReleases, String projectId, boolean extendedByPackages)
 			throws TException {
-		return handler.getReportDataStream(user, extendedByReleases, projectId);
+		return handler.getReportDataStream(user, extendedByReleases, projectId, extendedByPackages);
 	}
 
 	@Override
-	public String getReportInEmail(User user, boolean extendedByReleases, String projectId)
+	public String getReportInEmail(User user, boolean extendedByReleases, String projectId, boolean extendedByPackages)
 			throws TException {
-		return handler.getReportInEmail(user, extendedByReleases, projectId);
+		return handler.getReportInEmail(user, extendedByReleases, projectId, extendedByPackages);
 	}
 
     @Override

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -697,15 +697,15 @@ service ProjectService {
     /*
     * make excel export
     */
-    binary getReportDataStream(1: User user,2: bool extendedByReleases,3: string projectId) throws (1: SW360Exception exp);
+    binary getReportDataStream(1: User user,2: bool extendedByReleases,3: string projectId,4: bool extendedByPackages) throws (1: SW360Exception exp);
      /*
     * excel export - return the filepath
     */
-    string getReportInEmail(1: User user, 2: bool extendedByReleases, string projectId) throws (1: SW360Exception exp);
+    string getReportInEmail(1: User user, 2: bool extendedByReleases, string projectId,4: bool extendedByPackages) throws (1: SW360Exception exp);
     /*
     * download excel
     */
-    binary downloadExcel(1:User user,2:bool extendedByReleases,3:string token) throws (1: SW360Exception exc);
+    binary downloadExcel(1:User user,2:bool extendedByReleases,3:bool extendedByPackages,4:string token) throws (1: SW360Exception exc);
 
     /**
     * get list ReleaseLink in release network of project by project id and trace

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/PackageExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/PackageExporter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Siemens Healthineers GmBH, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.exporter;
+
+import com.google.common.collect.ImmutableList;
+import org.eclipse.sw360.datahandler.thrift.packages.*;
+import org.eclipse.sw360.datahandler.thrift.packages.Package;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.exporter.helper.PackageHelper;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.displayNameFor;
+import static org.eclipse.sw360.datahandler.thrift.packages.Package._Fields.*;
+import static org.eclipse.sw360.exporter.ReleaseExporter.RELEASE_HEADERS_PROJECT_EXPORT;
+
+
+public class PackageExporter extends ExcelExporter<Package, PackageHelper> {
+
+    private static final Map<String, String> nameToDisplayName;
+
+    static {
+        nameToDisplayName = new HashMap<>();
+        nameToDisplayName.put(Package._Fields.ID.getFieldName(), "package ID");
+        nameToDisplayName.put(Package._Fields.NAME.getFieldName(), "package name");
+        nameToDisplayName.put(Package._Fields.VERSION.getFieldName(), "package version");
+        nameToDisplayName.put(Package._Fields.DESCRIPTION.getFieldName(), "package description");
+        nameToDisplayName.put(Package._Fields.VENDOR.getFieldName(), "package vendor");
+        nameToDisplayName.put(Package._Fields.LICENSE_IDS.getFieldName(), "license IDs");
+        nameToDisplayName.put(Package._Fields.PACKAGE_TYPE.getFieldName(), "package type");
+        nameToDisplayName.put(Package._Fields.PURL.getFieldName(), "purl");
+        nameToDisplayName.put(Package._Fields.RELEASE.getFieldName(), "release");
+    }
+
+
+    public static final List<Package._Fields> PACKAGE_REQUIRED_FIELDS = ImmutableList.<Package._Fields>builder()
+            .add(ID)
+            .add(NAME)
+            .add(VERSION)
+            .add(PURL)
+            .add(PACKAGE_TYPE)
+            .add(RELEASE)
+            .build();
+
+    public static final List<Package._Fields> PACKAGE_RENDERED_FIELDS_PROJECTS = Package.metaDataMap.keySet()
+            .stream()
+            .filter(k -> PACKAGE_REQUIRED_FIELDS.contains(k))
+            .collect(Collectors.toList());
+
+
+    public PackageExporter(PackageService.Iface packageClient, User user, ComponentService.Iface cClient) {
+        super(new PackageHelper(packageClient, cClient, user));
+    }
+
+    public static final List<String> PACKAGE_HEADERS_PROJECT_EXPORT = makePackageHeadersForProjectExport();
+
+    private static List<String> makePackageHeadersForProjectExport() {
+        List<String> headers = new ArrayList<>();
+        for (Package._Fields field : PACKAGE_RENDERED_FIELDS_PROJECTS) {
+            addToHeadersForProjectExport(headers, field);
+        }
+        return headers;
+    }
+
+    private static void addToHeadersForProjectExport(List<String> headers, Package._Fields field) {
+        switch (field) {
+            case RELEASE:
+                headers.addAll(RELEASE_HEADERS_PROJECT_EXPORT);
+                break;
+            default:
+                headers.add(displayNameFor(field.getFieldName(), nameToDisplayName));
+        }
+    }
+}

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ProjectExporter.java
@@ -18,10 +18,12 @@ import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.packages.PackageService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.exporter.helper.ExporterHelper;
 import org.eclipse.sw360.exporter.helper.ProjectHelper;
 import org.eclipse.sw360.exporter.helper.ReleaseHelper;
+import org.eclipse.sw360.exporter.helper.PackageHelper;
 
 import java.util.*;
 import java.util.function.Function;
@@ -98,7 +100,7 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
             .collect(Collectors.toList());
 
     public static List<String> HEADERS_EXTENDED_BY_RELEASES = ExporterHelper.addSubheadersWithPrefixesAsNeeded(HEADERS, ReleaseExporter.RELEASE_HEADERS_PROJECT_EXPORT, "release: ");
-
+    public static List<String> HEADERS_EXTENDED_BY_PACKAGES = ExporterHelper.addSubheadersWithPrefixesAsNeeded(HEADERS, PackageExporter.PACKAGE_HEADERS_PROJECT_EXPORT, "package: ");
     public ProjectExporter(ComponentService.Iface componentClient, ProjectService.Iface projectClient, User user, List<Project> projects, boolean extendedByReleases) throws SW360Exception {
         super(new ProjectHelper(projectClient, user, extendedByReleases, new ReleaseHelper(componentClient, user)));
         preloadRelatedDataFor(projects, extendedByReleases, user);
@@ -107,6 +109,14 @@ public class ProjectExporter extends ExcelExporter<Project, ProjectHelper> {
     public ProjectExporter(ComponentService.Iface componentClient, ProjectService.Iface projectClient, User user,
             boolean extendedByReleases) throws SW360Exception {
         super(new ProjectHelper(projectClient, user, extendedByReleases, new ReleaseHelper(componentClient, user)));
+    }
+
+    public ProjectExporter(ComponentService.Iface cClient,PackageService.Iface packageClient, ProjectService.Iface projectClient, User user, List<Project> projects, boolean extendedByPackages) throws SW360Exception {
+        super(new ProjectHelper(projectClient, user, extendedByPackages, new PackageHelper(packageClient, cClient, user), new ReleaseHelper(cClient, user)));
+    }
+
+    public ProjectExporter(ComponentService.Iface cClient,PackageService.Iface packageClient, ProjectService.Iface projectClient, User user, boolean extendedByPackages) throws SW360Exception {
+        super(new ProjectHelper(projectClient, user, extendedByPackages, new PackageHelper(packageClient, cClient, user), new ReleaseHelper(cClient, user)));
     }
 
     private void preloadRelatedDataFor(List<Project> projects, boolean withLinkedOfLinked, User user) throws SW360Exception {

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/PackageHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/PackageHelper.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Siemens Healthineers GmBH, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.exporter.helper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.packages.Package;
+import org.eclipse.sw360.datahandler.thrift.packages.PackageService;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
+import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.exporter.utils.SubTable;
+import static org.eclipse.sw360.datahandler.common.SW360Utils.fieldValueAsString;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import static org.eclipse.sw360.exporter.PackageExporter.*;
+import static org.eclipse.sw360.exporter.ProjectExporter.HEADERS;
+import static org.eclipse.sw360.exporter.ReleaseExporter.*;
+
+public class PackageHelper implements ExporterHelper<Package> {
+    private static final Logger log = LogManager.getLogger(PackageHelper.class);
+    private final PackageService.Iface packageClient;
+    private final ComponentService.Iface cClient;
+    private final User user;
+    public static final Set<String> RELEASES_LINKED_TO_PACKAGES = new HashSet<>();
+
+    public PackageHelper(PackageService.Iface packageClient, ComponentService.Iface cClient, User user) {
+        this.packageClient = packageClient;
+        this.cClient = cClient;
+        this.user = user;
+    }
+
+    public int getColumns() {
+        return getHeaders().size();
+    }
+
+    public int getColumnsProjExport() {
+        return getHeadersProjExport().size();
+    }
+
+    public List<String> getHeadersProjExport() {
+        return PACKAGE_HEADERS_PROJECT_EXPORT;
+    }
+
+    @Override
+    public List<String> getHeaders() {
+        return HEADERS;
+    }
+
+    @Override
+    public SubTable makeRows(Package document) throws SW360Exception {
+        List<String> row = new ArrayList<>();
+        for(Package._Fields renderedField : PACKAGE_RENDERED_FIELDS_PROJECTS) {
+            addFieldValueToRow(row, renderedField, document);
+        }
+        return new SubTable(row);
+    }
+
+
+    private void addFieldValueToRow(List<String> row, Package._Fields field, Package document) throws SW360Exception {
+        switch (field) {
+            case ID:
+                row.add(document.getId());
+                break;
+            case NAME:
+                row.add(document.getName());
+                break;
+            case VERSION:
+                row.add(document.getVersion());
+                break;
+            case PURL:
+                row.add(document.getPurl());
+                break;
+            case PACKAGE_TYPE:
+                row.add(ThriftEnumUtils.enumToString(document.getPackageType()));
+                break;
+            case RELEASE:
+                try {
+                    ReleaseHelper releaseHelper = new ReleaseHelper(cClient, user);
+                    if (document.getReleaseId() == null || document.getReleaseId().isEmpty()) {
+                        // Ensure row is filled for each header of the release
+                        for (int i = 0; i < RELEASE_HEADERS_PROJECT_EXPORT.size(); i++) {
+                            row.add("");
+                        }
+                        break;
+                    }else{
+                        Release release = cClient.getReleaseById(document.getReleaseId(), user);
+                        RELEASES_LINKED_TO_PACKAGES.add(release.getId());
+                        if (release.isSetPermissions() && release.getPermissions().get(RequestedAction.READ)) {
+                            for (Release._Fields renderedField : RELEASE_RENDERED_FIELDS_PROJECTS) {
+                                releaseHelper.addFieldValueToRow(row, renderedField, release, true);
+                            }
+                        }
+                    }
+                }catch (TException e) {
+                    log.info("Failed to fetch release for ID for package: " + document.getName(), e);
+                }
+                break;
+            default:
+                Object fieldValue = document.getFieldValue(field);
+                row.add(fieldValueAsString(fieldValue));
+        }
+    }
+
+    public List<Package> getPackages(Set<String> packageIds) throws SW360Exception {
+        try {
+            return packageClient.getPackageByIds(packageIds);
+        } catch (TException e) {
+            log.error("Could not fetch packages", e);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/ProjectHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/ProjectHelper.java
@@ -14,6 +14,7 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -23,28 +24,39 @@ import com.google.common.collect.Sets;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.fieldValueAsString;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.putProjectNamesInMap;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.putAccessibleReleaseNamesInMap;
-import static org.eclipse.sw360.exporter.ProjectExporter.HEADERS;
-import static org.eclipse.sw360.exporter.ProjectExporter.HEADERS_EXTENDED_BY_RELEASES;
-import static org.eclipse.sw360.exporter.ProjectExporter.PROJECT_RENDERED_FIELDS;
+import static org.eclipse.sw360.exporter.ProjectExporter.*;
+import static org.eclipse.sw360.exporter.ReleaseExporter.RELEASE_HEADERS_PROJECT_EXPORT;
+import static org.eclipse.sw360.exporter.helper.PackageHelper.RELEASES_LINKED_TO_PACKAGES;
 
 public class ProjectHelper implements ExporterHelper<Project> {
 
     private static final String RELEASE_NOT_AVAILABLE = "Release not available";
+    private static final String PACKAGE_NOT_AVAILABLE = "Package not available";
     private final ProjectService.Iface projectClient;
     private final User user;
     private boolean extendedByReleases;
+    private boolean extendedByPackages;
     private ReleaseHelper releaseHelper;
+    private PackageHelper packageHelper;
     private Map<String, Project> preloadedLinkedProjects;
 
     public ProjectHelper(ProjectService.Iface projectClient, User user, boolean extendedByReleases, ReleaseHelper releaseHelper) {
         this.projectClient = projectClient;
         this.user = user;
         this.extendedByReleases = extendedByReleases;
+        this.releaseHelper = releaseHelper;
+    }
+
+    public ProjectHelper(ProjectService.Iface projectClient, User user, boolean extendedByPackages, PackageHelper packageHelper, ReleaseHelper releaseHelper) {
+        this.projectClient = projectClient;
+        this.user = user;
+        this.extendedByPackages = extendedByPackages;
+        this.packageHelper = packageHelper;
         this.releaseHelper = releaseHelper;
     }
 
@@ -55,11 +67,13 @@ public class ProjectHelper implements ExporterHelper<Project> {
 
     @Override
     public List<String> getHeaders() {
+        if(extendedByPackages) return HEADERS_EXTENDED_BY_PACKAGES;
         return extendedByReleases ? HEADERS_EXTENDED_BY_RELEASES : HEADERS;
     }
 
     @Override
     public SubTable makeRows(Project project) throws SW360Exception {
+        if(extendedByPackages) return makeRowsWithPackages(project);
         return extendedByReleases ? makeRowsWithReleases(project) : makeRowForProjectOnly(project);
     }
 
@@ -88,13 +102,53 @@ public class ProjectHelper implements ExporterHelper<Project> {
             }
         } else {
             List<String> projectRowWithEmptyReleaseFields = makeRowForProject(project);
-            for (int i = 0; i < releaseHelper.getColumnsProjExport(); i++) {
+            for (int i = 0; i < RELEASE_HEADERS_PROJECT_EXPORT.size(); i++) {
                 projectRowWithEmptyReleaseFields.add("");
             }
             table.addRow(projectRowWithEmptyReleaseFields);
         }
         return table;
     }
+
+    private SubTable makeRowsWithPackages(Project project) throws SW360Exception{
+        List<Package> packages = getPackages(project);
+        SubTable table = new SubTable();
+        Set<String> packageIdsNotAvailableInDB = Sets.difference(nullToEmptySet(project.getPackageIds()), packages.stream().map(Package::getId).collect(Collectors.toSet()));
+        if(packages.size() > 0){
+            for(Package pack : packages){
+                List<String> currentRow = makeRowForProject(project);
+                currentRow.addAll(packageHelper.makeRows(pack).getRow(0));
+                table.addRow(currentRow);
+            }
+
+            List<Release> leftoverReleases = releaseHelper.getAllReleases(Sets.difference(nullToEmptyMap(project.getReleaseIdToUsage()).keySet(), RELEASES_LINKED_TO_PACKAGES));
+            addReleaseInformation(project, table, leftoverReleases);
+
+            for(String packageId : packageIdsNotAvailableInDB){
+                List<String> projRowWithNotAvailablePackageFields = makeRowForProject(project);
+                for(int i = 0; i < packageHelper.getColumns(); i++){
+                    if(i == 0){
+                        projRowWithNotAvailablePackageFields.add(packageId);
+                        continue;
+                    }
+                    projRowWithNotAvailablePackageFields.add(PACKAGE_NOT_AVAILABLE);
+                }
+                table.addRow(projRowWithNotAvailablePackageFields);
+            }
+        } else {
+            List<String> projectRowWithEmptyPackageFields = makeRowForProject(project);
+            for(int i = 0; i < packageHelper.getColumnsProjExport(); i++){
+                projectRowWithEmptyPackageFields.add("");
+            }
+            table.addRow(projectRowWithEmptyPackageFields);
+
+            List<Release> releases = releaseHelper.getAllReleases(project.getReleaseIdToUsage().keySet());
+            addReleaseInformation(project, table, releases);
+        }
+        return table;
+    }
+
+
 
     private List<String> makeRowForProject(Project project) throws SW360Exception {
         if (!project.isSetAttachments()) {
@@ -148,6 +202,13 @@ public class ProjectHelper implements ExporterHelper<Project> {
         return releaseHelper.getReleases(ids);
     }
 
+    public List<Package> getPackages(Project project) throws SW360Exception {
+        return getPackages(project.getPackageIds());
+    }
+    public List<Package> getPackages(Set<String> ids) throws SW360Exception {
+        return packageHelper.getPackages(ids);
+    }
+
     public List<Project> getProjects(Set<String> ids, User user) throws SW360Exception {
         if (preloadedLinkedProjects != null) {
             return getPreloadedProjects(ids);
@@ -167,5 +228,16 @@ public class ProjectHelper implements ExporterHelper<Project> {
 
     public void setPreloadedLinkedProjects(Map<String, Project> preloadedLinkedProjects) {
         this.preloadedLinkedProjects = preloadedLinkedProjects;
+    }
+
+    private void addReleaseInformation(Project project, SubTable table, List<Release> leftoverReleases) throws SW360Exception {
+        for(Release release : leftoverReleases) {
+            List<String> projRow = makeRowForProject(project);
+            for(int i = 0; i < packageHelper.getColumnsProjExport() - RELEASE_HEADERS_PROJECT_EXPORT.size(); i++) {
+                projRow.add("");
+            }
+            projRow.addAll(releaseHelper.makeCustomRowsForProjectExport(release).getRow(0));
+            table.addRow(projRow);
+        }
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/ReleaseHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/ReleaseHelper.java
@@ -144,7 +144,7 @@ public class ReleaseHelper implements ExporterHelper<Release> {
     }
 
 
-    private void addFieldValueToRow(List<String> row, Release._Fields field, Release release, boolean isForProjectExport) throws SW360Exception {
+    protected void addFieldValueToRow(List<String> row, Release._Fields field, Release release, boolean isForProjectExport) throws SW360Exception {
         switch (field) {
             case COMPONENT_ID:
                 // first, add data for given field
@@ -377,6 +377,17 @@ public class ReleaseHelper implements ExporterHelper<Release> {
             throw new SW360Exception("Could not get Components for ids [" + cIds + "] because of:\n" + e.getMessage());
         }
     }
+
+    public List<Release> getAllReleases(Set<String> ids) throws SW360Exception {
+        List<Release> releasesByIdsForExport;
+        try {
+            releasesByIdsForExport = cClient.getReleasesWithAccessibilityByIdsForExport(nullToEmptySet(ids), user);
+        } catch (TException e) {
+            throw new SW360Exception("Error fetching release information");
+        }
+        return releasesByIdsForExport;
+    }
+
 
     public List<Release> getReleases(Set<String> ids) throws SW360Exception {
         if (preloadedLinkedReleases != null){

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportBean.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportBean.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Getter
 public class SW360ReportBean{
     boolean withLinkedReleases;
+    boolean withLinkedPackages;
     boolean excludeReleaseVersion;
     String generatorClassName;
     String variant;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -595,7 +595,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.importSPDX(any(),any())).willReturn(requestSummaryForSPDX);
         given(this.projectServiceMock.importCycloneDX(any(),any(),any(),anyBoolean())).willReturn(requestSummaryForCycloneDX);
         given(this.sw360ReportServiceMock.getDocumentName(any(), any(), any())).willReturn(projectName);
-        given(this.sw360ReportServiceMock.getProjectBuffer(any(),anyBoolean(),any())).willReturn(ByteBuffer.allocate(10000));
+        given(this.sw360ReportServiceMock.getProjectBuffer(any(),anyBoolean(),any(),anyBoolean())).willReturn(ByteBuffer.allocate(10000));
         given(this.sw360ReportServiceMock.getProjectReleaseSpreadSheetWithEcc(any(),any())).willReturn(ByteBuffer.allocate(10000));
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), any())).willReturn(project);
         given(this.projectServiceMock.searchAccessibleProjectByExactValues(any(), any(), any())).willReturn(
@@ -2529,6 +2529,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(get("/api/reports")
                         .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                         .queryParam("withlinkedreleases", "true")
+                        .queryParam("withlinkedpackages", "true")
                         .queryParam("module", "projects")
                         .queryParam("projectId", project.getId())
                         .queryParam("excludeReleaseVersion", "false")
@@ -2537,6 +2538,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .andDo(this.documentationHandler.document(
                         queryParameters(
                                 parameterWithName("withlinkedreleases").description("Projects with linked releases. Possible values are `<true|false>`"),
+                                parameterWithName("withlinkedpackages").description("Projects with linked releases and packages. Mutually exclusive with `withlinkedreleases`. Possible values are `<true|false>`"),
                                 parameterWithName("module").description("module represent the project or component. Possible values are `<components|projects>`"),
                                 parameterWithName("projectId").description("Id of a project"),
                                 parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "


### PR DESCRIPTION
closes : #2948 

Endpoint url : http://localhost:8080/resource/api/reports

parameters : 
**withlinkedpackages** - `true`
**mimetype** -` xlsx`
**module** - `projects`
**Id** - `projectId`

Sample url : http://localhost:8080/resource/api/reports?withlinkedpackages=true&mimetype=xlsx&module=projects&projectId={projectId}

Sample response : Excel sheet.

![image](https://github.com/user-attachments/assets/418227c9-ed27-473c-b05b-8d5e5d74bcac)
