### PR TITLE
fix(SPDXDocument): Fix bug add SPDX document always return fail

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/SW360SPDXDocumentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/SW360SPDXDocumentService.java
@@ -167,7 +167,7 @@ public class SW360SPDXDocumentService {
 
     public String addSPDX(Release release, User user) throws TException {
         String spdxId = addSPDXDocument(release, user);
-        if (CommonUtils.isNotNullEmptyOrWhitespace(spdxId)) {
+        if (CommonUtils.isNullEmptyOrWhitespace(spdxId)) {
             throw new HttpMessageNotReadableException("Add SPDXDocument Failed!");
         }
         addDocumentCreationInformation(spdxId, release.getModerators(), user);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue:  Update a non existing SPDX Document will not create a new one. Response always:
Status: 400
Message:
```
Add SPDXDocument Failed!
```


### How To Test?
Edit sw360.properties
```properties
spdx.document.enabled = true
```

URL: http://{ip}:8080/resource/api/releases/${releaseId}/spdx
Body:
```json
{
    "documentCreationInformation": {
        "creator": [
            {
                "type": "Person",
                "value": "Test Admin (admin@sw360.org)",
                "index": 0
            }
        ],
        "created": "2025-03-07T02:52:37.360Z"
    }
}
```
Expected: Status 200

