### PR TITLE
feat(rest): endpoint to get src file list for the licenses.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -1805,7 +1805,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @GetMapping(value = RELEASES_URL + "/{id}/licenseData/{attachContentId}" )
+    @RequestMapping(value = RELEASES_URL + "/{id}/licenseData/{attachContentId}", method = RequestMethod.GET)
     public ResponseEntity<List<Map<String,String>>> getReleaseLicenseInfo(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String relId,
@@ -1826,12 +1826,66 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             }
         }
         if (!found) {
-            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "Attachment not found");
+            throw new ResourceNotFoundException("Attachment not found");
         }
         results = releaseService.getReleaseLicenseInfo(sw360Release, user, attachContentId);
         if (!type) {
             return new ResponseEntity<>(results, HttpStatus.BAD_REQUEST);
         }
+        return new ResponseEntity<>(results, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Get license data.",
+            description = "Get license source files list and other license data from release attachment.",
+            tags = {"Releases"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", description = "License Data for the attachment.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(
+                                                    example = """
+                                                        {
+                                                          "relId": "54321",
+                                                          "relName": "releaseName",
+                                                          "data": [
+                                                            {
+                                                              "licName": "MIT",
+                                                              "licType": "Global",
+                                                              "srcFiles": [ "dir1/file1", "dir2/file2" ],
+                                                              "licSpdxId": "MIT"
+                                                            }
+                                                          ],
+                                                          "attName": "filename.xml"
+                                                        }
+                                                        """
+                                            ))
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "400", description = "source file information not found in cli attachment"
+                    ),
+                    @ApiResponse(
+                            responseCode = "409", description = "multiple approved cli are found in the release"
+                    ),
+                    @ApiResponse(
+                            responseCode = "404", description = "cli attachment not found in the release"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500", description = "Internal server error, while processing the request."
+                    )
+
+            }
+    )
+    @RequestMapping(value = RELEASES_URL + "/{id}/licenseFileList", method = RequestMethod.GET)
+    public ResponseEntity<Map<String, Object>> getReleaseLicenseFileList(
+            @Parameter(description = "The ID of the release.")
+            @PathVariable("id") String relId
+    ) throws TException {
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        Release sw360Release = releaseService.getReleaseForUserById(relId, user);
+        Map<String, Object> results = releaseService.getReleaseLicenseFileListInfo(sw360Release, user);
         return new ResponseEntity<>(results, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
Issue: #3144

Description: this new endpoint will help to get the licenses info present in release attachment in project's license clearing page.

![image](https://github.com/user-attachments/assets/ce6d0d03-e39d-4c8e-afb4-e82c9d1e7416)

