### PR TITLE
feat(projects): Improve project relationship iteration with VersionComparator

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/common/utils/VersionComparator.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/utils/VersionComparator.java
@@ -1,0 +1,25 @@
+package org.eclipse.sw360.common.utils;
+
+import java.util.Comparator;
+
+public class VersionComparator implements Comparator<String> {
+    @Override
+    public int compare(String v1, String v2) {
+        if (v1 == null || v2 == null) {
+            return (v1 == null) ? ((v2 == null) ? 0 : -1) : 1;
+        }
+        String[] parts1 = v1.split("\\.");
+        String[] parts2 = v2.split("\\.");
+        
+        int length = Math.max(parts1.length, parts2.length);
+        for (int i = 0; i < length; i++) {
+            int num1 = (i < parts1.length) ? Integer.parseInt(parts1[i]) : 0;
+            int num2 = (i < parts2.length) ? Integer.parseInt(parts2[i]) : 0;
+            
+            if (num1 != num2) {
+                return Integer.compare(num1, num2);
+            }
+        }
+        return 0;
+    }
+}

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -90,7 +90,7 @@ import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTExcepti
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import org.eclipse.sw360.exporter.ProjectExporter;
 import java.nio.ByteBuffer;
-
+import org.eclipse.sw360.common.utils.VersionComparator;
 /**
  * Class for accessing the CouchDB database
  *
@@ -991,7 +991,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }
             projectLinkOptional.ifPresent(out::add);
         }
-        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion));
+        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion,new VersionComparator()));
         return out;
     }
 
@@ -2444,7 +2444,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }
             projectLinkOptional.ifPresent(out::add);
         }
-        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion));
+        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion, new VersionComparator()));
         return out;
     }
 
@@ -2473,7 +2473,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                     parentNodeId, visitedIds, maxDepth, user, true, WITH_ALL_RELEASES);
             projectLinkOptional.ifPresent(out::add);
         }
-        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion));
+        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion,new VersionComparator()));
         return out;
     }
 


### PR DESCRIPTION

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
- Added VersionComparator in common/utils for accurate version sorting
- Updated iterateProjectRelationShips methods to use VersionComparator
- Improved sorting logic for project links based on name and version
- Ensured compatibility with existing project relationship handling


Issue: #236 

### Suggest Reviewer


### How To Test?
1. Run the SW360 backend and verify project relationships are sorted correctly.
2. Ensure no functionality is broken by running tests.
3. Validate the sorting logic using different project versions.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
