### PR TITLE
fix(Rest): Only admin users can delete license types in the admin license type.

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/licenses.adoc
+++ b/rest/resource-server/src/docs/asciidoc/licenses.adoc
@@ -270,3 +270,14 @@ include::{snippets}/should_document_get_license_report/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_get_license_report/http-response.adoc[]
+
+[[resources-license-type-delete]]
+==== Delete a single license type
+
+A `DELETE` request will delete a single license type.
+
+===== Example request
+include::{snippets}/should_document_delete_license_type/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_delete_license_type/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -540,4 +540,21 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         HttpStatus status = HttpStatus.OK;
         return new ResponseEntity<>(requestStatus, status);
     }
+
+    @Operation(
+            summary = "Delete a specific license type.",
+            description = "Delete a specific license type.",
+            tags = {"Licenses"}
+    )
+    @PreAuthorize("hasAuthority('WRITE')")
+    @RequestMapping(value = LICENSE_TYPES_URL + "/{id}", method = RequestMethod.DELETE)
+    public ResponseEntity deleteLicenseType(
+            @Parameter(description = "The id of the license type.")
+            @PathVariable("id") String id
+    ) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus status = licenseService.deleteLicenseType(id, sw360User);
+
+        return ResponseEntity.ok("License type deleted successfully: " + status.name());
+    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -121,6 +121,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         Mockito.doNothing().when(licenseServiceMock).importSpdxInformation(any());
         Mockito.doNothing().when(licenseServiceMock).getDownloadLicenseArchive(any(), any(), any());
         Mockito.doNothing().when(licenseServiceMock).uploadLicense(any(), any(), anyBoolean(), anyBoolean());
+        given(this.licenseServiceMock.deleteLicenseType(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.licenseServiceMock.importOsadlInformation(any())).willReturn(requestSummary);
         given(this.licenseServiceMock.addLicenseType(any(),any() , any())).willReturn(RequestStatus.SUCCESS);
         given(this.sw360ReportServiceMock.getLicenseBuffer()).willReturn(ByteBuffer.allocate(10000));
@@ -454,5 +455,13 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                     queryParameters(
                             parameterWithName("module").description("module represent the licenses. Possible values are `<licenses>`")
                     )));
+    }
+
+    @Test
+    public void should_document_delete_license_type() throws Exception {
+        mockMvc.perform(delete("/api/licenseTypes/" + license.getId())
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+        .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
…ense tab.

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #3114 
### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?
endpoint: 
http://localhost:8080/resource/api/licenses/6d990cf76cc16de6068e32ebd100091b/deleteLicenseType

![image](https://github.com/user-attachments/assets/06aa7a3b-d440-4139-9760-da1144b64116)


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
