### PR TITLE
fix(Project): Resolve issue with GET project release when response length is 0

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1051,7 +1051,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         CollectionModel resources;
         if (releaseResources.size() == 0) {
-            resources = restControllerHelper.emptyPageResource(Project.class, paginationResult);
+            resources = restControllerHelper.emptyPageResource(Release.class, paginationResult);
         } else {
             resources = restControllerHelper.generatePagesResource(paginationResult, releaseResources);
         }


### PR DESCRIPTION
# Fix Embedded Type in Project Release Response

When calling the API to get project releases and there are no releases (length = 0), the backend returns an embedded type of `Project`, while the frontend expects `[sw360:releases]`. This mismatch causes rendering issues on the frontend. The change ensures the embedded type aligns with the expected `[sw360:releases]`.