### PR TITLE
feat(project): add new values to project state field

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -249,7 +249,11 @@ public class ThriftEnumUtils {
     private static final ImmutableMap<ProjectState, String> MAP_PROJECT_STATE_STRING = ImmutableMap.of(
             ProjectState.ACTIVE, "Active" ,
             ProjectState.PHASE_OUT, "Phase out" ,
-            ProjectState.UNKNOWN, "Unknown");
+            ProjectState.UNKNOWN, "Unknown",
+            ProjectState.SVM_ONLY, "SVM Only",
+            ProjectState.PRIVATE, "Private",
+            ProjectState.UNDER_DEVELOPMENT, "Under Development",
+            ProjectState.RELEASED, "Released");
 
     private static final ImmutableMap<ProjectClearingState, String> MAP_PROJECT_CLEARING_STATE_STRING = ImmutableMap.of(
             ProjectClearingState.OPEN, "Open",

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -53,6 +53,10 @@ enum ProjectState {
     ACTIVE = 0,
     PHASE_OUT = 1,
     UNKNOWN = 2,
+    SVM_ONLY = 3,
+    PRIVATE = 4,
+    UNDER_DEVELOPMENT = 5,
+    RELEASED = 6
 }
 
 enum ProjectType {


### PR DESCRIPTION
This PR adds new project state values under the Administration tab of the project.


Previously available values:

- Active
- Phaseout
- Unknown



Newly added values:

- SVM Only
- Private
- Under Development
- Released