### PR TITLE
fix(fossology): Fetch download timeout from ConfigContainer repository

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ConfigContainerRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ConfigContainerRepository.java
@@ -9,6 +9,8 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
 import org.eclipse.sw360.datahandler.thrift.ConfigContainer;
@@ -23,6 +25,9 @@ import java.util.List;
 import java.util.Map;
 
 public class ConfigContainerRepository extends DatabaseRepositoryCloudantClient<ConfigContainer> {
+
+    private static final Logger log = LogManager.getLogger(ConfigContainerRepository.class);
+
     private static final String ALL = "function(doc) { emit(null, doc._id); }";
     private static final String BYID = "function(doc) { emit(doc._id, null); }";
     private static final String BYCONFIGFOR = "function(doc) { emit(doc.configFor, null); }";
@@ -37,17 +42,32 @@ public class ConfigContainerRepository extends DatabaseRepositoryCloudantClient<
     }
 
     public ConfigContainer getByConfigFor(ConfigFor configFor) {
-        PostViewOptions query = getConnector().getPostViewQueryBuilder(ConfigContainer.class, "byConfigFor")
-                .keys(Collections.singletonList(configFor.toString()))
-                .includeDocs(true).build();
+        try {
+            PostViewOptions query = getConnector().getPostViewQueryBuilder(ConfigContainer.class, "byConfigFor")
+                    .keys(Collections.singletonList(configFor.toString()))
+                    .includeDocs(true).build();
 
-        List<ConfigContainer> configs = queryView(query);
-        if (configs.size() != 1) {
-            throw new IllegalStateException(
-                    "There are " + configs.size() + " configuration objects in the couch db for type " + configFor
-                            + " while there should be exactly one!");
-        } else {
+            List<ConfigContainer> configs = queryView(query);
+
+            if (configs == null || configs.isEmpty()) {
+                log.warn("No ConfigContainer found for " + configFor + ". Using default config.");
+                return createDefaultFossologyConfig();
+            }
+
             return configs.get(0);
+        } catch (Exception e) {
+            log.error("Error fetching ConfigContainer for " + configFor, e);
+            return createDefaultFossologyConfig();
         }
+    }
+
+    private ConfigContainer createDefaultFossologyConfig() {
+        log.info("Creating default FOSSology configuration.");
+        ConfigContainer defaultConfig = new ConfigContainer();
+        defaultConfig.setConfigFor(ConfigFor.FOSSOLOGY_REST);
+        defaultConfig.setConfigKeyToValues(new HashMap<>());
+        defaultConfig.getConfigKeyToValues().put("fossology.downloadTimeout", Collections.singleton("2"));
+        defaultConfig.getConfigKeyToValues().put("fossology.downloadTimeoutUnit", Collections.singleton("MINUTES"));
+        return defaultConfig;
     }
 }

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyConfig.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyConfig.java
@@ -10,71 +10,80 @@
 
 package org.eclipse.sw360.fossology.config;
 
-import java.net.MalformedURLException;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import static org.eclipse.sw360.datahandler.common.DatabaseSettings.COUCH_DB_ATTACHMENTS;
-import static org.eclipse.sw360.datahandler.common.DatabaseSettings.getConfiguredClient;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.Duration;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.db.ConfigContainerRepository;
-import org.eclipse.sw360.datahandler.thrift.ConfigContainer;
-import org.eclipse.sw360.datahandler.thrift.ConfigFor;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.MalformedURLException;
+import java.util.concurrent.TimeUnit;
+
+import static org.eclipse.sw360.datahandler.common.DatabaseSettings.COUCH_DB_ATTACHMENTS;
+import static org.eclipse.sw360.datahandler.common.DatabaseSettings.COUCH_DB_CONFIG;
+import static org.eclipse.sw360.datahandler.common.DatabaseSettings.getConfiguredClient;
+import static org.eclipse.sw360.datahandler.common.Duration.durationOf;
 
 @Configuration
 @ComponentScan({"org.eclipse.sw360.fossology"})
 public class FossologyConfig {
 
     private static final Logger log = LogManager.getLogger(FossologyConfig.class);
-    private final Duration downloadTimeout;
+    private Duration downloadTimeout = null;
 
-    @Autowired
-    public FossologyConfig(ConfigContainerRepository configContainerRepository) {
-        ConfigContainer config = configContainerRepository.getByConfigFor(ConfigFor.FOSSOLOGY_REST);
-        int timeoutValue = 2; // Set the default to 2 (same as the hardcoded value earlier)
+    private Duration getDownloadTimeout() {
+        FossologyRestConfig fossologyRestConfig;
+        try {
+            fossologyRestConfig = new FossologyRestConfig(configContainerRepository());
+        } catch (SW360Exception e) {
+            log.error("Failed to load Fossology configuration.", e);
+            return durationOf(2, TimeUnit.MINUTES);
+        }
+        long timeoutValue = 2; // Set the default to 2
         TimeUnit timeoutUnit = TimeUnit.MINUTES;
 
-        if (config != null && config.isSetConfigKeyToValues()) {
+        String timeoutStr = fossologyRestConfig.getDownloadTimeout();
+        String timeoutUnitStr = fossologyRestConfig.getDownloadTimeoutUnit();
+
+        if (timeoutStr != null) {
             try {
-                Map<String, Set<String>> configMap = config.getConfigKeyToValues();
-                Set<String> timeoutValues = configMap.get("fossology.downloadTimeout");
-                String timeoutStr = (timeoutValues != null && !timeoutValues.isEmpty()) ? timeoutValues.iterator().next() : null;
-
-                Set<String> timeoutUnitValues = configMap.get("fossology.downloadTimeoutUnit");
-                String timeoutUnitStr = (timeoutUnitValues != null && !timeoutUnitValues.isEmpty()) ? timeoutUnitValues.iterator().next() : null;
-
-                if (timeoutStr != null) {
-                    timeoutValue = Integer.parseInt(timeoutStr);
-                }
-
-                if (timeoutUnitStr != null) {
-                    timeoutUnit = TimeUnit.valueOf(timeoutUnitStr.toUpperCase());
-                }
-            } catch (Exception e) {
-                log.warn("Invalid timeout configuration, falling back to defaults (2 minutes).", e);
+                timeoutValue = Long.parseLong(timeoutStr);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid timeout value in config, using default (2 minutes).", e);
             }
-        } else {
-            log.warn("ConfigContainer is null or has no configKeyToValues, using default timeout (2 minutes).");
         }
 
-        this.downloadTimeout = Duration.durationOf(timeoutValue, timeoutUnit);
-        log.info("Initialized downloadTimeout as {} {}", timeoutValue, timeoutUnit);
+        if (timeoutUnitStr != null) {
+            try {
+                timeoutUnit = TimeUnit.valueOf(timeoutUnitStr.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                log.warn("Invalid timeout unit in config, using default (MINUTES).", e);
+            }
+        }
+
+        return durationOf(timeoutValue, timeoutUnit);
+    }
+
+    @Bean
+    public ConfigContainerRepository configContainerRepository() {
+        DatabaseConnectorCloudant configContainerDatabaseConnector = new DatabaseConnectorCloudant(getConfiguredClient(),
+                COUCH_DB_CONFIG);
+        return new ConfigContainerRepository(configContainerDatabaseConnector);
     }
 
     @Bean
     public AttachmentConnector attachmentConnector() throws MalformedURLException {
+        if (this.downloadTimeout == null) {
+            this.downloadTimeout = getDownloadTimeout();
+        }
         return new AttachmentConnector(getConfiguredClient(), COUCH_DB_ATTACHMENTS, downloadTimeout);
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
@@ -14,9 +14,11 @@ package org.eclipse.sw360.rest.resourceserver.admin.fossology;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.StringToClassMapItem;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
@@ -65,14 +67,28 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
     )
     @PostMapping(value = FOSSOLOGY_URL + "/saveConfig", consumes  = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<?> saveConfigration(
-            @Parameter(description = "Request body containing the configuration parameters.",
+            @Parameter(description = "Request body containing the configuration parameters. The parameters are:\n" +
+                    "`url`: The URL of the FOSSology server.\n" +
+                    "`folderId`: The ID of the folder in FOSSology.\n" +
+                    "`token`: The access token for FOSSology.\n" +
+                    "`downloadTimeout`: (Optional) The timeout for attachment download from CouchDB.\n" +
+                    "`downloadTimeoutUnit`: (Required with `downloadTimeout`) The unit of the download timeout (e.g., `MINUTES`, `SECONDS`).",
                     schema = @Schema(
                             type = "object",
+                            properties = {
+                                    @StringToClassMapItem(key = "url", value = String.class),
+                                    @StringToClassMapItem(key = "folderId", value = String.class),
+                                    @StringToClassMapItem(key = "token", value = String.class),
+                                    @StringToClassMapItem(key = "downloadTimeout", value = String.class),
+                                    @StringToClassMapItem(key = "downloadTimeoutUnit", value = TimeUnit.class)
+                            },
                             example = """
                                     {
                                       "url": "https://fossology.com/repo/api/v1/",
                                       "folderId": "2",
-                                      "token": "dead.beef"
+                                      "token": "dead.beef",
+                                      "downloadTimeout": "2",
+                                      "downloadTimeoutUnit": "MINUTES"
                                     }""",
                             requiredProperties = {"url", "folderId", "token"}
                     )
@@ -84,7 +100,10 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
             String url = request.get("url");
             String folderId = request.get("folderId");
             String token = request.get("token");
-            sw360FossologyAdminServices.saveConfig(sw360User, url, folderId, token);
+            String downloadTimeout = request.get("downloadTimeout");
+            String downloadTimeoutUnit = request.get("downloadTimeoutUnit");
+            sw360FossologyAdminServices.saveConfig(sw360User, url, folderId, token,
+                    downloadTimeout, downloadTimeoutUnit);
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
@@ -48,7 +48,10 @@ public class Sw360FossologyAdminServices {
 
     String key;
 
-    public void saveConfig(User sw360User, String url, String folderId, String token) throws TException {
+    public void saveConfig(
+            User sw360User, String url, String folderId, String token,
+            String downloadTimeout, String downloadTimeoutUnit
+    ) throws TException {
         FossologyService.Iface client = getThriftFossologyClient();
         ConfigContainer fossologyConfig = client.getFossologyConfig();
 
@@ -57,6 +60,13 @@ public class Sw360FossologyAdminServices {
             setConfigValues(configKeyToValues, "url", url);
             setConfigValues(configKeyToValues, "folderId", folderId);
             setConfigValues(configKeyToValues, "token", token);
+            if (downloadTimeout != null && !downloadTimeout.isEmpty()) {
+                setConfigValues(configKeyToValues, "fossology.downloadTimeout", downloadTimeout);
+                if (downloadTimeoutUnit == null || downloadTimeoutUnit.isEmpty()) {
+                    throw new BadRequestClientException("downloadTimeoutUnit required if downloadTimeout is set.");
+                }
+                setConfigValues(configKeyToValues, "fossology.downloadTimeoutUnit", downloadTimeoutUnit);
+            }
             fossologyConfig.setConfigKeyToValues(configKeyToValues);
             if (client != null && fossologyConfig != null) {
                 client.setFossologyConfig(fossologyConfig);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/FossologySpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/FossologySpecTest.java
@@ -49,16 +49,16 @@ public class FossologySpecTest extends TestRestDocsSpecBase {
 
     @Value("${sw360.test-user-password}")
     private String testUserPassword;
-    
+
     @MockBean
     Sw360FossologyAdminServices fossologyAdminServices;
-    
+
     @MockBean
     FossologyService.Iface fossologyClient;
-    
+
     @MockBean
     private ConfigContainer fossologyConfig;
-    
+
     @Before
     public void before() throws TException, IOException,TTransportException {
         fossologyClient = mock(FossologyService.Iface.class);
@@ -70,10 +70,10 @@ public class FossologySpecTest extends TestRestDocsSpecBase {
                 new User("admin@sw360.org", "sw360").setId("123456789"));
         when(fossologyAdminServices.getThriftFossologyClient()).thenReturn(fossologyClient);
         when(fossologyClient.getFossologyConfig()).thenReturn(fossologyConfig);
-        Mockito.doNothing().when(fossologyAdminServices).saveConfig(any(), any(), any(), any());
+        Mockito.doNothing().when(fossologyAdminServices).saveConfig(any(), any(), any(), any(), any(), any());
         Mockito.doNothing().when(fossologyAdminServices).serverConnection(any());
     }
-    
+
     @Test
     public void should_document_save_configuration() throws Exception {
         Map<String, String> myMap = new HashMap<>();
@@ -87,7 +87,7 @@ public class FossologySpecTest extends TestRestDocsSpecBase {
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk());
     }
-    
+
     @Test
     public void should_document_check_server_configuration() throws Exception {
         mockMvc.perform(get("/api/fossology/reServerConnection")


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


This PR replaces the hardcoded download timeout in FossologyConfig.java with a dynamic configuration fetched from ConfigContainerRepository. The timeout value is now configurable via the database  allowing administrators to adjust it without modifying the source code (hardcoding the timeout values ).


Issue: 
Resolves the TODO: "TODO get from a config class" in FossologyConfig.java.

### Suggest Reviewer
@GMishx @keerthi-bl 

### How To Test?

1. Ensure CouchDB contains a valid ConfigContainer entry with keys:
-    "fossology.downloadTimeout" (numeric value for timeout)
-   fossology.downloadTimeoutUnit" (e.g., "MINUTES", "SECONDS")
2. Run the application and verify that the timeout value is correctly fetched and applied.
3. Modify the timeout values in CouchDB and restart the service to confirm the changes are reflected dynamically.
4. Ensure the default timeout (2 minutes) is used when no configuration is found.

