### PR TITLE
Fix OAuth Client deserialization and database operations

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -9,6 +9,8 @@
  */
 package org.eclipse.sw360.datahandler.cloudantclient;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
@@ -370,6 +372,15 @@ public class DatabaseRepositoryCloudantClient<T> {
             TFieldIdEnum id = tbase.fieldForId(1);
             String docId = (String) tbase.getFieldValue(id);
             return connector.deleteById(docId);
+        } else if (doc.getClass().getSimpleName().equals("OAuthClientEntity")) {
+            Class<?> clazz = doc.getClass();
+            try {
+                Method getIdMethod = clazz.getMethod("getId");
+                String id = (String) getIdMethod.invoke(doc);
+                return connector.deleteById(id);
+            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                log.error(e.getMessage());
+            }
         }
         return connector.remove(doc);
     }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientDeserializer.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientDeserializer.java
@@ -1,0 +1,76 @@
+// Copyright (C) TOSHIBA CORPORATION, 2025. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+package org.eclipse.sw360.rest.authserver.client.persistence;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OAuthClientDeserializer extends JsonDeserializer<OAuthClientEntity> {
+
+    @Override
+    public OAuthClientEntity deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+
+        JsonNode node = p.getCodec().readTree(p);
+        OAuthClientEntity client = new OAuthClientEntity();
+
+        client.setId(node.get("_id").asText());
+        client.setRev(node.get("_rev").asText());
+        client.setClientId(node.get("client_id").asText());
+        client.setClientSecret(node.get("client_secret").asText());
+        client.setDescription(node.get("description").asText());
+
+        client.setSecretRequired(node.get("secretRequired").asBoolean());
+        client.setScoped(node.get("scoped").asBoolean());
+
+        client.setResourceIds(jsonNodeToSet(node.get("resource_ids")));
+        client.setAuthorizedGrantTypes(jsonNodeToSet(node.get("authorized_grant_types")));
+        client.setScope(jsonNodeToSet(node.get("scope")));
+        client.setRegisteredRedirectUri(jsonNodeToSet(node.get("redirect_uri")));
+        client.setAutoApproveScopes(jsonNodeToSet(node.get("autoapprove")));
+
+        if (node.has("access_token_validity")) {
+            client.setAccessTokenValiditySeconds(node.get("access_token_validity").asInt());
+        }
+        if (node.has("refresh_token_validity")) {
+            client.setRefreshTokenValiditySeconds(node.get("refresh_token_validity").asInt());
+        }
+
+        Set<String> authorities = jsonNodeToSet(node.get("authorities"));
+        client.setAuthorities(authorities);
+
+        return client;
+    }
+
+    private Set<String> jsonNodeToSet(JsonNode node) {
+        if (node == null || !node.isArray()) {
+            return new HashSet<>();
+        }
+        Set<String> result = new HashSet<>();
+        for (JsonNode element : node) {
+            if (element.isTextual()) {
+                result.add(element.asText());
+            } else if (element.isObject() && element.has("role")) {
+                result.add(element.get("role").asText());
+            }
+        }
+        return result;
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientEntity.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientEntity.java
@@ -11,15 +11,12 @@ package org.eclipse.sw360.rest.authserver.client.persistence;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.Set;
-
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.AuthorityUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+@JsonDeserialize(using = OAuthClientDeserializer.class)
 public class OAuthClientEntity implements Serializable {
 
     @Serial
@@ -31,7 +28,7 @@ public class OAuthClientEntity implements Serializable {
     private String description;
     private Set<String> resourceIds;
     private Set<String> authorizedGrantTypes;
-    private Collection<GrantedAuthority> authorities;
+    private Set<String> authorities;
     private Set<String> scope;
     private boolean secretRequired;
     private boolean scoped;
@@ -51,12 +48,12 @@ public class OAuthClientEntity implements Serializable {
     }
 
     @JsonProperty("_rev")
-    public void setRevision(String revision) {
+    public void setRev(String revision) {
         this.revision = revision;
     }
 
     @JsonProperty("_rev")
-    public String getRevision() {
+    public String getRev() {
         return revision;
     }
 
@@ -122,23 +119,14 @@ public class OAuthClientEntity implements Serializable {
         this.authorizedGrantTypes=authorizedGrantTypes;
     }
 
-    public Collection<GrantedAuthority> getAuthorities() {
+    @JsonProperty("authorities")
+    public Set<String> getAuthorities() {
         return authorities;
     }
 
-    public void setAuthorities(Collection<GrantedAuthority> authorities) {
-        this.authorities=authorities;
-    }
-
     @JsonProperty("authorities")
-    public Set<String> getAuthoritiesAsStrings() {
-        return AuthorityUtils.authorityListToSet(this.authorities);
-    }
-
-    @JsonProperty("authorities")
-    @JsonDeserialize()
-    public void setAuthoritiesAsStrings(Set<String> values) {
-        this.setAuthorities(AuthorityUtils.createAuthorityList(values.toArray(new String[values.size()])));
+    public void setAuthorities(Set<String> values) {
+        this.authorities = values;
     }
 
     @JsonProperty("scope")

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -127,7 +127,7 @@ public class OAuthClientController {
     private void updateClientEntityFromResource(OAuthClientEntity clientEntity, OAuthClientResource clientResource) {
         // updateable properties (clientId and clientSecret cannot be changed)
         clientEntity.setDescription(clientResource.getDescription());
-        clientEntity.setAuthoritiesAsStrings(clientResource.getAuthorities());
+        clientEntity.setAuthorities(clientResource.getAuthorities());
         clientEntity.setScope(clientResource.getScope());
         clientEntity.setAccessTokenValiditySeconds(clientResource.getAccessTokenValidity());
         clientEntity.setRefreshTokenValiditySeconds(clientResource.getRefreshTokenValidity());

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientResource.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientResource.java
@@ -50,7 +50,7 @@ public class OAuthClientResource {
         this.description = clientEntity.getDescription();
         this.clientId = clientEntity.getClientId();
         this.clientSecret = clientEntity.getClientSecret();
-        this.authorities = clientEntity.getAuthoritiesAsStrings();
+        this.authorities = clientEntity.getAuthorities();
         this.scope = clientEntity.getScope();
         this.accessTokenValidity = clientEntity.getAccessTokenValiditySeconds();
         this.refreshTokenValidity = clientEntity.getRefreshTokenValiditySeconds();


### PR DESCRIPTION
# Pull Request Description

## Overview

This pull request addresses issues with database operations for `OAuthClientEntity`, ensuring performing CRUD properly and compatible with the existing database and response formats.

## Changes

1. **Fix for `updateIdAndRev` in `OAuthClientEntity`**

   - **Issue**: The  changes in [#2607](https://github.com/eclipse-sw360/sw360/pull/2607) refactored `OAuthClientEntity` from implementing `CouchDbDocument` to `Serializable`, breaking `_id` and `_rev` updates due to a Thrift type check (`TBase` mismatch) in DatabaseCloudantConnector.
   - **Solution**: Added custom handling for `OAuthClientEntity` in Thrift checking methods.

2. **Custom Deserializer for Database Compatibility**
   - **Issue**: The switch to `Serializable` led to JSON-format storage and responses, misaligning with the GSON-based format (e.g., `clientId` vs. `client_id`, `clientSecret` vs. `client_secret`).
   - **Solution**: Implemented a custom deserializer class and updated the `getPojoFromDocument` and `getDocumentFromPojo` methods to use `ObjectMapper` (JSON) instead of GSON for `OAuthClientEntity`.

## Why This Change?

- **ID/Revision Updates**: `OAuthClientEntity` wasn’t recognized as a Thrift object, skipping `_id` and `_rev` updates.
- **Data Format**: The serialization mismatch caused by `getPojoFromDocument` and `getDocumentFromPojo` treating any document with a GSON structure, which impacted the `getClientById` query.
