### PR TITLE
fix(rest) : Missing request param for downloadlicenseinfo report.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportBean.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportBean.java
@@ -1,0 +1,26 @@
+/*
+SPDX-FileCopyrightText: © 2025 Siemens AG
+SPDX-License-Identifier: EPL-2.0
+*/
+
+package org.eclipse.sw360.rest.resourceserver.report;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
+
+import java.util.List;
+
+@Setter
+@Getter
+public class SW360ReportBean{
+    boolean withLinkedReleases;
+    boolean excludeReleaseVersion;
+    String generatorClassName;
+    String variant;
+    String template;
+    String externalIds;
+    boolean withSubProject;
+    String bomType;
+    List<ReleaseRelationship> selectedRelRelationship;
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -69,6 +69,7 @@ import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService
 import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
+import org.eclipse.sw360.rest.resourceserver.report.SW360ReportBean;
 import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
@@ -579,6 +580,15 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         requestSummaryForCR.setRequestStatus(AddDocumentRequestStatus.SUCCESS);
         requestSummaryForCR.setId("CR-1");
 
+        SW360ReportBean reportBean = new SW360ReportBean();
+        reportBean.setWithLinkedReleases(false);
+        reportBean.setExcludeReleaseVersion(true);
+        reportBean.setGeneratorClassName("DocxGenerator");
+        reportBean.setVariant("REPORT");
+        reportBean.setExternalIds("portal-id");
+        reportBean.setWithSubProject(false);
+        reportBean.setBomType(null);
+
         given(this.projectServiceMock.createClearingRequest(any(),any(),any(),eq(project.getId()))).willReturn(requestSummaryForCR);
         given(this.projectServiceMock.loadPreferredClearingDateLimit()).willReturn(Integer.valueOf(7));
 
@@ -598,7 +608,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.getProjectForUserById(eq(project7.getId()), any())).willReturn(project7);
         given(this.projectServiceMock.getProjectForUserById(eq(project8.getId()), any())).willReturn(project8);
         given(this.sw360ReportServiceMock.downloadSourceCodeBundle(any(), any(), anyBoolean())).willReturn(ByteBuffer.allocate(10000));
-        given(this.sw360ReportServiceMock.getLicenseInfoBuffer(any(), any(), any(), any(), any(), any(), anyBoolean())).willReturn(ByteBuffer.allocate(10000));
+        given(this.sw360ReportServiceMock.getLicenseInfoBuffer(any(), any(), any())).willReturn(ByteBuffer.allocate(10000));
         given(this.sw360ReportServiceMock.getSourceCodeBundleName(any(), any())).willReturn("SourceCodeBundle-ProjectName");
         given(this.projectServiceMock.getLicenseInfoAttachmentUsage(eq(project8.getId()))).willReturn(licenseInfoUsages);
         given(this.projectServiceMock.getObligationData(eq(project8.getLinkedObligationId()), any())).willReturn(obligationLists);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

Closes : #3052 

### Suggest Reviewer
@GMishx 

### How To Test?
> How should these changes be tested by the reviewer?

1. Check existing end point for download licenseinfo report and add param for it selectedRelRelationship. 
Sample URL : GET :
 http://localhost:8080/resource/api/reports?projectId={projectId}&module=licenseInfo&variant=REPORT&generatorClassName=DocxGenerator&selectedRelRelationship=CONTAINED,UNKNOWN

2. It should filter the releases based on selectedRelRelationship values as well.

3. Report can be downloaded and tested as Doc, Hhtml.


> Have you implemented any additional tests?
NA

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
