### PR TITLE
feat(keycloak): allow thrift loc to be configured

### DIFF
--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -52,6 +52,10 @@ db-password=password
 
 # The full database JDBC URL. If not provided, a default URL is set based on the selected database vendor.
 db-url=jdbc:postgresql://localhost/keycloak
+
+# If thrift/backend is running on a different host, set these URL
+spi-events-listener-sw360-add-user-to-couchdb-thrift=http://localhost:8080
+spi-storage-sw360-user-storage-jpa-thrift=http://localhost:8080
 ```
 * Set environment variables for Keycloak administration:
 ```

--- a/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/Sw360CustomEventListenerProviderFactory.java
+++ b/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/Sw360CustomEventListenerProviderFactory.java
@@ -4,12 +4,14 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.keycloak.event.listener;
 
+import org.eclipse.sw360.keycloak.event.listener.service.Sw360UserService;
 import org.jboss.logging.Logger;
-import org.keycloak.Config.Scope;
+import org.keycloak.Config;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventListenerProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+
 /**
  * Factory class for creating instances of Sw360CustomEventListenerProvider.
  *
@@ -27,8 +29,13 @@ public class Sw360CustomEventListenerProviderFactory implements EventListenerPro
     }
 
     @Override
-    public void init(Scope config) {
+    public void init(Config.Scope config) {
         logger.info("Initializing Sw360CustomEventListenerProviderFactory with config: " + config);
+        if (config.get("thrift") != null && !config.get("thrift").isEmpty()) {
+            logger.infof("In SPI %s, setting thrift server URL to: '%s'",
+                    SW360_ADD_USER_TO_COUCHDB, config.get("thrift"));
+            Sw360UserService.thriftServerUrl = config.get("thrift");
+        }
     }
 
     @Override

--- a/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/service/Sw360UserService.java
+++ b/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/service/Sw360UserService.java
@@ -24,7 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.jboss.logging.Logger;
 
 public class Sw360UserService {
-    private String thriftServerUrl = "http://localhost:8080";
+    public static String thriftServerUrl = "http://localhost:8080";
     private static final Logger logger = Logger.getLogger(Sw360UserService.class);
 
     public List<User> getAllUsers() {

--- a/keycloak/user-storage-provider/src/main/java/org/eclipse/sw360/keycloak/spi/Sw360UserStorageProviderFactory.java
+++ b/keycloak/user-storage-provider/src/main/java/org/eclipse/sw360/keycloak/spi/Sw360UserStorageProviderFactory.java
@@ -9,6 +9,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.keycloak.spi.service.Sw360UserService;
 
+import org.keycloak.Config;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.*;
 import org.keycloak.storage.UserStorageProviderFactory;
@@ -49,8 +50,17 @@ public class Sw360UserStorageProviderFactory implements UserStorageProviderFacto
 	@Override
 	public void close() {
 		logger.debug("<<<<<< Closing factory");
-
 	}
+
+	@Override
+    public void init(Config.Scope config) {
+        logger.info("Initializing Sw360UserStorageProviderFactory with config: {}", config);
+        if (config.get("thrift") != null && !config.get("thrift").isEmpty()) {
+			logger.info("In SPI {}, setting thrift server URL to: '{}'",
+					PROVIDER_ID, config.get("thrift"));
+            Sw360UserService.thriftServerUrl = config.get("thrift");
+        }
+    }
 
 	/**
 	 * Synchronizes users from an external service with Keycloak.

--- a/keycloak/user-storage-provider/src/main/java/org/eclipse/sw360/keycloak/spi/service/Sw360UserService.java
+++ b/keycloak/user-storage-provider/src/main/java/org/eclipse/sw360/keycloak/spi/service/Sw360UserService.java
@@ -24,7 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.jboss.logging.Logger;
 
 public class Sw360UserService {
-    private String thriftServerUrl = "http://localhost:8080";
+    public static String thriftServerUrl = "http://localhost:8080";
     private static final Logger logger = Logger.getLogger(Sw360UserService.class);
 
     public List<User> getAllUsers() {
@@ -102,7 +102,7 @@ public class Sw360UserService {
         }
         return null;
     }
-    
+
     public RequestStatus updateUser(User user) throws Exception{
         UserService.Iface sw360UserClient = getThriftUserClient();
         RequestStatus requestStatus = sw360UserClient.updateUser(user);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Feature to make thrift location configurable in KeyCloak SPI.

Read thrift server location from KeyCloak SPI configuration provider as
1. Either config
    ```
    spi-events-listener-sw360-add-user-to-couchdb-thrift=http://thrift:8080
    spi-storage-sw360-user-storage-jpa-thrift=http://thrift:8080
    ```
2. Environment variable
    ```
    KC_SPI_EVENTS_LISTENER_SW360_ADD_USER_TO_COUCHDB_THRIFT=http://thrift:8080
    KC_SPI_STORAGE_SW360_USER_STORAGE_JPA_THRIFT=http://thrift:8080
    ```

Both have default value to `http://localhost:8080`

### How To Test?
Try to connect with backend not running on `localhost:8080` and:
1. Modify an existing user.
2. Import users from CouchDB.