### PR TITLE
 feat(projects): Support Multiple Values for External IDs

### DIFF
--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -268,7 +268,7 @@ struct ProjectDTO{
     7: optional string domain,
 
     // information from external data sources
-    9: optional map<string, string> externalIds,
+    9: optional map<string, set<string>> externalIds,
     300: optional map<string, string> additionalData,
 
     // Additional informations


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)
###Description
This PR implements support for storing and searching multiple values per external ID key in SW360 projects, as discussed.
###Key Changes:

Updated Project.thrift to use map<string, set<string>> for the externalIds field, allowing projects to reference multiple external IDs under the same key.

Verified that service and search functionality returns all projects matching any provided external ID value.

Ensured that no restrictions are imposed on external ID duplication across projects, in line with SW360’s user-managed philosophy.



Issue: 
Resolves Issue #3046 
#3093 

### Suggest Reviewer
@GMishx 

### How To Test?
Create a project with multiple values for a single external ID key and confirm they are all stored.

Use the /projects/searchByExternalIds endpoint to search for projects by external ID and verify that all matching projects are returned.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
