### PR TITLE
fix(spdx): add null and empty field checks for SPDX documents

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -276,7 +276,9 @@ public class ThriftValidate {
 
     public static void prepareSPDXDocument(SPDXDocument spdx) throws SW360Exception {
         // Check required fields
-
+        assert spdx != null : "SPDXDocument object cannot be null";
+        assertNotEmpty(spdx.getId());
+        assertNotEmpty(spdx.getSpdxDocumentCreationInfoId());
         // Check type
         spdx.setType(TYPE_SPDX_DOCUMENT);
         // Unset temporary fields
@@ -285,7 +287,9 @@ public class ThriftValidate {
 
     public static void prepareSpdxDocumentCreationInfo(DocumentCreationInformation documentCreationInfo) throws SW360Exception {
         // Check required fields
-
+        assert documentCreationInfo != null : "DocumentCreationInformation object cannot be null";
+        assertNotEmpty(documentCreationInfo.getCreator());
+        assertNotEmpty(documentCreationInfo.getCreated());
         // Check type
         documentCreationInfo.setType(TYPE_SPDX_DOCUMENT_CREATION_INFO);
         // Unset temporary fields


### PR DESCRIPTION
Add validation checks to ensure SPDX documents have required fields:
- Add null object validation for SPDXDocument and DocumentCreationInformation
- Validate ID fields in SPDXDocument are not empty
- Ensure creator and creation date are present in DocumentCreationInformation

### Suggest Reviewer
@GMishx @KoukiHama 

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
