### PR TITLE
fix(component): ComponentDTO for /splitcomponent

### DIFF
--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -31,7 +31,6 @@ typedef sw360.PaginationData PaginationData
 typedef sw360.ClearingReportStatus ClearingReportStatus
 typedef sw360.ImportBomRequestPreparation ImportBomRequestPreparation
 typedef attachments.Attachment Attachment
-typedef attachments.AttachmentDTO AttachmentDTO
 typedef attachments.FilledAttachment FilledAttachment
 typedef users.User User
 typedef users.RequestedAction RequestedAction
@@ -141,7 +140,7 @@ struct ReleaseClearingStateSummary {
     3: required i32 underClearing,
     4: required i32 reportAvailable,
     5: required i32 approved,
-    6: required i32 scanAvailable, 
+    6: required i32 scanAvailable,
     7: required i32 internalUseScanAvailable,
 }
 
@@ -235,7 +234,7 @@ struct Release {
     // information from external data sources
     9: optional  map<string, string> externalIds,
     300: optional map<string, string> additionalData,
-    
+
     // Urls for the project
     70: optional string sourceCodeDownloadurl, // URL for download page for this release source code
     71: optional string binaryDownloadurl, // URL for download page for this release binaries
@@ -395,6 +394,7 @@ struct ComponentDTO {
     // information from external data sources
     31: optional  map<string, string> externalIds,
     300: optional map<string, string> additionalData,
+    33: optional set<string> releaseIds,
 
     36: optional Vendor defaultVendor,
     37: optional string defaultVendorId,
@@ -544,7 +544,7 @@ service ComponentService {
      * short summary of all accessible releases.
      **/
     list<Release> getAccessibleReleaseSummary(1: User user);
-    
+
     /**
      * search components in database that match subQueryRestrictions
      **/
@@ -801,7 +801,7 @@ service ComponentService {
 
     /**
      * Update the set of releases. Do only use for updating simple fields.
-     */ 
+     */
     RequestSummary updateReleasesDirectly(1: set<Release> releases, 2: User user);
 
     /**
@@ -849,7 +849,7 @@ service ComponentService {
      * get components with accessibility belonging to linked releases of the releases specified by releaseId
      **/
     set <Component> getUsingComponentsWithAccessibilityForComponent(1: set <string> releaseId, 2: User user);
-    
+
     /**
      * get components using the given vendor id
      */
@@ -988,7 +988,7 @@ service ComponentService {
 
     /**
      * Gets releases referencing the given release id
-     */ 
+     */
     list<Release> getReferencingReleases(1: string releaseId);
 
     /**
@@ -1028,7 +1028,7 @@ service ComponentService {
     /*
     * get component report in mail
     */
-    string getComponentReportInEmail(1: User user, 2: bool extendedByReleases) throws (1: SW360Exception exp); 
+    string getComponentReportInEmail(1: User user, 2: bool extendedByReleases) throws (1: SW360Exception exp);
 
     /**
     * Check accessible of release

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -53,6 +53,7 @@ import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.core.RestExceptionHandler;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.user.UserController;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
@@ -1089,7 +1090,40 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     @Operation(
             summary = "Split two components.",
             description = "Split source component into target component.",
-            tags = {"Components"}
+            tags = {"Components"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", description = "Request completed successfully."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404", description = "Source or target component not found.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "403", description = "Don't have permission to perform the action.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "409", description = "Source or target component has a Moderation Request open.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "500", description = "Internal server error.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
+                    )
+            }
     )
     @RequestMapping(value = COMPONENTS_URL + "/splitComponents", method = RequestMethod.PATCH)
     public ResponseEntity<RequestStatus> splitComponents(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -697,7 +697,6 @@ public class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties(value = {
-                "id",
                 "type",
                 "revision",
                 "createdBy",


### PR DESCRIPTION
> Please provide a summary of your changes here.

1. Use `ComponentDTO` for `/splitcomponent` as `Component` does not accept attachments.
2. Add `releaseIds` to `ComponentDTO` as `Component` has it and makes it easy for client to provide the release info.

### How To Test?
Try to split some components with multiple releases and attachments.