### PR TITLE
fix(rest) : Avoid multiple entries of same license in ReadMeOSS generated from SW360

### DIFF
--- a/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -139,11 +139,14 @@
 #foreach($ack in ${acks})
     #set($containsLink = $ack.matches($anchorRegEx))
     #set($containsScript = $ack.matches($scriptRegEx))
-    #set($ackAsHtml = $esc.xml($ack))
+    #set($isSkipValue = $ack.matches("skip\\$\\d+")) ## Check if the value matches skip$1, skip$2, etc.
+    #if(!$isSkipValue) ## Only process if it is not a skip value
+        #set($ackAsHtml = $esc.xml($ack))
     #if($containsLink && !$containsScript)
         #set($ackAsHtml = $ack)
     #end
 $ackAsHtml
+    #end
 #end
     </pre>
                     #end
@@ -212,13 +215,15 @@ $copyrightAsHtml
                 #end
             #end
 
-            #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
-            <li id="licenseTextItem$licenseId">
-                <h3>$licenseId: $licenseName<a class="top" href="#releaseHeader">&#8679;</a></h3>
-    <pre class="licenseText" id="licenseText$licenseId">
-$licenseTextAsHtml
-    </pre>
-            </li>
+            #if($licenseTextAsHtml != "&lt;no license text available&gt;")
+                #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
+                <li id="licenseTextItem$licenseId">
+                    <h3>$licenseId: $licenseName<a class="top" href="#releaseHeader">&#8679;</a></h3>
+                    <pre class="licenseText" id="licenseText$licenseId">
+                        $licenseTextAsHtml
+                    </pre>
+                </li>
+            #end
         #end
         </ul>
     #end


### PR DESCRIPTION
…

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 


### How To Test?
Sample URL : 

http://localhost:8080/resource/api/reports?projectId=6f3fe36085b49ea07ef51bec50000f6b&module=licenseInfo&variant=DISCLOSURE&generatorClassName=XhtmlGenerator

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
