### PR TITLE
feat(Release): Need createdBy field for list of releases under a comp…

### DIFF
--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -440,7 +440,8 @@ struct ReleaseLink{
     107: optional i32 index,
     108: optional string defaultValue,
     109: optional string projectId,
-    110: optional MainlineState releaseMainLineState
+    110: optional MainlineState releaseMainLineState,
+    112: optional string createdBy // person who created the release
 }
 
 struct ReleaseClearingStatusData {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -204,6 +204,9 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
             releaseLink.setVersion(release.getVersion());
             releaseLink.setClearingState(release.getClearingState());
 
+            //  Added as part of https://github.com/eclipse-sw360/sw360/issues/3161
+            releaseLink.setCreatedBy(release.getCreatedBy());
+
             ClearingReport clearingReport = new ClearingReport();
             Set<Attachment> attachments = getAttachmentForClearingReport(release);
             if (!attachments.equals(Collections.emptySet())) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -1376,7 +1376,9 @@ public class JacksonCustomizations {
                 "setDefaultValue",
                 "setProjectId",
                 "setReleaseMainLineState",
-                "setComponentId"
+                "setComponentId",
+                "setCreatedBy",
+                "createdByIsSet"
         })
         static abstract class ReleaseLinkMixin extends ReleaseLink {
 


### PR DESCRIPTION
…onent

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Added field CreatedBy in ReleaseLink of component.thrift and reading createdBy value from Realese and set to ReleaseLink in Sw360ComponentService.convertReleaseToReleaseLink()


Closes #3161

### Suggest Reviewer
@GMishx 

### How To Test?
> CreateBy should be available in Response of API : /components/{componentId}/releases

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
