### PR TITLE
chore(rest): rework exceptions

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/api-guide.adoc
+++ b/rest/resource-server/src/docs/asciidoc/api-guide.adoc
@@ -114,7 +114,7 @@ that describes the problem. The error object has the following structure:
 include::{snippets}/should_document_error_internal_error/response-fields.adoc[]
 
 For example, a request that attempts to get a non-existent project will produce a
-`500 Internal Server Error` response:
+`404 Not Found Error` response:
 
 include::{snippets}/should_document_error_internal_error/http-response.adoc[]
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.rest.resourceserver.admin.attachment;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
+import io.swagger.v3.oas.annotations.Operation;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -27,8 +28,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
 
 
+@RestController
 @BasePathAwareController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class AttachmentCleanUpController implements RepresentationModelProcessor<RepositoryLinksResource> {
@@ -39,13 +42,18 @@ public class AttachmentCleanUpController implements RepresentationModelProcessor
 
     @NonNull
     private final Sw360AttachmentCleanUpService attachmentCleanUpService;
-	
+
 	@Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(AttachmentCleanUpController.class).slash("api" + ATTACHMENT_CLEANUP_URL).withRel("attachmentCleanUp"));
         return resource;
     }
-	
+
+    @Operation(
+            summary = "Clean up all the attachment.",
+            description = "Cleanup all the unused attachments.",
+            tags = {"Admin"}
+    )
     @RequestMapping(value = ATTACHMENT_CLEANUP_URL + "/deleteAll", method = RequestMethod.DELETE)
     public ResponseEntity<RequestSummary> cleanUpAttachment() throws TException  {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/Sw360AttachmentCleanUpService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/Sw360AttachmentCleanUpService.java
@@ -13,14 +13,11 @@ package org.eclipse.sw360.rest.resourceserver.admin.attachment;
 import java.util.Set;
 
 import org.apache.thrift.TException;
-import org.apache.thrift.transport.TTransportException;
-import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -39,13 +36,13 @@ public class Sw360AttachmentCleanUpService {
 
     ComponentService.Iface componentClient;
     AttachmentService.Iface attachmentClient;
-	
-    private ComponentService.Iface getThriftComponentClient() throws TTransportException {
+
+    private ComponentService.Iface getThriftComponentClient() {
         ComponentService.Iface componentClient = new ThriftClients().makeComponentClient();
         return componentClient;
     }
-	
-    private AttachmentService.Iface getThriftAttachmentClient() throws TTransportException {
+
+    private AttachmentService.Iface getThriftAttachmentClient() {
         AttachmentService.Iface attachmentClient = new ThriftClients().makeAttachmentClient();
         return attachmentClient;
     }
@@ -56,5 +53,4 @@ public class Sw360AttachmentCleanUpService {
         final Set<String> usedAttachmentIds = componentClient.getUsedAttachmentContentIds();
         return attachmentClient.vacuumAttachmentDB(sw360User, usedAttachmentIds);
     }
-
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
@@ -15,8 +15,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import java.util.Map;
 
-import org.apache.thrift.TException;
-import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,10 +31,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
 @BasePathAwareController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class FossologyAdminController implements RepresentationModelProcessor<RepositoryLinksResource> {
@@ -52,8 +53,13 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
         return resource;
     }
 
+    @Operation(
+            summary = "Save the FOSSology service configuration.",
+            description = "Save the FOSSology service configuration.",
+            tags = {"Admin"}
+    )
     @PostMapping(value = FOSSOLOGY_URL + "/saveConfig", consumes  = {MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<?> saveConfigration(@RequestBody Map<String, String> request) throws TException {
+    public ResponseEntity<?> saveConfigration(@RequestBody Map<String, String> request) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             String url = request.get("url");
@@ -61,18 +67,23 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
             String token = request.get("token");
             sw360FossologyAdminServices.saveConfig(sw360User, url, folderId, token);
         } catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
         return ResponseEntity.ok(Series.SUCCESSFUL);
     }
 
+    @Operation(
+            summary = "Check the FOSSology server connection.",
+            description = "Make a test call and check the FOSSology server connection.",
+            tags = {"Admin"}
+    )
     @RequestMapping(value = FOSSOLOGY_URL + "/reServerConnection", method = RequestMethod.GET)
-    public ResponseEntity<?> checkServerConnection()throws TException {
+    public ResponseEntity<?> checkServerConnection() throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             sw360FossologyAdminServices.serverConnection(sw360User);
         } catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
         return ResponseEntity.ok(Series.SUCCESSFUL);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
@@ -26,9 +26,10 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -60,12 +61,12 @@ public class Sw360FossologyAdminServices {
             if (client != null && fossologyConfig != null) {
                 client.setFossologyConfig(fossologyConfig);
             } else {
-                throw new HttpMessageNotReadableException("fossologyConfig value is null.");
+                throw new BadRequestClientException("fossologyConfig value is null.");
             }
             setKeyValuePair(configKeyToValues, key, url, folderId, token);
             fossologyConfig.setConfigKeyToValues(configKeyToValues);
         } else {
-            throw new HttpMessageNotReadableException("Unable to save the details. User is not admin");
+            throw new BadRequestClientException("Unable to save the details. User is not admin");
         }
     }
 
@@ -94,13 +95,12 @@ public class Sw360FossologyAdminServices {
         map.computeIfAbsent(key, k -> new HashSet<>()).addAll(Set.of(url, folderId, token));
     }
 
-    public void serverConnection(User sw360User) throws TException{
+    public void serverConnection(User sw360User) {
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             serveCheckConnection();
         } else {
-            throw new HttpMessageNotReadableException("User is not admin");
+            throw new AccessDeniedException("User is not admin");
         }
-
     }
 
     private void serveCheckConnection() {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
@@ -23,14 +23,11 @@ import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.ConfigContainer;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 
@@ -47,26 +44,8 @@ public class Sw360FossologyAdminServices {
 
     private static FossologyService.Iface fossologyClient;
     public static Sw360FossologyAdminServices instance;
-    private boolean fossologyConnectionEnabled;
 
     String key;
-
-    public RequestStatus checkFossologyConnection() throws TException {
-
-        RequestStatus checkConnection = null;
-        try {
-            checkConnection = new ThriftClients().makeFossologyClient().checkConnection();
-        } catch (SW360Exception exp) {
-            if (exp.getErrorCode() == 404) {
-                throw new ResourceNotFoundException(exp.getWhy());
-            } else {
-                throw new RuntimeException(exp.getWhy());
-            }
-        }
-        fossologyConnectionEnabled = checkConnection.equals(RequestStatus.SUCCESS);
-        return checkConnection;
-
-    }
 
     public void saveConfig(User sw360User, String url, String folderId, String token) throws TException {
         FossologyService.Iface client = getThriftFossologyClient();
@@ -124,10 +103,10 @@ public class Sw360FossologyAdminServices {
 
     }
 
-    private void serveCheckConnection() throws TException{
-        FossologyService.Iface sw360FossologyClient = getThriftFossologyClient();
-        RequestStatus checkConnection = null;
+    private void serveCheckConnection() {
+        RequestStatus checkConnection;
         try {
+            FossologyService.Iface sw360FossologyClient = getThriftFossologyClient();
             checkConnection = sw360FossologyClient.checkConnection();
         } catch (TException exp) {
             throw new RuntimeException("Connection to Fossology server Failed.");
@@ -137,5 +116,4 @@ public class Sw360FossologyAdminServices {
             throw new RuntimeException("Connection to Fossology server Failed.");
         }
     }
-
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -340,18 +340,18 @@ public class Sw360AttachmentService {
         throw new ResourceNotFoundException("Requested Attachment Not Found");
     }
 
-    private AttachmentConnector getConnector() throws TException {
+    private AttachmentConnector getConnector() throws SW360Exception {
         if (attachmentConnector == null) makeConnector();
         return attachmentConnector;
     }
 
-    private synchronized void makeConnector() throws TException {
+    private synchronized void makeConnector() throws SW360Exception {
         if (attachmentConnector == null) {
             try {
                 attachmentConnector = new AttachmentConnector(DatabaseSettings.getConfiguredClient(), DatabaseSettings.COUCH_DB_ATTACHMENTS, downloadTimeout);
             } catch (MalformedURLException e) {
                 log.error("Invalid database address received...", e);
-                throw new TException(e);
+                throw new SW360Exception(e.getMessage());
             }
         }
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -35,9 +35,9 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -147,9 +147,9 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
             throw new DataIntegrityViolationException("sw360 component with name '" + component.getName() + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
-            throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+            throw new BadRequestClientException("Dependent document Id/ids not valid.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
-            throw new HttpMessageNotReadableException("Component name field cannot be empty or contain only whitespace character");
+            throw new BadRequestClientException("Component name field cannot be empty or contain only whitespace character");
         }
         return null;
     }
@@ -163,9 +163,9 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
             requestStatus = sw360ComponentClient.updateComponent(component, sw360User);
         }
         if (requestStatus == RequestStatus.INVALID_INPUT) {
-            throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+            throw new BadRequestClientException("Dependent document Id/ids not valid.");
         } else if (requestStatus == RequestStatus.NAMINGERROR) {
-            throw new HttpMessageNotReadableException("Component name field cannot be empty or contain only whitespace character");
+            throw new BadRequestClientException("Component name field cannot be empty or contain only whitespace character");
         } else if (requestStatus == RequestStatus.DUPLICATE_ATTACHMENT) {
             throw new RuntimeException("Multiple attachments with same name or content cannot be present in attachment list.");
         } else if (requestStatus != RequestStatus.SUCCESS && requestStatus != RequestStatus.SENT_TO_MODERATOR) {
@@ -264,7 +264,7 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.getMyComponents(sw360User);
     }
-    
+
     public List<VulnerabilityDTO> getVulnerabilitiesByComponent(String componentId, User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         List<String> releaseIds = sw360ComponentClient.getReleaseIdsFromComponentId(componentId, sw360User);
@@ -296,9 +296,9 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         requestStatus =  sw360ComponentClient.mergeComponents(componentTargetId, componentSourceId, componentSelection, user);
 
         if (requestStatus == RequestStatus.IN_USE) {
-            throw new HttpMessageNotReadableException("Component already in use.");
+            throw new BadRequestClientException("Component already in use.");
         } else if (requestStatus == RequestStatus.FAILURE) {
-            throw new HttpMessageNotReadableException("Cannot merge these components");
+            throw new BadRequestClientException("Cannot merge these components");
         } else if (requestStatus == RequestStatus.ACCESS_DENIED) {
             throw new RuntimeException("Access denied");
         }
@@ -312,9 +312,9 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         requestStatus = sw360ComponentClient.splitComponent(srcComponent, targetComponent, sw360User);
 
         if (requestStatus == RequestStatus.IN_USE) {
-            throw new HttpMessageNotReadableException("Component already in use.");
+            throw new BadRequestClientException("Component already in use.");
         } else if (requestStatus == RequestStatus.FAILURE) {
-            throw new HttpMessageNotReadableException("Cannot split these components");
+            throw new BadRequestClientException("Cannot split these components");
         } else if (requestStatus == RequestStatus.ACCESS_DENIED) {
             throw new RuntimeException("Access denied...!");
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
@@ -158,7 +159,8 @@ public class SW360ConfigurationsController implements RepresentationModelProcess
                 return new ResponseEntity<>("Configurations are being updated by another administrator, please try again later", HttpStatus.CONFLICT);
             }
         } catch (InvalidPropertiesFormatException invalidPropertiesFormatException) {
-            return new ResponseEntity<>(invalidPropertiesFormatException.getMessage(), HttpStatus.BAD_REQUEST);
+            throw new BadRequestClientException(invalidPropertiesFormatException.getMessage(),
+                    invalidPropertiesFormatException);
         }
         return ResponseEntity.ok("Configurations are updated successfully");
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/BadRequestClientException.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/BadRequestClientException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.core;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestClientException extends RuntimeException {
+    public BadRequestClientException(String message) {
+        super(message);
+    }
+
+    public BadRequestClientException(String message, Throwable e) {
+        super(message, e);
+    }
+
+    public BadRequestClientException(Throwable e) {
+        super(e);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -2579,7 +2579,8 @@ public class JacksonCustomizations {
                 "nameIsSet",
                 "createdOnIsSet",
                 "tokenIsSet",
-                "authoritiesIsSet"
+                "authoritiesIsSet",
+                "numberOfDaysValidIsSet"
         })
         public abstract static class RestApiTokenMixin extends RestApiToken {
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -35,8 +35,6 @@ import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
-import org.eclipse.sw360.datahandler.thrift.attachments.ProjectAttachmentUsage;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
@@ -69,7 +67,6 @@ import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProject;
 import org.jetbrains.annotations.NotNull;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProjectDTO;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
 import org.eclipse.sw360.rest.resourceserver.obligation.ObligationController;
@@ -103,8 +100,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
-import static org.eclipse.sw360.datahandler.common.WrappedException.wrapSW360Exception;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -821,7 +816,7 @@ public class RestControllerHelper<T> {
             }
         }
         if (!licenseIncorrect.isEmpty()) {
-            throw new HttpMessageNotReadableException("License with ids " + licenseIncorrect + " does not exist in SW360 database.");
+            throw new BadRequestClientException("License with ids " + licenseIncorrect + " does not exist in SW360 database.");
         }
     }
 
@@ -853,7 +848,7 @@ public class RestControllerHelper<T> {
             }
         }
         if (!obligationIncorrect.isEmpty()) {
-            throw new HttpMessageNotReadableException("Obligation with ids " + obligationIncorrect + " does not exist in SW360 database.");
+            throw new BadRequestClientException("Obligation with ids " + obligationIncorrect + " does not exist in SW360 database.");
         }
     }
 
@@ -1353,7 +1348,7 @@ public class RestControllerHelper<T> {
             }
         } catch (SW360Exception sw360Exp) {
             if (sw360Exp.getErrorCode() == 404) {
-                throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+                throw new BadRequestClientException("Dependent document Id/ids not valid.", sw360Exp);
             } else if (sw360Exp.getErrorCode() == 403) {
                 if (element instanceof Project) {
                     throw new AccessDeniedException(
@@ -1365,9 +1360,9 @@ public class RestControllerHelper<T> {
         }
         if (!isNullEmptyOrWhitespace(cyclicLinkedElementPath)) {
             if (element instanceof Project) {
-                throw new HttpMessageNotReadableException("Cyclic linked Project : " + cyclicLinkedElementPath);
+                throw new BadRequestClientException("Cyclic linked Project : " + cyclicLinkedElementPath);
             } else if (element instanceof Release) {
-                throw new HttpMessageNotReadableException("Cyclic linked Release : " + cyclicLinkedElementPath);
+                throw new BadRequestClientException("Cyclic linked Release : " + cyclicLinkedElementPath);
             }
         }
     }
@@ -1660,7 +1655,6 @@ public class RestControllerHelper<T> {
         }
         return clearingRequestService.getClearingRequestById(clearingRequest.getId(), sw360User);
     }
-    
 
     public boolean isWriteActionAllowed(Object object, User user) {
         return makePermission(object, user).isActionAllowed(RequestedAction.WRITE);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonInstantSerializer;
 import org.apache.thrift.TException;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -24,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -56,6 +58,11 @@ public class RestExceptionHandler {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorMessage> handleRuntimeException(RuntimeException e) {
+        return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorMessage> handleRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.METHOD_NOT_ALLOWED), HttpStatus.METHOD_NOT_ALLOWED);
@@ -79,6 +86,16 @@ public class RestExceptionHandler {
     @ExceptionHandler({OptimisticLockingFailureException.class, DataIntegrityViolationException.class})
     public ResponseEntity<ErrorMessage> handleConflict(Exception e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.CONFLICT), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler({AuthenticationException.class})
+    public ResponseEntity<ErrorMessage> handleInvalidApiToken(AuthenticationException e) {
+        return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.UNAUTHORIZED), HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler({SW360Exception.class})
+    public ResponseEntity<ErrorMessage> handleSw360Exception(SW360Exception e) {
+        return new ResponseEntity<>(new ErrorMessage(new Exception(e.getWhy()), HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Data

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -53,8 +53,8 @@ public class RestExceptionHandler {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.NOT_FOUND), HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorMessage> handleMessageNotReadableException(HttpMessageNotReadableException e) {
+    @ExceptionHandler({HttpMessageNotReadableException.class, BadRequestClientException.class})
+    public ResponseEntity<ErrorMessage> handleMessageNotReadableException(RuntimeException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/SimpleAuthenticationEntryPoint.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/SimpleAuthenticationEntryPoint.java
@@ -13,7 +13,6 @@ package org.eclipse.sw360.rest.resourceserver.core;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -29,7 +28,7 @@ import org.springframework.stereotype.Component;
 public class SimpleAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-            AuthenticationException authException) throws IOException, ServletException {
+            AuthenticationException authException) throws IOException {
         RestExceptionHandler.ErrorMessage message = new RestExceptionHandler.ErrorMessage(authException, HttpStatus.UNAUTHORIZED);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setCharacterEncoding("utf-8");

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/Sw360DatabaseSanitationService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/Sw360DatabaseSanitationService.java
@@ -48,7 +48,7 @@ public class Sw360DatabaseSanitationService {
     public Map<String, Map<String, List<String>>> duplicateIdentifiers(User sw360User) throws TException, SW360Exception {
         try {
             if (!PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                throw new SW360Exception("Access Denied").setErrorCode(403);
+                throw new AccessDeniedException("Access Denied");
             }
 
             Map<String, Map<String, List<String>>> responseMap = new HashMap<>();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
@@ -69,7 +69,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
 
     @Operation(
             description = "Manually active the service.",
-            tags = {"Department"}
+            tags = {"Departments"}
     )
     @RequestMapping(value = DEPARTMENT_URL + "/manuallyactive", method = RequestMethod.POST)
     public ResponseEntity<RequestSummary> importDepartmentManually() throws SW360Exception {
@@ -89,7 +89,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
 
     @Operation(
             description = "Schedule import.",
-            tags = {"Department"}
+            tags = {"Departments"}
     )
     @RequestMapping(value = DEPARTMENT_URL + "/scheduleImport", method = RequestMethod.POST)
     public ResponseEntity<Map<String, String>> scheduleImportDepartment() throws SW360Exception {
@@ -119,7 +119,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
 
     @Operation(summary = "Unschedule Department Import",
             description = "Cancels the scheduled import task for the department.",
-            tags = {"Department"})
+            tags = {"Departments"})
     @RequestMapping(value = DEPARTMENT_URL + "/unscheduleImport", method = RequestMethod.POST)
     public ResponseEntity<Map<String, String>> unScheduleImportDepartment() throws SW360Exception {
 
@@ -138,8 +138,11 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
         }
     }
 
-    @Operation(summary = "Update Folder Path Configuration",
-            description = "Updates the department folder path configuration.")
+    @Operation(
+            summary = "Update Folder Path Configuration",
+            description = "Updates the department folder path configuration.",
+            tags = {"Departments"}
+    )
     @RequestMapping(value = DEPARTMENT_URL + "/writePathFolder", method = RequestMethod.POST)
     public ResponseEntity<String> updatePath(
             @Parameter(description = "The path of the folder")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/Sw360DepartmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/Sw360DepartmentService.java
@@ -102,7 +102,7 @@ public class Sw360DepartmentService {
         }
         UserService.Iface userClient = thriftClients.makeUserClient();
         if (userClient == null) {
-            throw new TException("Failed to create UserService client");
+            throw new SW360Exception("Failed to create UserService client");
         }
         userClient.writePathFolderConfig(pathFolder);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
@@ -13,8 +13,8 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -67,7 +67,7 @@ public class EccController implements RepresentationModelProcessor<RepositoryLin
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getEccDetails(
             HttpServletRequest request,
             Pageable pageable
-    ) throws TException {
+    ) throws SW360Exception {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         try {
             List<Release> releases = releaseService.getReleasesForUser(user);
@@ -89,8 +89,7 @@ public class EccController implements RepresentationModelProcessor<RepositoryLin
             HttpStatus status = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
             return new ResponseEntity<>(resources, status);
         } catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
-
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
@@ -17,35 +17,28 @@ import java.io.IOException;
 
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.eclipse.sw360.datahandler.common.CommonUtils;
-import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
-import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.MediaType;
-import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -88,13 +81,13 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadComponentTemplate")
-    public void downloadComponentTemplate(HttpServletResponse response) {
+    public void downloadComponentTemplate(HttpServletResponse response) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             importExportService.getDownloadCsvComponentTemplate(sw360User, response);
         } catch (IOException e) {
             LOGGER.error("Error downloading component template: {}", e.getMessage(), e);
-            handleException(response, e);
+            throw new SW360Exception("Error downloading component template: " + e.getMessage());
         }
     }
 
@@ -108,13 +101,13 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadAttachmentSample")
-    public void downloadAttachmentSample(HttpServletResponse response) {
+    public void downloadAttachmentSample(HttpServletResponse response) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             importExportService.getDownloadAttachmentTemplate(sw360User, response);
         } catch (IOException e) {
             LOGGER.error("Error downloading attachment sample: {}", e.getMessage(), e);
-            handleException(response, e);
+            throw new SW360Exception("Error downloading attachment sample: " + e.getMessage());
         }
     }
 
@@ -128,13 +121,13 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadAttachmentInfo")
-    public void downloadAttachmentInfo(HttpServletResponse response) throws TTransportException{
+    public void downloadAttachmentInfo(HttpServletResponse response) throws TTransportException, SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             importExportService.getDownloadAttachmentInfo(sw360User, response);
         } catch (IOException e) {
             LOGGER.error("Error downloading attachment info: {}", e.getMessage(), e);
-            handleException(response, e);
+            throw new SW360Exception("Error downloading attachment info: " + e.getMessage());
         }
     }
 
@@ -148,13 +141,13 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadReleaseSample")
-    public void downloadReleaseSample(HttpServletResponse response) {
+    public void downloadReleaseSample(HttpServletResponse response) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             importExportService.getDownloadReleaseSample(sw360User, response);
         } catch (TException | IOException e) {
             LOGGER.error("Error downloading release sample: {}", e.getMessage(), e);
-            handleException(response, e);
+            throw new SW360Exception("Error downloading release sample: " + e.getMessage());
         }
     }
 
@@ -168,13 +161,13 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadReleaseLink")
-    public void downloadReleaseLink(HttpServletResponse response) {
+    public void downloadReleaseLink(HttpServletResponse response) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             importExportService.getDownloadReleaseLink(sw360User, response);
         } catch (TException | IOException e) {
             LOGGER.error("Error downloading release link: {}", e.getMessage(), e);
-            handleException(response, e);
+            throw new SW360Exception("Error downloading release link: " + e.getMessage());
         }
     }
 
@@ -188,29 +181,14 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadComponent")
-    public void downloadComponent(HttpServletResponse response) {
+    public void downloadComponent(HttpServletResponse response) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             importExportService.getComponentDetailedExport(sw360User, response);
         } catch (TException | IOException e) {
             LOGGER.error("Error downloading component: {}", e.getMessage(), e);
-            handleException(response, e);
+            throw new SW360Exception("Error downloading component: " + e.getMessage());
         }
-    }
-
-    private void handleException(HttpServletResponse response, Exception e) {
-        try {
-            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
-        } catch (IOException ioException) {
-            LOGGER.error("Error sending error response: {}", ioException.getMessage(), ioException);
-        }
-    }
-
-    @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ResponseEntity<String> handleGlobalException(Exception e) {
-        LOGGER.error("Unhandled exception: {}", e.getMessage(), e);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 
     @Operation(
@@ -218,15 +196,17 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             description = "Upload a component CSV file to the system.",
             tags = {"ImportExport"},
             parameters = {
-                @Parameter(name = "Content-Type", in = ParameterIn.HEADER, required = true, description = "The content type of the request. Supported values: multipart/mixed or multipart/form-data.")
+                    @Parameter(name = "Content-Type", in = ParameterIn.HEADER, required = true, description = "The content type of the request. Supported values: multipart/mixed or multipart/form-data.")
             }
-        )
+    )
     @RequestMapping(value = IMPORTEXPORT_URL + "/uploadComponent", method = RequestMethod.POST, consumes = {
             MediaType.MULTIPART_MIXED_VALUE,
             MediaType.MULTIPART_FORM_DATA_VALUE }, produces = { MediaType.APPLICATION_JSON_VALUE })
     public ResponseEntity<RequestSummary> uploadComponentCsv(
-            @Parameter(description = "The component csv file to be uploaded.") @RequestParam("componentFile") MultipartFile file,
-            HttpServletRequest request, HttpServletResponse response) throws TException, IOException, ServletException {
+            @Parameter(description = "The component csv file to be uploaded.")
+            @RequestParam("componentFile") MultipartFile file,
+            HttpServletRequest request, HttpServletResponse response
+    ) throws TException, IOException, ServletException {
 
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = importExportService.uploadComponent(sw360User, file, request, response);
@@ -245,8 +225,10 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             MediaType.MULTIPART_MIXED_VALUE,
             MediaType.MULTIPART_FORM_DATA_VALUE }, produces = { MediaType.APPLICATION_JSON_VALUE })
     public ResponseEntity<RequestSummary> uploadReleaseCsv(
-            @Parameter(description = "The release csv file to be uploaded.") @RequestParam("releaseFile") MultipartFile file,
-            HttpServletRequest request, HttpServletResponse response) throws TException, IOException, ServletException {
+            @Parameter(description = "The release csv file to be uploaded.")
+            @RequestParam("releaseFile") MultipartFile file,
+            HttpServletRequest request
+    ) throws TException, IOException, ServletException {
 
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = importExportService.uploadReleaseLink(sw360User, file, request);
@@ -265,8 +247,10 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             MediaType.MULTIPART_MIXED_VALUE,
             MediaType.MULTIPART_FORM_DATA_VALUE }, produces = { MediaType.APPLICATION_JSON_VALUE })
     public ResponseEntity<RequestSummary> uploadComponentAttachment(
-            @Parameter(description = "The component attachment csv file to be uploaded.") @RequestParam("attachmentFile") MultipartFile file,
-            HttpServletRequest request, HttpServletResponse response) throws TException, IOException, ServletException {
+            @Parameter(description = "The component attachment csv file to be uploaded.")
+            @RequestParam("attachmentFile") MultipartFile file,
+            HttpServletRequest request
+    ) throws TException, IOException, ServletException {
 
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = importExportService.uploadComponentAttachment(sw360User, file, request);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
@@ -22,11 +22,8 @@ import static org.eclipse.sw360.importer.ComponentImportUtils.writeReleaseLinksT
 import static org.eclipse.sw360.importer.ComponentImportUtils.writeToDatabase;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,17 +31,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TCompactProtocol;
-import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
-import org.apache.tomcat.util.http.fileupload.FileItem;
-import org.apache.tomcat.util.http.fileupload.RequestContext;
-import org.apache.tomcat.util.http.fileupload.disk.DiskFileItemFactory;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
@@ -55,7 +44,6 @@ import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
-import org.eclipse.sw360.datahandler.thrift.components.ComponentService.Iface;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
@@ -76,7 +64,6 @@ import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
@@ -300,7 +287,7 @@ public class Sw360ImportExportService {
     }
 
     private List<CSVRecord> getCSVFromRequest(HttpServletRequest request, String fileUploadFormId)
-            throws IOException, TException, ServletException {
+            throws IOException, ServletException {
         final InputStream stream = getInputStreamFromRequest(request, fileUploadFormId);
         return readAsCSVRecords(stream);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -38,6 +38,7 @@ import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +52,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
@@ -297,7 +297,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         Set<String> commonExtIds = Sets.intersection(obligationIdsByLicense, obligationIds);
         Set<String> diffIds = Sets.difference(obligationIdsByLicense, obligationIds);
         if (commonExtIds.size() != obligationIds.size()) {
-            throw new HttpMessageNotReadableException("Obligation Ids not in license!" + license.getShortname());
+            throw new BadRequestClientException("Obligation Ids not in license!" + license.getShortname());
         }
 
         Set<String> obligationIdTrue = licenseService.getIdObligationsContainWhitelist(sw360User, licenseId, diffIds);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -15,7 +15,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.Explode;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -34,6 +33,7 @@ import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
@@ -120,7 +120,8 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     )
     @RequestMapping(value = LICENSES_URL + "/{id}/obligations", method = RequestMethod.GET)
     public ResponseEntity<CollectionModel<EntityModel<Obligation>>> getObligationsByLicenseId(
-            @PathVariable("id") String id) throws TException {
+            @PathVariable("id") String id
+    ) throws TException {
         List<Obligation> obligations = licenseService.getObligationsByLicenseId(id);
         List<EntityModel<Obligation>> obligationResources = new ArrayList<>();
         obligations.forEach(o -> {
@@ -311,7 +312,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             halResource = createHalLicense(licenseUpdate);
             return new ResponseEntity<>(halResource, HttpStatus.OK);
         } else {
-            return new ResponseEntity("Update Whitelist to Obligation Fail!", HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new SW360Exception("Update Whitelist to Obligation Fail!");
         }
     }
 
@@ -470,13 +471,13 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "overwriteIfExternalIdMatches", required = false) boolean overwriteIfExternalIdMatches,
             @Parameter(description = "Overwrite if id matches even without external id match.")
             @RequestParam(value = "overwriteIfIdMatchesEvenWithoutExternalIdMatch", required = false) boolean overwriteIfIdMatchesEvenWithoutExternalIdMatch
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             licenseService.uploadLicense(sw360User, file, overwriteIfExternalIdMatches,
                     overwriteIfIdMatchesEvenWithoutExternalIdMatch);
         } catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
 	    }
        return ResponseEntity.ok(Series.SUCCESSFUL);
      }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -43,6 +43,7 @@ import org.eclipse.sw360.datahandler.thrift.spdx.spdxdocument.SPDXDocument;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformation;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
@@ -61,7 +62,6 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
@@ -187,7 +187,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
         stateOptions.add("open");
         stateOptions.add("closed");
         if (!stateOptions.contains(state)) {
-            throw new HttpMessageNotReadableException(String.format(
+            throw new BadRequestClientException(String.format(
                     "Invalid ModerationRequest state '%s', possible values are: %s", state, stateOptions));
         }
 
@@ -287,7 +287,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
                 moderationStatus = sw360ModerationRequestService.postponeRequest(moderationRequest, patch.getComment());
                 break;
             default:
-                throw new HttpMessageNotReadableException(
+                throw new BadRequestClientException(
                         "Action should be `" +
                                 Arrays.asList(ModerationPatch.ModerationAction.values()) +
                                 "`, '" + patch.getAction() + "' received.");
@@ -593,7 +593,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
         } catch (SW360Exception ex) {
             throw new ResourceNotFoundException("Entity not found for the given ID: " + entityId);
         } catch (IllegalArgumentException ex) {
-            throw new HttpMessageNotReadableException("Invalid entity type provided: " + ex.getMessage());
+            throw new BadRequestClientException("Invalid entity type provided: " + ex.getMessage());
         } catch (TException ex) {
             throw new SW360Exception("An error occurred while processing the request: " + ex.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
@@ -27,6 +27,7 @@ import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -40,7 +41,6 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -204,7 +204,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
                 || CommonUtils.isNullEmptyOrWhitespace(obligation.getText())
         ) {
             log.error("Obligation title or text is empty");
-            throw new HttpMessageNotReadableException("Obligation title or text is empty");
+            throw new BadRequestClientException("Obligation title or text is empty");
         }
 
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
@@ -22,9 +22,9 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -64,7 +64,7 @@ public class Sw360ObligationService {
                 obligation.setId(obligationId);
                 return obligation;
             } else {
-                throw new HttpMessageNotReadableException("Obligation Title, Text, Level are required. Obligation Title, Text cannot contain only space character.");
+                throw new BadRequestClientException("Obligation Title, Text, Level are required. Obligation Title, Text cannot contain only space character.");
             }
         } catch (TException e) {
             throw new RuntimeException(e);
@@ -93,7 +93,7 @@ public class Sw360ObligationService {
                 throw new RuntimeException("Error updating obligation", e);
             }
         } else {
-            throw new HttpMessageNotReadableException("Obligation Title, Text are required. Obligation Title, Text cannot contain only space character.");
+            throw new BadRequestClientException("Obligation Title, Text are required. Obligation Title, Text cannot contain only space character.");
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
@@ -45,6 +45,7 @@ import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.packages.PackageManager;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
@@ -60,7 +61,6 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -248,7 +248,7 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             packageManager = packageManager.toUpperCase();
 
             if (!EnumUtils.isValidEnum(PackageManager.class, packageManager)) {
-                throw new HttpMessageNotReadableException("Invalid package manager type. Possible values are "
+                throw new BadRequestClientException("Invalid package manager type. Possible values are "
                         + Arrays.asList(PackageManager.values()));
             }
             sw360Packages.addAll(packageService.searchByPackageManager(packageManager));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
@@ -98,15 +98,15 @@ public class SW360PackageService {
     }
 
     public Package getPackageForUserById(String id) throws TException {
-            PackageService.Iface sw360PackageClient = getThriftPackageClient();
-            try {
-                return sw360PackageClient.getPackageById(id);
-            } catch (SW360Exception sw360Exp) {
-                if (sw360Exp.getErrorCode() == 404) {
-                    throw new ResourceNotFoundException("Package does not exist! id=" + id);
-                } else {
-                    throw sw360Exp;
-                }
+        PackageService.Iface sw360PackageClient = getThriftPackageClient();
+        try {
+            return sw360PackageClient.getPackageById(id);
+        } catch (SW360Exception sw360Exp) {
+            if (sw360Exp.getErrorCode() == 404) {
+                throw new ResourceNotFoundException("Package does not exist! id=" + id);
+            } else {
+                throw sw360Exp;
+            }
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
@@ -28,12 +28,12 @@ import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.packages.PackageService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 
 import lombok.NonNull;
@@ -61,9 +61,9 @@ public class SW360PackageService {
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
             throw new DataIntegrityViolationException("sw360 package with same name and version '" + pkg.getName() + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
-            throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+            throw new BadRequestClientException("Dependent document Id/ids not valid.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
-            throw new HttpMessageNotReadableException("Package name field cannot be empty or contain only whitespace character");
+            throw new BadRequestClientException("Package name field cannot be empty or contain only whitespace character");
         }
         return null;
     }
@@ -76,11 +76,11 @@ public class SW360PackageService {
         requestStatus = sw360PackageClient.updatePackage(pkg, sw360User);
 
         if (requestStatus == RequestStatus.INVALID_INPUT) {
-            throw new HttpMessageNotReadableException("Invalid Purl or linked release id.");
+            throw new BadRequestClientException("Invalid Purl or linked release id.");
         } else if (requestStatus == RequestStatus.DUPLICATE) {
             throw new DataIntegrityViolationException("sw360 package with same name and version '" + pkg.getName() + "' already exists.");
         } else if (requestStatus == RequestStatus.NAMINGERROR) {
-            throw new HttpMessageNotReadableException("Package name and version field cannot be empty or contain only whitespace character");
+            throw new BadRequestClientException("Package name and version field cannot be empty or contain only whitespace character");
         } else if (requestStatus == RequestStatus.FAILURE) {
             throw new RuntimeException("sw360 Package with id '" + pkg.getId() + " cannot be updated.");
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3707,7 +3707,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     @Operation(
             summary = "Add licenses to linked releases of a project.",
             description = "This API adds license information to linked releases of a project by processing the approved CLI attachments for each release. It categorizes releases based on the number of CLI attachments (single, multiple, or none) and updates their main and other licenses accordingly.",
-            tags = {"Project"},
+            tags = {"Projects"},
                     parameters = {
                             @Parameter(
                                 name = "projectId",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -62,6 +62,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
@@ -73,7 +74,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.Link;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
@@ -779,9 +779,9 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             throw new DataIntegrityViolationException(
                     "sw360 project with name '" + project.getName() + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
-            throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+            throw new BadRequestClientException("Dependent document Id/ids not valid.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
-            throw new HttpMessageNotReadableException(
+            throw new BadRequestClientException(
                     "Project name field cannot be empty or contain only whitespace character");
         }
         return null;
@@ -796,7 +796,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         if (project.getReleaseIdToUsage() != null) {
             for (String releaseId : project.getReleaseIdToUsage().keySet()) {
                 if (isNullEmptyOrWhitespace(releaseId)) {
-                    throw new HttpMessageNotReadableException("Release Id can't be empty");
+                    throw new BadRequestClientException("Release Id can't be empty");
                 }
             }
         }
@@ -812,7 +812,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             requestStatus = sw360ProjectClient.updateProject(project, sw360User);
         }
         if (requestStatus == RequestStatus.NAMINGERROR) {
-            throw new HttpMessageNotReadableException(
+            throw new BadRequestClientException(
                     "Project name field cannot be empty or contain only whitespace character");
         }
 
@@ -823,7 +823,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             return requestStatus;
         }
         if (requestStatus == RequestStatus.INVALID_INPUT) {
-            throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+            throw new BadRequestClientException("Dependent document Id/ids not valid.");
         } else if (requestStatus != RequestStatus.SENT_TO_MODERATOR && requestStatus != RequestStatus.SUCCESS) {
             throw new RuntimeException("sw360 project with name '" + project.getName() + " cannot be updated.");
         }
@@ -1408,7 +1408,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         if (project.getReleaseIdToUsage() != null) {
             for (String releaseId : project.getReleaseIdToUsage().keySet()) {
                 if (isNullEmptyOrWhitespace(releaseId)) {
-                    throw new HttpMessageNotReadableException("Release Id can't be empty");
+                    throw new BadRequestClientException("Release Id can't be empty");
                 }
             }
         }
@@ -1424,7 +1424,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             requestStatus = sw360ProjectClient.updateProject(project, sw360User);
         }
         if (requestStatus == RequestStatus.NAMINGERROR) {
-            throw new HttpMessageNotReadableException(
+            throw new BadRequestClientException(
                     "Project name field cannot be empty or contain only whitespace character");
         }
         if(requestStatus == RequestStatus.DUPLICATE_ATTACHMENT) {
@@ -1434,7 +1434,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             throw new RuntimeException("User cannot modify a closed project");
         }
         if (requestStatus == RequestStatus.INVALID_INPUT) {
-            throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+            throw new BadRequestClientException("Dependent document Id/ids not valid.");
         } else if (requestStatus != RequestStatus.SENT_TO_MODERATOR && requestStatus != RequestStatus.SUCCESS) {
             throw new RuntimeException("sw360 project with name '" + project.getName() + " cannot be updated.");
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -74,6 +74,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityState;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -94,7 +95,6 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.bind.annotation.*;
@@ -627,7 +627,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             throw new SW360Exception("Feature SPDXDocument disable");
         }
         if (CommonUtils.isNullEmptyOrWhitespace(releaseId)) {
-            throw new HttpMessageNotReadableException("Release id not found");
+            throw new BadRequestClientException("Release id not found");
         }
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Release release = releaseService.getReleaseForUserById(releaseId, user);
@@ -641,7 +641,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                 : releaseService.getSPDXDocumentById(spdxId, user);
         spdxId = spdxDocumentActual.getId();
         if (CommonUtils.isNullEmptyOrWhitespace(spdxId)) {
-            throw new HttpMessageNotReadableException("Update SPDXDocument Failed!");
+            throw new BadRequestClientException("Update SPDXDocument Failed!");
         }
         HalResource<Release> halRelease = createHalReleaseResource(release, false);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/SW360SPDXDocumentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/SW360SPDXDocumentService.java
@@ -33,8 +33,8 @@ import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.ExternalReferen
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformation;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformationService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -56,21 +56,21 @@ public class SW360SPDXDocumentService {
                                                       Set<String> moderators) {
         if(CommonUtils.isNotEmpty(spdxDocumentRequest.getSnippets())) {
             if(!checkIndexSnippetInformations(spdxDocumentRequest.getSnippets())) {
-                throw new HttpMessageNotReadableException("Index of SnippetInformations invalid!");
+                throw new BadRequestClientException("Index of SnippetInformations invalid!");
             }
             if(!checkIndexSnippetRanges(spdxDocumentRequest.getSnippets())) {
-                throw new HttpMessageNotReadableException("Index of SnippetRanges invalid!");
+                throw new BadRequestClientException("Index of SnippetRanges invalid!");
             }
         }
         if(CommonUtils.isNotEmpty(spdxDocumentRequest.getRelationships()) && !checkIndexRelationships(spdxDocumentRequest.getRelationships())) {
-            throw new HttpMessageNotReadableException("Index of Relationships SPDXDocument invalid!");
+            throw new BadRequestClientException("Index of Relationships SPDXDocument invalid!");
         }
         if(CommonUtils.isNotEmpty(spdxDocumentRequest.getAnnotations()) && !checkIndexAnnotations(spdxDocumentRequest.getAnnotations())) {
-            throw new HttpMessageNotReadableException("Index of Annotations SPDXDocument invalid!");
+            throw new BadRequestClientException("Index of Annotations SPDXDocument invalid!");
         }
         if(CommonUtils.isNotEmpty(spdxDocumentRequest.getOtherLicensingInformationDetecteds())
                 && !checkIndexOtherLicensingInformationDetected(spdxDocumentRequest.getOtherLicensingInformationDetecteds())) {
-            throw new HttpMessageNotReadableException("Index of OtherLicensingInformationDetecteds invalid!");
+            throw new BadRequestClientException("Index of OtherLicensingInformationDetecteds invalid!");
         }
 
         return spdxDocumentRequest.setModerators(moderators)
@@ -85,11 +85,11 @@ public class SW360SPDXDocumentService {
                                                                                     Set<String> moderators) {
         if(CommonUtils.isNotEmpty(documentCreationInformation.getExternalDocumentRefs()) &&
                 !checkIndexExternalDocumentReferences(documentCreationInformation.getExternalDocumentRefs())) {
-            throw new HttpMessageNotReadableException("Index of xternalDocumentReferences invalid!");
+            throw new BadRequestClientException("Index of xternalDocumentReferences invalid!");
         }
         if(CommonUtils.isNotEmpty(documentCreationInformation.getCreator()) &&
                 !checkIndexCreator(documentCreationInformation.getCreator())) {
-            throw new HttpMessageNotReadableException("Index of Creators invalid!");
+            throw new BadRequestClientException("Index of Creators invalid!");
         }
         return documentCreationInformation.setModerators(moderators)
                 .setId(spdxDocumentActual.getSpdxDocumentCreationInfoId());
@@ -99,27 +99,27 @@ public class SW360SPDXDocumentService {
                                                                   SPDXDocument spdxDocumentActual,
                                                                   Set<String> moderators) {
         if(packageInformation.getIndex() != 0) {
-            throw new HttpMessageNotReadableException("Index of PackageInformation invalid!");
+            throw new BadRequestClientException("Index of PackageInformation invalid!");
         }
 
         if(CommonUtils.isNotEmpty(packageInformation.getExternalRefs()) &&
                 !checkIndexExternalReference(packageInformation.getExternalRefs())) {
-            throw new HttpMessageNotReadableException("Index of ExternalReference invalid!");
+            throw new BadRequestClientException("Index of ExternalReference invalid!");
         }
 
         if(CommonUtils.isNotEmpty(packageInformation.getAnnotations()) &&
                 !checkIndexAnnotations(packageInformation.getAnnotations())) {
-            throw new HttpMessageNotReadableException("Index of Annotations PackageInformation invalid!");
+            throw new BadRequestClientException("Index of Annotations PackageInformation invalid!");
         }
 
         if(CommonUtils.isNotEmpty(packageInformation.getRelationships()) &&
                 !checkIndexRelationships(packageInformation.getRelationships())) {
-            throw new HttpMessageNotReadableException("Index of Relationships PackageInformation invalid!");
+            throw new BadRequestClientException("Index of Relationships PackageInformation invalid!");
         }
 
         if(CommonUtils.isNotEmpty(packageInformation.getChecksums()) &&
                 !checkIndexChecksums(packageInformation.getChecksums())) {
-            throw new HttpMessageNotReadableException("Index of Checksums PackageInformation invalid!");
+            throw new BadRequestClientException("Index of Checksums PackageInformation invalid!");
         }
 
         packageInformation.setModerators(moderators);
@@ -168,7 +168,7 @@ public class SW360SPDXDocumentService {
     public String addSPDX(Release release, User user) throws TException {
         String spdxId = addSPDXDocument(release, user);
         if (CommonUtils.isNullEmptyOrWhitespace(spdxId)) {
-            throw new HttpMessageNotReadableException("Add SPDXDocument Failed!");
+            throw new BadRequestClientException("Add SPDXDocument Failed!");
         }
         addDocumentCreationInformation(spdxId, release.getModerators(), user);
         addPackageInformation(spdxId, release.getModerators(), user);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -184,7 +184,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         } catch (TException e) {
             throw new HttpMessageNotReadableException("No Components found");
         }
-        
+
         for (Release release : releases) {
             String componentId = release.getComponentId();
             if (CommonUtils.isNullEmptyOrWhitespace(componentId)) {
@@ -198,7 +198,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         }
         return releases;
     }
-    
+
     public List<Release> getReleaseSubscriptions(User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.getSubscribedReleases(sw360User);
@@ -817,7 +817,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         }
         return deleteStatus;
     }
-    
+
     public BulkOperationNode deleteBulkRelease(String releaseId,  User sw360User, boolean isPreview) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.deleteBulkRelease(releaseId, sw360User, isPreview);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -34,12 +34,12 @@ import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -113,7 +113,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response
     ) throws SW360Exception {
         if (GENERATOR_MODULES.contains(module) && (isNullOrEmpty(generatorClassName) || isNullOrEmpty(variant))) {
-            throw new HttpMessageNotReadableException("Error : GeneratorClassName and Variant is required for module " + module);
+            throw new BadRequestClientException("Error : GeneratorClassName and Variant is required for module " + module);
         }
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         String baseUrl = getBaseUrl(request);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -110,7 +111,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "bomType", required = false) String bomType,
             HttpServletRequest request,
             HttpServletResponse response
-    ) throws TException {
+    ) throws SW360Exception {
         if (GENERATOR_MODULES.contains(module) && (isNullOrEmpty(generatorClassName) || isNullOrEmpty(variant))) {
             throw new HttpMessageNotReadableException("Error : GeneratorClassName and Variant is required for module " + module);
         }
@@ -158,7 +159,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             throw  e;
         }
         catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
@@ -166,7 +167,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             boolean withLinkedReleases, HttpServletResponse response, User sw360User, String module, String projectId,
             boolean excludeReleaseVersion, String baseUrl, String generatorClassName, String variant, String template,
             String externalIds
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             if (SW360Utils.readConfig(MAIL_REQUEST_FOR_PROJECT_REPORT, false)) {
                 sw360ReportService.getUploadedProjectPath(sw360User, withLinkedReleases, baseUrl, projectId);
@@ -179,7 +180,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             }
         } catch (Exception e) {
             log.error(e);
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
@@ -187,7 +188,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             boolean withLinkedReleases, HttpServletResponse response, User sw360User, String module,
             boolean excludeReleaseVersion, String baseUrl, String generatorClassName, String variant, String template,
             String externalIds
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             if (SW360Utils.readConfig(MAIL_REQUEST_FOR_COMPONENT_REPORT, false)) {
                 sw360ReportService.getUploadedComponentPath(sw360User, withLinkedReleases, baseUrl);
@@ -200,20 +201,20 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             }
         } catch (Exception e) {
             log.error(e);
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
     private void getLicensesReports(
             HttpServletResponse response, User sw360User, String module, boolean excludeReleaseVersion,
             String generatorClassName, String variant, String template, String externalIds
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             downloadExcelReport(false, response, sw360User, module, null, excludeReleaseVersion,
                     defaultByteBufferVal, generatorClassName, variant, template, externalIds);
         } catch (Exception e) {
             log.error(e);
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
@@ -221,14 +222,14 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, String projectId,
             boolean excludeReleaseVersion, String generatorClassName, String variant, String template,
             String externalIds, boolean withSubProject
-    ) throws TException {
+    ) throws SW360Exception {
         // TODO: use `withSubProject` while generating LicenseInfo report.
         try {
             downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
                     defaultByteBufferVal, generatorClassName, variant, template, externalIds);
         } catch (Exception e) {
             log.error(e);
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
@@ -236,12 +237,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, String projectId,
             boolean excludeReleaseVersion, String generatorClassName, String variant, String template,
             String externalIds
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
                     defaultByteBufferVal, generatorClassName, variant, template, externalIds);
         } catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
@@ -249,13 +250,13 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, String projectId,
             boolean excludeReleaseVersion, String generatorClassName, String variant, String template,
             String externalIds
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
                     defaultByteBufferVal, generatorClassName, variant, template, externalIds);
         } catch (Exception e) {
             log.error(e);
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
@@ -263,7 +264,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             boolean withLinkedReleases, HttpServletResponse response, User user, String module, String projectId,
             boolean excludeReleaseVersion, ByteBuffer buffer, String generatorClassName, String variant,
             String template, String externalIds
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             ByteBuffer buff = null;
             String fileName = sw360ReportService.getDocumentName(user, null, module);
@@ -307,20 +308,20 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             copyDataStreamToResponse(response, buff);
         } catch (Exception e) {
             log.error(e);
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
     private void getLicenseResourceBundleReports(
             String projectId, HttpServletResponse response, User sw360User, String module, String generatorClassName,
             String variant, String template, String externalIds, boolean excludeReleaseVersion, boolean withSubProject
-    ) throws TException {
+    ) throws SW360Exception {
         try {
             ByteBuffer buffer = sw360ReportService.downloadSourceCodeBundle(projectId, sw360User, withSubProject);
             downloadExcelReport(false, response, sw360User, module, projectId, excludeReleaseVersion,
                     buffer, generatorClassName, variant, template, externalIds);
         } catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 
@@ -349,7 +350,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "token", required = true) String token,
             @Parameter(description = "Extended by releases.")
             @RequestParam(value = "extendedByReleases", required = false, defaultValue = "false") boolean extendedByReleases
-    ) throws TException {
+    ) throws SW360Exception {
         final User user = restControllerHelper.getUserByEmail(request.getParameter("user"));
         try {
             ByteBuffer buffer = null;
@@ -376,7 +377,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", fileName));
             copyDataStreamToResponse(response, buffer);
         } catch (Exception e) {
-            throw new TException(e.getMessage());
+            throw new SW360Exception(e.getMessage());
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -23,6 +23,7 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.attachments.SourcePackageUsage;
@@ -52,9 +53,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import jakarta.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
@@ -167,7 +167,7 @@ public class SW360ReportService {
     public void getUploadedProjectPath(User user, boolean withLinkedReleases, String base, String projectId)
             throws TException {
         if (projectId!=null && !validateProject(projectId, user)) {
-            throw new TException("No project record found for the project Id : " + projectId);
+            throw new SW360Exception("No project record found for the project Id : " + projectId);
         }
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -341,7 +341,7 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
     @PostMapping(SCHEDULE_URL + "/srcUpload")
     public ResponseEntity<?> srcUpload()throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.triggeSrcUpload(sw360User);
+        RequestSummary requestSummary = scheduleService.triggerSrcUpload(sw360User);
         HttpStatus status = HttpStatus.ACCEPTED;
         return new ResponseEntity<>(requestSummary, status);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
@@ -407,7 +408,7 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
         if (CommonUtils.isNullEmptyOrWhitespace(serviceName)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Service name is required");
+            throw new BadRequestClientException("Service name is required");
         }
 
         RequestStatus requestStatus = scheduleService.isServiceScheduled(serviceName, sw360User);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
@@ -149,17 +149,14 @@ public class Sw360ScheduleService {
     }
 
     public RequestStatus isServiceScheduled(String serviceName, User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                boolean requestStatusWithBoolean = new ThriftClients()
-                        .makeScheduleClient()
-                        .isServiceScheduled(serviceName, sw360User)
-                        .isAnswerPositive();
+            boolean requestStatusWithBoolean = new ThriftClients()
+                    .makeScheduleClient()
+                    .isServiceScheduled(serviceName, sw360User)
+                    .isAnswerPositive();
 
-                return requestStatusWithBoolean ? RequestStatus.SUCCESS : RequestStatus.FAILURE;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
+            return requestStatusWithBoolean ? RequestStatus.SUCCESS : RequestStatus.FAILURE;
         } catch (TException e) {
             log.error("Error occurred while fetching the status of service '{}':", serviceName, e);
             throw e;
@@ -167,17 +164,14 @@ public class Sw360ScheduleService {
     }
 
     public RequestStatus isAnyServiceScheduled(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                boolean requestStatusWithBoolean = new ThriftClients()
-                        .makeScheduleClient()
-                        .isAnyServiceScheduled(sw360User)
-                        .isAnswerPositive();
+            boolean requestStatusWithBoolean = new ThriftClients()
+                    .makeScheduleClient()
+                    .isAnyServiceScheduled(sw360User)
+                    .isAnswerPositive();
 
-                return requestStatusWithBoolean ? RequestStatus.SUCCESS : RequestStatus.FAILURE;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
+            return requestStatusWithBoolean ? RequestStatus.SUCCESS : RequestStatus.FAILURE;
         } catch (TException e) {
             log.error("Error occurred while fetching the status of services", e);
             throw e;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
@@ -17,10 +17,8 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -33,56 +31,28 @@ public class Sw360ScheduleService {
     private static final Logger log = LogManager.getLogger(Sw360ScheduleService.class);
 
     private RequestSummary scheduleService(User sw360User, String serviceName) throws TException {
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                ThriftClients thriftClients = new ThriftClients();
-                return thriftClients.makeScheduleClient().scheduleService(serviceName);
-            } else {
-                throw new AccessDeniedException("User does not have admin access");
-            }
-        } catch (SW360Exception sw360Exp) {
-            if (sw360Exp.getErrorCode() == 403) {
-                throw new AccessDeniedException("User does not have admin access", sw360Exp);
-            } else {
-                throw sw360Exp;
-            }
+        throwIfNotAdmin(sw360User);
+        ThriftClients thriftClients = new ThriftClients();
+        return thriftClients.makeScheduleClient().scheduleService(serviceName);
+    }
+
+    private static void throwIfNotAdmin(User sw360User) throws AccessDeniedException {
+        if (PermissionUtils.isAdmin(sw360User)) {
+            throw new AccessDeniedException("User does not have admin access");
         }
     }
 
     private RequestStatus unscheduleService(User sw360User, String serviceName) throws TException {
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                ThriftClients thriftClients = new ThriftClients();
-                return thriftClients.makeScheduleClient().unscheduleService(serviceName, sw360User);
-            } else {
-                throw new AccessDeniedException("User does not have admin access");
-            }
-        } catch (SW360Exception sw360Exp) {
-            if (sw360Exp.getErrorCode() == 403) {
-                throw new AccessDeniedException("User does not have admin access", sw360Exp);
-            } else {
-                throw sw360Exp;
-            }
-        }
+        throwIfNotAdmin(sw360User);
+        ThriftClients thriftClients = new ThriftClients();
+        return thriftClients.makeScheduleClient().unscheduleService(serviceName, sw360User);
     }
 
     public RequestStatus cancelAllServices(User sw360User) throws TException {
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                ThriftClients thriftClients = new ThriftClients();
-                return thriftClients.makeScheduleClient().unscheduleAllServices(sw360User);
-            } else {
-                throw new AccessDeniedException("User does not have admin access");
-            }
-        } catch (SW360Exception sw360Exp) {
-            if (sw360Exp.getErrorCode() == 403) {
-                throw new AccessDeniedException("User does not have admin access", sw360Exp);
-            } else {
-                throw sw360Exp;
-            }
-        }
+        throwIfNotAdmin(sw360User);
+        ThriftClients thriftClients = new ThriftClients();
+        return thriftClients.makeScheduleClient().unscheduleAllServices(sw360User);
     }
-
 
     public RequestSummary scheduleCveSearch(User sw360User) throws TException {
         return scheduleService(sw360User, ThriftClients.CVESEARCH_SERVICE);
@@ -105,176 +75,77 @@ public class Sw360ScheduleService {
     }
 
     public RequestStatus triggerCveSearch(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                ThriftClients thriftClients = new ThriftClients();
-                return thriftClients.makeCvesearchClient().update();
-            } else {
-                throw new AccessDeniedException("User does not have admin access");
-            }
-        } catch (SW360Exception sw360Exp) {
-            if (sw360Exp.getErrorCode() == 403) {
-                throw new AccessDeniedException("User does not have admin access", sw360Exp);
-            } else {
-                throw sw360Exp;
-            }
+            ThriftClients thriftClients = new ThriftClients();
+            return thriftClients.makeCvesearchClient().update();
         } catch (TException e) {
-            log.error("Error occurred while triggering CVE search: " + e.getMessage());
+            log.error("Error occurred while triggering CVE search: " + e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            log.error("Unexpected error occurred while triggering CVE search: " + e.getMessage());
+            log.error("Unexpected error occurred while triggering CVE search: " + e.getMessage(), e);
             throw new TException("Unexpected error", e);
         }
     }
 
     public RequestSummary svmSync(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SVMSYNC_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
-                return requestSummary;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().scheduleService(serviceName);
     }
 
     public RequestStatus cancelSvmSync(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SVMSYNC_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
-                return requestStatus;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
     }
 
     public RequestSummary scheduleSvmReverseMatch(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SVMMATCH_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
-                return requestSummary;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().scheduleService(serviceName);
     }
 
     public RequestStatus cancelSvmReverseMatch(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SVMMATCH_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
-                return requestStatus;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
     }
 
     public RequestSummary svmReleaseTrackingFeedback(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SVM_TRACKING_FEEDBACK_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);;
-                return requestSummary;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().scheduleService(serviceName);
     }
 
     public RequestSummary svmMonitoringListUpdate(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SVM_LIST_UPDATE_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
-                return requestSummary;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().scheduleService(serviceName);
     }
 
     public RequestStatus cancelSvmMonitoringListUpdate(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SVM_LIST_UPDATE_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
-                return requestStatus;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
     }
 
-    public RequestSummary triggeSrcUpload(User sw360User) throws TException {
+    public RequestSummary triggerSrcUpload(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SRC_UPLOAD_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestSummary requestSummary = new ThriftClients().makeScheduleClient().scheduleService(serviceName);
-                return requestSummary;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().scheduleService(serviceName);
     }
 
     public RequestStatus unscheduleSrcUpload(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
         String serviceName = ThriftClients.SRC_UPLOAD_SERVICE;
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestStatus requestStatus = new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
-                return requestStatus;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + serviceName, e);
-            throw e;
-        }
+        return new ThriftClients().makeScheduleClient().unscheduleService(serviceName, sw360User);
     }
 
     public RequestStatus triggerSourceUploadForReleaseComponents(User sw360User) throws TException {
-        try {
-            if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
-                RequestStatus requestStatus = new ThriftClients().makeComponentClient()
-                        .uploadSourceCodeAttachmentToReleases();
-                return requestStatus;
-            } else {
-                throw new AccessDeniedException("User is not admin");
-            }
-        } catch (TException e) {
-            log.error("Error occurred while scheduling service: " + e);
-            throw e;
-        }
+        throwIfNotAdmin(sw360User);
+        return new ThriftClients().makeComponentClient()
+                .uploadSourceCodeAttachmentToReleases();
     }
 
     public RequestStatus isServiceScheduled(String serviceName, User sw360User) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -53,9 +53,9 @@ public class Sw360UserService {
     private static final Logger log = LogManager.getLogger(Sw360UserService.class);
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
-    private static final String AUTHORITIES_READ = "READ";
-    private static final String AUTHORITIES_WRITE = "WRITE";
-    private static final String EXPIRATION_DATE_PROPERTY = "expirationDate";
+    public static final String AUTHORITIES_READ = "READ";
+    public static final String AUTHORITIES_WRITE = "WRITE";
+    public static final String EXPIRATION_DATE_PROPERTY = "expirationDate";
 
     public List<User> getAllUsers() {
         try {
@@ -193,10 +193,10 @@ public class Sw360UserService {
 
         if (!requestBody.containsKey(EXPIRATION_DATE_PROPERTY)
                 || CommonUtils.isNullEmptyOrWhitespace(requestBody.get(EXPIRATION_DATE_PROPERTY).toString())) {
-            throw new IllegalArgumentException("expirationDate is a required field.");
+            throw new IllegalArgumentException(EXPIRATION_DATE_PROPERTY + " is a required field.");
         }
         if (!(requestBody.get(EXPIRATION_DATE_PROPERTY) instanceof String)) {
-            throw new IllegalArgumentException("expirationDate must be a string.");
+            throw new IllegalArgumentException(EXPIRATION_DATE_PROPERTY + " must be a string.");
         }
 
         RestApiToken restApiToken = mapper.convertValue(requestBody, RestApiToken.class);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -30,10 +30,10 @@ import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -127,10 +127,10 @@ public class Sw360UserService {
                 throw new DataIntegrityViolationException("sw360 user with name '" + user.getEmail()
                         + "' already exists, having database identifier " + documentRequestSummary.getId());
             } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
-                throw new HttpMessageNotReadableException(documentRequestSummary.getMessage());
+                throw new BadRequestClientException(documentRequestSummary.getMessage());
             }
         } catch (TException e) {
-            throw new HttpMessageNotReadableException(e.getMessage());
+            throw new BadRequestClientException(e.getMessage());
         }
         return null;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -115,7 +115,7 @@ public class Sw360UserService {
         }
     }
 
-    public User addUser(User user) throws TException{
+    public User addUser(User user) {
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();
             user.setUserGroup(UserGroup.USER);
@@ -129,8 +129,6 @@ public class Sw360UserService {
             } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
                 throw new HttpMessageNotReadableException(documentRequestSummary.getMessage());
             }
-        } catch (SW360Exception sw360Exp) {
-            throw new HttpMessageNotReadableException(sw360Exp.getMessage());
         } catch (TException e) {
             throw new HttpMessageNotReadableException(e.getMessage());
         }
@@ -153,7 +151,7 @@ public class Sw360UserService {
         return sw360UserClient.refineSearch(null, filterMap);
     }
 
-    public List<User> searchUserByName(String givenname) throws TException {
+    public List<User> searchUserByName(String givenname) {
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();
             return sw360UserClient.searchUsers(givenname);
@@ -162,7 +160,7 @@ public class Sw360UserService {
         }
     }
 
-    public List<User> searchUserByLastName(String lastname) throws TException {
+    public List<User> searchUserByLastName(String lastname) {
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();
             return sw360UserClient.searchUsers(lastname);
@@ -171,7 +169,7 @@ public class Sw360UserService {
         }
     }
 
-    public List<User> searchUserByDepartment(String department) throws TException {
+    public List<User> searchUserByDepartment(String department) {
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();
             return sw360UserClient.searchDepartmentUsers(department);
@@ -180,7 +178,7 @@ public class Sw360UserService {
         }
     }
 
-    public List<User> searchUserByUserGroup(UserGroup usergroup) throws TException {
+    public List<User> searchUserByUserGroup(UserGroup usergroup) {
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();
             return sw360UserClient.searchUsersGroup(usergroup);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -69,6 +69,9 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_TOKEN_HASH_SALT;
+import static org.eclipse.sw360.rest.resourceserver.user.Sw360UserService.AUTHORITIES_READ;
+import static org.eclipse.sw360.rest.resourceserver.user.Sw360UserService.AUTHORITIES_WRITE;
+import static org.eclipse.sw360.rest.resourceserver.user.Sw360UserService.EXPIRATION_DATE_PROPERTY;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @BasePathAwareController
@@ -311,8 +314,18 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             tags = {"Users"})
     @RequestMapping(value = USERS_URL + "/tokens", method = RequestMethod.POST)
     public ResponseEntity<String> createUserRestApiToken(
-            @Parameter(description = "Token request", schema = @Schema(
-                    implementation = RestApiToken.class))
+            @Parameter(description = "Token request",
+                    schema = @Schema(
+                            type = "object",
+                            example = "{\n" +
+                              "  \"name\": \"my-new-token\",\n" +
+                              "  \"" + EXPIRATION_DATE_PROPERTY + "\": \"2025-12-31\",\n" +
+                              "  \"authorities\": [\n" +
+                              "  \"" + AUTHORITIES_READ + "\",\n" +
+                              "  \"" + AUTHORITIES_WRITE + "\"\n" +
+                              "  ]\n}",
+                            requiredProperties = {"name", "authorities", EXPIRATION_DATE_PROPERTY}
+                    ))
             @RequestBody Map<String, Object> requestBody
     ) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -33,6 +33,7 @@ import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.jetbrains.annotations.NotNull;
@@ -46,7 +47,6 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -222,7 +222,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             @RequestBody User user
     ) {
         if (CommonUtils.isNullEmptyOrWhitespace(user.getPassword())) {
-            throw new HttpMessageNotReadableException(
+            throw new BadRequestClientException(
                     "Password can not be null or empty or whitespace!");
         }
         String encodedPassword = passwordEncoder.encode(user.getPassword());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
@@ -24,10 +24,10 @@ import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
@@ -85,7 +85,7 @@ public class Sw360VendorService {
             VendorService.Iface sw360VendorClient = getThriftVendorClient();
             if (CommonUtils.isNullEmptyOrWhitespace(vendor.getFullname()) || CommonUtils.isNullEmptyOrWhitespace(vendor.getShortname())
                     || CommonUtils.isNullEmptyOrWhitespace(vendor.getUrl())) {
-                throw new HttpMessageNotReadableException("A Vendor cannot have null or empty 'Full Name' or 'Short Name' or 'URL'!");
+                throw new BadRequestClientException("A Vendor cannot have null or empty 'Full Name' or 'Short Name' or 'URL'!");
             }
             AddDocumentRequestSummary summary = sw360VendorClient.addVendor(vendor);
             if (AddDocumentRequestStatus.SUCCESS.equals(summary.getRequestStatus())) {
@@ -94,7 +94,7 @@ public class Sw360VendorService {
             } else if (AddDocumentRequestStatus.DUPLICATE.equals(summary.getRequestStatus())) {
                 throw new DataIntegrityViolationException("A Vendor with same full name '" + vendor.getFullname() + "' and URL already exists!");
             } else if (AddDocumentRequestStatus.FAILURE.equals(summary.getRequestStatus())) {
-                throw new HttpMessageNotReadableException(summary.getMessage());
+                throw new BadRequestClientException(summary.getMessage());
             }
             return null;
         } catch (TException e) {
@@ -204,7 +204,7 @@ public class Sw360VendorService {
         requestStatus =  sw360VendorClient.mergeVendors(vendorTargetId, vendorSourceId, vendorSelection, user);
 
         if (requestStatus == RequestStatus.IN_USE) {
-            throw new HttpMessageNotReadableException("Vendor used as source or target has an open MR");
+            throw new BadRequestClientException("Vendor used as source or target has an open MR");
         } else if (requestStatus == RequestStatus.FAILURE) {
             throw new ResourceClassNotFoundException("Internal server error while merging the vendors");
         } else if (requestStatus == RequestStatus.ACCESS_DENIED) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +36,6 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.*;
@@ -172,7 +172,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
         if (requestStatus == RequestStatus.SUCCESS) {
             return new ResponseEntity<>("Vendor with full name " + sw360Vendor.getFullname() + " deleted successfully.", HttpStatus.OK);
         } else {
-            throw new HttpMessageNotReadableException("Vendor with full name " + sw360Vendor.getFullname() + " cannot be deleted.");
+            throw new BadRequestClientException("Vendor with full name " + sw360Vendor.getFullname() + " cannot be deleted.");
         }
     }
 
@@ -238,7 +238,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
     ) {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         if (vendor.getFullname() == null && vendor.getShortname() == null && vendor.getUrl() == null) {
-            throw new HttpMessageNotReadableException("Vendor cannot be null");
+            throw new BadRequestClientException("Vendor cannot be null");
         }
         RequestStatus status = vendorService.vendorUpdate(vendor, sw360User, id);
         if (RequestStatus.SUCCESS.equals(status)) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
@@ -37,13 +37,13 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityService;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityWithReleaseRelations;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.JacksonCustomizations.Sw360Module.CVEReferenceMixin;
 import org.eclipse.sw360.rest.resourceserver.core.JacksonCustomizations.Sw360Module.VendorAdvisoryMixin;
 import org.eclipse.sw360.rest.resourceserver.core.JacksonCustomizations.Sw360Module.VulnerabilityMixinForCreateUpdate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
@@ -202,7 +202,7 @@ public class Sw360VulnerabilityService {
             }
         } catch (SW360Exception sw360Exp) {
             if (sw360Exp.getErrorCode() == HttpStatus.SC_BAD_REQUEST) {
-                throw new HttpMessageNotReadableException(sw360Exp.getWhy());
+                throw new BadRequestClientException(sw360Exp.getWhy());
             } else {
                 throw new RuntimeException(sw360Exp);
             }
@@ -234,7 +234,7 @@ public class Sw360VulnerabilityService {
             }
         } catch (SW360Exception sw360Exp) {
             if (sw360Exp.getErrorCode() == HttpStatus.SC_BAD_REQUEST) {
-                throw new HttpMessageNotReadableException(sw360Exp.getWhy());
+                throw new BadRequestClientException(sw360Exp.getWhy());
             } else {
                 throw new RuntimeException(sw360Exp);
             }
@@ -248,7 +248,7 @@ public class Sw360VulnerabilityService {
             throw new RuntimeException("Failed to add/update vulnerability");
         }
     }
-    
+
     public Vulnerability updateFromVulnerability(Vulnerability destination, Vulnerability source) {
         for (Vulnerability._Fields field : Vulnerability._Fields.values()) {
             if (field.equals(Vulnerability._Fields.REVISION) || field.equals(Vulnerability._Fields.ID)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -50,6 +50,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerability
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityApiDTO;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityWithReleaseRelations;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -439,9 +440,9 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
                     user, VulnerabilityOperation.DELETE);
             results.add(new MultiStatus(resourceId, HttpStatus.OK));
             return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
-        } catch (HttpMessageNotReadableException httpMessageNotReadableException) {
+        } catch (HttpMessageNotReadableException | BadRequestClientException ex) {
             results.add(new MultiStatus(resourceId, HttpStatus.BAD_REQUEST));
-            log.error(httpMessageNotReadableException.getMessage());
+            log.error(ex.getMessage());
             return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
         } catch (AccessDeniedException accessDeniedException) {
             results.add(new MultiStatus(resourceId, HttpStatus.FORBIDDEN));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -352,7 +352,7 @@ public class ComponentTest extends TestIntegrationBase {
                         HttpMethod.DELETE,
                         new HttpEntity<>(null, getHeaders(port)),
                         String.class);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         then(componentServiceMock)
                 .should(never())
                 .updateComponent(any(), any());

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -268,7 +268,7 @@ public class ReleaseTest extends TestIntegrationBase {
                         HttpMethod.DELETE,
                         new HttpEntity<>(null, getHeaders(port)),
                         String.class);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         then(releaseServiceMock)
                 .should(never())
                 .updateRelease(any(), any());

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ApiSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ApiSpecTest.java
@@ -10,13 +10,13 @@
 
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
-import org.apache.thrift.TException;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -133,10 +133,10 @@ public class ApiSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_document_error_internal_error() throws Exception {
-        given(this.projectServiceMock.getProjectForUserById(anyString(), any())).willThrow(new RuntimeException(new TException("Internal error processing getProjectById")));
+        given(this.projectServiceMock.getProjectForUserById(anyString(), any())).willThrow(new ResourceNotFoundException("Requested Project Not Found"));
         this.mockMvc.perform(RestDocumentationRequestBuilders.get("/api/projects/12321")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)))
-                .andExpect(status().isInternalServerError())
+                .andExpect(status().isNotFound())
                 .andDo(this.documentationHandler.document(
                         responseFields(
                                 fieldWithPath("timestamp").description("The timestamp when the error occurred"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
@@ -14,14 +14,11 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -42,7 +39,7 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
 
     @Value("${sw360.test-user-password}")
     private String testUserPassword;
-    
+
     @MockBean
     private Sw360ScheduleService scheduleServiceMock;
     private RequestSummary requestSummary = new RequestSummary();
@@ -67,10 +64,10 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
         given(this.scheduleServiceMock.scheduleSvmReverseMatch(any())).willReturn(requestSummary);
         given(this.scheduleServiceMock.svmReleaseTrackingFeedback(any())).willReturn(requestSummary);
         given(this.scheduleServiceMock.svmMonitoringListUpdate(any())).willReturn(requestSummary);
-        given(this.scheduleServiceMock.triggeSrcUpload(any())).willReturn(requestSummary);
+        given(this.scheduleServiceMock.triggerSrcUpload(any())).willReturn(requestSummary);
         given(this.scheduleServiceMock.cancelSvmMonitoringListUpdate(any())).willReturn(RequestStatus.SUCCESS);
         given(this.scheduleServiceMock.unscheduleSrcUpload(any())).willReturn(RequestStatus.SUCCESS);
-        
+
     }
 
     @Test
@@ -80,7 +77,7 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isAccepted());
     }
-    
+
     @Test
     public void should_document_schedule_cve_service() throws Exception {
         mockMvc.perform(post("/api/schedule/cveService")
@@ -160,7 +157,7 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isAccepted());
     }
-    
+
     @Test
     public void should_document_unschedule_cve_search() throws Exception {
         mockMvc.perform(post("/api/schedule/unscheduleCve")
@@ -168,7 +165,7 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isAccepted());
     }
-    
+
     @Test
     public void should_document_schedule_service_from_local() throws Exception {
         mockMvc.perform(post("/api/schedule/deleteAttachment")

--- a/third-party/thrift/install-thrift.sh
+++ b/third-party/thrift/install-thrift.sh
@@ -45,7 +45,12 @@ processThrift() {
     -DWITH_OPENSSL=OFF \
     -DBUILD_PYTHON=OFF \
     -DBUILD_TESTING=OFF \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     "${BASEDIR}/thrift/"
+
+  # -DCMAKE_POLICY_VERSION_MINIMUM=3.5 is added to fix the cmake error:
+  # CMake Error at CMakeLists.txt:20 (cmake_minimum_required):
+  #  Compatibility with CMake < 3.5 has been removed from CMake.
 
   make -j"$(nproc)"
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

1. Replace `TException` with `SW360Exception` wherever possible.
2. Add missing exception handlers to `RestExceptionHandler`.
3. Throw exception instead of returning error response to keep response format consistent.
4. Replace deprecated exception `HttpMessageNotReadableException` with custom `BadRequestClientException` to server the purpose of BadRequest.

### Suggest Reviewer
@Farooq-Fateh-Aftab @heliocastro @rudra-superrr

### How To Test?
Ideally there should be no changes for client other than consistent error message format.