### PR TITLE
fix(svm): SVMSyncHandler dont return loop

### DIFF
--- a/backend/schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
+++ b/backend/schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
@@ -80,6 +80,7 @@ public class ScheduleHandler implements ScheduleService.Iface {
                 break;
             case ThriftClients.SVM_TRACKING_FEEDBACK_SERVICE:
                 successSync = wrapSupplierException(() -> thriftClients.makeComponentClient().updateReleasesWithSvmTrackingFeedback(), serviceName);
+                break;
             case ThriftClients.DELETE_ATTACHMENT_SERVICE:
                 successSync = wrapSupplierException(() -> thriftClients.makeAttachmentClient().deleteOldAttachmentFromFileSystem(), serviceName);
                 break;


### PR DESCRIPTION
In SVMSyncHandler::getVulnerabilitiesByComponent
function, used to create ReleaseVulnerabilityRelation, do not return in between the loop.

Closes #3173

