### PR TITLE
fix(rest): improve error messages for invalid SBOM file imports

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2361,14 +2361,14 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             requestSummary = projectService.importSPDX(sw360User, attachment.getAttachmentContentId());
 
             if (!(requestSummary.getRequestStatus() == RequestStatus.SUCCESS)) {
-                throw new BadRequestClientException(requestSummary.getMessage());
+                throw new BadRequestClientException((requestSummary.getMessage()!=null)? requestSummary.getMessage() : "Invalid SBOM file");
             }
             projectId = requestSummary.getMessage();
         } else {
             requestSummary = projectService.importCycloneDX(sw360User, attachment.getAttachmentContentId(), "", true);
 
             if (requestSummary.getRequestStatus() == RequestStatus.FAILURE) {
-                throw new BadRequestClientException(requestSummary.getMessage());
+                throw new BadRequestClientException((requestSummary.getMessage()!=null)? requestSummary.getMessage() : "Invalid SBOM file");
             }
             else if (requestSummary.getRequestStatus() == RequestStatus.ACCESS_DENIED) {
                 throw new BadCredentialsException("You do not have sufficient permissions.");
@@ -2439,7 +2439,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         requestSummary = projectService.importCycloneDX(sw360User, attachment.getAttachmentContentId(), id, doNotReplacePackageAndRelease);
 
         if (requestSummary.getRequestStatus() == RequestStatus.FAILURE) {
-            throw new BadRequestClientException(requestSummary.getMessage());
+            throw new BadRequestClientException((requestSummary.getMessage()!=null)? requestSummary.getMessage() : "Invalid SBOM file");
         }else if(requestSummary.getRequestStatus() == RequestStatus.ACCESS_DENIED){
             throw new BadCredentialsException("You do not have sufficient permissions.");
         }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

i traced `importSBOM` method in  `ComponentController.java` and this problem handled by return message 'Invalid SBOM file' so i followed the same approch in `ProjectController.java` to achive consistent error handling for invalid SBOM uploads across both controllers.
Issue: 
closes: #3104
### Suggest Reviewer
> @GMishx 

### How To Test?
>  send invaild SBOM file
### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
