### PR TITLE
chore(authorizationserver): remove unused vars

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
@@ -31,8 +31,6 @@ public class Sw360AuthorizationServer extends SpringBootServletInitializer {
     private static final String DEFAULT_ADMIN_ACCESS_USERGROUP = UserGroup.SW360_ADMIN.name();
     private static final String APPLICATION_ID = "authorization";
 
-    public static final String SW360_LIFERAY_COMPANY_ID;
-    public static final String CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS;
     public static final UserGroup CONFIG_WRITE_ACCESS_USERGROUP;
     public static final UserGroup CONFIG_ADMIN_ACCESS_USERGROUP;
 
@@ -40,8 +38,6 @@ public class Sw360AuthorizationServer extends SpringBootServletInitializer {
         Properties props = CommonUtils.loadProperties(Sw360AuthorizationServer.class, SW360_PROPERTIES_FILE_PATH);
         CONFIG_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", DEFAULT_WRITE_ACCESS_USERGROUP));
         CONFIG_ADMIN_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.admin.access.usergroup", DEFAULT_ADMIN_ACCESS_USERGROUP));
-        CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS = props.getProperty("rest.access.token.validity.seconds", null);
-        SW360_LIFERAY_COMPANY_ID = props.getProperty("sw360.liferay.company.id", null);
     }
 
     @Override


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Remove unused property variables:
- `rest.access.token.validity.seconds`
- `sw360.liferay.company.id`