### PR TITLE
feat(projects): Add duplicate external ID validation in project creation

### DIFF
--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -304,6 +304,14 @@ public class ProjectHandler implements ProjectService.Iface {
         assertIdUnset(project.getId());
         assertUser(user);
 
+        // Prevent duplicate external IDs
+        if (project.isSetExternalIds()) {
+            Set<Project> existingProjects = searchByExternalIds(project.getExternalIds(), user);
+            if (!existingProjects.isEmpty()) {
+                return new AddDocumentRequestSummary().setRequestStatus(RequestStatus.DUPLICATE);
+            }
+        }
+
         return handler.addProject(project, user);
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

>Summary of key changes:

Added validation in addProject() to check for duplicate external IDs

Returns RequestStatus.DUPLICATE if matching external IDs found

Uses existing searchByExternalIds() method for consistency

Dependencies
None

Testing
How to verify:

Attempt to create project with existing external IDs (should fail with DUPLICATE status)

Create project with unique external IDs (should succeed)

Verify projects without external IDs are unaffected

Test coverage:

Unit tests to be added

Manual testing performed

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
