### PR TITLE
Bug/token creation has missing information on the endpoint causing server error

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -96,6 +96,10 @@ public class OAuthClientController {
                         HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
+            // Ensure the entity has a non-empty id; if not, generate one.
+            if (StringUtils.isEmpty(clientEntity.getId())) {
+                clientEntity.setId(UUID.randomUUID().toString());
+            }
             clientEntity.setClientId(clientEntity.getId());
             clientEntity.setClientSecret(passwordEncoder.encode(UUID.randomUUID().toString()));
         }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -100,6 +100,7 @@ public class OAuthClientController {
             if (StringUtils.isEmpty(clientEntity.getId())) {
                 clientEntity.setId(UUID.randomUUID().toString());
             }
+            
             clientEntity.setClientId(clientEntity.getId());
             clientEntity.setClientSecret(passwordEncoder.encode(UUID.randomUUID().toString()));
         }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This PR fixes the issue #2819

## Changes

 - Ensured a Non-Empty Document ID for OAuth Clients
In the OAuthClientController, you added logic to check if the client_id is empty when creating a new OAuth client. If it is, you generate a unique ID using UUID.randomUUID().toString().

## Solving the issue

This prevents the “docId cannot be empty” error by ensuring that every client document has a valid ID before it's saved to CouchDB/Cloudant.


### How To Test?

I had updated the rest folder pom.xml file for proper testing of this PR. I will be including that as well.

### Checklist
Must:
- [ x] All related issues are referenced in commit messages and in PR
