### PR TITLE
feat(component): use DB side pagination

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -785,6 +785,14 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
     }
 
+    public Map<PaginationData, List<Component>> searchComponentByNamePrefixPaginated(User user, String name, PaginationData pageData) {
+        return componentRepository.searchComponentByNamePrefixPaginated(user, name, pageData);
+    }
+
+    public Map<PaginationData, List<Component>> searchComponentByExactNamePaginated(User user, String name, PaginationData pageData) {
+        return componentRepository.searchComponentByExactNamePaginated(user, name, pageData);
+    }
+
     private boolean isDependenciesExistInComponent(Component component) {
         boolean isValidDependentIds = true;
         if (component.isSetReleaseIds()) {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -16,14 +16,14 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.SummaryAwareRepository;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
 import com.ibm.cloud.cloudant.v1.model.PostViewOptions;
-import com.ibm.cloud.cloudant.v1.model.ViewResult;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 
 /**
@@ -274,53 +274,36 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
     }
 
     public Map<PaginationData, List<Component>> getRecentComponentsSummary(User user, PaginationData pageData) {
-        final int rowsPerPage = pageData.getRowsPerPage();
-        final int offset = pageData.getDisplayStart();
         Map<PaginationData, List<Component>> result = Maps.newHashMap();
-        List<Component> components = Lists.newArrayList();
-        final boolean ascending = pageData.isAscending();
-        final int sortColumnNo = pageData.getSortColumnNumber();
+        List<Component> components = queryViewPaginated(getViewFromPagination(pageData), pageData);
 
-        PostViewOptions.Builder query;
-        switch (sortColumnNo) {
-            case -1:
-                query = getConnector().getPostViewQueryBuilder(Component.class, "byCreatedOn");
-                break;
-            case 0:
-                query = getConnector().getPostViewQueryBuilder(Component.class, "byvendor");
-                break;
-            case 1:
-                query = getConnector().getPostViewQueryBuilder(Component.class, "byname");
-                break;
-            case 2:
-                query = getConnector().getPostViewQueryBuilder(Component.class, "bymainlicense");
-                break;
-            case 3:
-                query = getConnector().getPostViewQueryBuilder(Component.class, "bycomponenttype");
-                break;
-            default:
-                query = getConnector().getPostViewQueryBuilder(Component.class, "all");
-                break;
-        }
-
-        PostViewOptions request;
-        if (rowsPerPage == -1) {
-            request = query.descending(!ascending).includeDocs(true).build();
-        } else {
-            request = query.limit(rowsPerPage).skip(offset)
-                    .descending(!ascending).includeDocs(true).build();
-        }
-
-        try {
-            ViewResult response = getConnector().getPostViewQueryResponse(request);
-            components = getPojoFromViewResponse(response);
-            pageData.setTotalRowCount(response.getTotalRows());
-        } catch (ServiceConfigurationError e) {
-            log.error("Error getting recent components", e);
-        }
-        components = makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, components, user);
-        result.put(pageData, components);
+        result.put(pageData, makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, components, user));
         return result;
+    }
+
+    public Map<PaginationData, List<Component>> searchComponentByNamePrefixPaginated(User user, String name, PaginationData pageData) {
+        Map<PaginationData, List<Component>> result = Maps.newHashMap();
+        List<Component> components = queryByPrefixPaginated("bynamelowercase", name, pageData);
+        result.put(pageData, makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, components, user));
+        return result;
+    }
+
+    public Map<PaginationData, List<Component>> searchComponentByExactNamePaginated(User user, String name, PaginationData pageData) {
+        Map<PaginationData, List<Component>> result = Maps.newHashMap();
+        List<Component> components = queryViewPaginated("bynamelowercase", name, pageData);
+        result.put(pageData, makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, components, user));
+        return result;
+    }
+
+    private static @Nonnull String getViewFromPagination(PaginationData pageData) {
+        return switch (ComponentSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ComponentSortColumn.BY_CREATEDON -> "byCreatedOn";
+            case ComponentSortColumn.BY_VENDOR -> "byvendor";
+            case ComponentSortColumn.BY_NAME -> "byname";
+            case ComponentSortColumn.BY_MAINLICENSE -> "bymainlicense";
+            case ComponentSortColumn.BY_TYPE -> "bycomponenttype";
+            case null -> "all";
+        };
     }
 
     public List<Component> getComponentsByVCS() {

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -134,8 +134,8 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
-    public List<Component> refineSearchAccessibleComponents(String text, Map<String,Set<String>> subQueryRestrictions, User user) throws TException {
-        return componentSearchHandler.searchAccessibleComponents(text, subQueryRestrictions, user);
+    public Map<PaginationData, List<Component>> refineSearchAccessibleComponents(String text, Map<String,Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        return componentSearchHandler.searchAccessibleComponents(text, subQueryRestrictions, user, pageData);
     }
 
     @Override
@@ -163,6 +163,16 @@ public class ComponentHandler implements ComponentService.Iface {
     @Override
     public List<Release> searchReleaseByNamePrefix(String name) throws TException {
         return handler.searchReleaseByNamePrefix(name);
+    }
+
+    @Override
+    public Map<PaginationData, List<Component>> searchComponentByNamePrefixPaginated(User user, String name, PaginationData pageData) {
+        return handler.searchComponentByNamePrefixPaginated(user, name, pageData);
+    }
+
+    @Override
+    public Map<PaginationData, List<Component>> searchComponentByExactNamePaginated(User user, String name, PaginationData pageData) {
+        return handler.searchComponentByExactNamePaginated(user, name, pageData);
     }
 
     @Override

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -12,8 +12,6 @@ package org.eclipse.sw360.datahandler.cloudantclient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -40,7 +38,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -428,17 +425,22 @@ public class DatabaseConnectorCloudant {
     }
 
     public <T> PostViewOptions.Builder getPostViewQueryBuilder(
-            @NotNull Class<T> type, String queryName) {
+            @NotNull Class<T> type, String viewName) {
         return new PostViewOptions.Builder()
                 .db(this.dbName)
                 .ddoc(type.getSimpleName())
-                .view(queryName);
+                .view(viewName);
     }
 
     public ViewResult getPostViewQueryResponse(PostViewOptions options) {
-        return this.instance.getClient().postView(options)
-                .execute()
-                .getResult();
+        try {
+            return this.instance.getClient().postView(options)
+                    .execute()
+                    .getResult();
+        } catch (ServiceResponseException e) {
+            log.error("Unable to run query on view {}. Check response: {}", options.view(), e.getMessage());
+            throw new RuntimeException("Something went wrong. Please try again later.", e);
+        }
     }
 
     public InputStream getAttachment(String docId, String attachmentName) {
@@ -754,7 +756,7 @@ public class DatabaseConnectorCloudant {
         }
     }
 
-    private <T> boolean isInstanceOfOAuthClientEntity(T doc) {    
+    private <T> boolean isInstanceOfOAuthClientEntity(T doc) {
         return doc.getClass().getSimpleName().equals("OAuthClientEntity");
     }
 

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -12,7 +12,6 @@ package org.eclipse.sw360.datahandler.cloudantclient;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -25,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TFieldIdEnum;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -49,7 +49,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class DatabaseRepositoryCloudantClient<T> {
 
-    protected final Logger log = LogManager.getLogger(DatabaseConnectorCloudant.class);
+    protected final Logger log = LogManager.getLogger(DatabaseRepositoryCloudantClient.class);
     private static final char HIGH_VALUE_UNICODE_CHARACTER = '\uFFF0';
 
     private final Class<T> type;
@@ -156,6 +156,47 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryView(query);
     }
 
+    public List<T> queryViewPaginated(String viewName, String startKey, String endKey, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, viewName)
+                .descending(!ascending)
+                .includeDocs(true);
+
+        if (ascending) {
+            query.startKey(startKey)
+                    .endKey(endKey);
+        } else {
+            query.startKey(endKey)
+                    .endKey(startKey);
+        }
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryViewPaginated(query.build(), pageData);
+    }
+
+    public List<T> queryViewPaginated(String viewName, String key, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, viewName)
+                .descending(!ascending)
+                .keys(Collections.singletonList(key))
+                .includeDocs(true);
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryViewPaginated(query.build(), pageData);
+    }
+
     public List<T> queryView(String viewName, String key) {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, viewName)
                 .keys(Collections.singletonList(key))
@@ -169,12 +210,38 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryView(query);
     }
 
+    public List<T> queryViewPaginated(String viewName, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, viewName)
+                .descending(!ascending)
+                .includeDocs(true);
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryViewPaginated(query.build(), pageData);
+    }
+
     public Set<String> queryForIds(PostViewOptions query) {
         ViewResult response = this.connector.getPostViewQueryResponse(query);
         HashSet<String> ids = new HashSet<>();
         for (ViewResultRow row : response.getRows()) {
             ids.add(row.getId());
         }
+        return ids;
+    }
+
+    public Set<String> queryForIdsPaginated(PostViewOptions query, PaginationData pageData) {
+        ViewResult response = this.connector.getPostViewQueryResponse(query);
+        HashSet<String> ids = new HashSet<>();
+        for (ViewResultRow row : response.getRows()) {
+            ids.add(row.getId());
+        }
+        pageData.setTotalRowCount(response.getTotalRows());
         return ids;
     }
 
@@ -200,8 +267,16 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryView(viewName, key, key + HIGH_VALUE_UNICODE_CHARACTER);
     }
 
+    public List<T> queryByPrefixPaginated(String viewName, String key, PaginationData pageData) {
+        return queryViewPaginated(viewName, key, key + HIGH_VALUE_UNICODE_CHARACTER, pageData);
+    }
+
     public Set<String> queryForIdsByPrefix(String viewName, String prefix) {
         return queryForIds(viewName, prefix, prefix + HIGH_VALUE_UNICODE_CHARACTER);
+    }
+
+    public Set<String> queryForIdsByPrefixPaginated(String viewName, String prefix, PaginationData pageData) {
+        return queryForIdsPaginated(viewName, prefix, prefix + HIGH_VALUE_UNICODE_CHARACTER, pageData);
     }
 
     public Set<String> queryForIdsAsValueByPrefix(String viewName, String prefix) {
@@ -216,6 +291,29 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryForIds(query);
     }
 
+    public Set<String> queryForIdsPaginated(String queryName, String startKey, String endKey, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, queryName)
+                .descending(!ascending);
+
+        if (ascending) {
+            query.startKey(startKey)
+                    .endKey(endKey);
+        } else {
+            query.startKey(endKey)
+                    .endKey(startKey);
+        }
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryForIdsPaginated(query.build(), pageData);
+    }
+
     public Set<String> queryForIdsAsValue(String queryName, String startKey, String endKey) {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, queryName)
                 .startKey(startKey)
@@ -228,6 +326,22 @@ public class DatabaseRepositoryCloudantClient<T> {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, queryName)
                 .keys(Collections.singletonList(key)).build();
         return queryForIds(query);
+    }
+
+    public Set<String> queryForIdsPaginated(String queryName, String key, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, queryName)
+                .keys(Collections.singletonList(key))
+                .descending(!ascending);
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryForIdsPaginated(query.build(), pageData);
     }
 
     public Set<String> queryForIdsAsComplexValue(String queryName, String... keys) {
@@ -279,6 +393,18 @@ public class DatabaseRepositoryCloudantClient<T> {
         try {
             ViewResult response = getConnector().getPostViewQueryResponse(req);
             docList = getPojoFromViewResponse(response);
+        } catch (ServiceResponseException e) {
+            log.warn("Error in getting documents", e);
+        }
+        return docList;
+    }
+
+    public List<T> queryViewPaginated(PostViewOptions req, PaginationData pageData) {
+        List<T> docList = Lists.newArrayList();
+        try {
+            ViewResult response = getConnector().getPostViewQueryResponse(req);
+            docList = getPojoFromViewResponse(response);
+            pageData.setTotalRowCount(response.getTotalRows());
         } catch (ServiceResponseException e) {
             log.warn("Error in getting documents", e);
         }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -32,6 +33,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -117,11 +119,44 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     }
 
     /**
+     * Search with lucene with pagination support
+     */
+    public <T> Map<PaginationData, List<T>> searchView(
+            Class<T> type, String indexName, String queryString,
+            PaginationData pageData, String sortColumn, boolean sortAscending
+    ) {
+        Map<PaginationData, List<String>> idMap = searchIds(type, indexName, queryString,
+                pageData, sortColumn, sortAscending);
+
+        PaginationData respPageData = idMap.keySet().iterator().next();
+        List<T> collections = connector.get(type, idMap.values().iterator().next());
+
+        return Collections.singletonMap(respPageData, collections);
+    }
+
+    /**
      * Search with lucene using the previously declared search function only for ids
      */
     public <T> List<String> searchIds(Class<T> type, String indexName, String queryString) {
         NouveauResult queryNouveauResult = searchView(indexName, queryString, false);
         return getIdsFromResult(queryNouveauResult);
+    }
+
+    /**
+     * Search with lucene for ids with pagination support.
+     */
+    public <T> Map<PaginationData, List<String>> searchIds(
+            Class<T> type, String indexName, String queryString,
+            PaginationData pageData, String sortColumn, boolean sortAscending
+    ) {
+        NouveauResult queryNouveauResult = searchView(indexName, queryString,
+                false, pageData, sortColumn, sortAscending);
+        if (queryNouveauResult != null) {
+            pageData.setTotalRowCount(queryNouveauResult.getTotalHits());
+        } else {
+            pageData.setTotalRowCount(0);
+        }
+        return Collections.singletonMap(pageData, getIdsFromResult(queryNouveauResult));
     }
 
     /**
@@ -183,6 +218,19 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return callLuceneDirectly(indexName, queryString, includeDocs);
     }
 
+    /**
+     * Search with lucene with pagination support
+     */
+    private @Nullable NouveauResult searchView(String indexName, String queryString, boolean includeDocs,
+                                               PaginationData pageData, String sortColumn,
+                                               boolean sortAscending) {
+        if (isNullOrEmpty(queryString)) {
+            return null;
+        }
+
+        return callLuceneDirectly(indexName, queryString, includeDocs, pageData, sortColumn, sortAscending);
+    }
+
     private @Nullable NouveauResult callLuceneDirectly(String indexName, String queryString, boolean includeDocs) {
         NouveauQuery query = new NouveauQuery(queryString);
         query.setIncludeDocs(includeDocs);
@@ -195,6 +243,53 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             log.error("Nouveau query failed: {}", e.getResponseBody(), e);
         }
         return null;
+    }
+
+    private @Nullable NouveauResult callLuceneDirectly(String indexName, String queryString, boolean includeDocs,
+                                                       @NotNull PaginationData pageData, String sortColumn,
+                                                       boolean sortAscending) {
+        final int limit = pageData.getRowsPerPage() > 0 ? pageData.getRowsPerPage() : DatabaseSettings.LUCENE_SEARCH_LIMIT;
+        final int requiredPage = pageData.getDisplayStart() / limit;
+
+        NouveauQuery query = new NouveauQuery(queryString);
+        query.setIncludeDocs(includeDocs);
+        if (sortColumn != null && !sortColumn.isEmpty()) {
+            query.setSort(sortAscending ? sortColumn : "-" + sortColumn);
+        } else {
+            query.setSort(null);
+        }
+        query.setLimit(limit);
+
+        int currentPage = 0;
+        String bookmark = "";
+        String previousBookmark = "";
+        NouveauResult result = null;
+        try {
+            do {
+                if (!bookmark.isEmpty()) {
+                    query.reset();
+                    query.setBookmark(bookmark);
+                    previousBookmark = bookmark;
+                }
+                result = queryNouveau(indexName, query);
+                bookmark = result.getBookmark();
+                currentPage += 1;
+            } while (moreResultsAvailable(result, previousBookmark) && currentPage <= requiredPage);
+        } catch (ServiceResponseException e) {
+            log.error("Nouveau query failed: {}", e.getResponseBody(), e);
+        }
+        return result;
+    }
+
+    /**
+     * Check if there are more results available based on the current result and bookmark.
+     * @param result The result of the previous query.
+     * @param bookmark The bookmark from the previous query.
+     * @return True if there are more results available, false otherwise.
+     */
+    private boolean moreResultsAvailable(NouveauResult result, String bookmark) {
+        return result != null && result.getHits() != null && !result.getHits().isEmpty()
+                && !bookmark.equals(result.getBookmark());
     }
 
     /////////////////////////
@@ -226,9 +321,26 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     public <T> List<T> searchViewWithRestrictions(Class<T> type, String indexName,
                                                   String text,
                                                   final @NotNull Map<String, Set<String>> subQueryRestrictions) {
+        String query = convertToRestrictiveQuery(type, text, subQueryRestrictions);
+
+        return searchView(type, indexName, query);
+    }
+
+    /**
+     * Search the database for a given string and types, with pagination support.
+     */
+    public <T> Map<PaginationData, List<T>> searchViewWithRestrictions(
+            Class<T> type, String indexName, String text,
+            final @NotNull Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData, String sortColumn, boolean sortAscending
+    ) {
+        String query = convertToRestrictiveQuery(type, text, subQueryRestrictions);
+        return searchView(type, indexName, query, pageData, sortColumn, sortAscending);
+    }
+
+    private static <T> @NotNull String convertToRestrictiveQuery(Class<T> type, String text, @NotNull Map<String, Set<String>> subQueryRestrictions) {
         List <String> subQueries = new ArrayList<>();
         for (Map.Entry<String, Set<String>> restriction : subQueryRestrictions.entrySet()) {
-
             final Set<String> filterSet = restriction.getValue();
 
             if (!filterSet.isEmpty()) {
@@ -246,9 +358,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             // get all packages with name field and then negate with releaseId field to find orphan packages
             subQueries.add("(name:*) NOT (releaseId:*)");
         }
-        String query = AND.join(subQueries);
-
-        return searchView(type, indexName, query);
+        return AND.join(subQueries);
     }
 
     private static @NotNull String formatSubquery(@NotNull Set<String> filterSet, final String fieldName) {

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
@@ -41,7 +41,14 @@ public class ResourceListController<T> {
 
     public PaginationResult<T> getPaginationResultFromPaginatedList(List<T> resources,
                                                                     PaginationOptions<T> paginationOptions,
-                                                                    int totalCount) {
+                                                                    int totalCount) throws PaginationParameterException {
+        if (resources.isEmpty()) {
+            if (paginationOptions.getPageNumber() == 0) {
+                return new PaginationResult<>(resources, 0, paginationOptions);
+            } else {
+                throw new PaginationParameterException(PAGINATION_PARAMETER_EXCEPTION_MESSAGE);
+            }
+        }
         return new PaginationResult<>(this.sortList(resources, paginationOptions.getSortComparator()),
                 totalCount, paginationOptions);
     }

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -459,6 +459,14 @@ enum BulkOperationResultState {
     EXCLUDED = 3,
 }
 
+enum ComponentSortColumn {
+    BY_CREATEDON = -1,
+    BY_VENDOR = 0,
+    BY_NAME = 1,
+    BY_MAINLICENSE = 2,
+    BY_TYPE = 3,
+}
+
 enum BulkOperationNodeType {
     PROJECT = 0,
     COMPONENT = 1,
@@ -555,7 +563,7 @@ service ComponentService {
      * search components in database that match subQueryRestrictions
      * They are only the components which are visible to user.
      **/
-    list<Component> refineSearchAccessibleComponents(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: User user);
+    map<PaginationData, list<Component>> refineSearchAccessibleComponents(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: User user, 4: PaginationData pageData);
 
     /**
      * search components with the accessibility in database that match subQueryRestrictions
@@ -581,6 +589,16 @@ service ComponentService {
      * get short summary of release by release name prefix
      **/
     list<Release> searchReleaseByNamePrefix(1: string name);
+
+    /**
+     * Get Components with name prefix and paginated
+     **/
+    map<PaginationData, list<Component>> searchComponentByNamePrefixPaginated(1: User user, 2: string name, 3: PaginationData pageData);
+
+    /**
+     * Get Components with exact name and paginated
+     **/
+    map<PaginationData, list<Component>> searchComponentByExactNamePaginated(1: User user, 2: string name, 3: PaginationData pageData);
 
     /**
      * information for home portlet

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -29,6 +29,7 @@ import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseCo
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.ImportBomRequestPreparation;
@@ -180,35 +181,41 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
         List<Component> allComponents = new ArrayList<>();
-        String queryString = request.getQueryString();
-        Map<String, String> params = restControllerHelper.parseQueryString(queryString);
+        Map<PaginationData, List<Component>> paginatedComponents = null;
 
+        Map<String, Set<String>> filterMap = getFilterMap(categories, componentType, languages, softwarePlatforms,
+                operatingSystems, vendors, mainLicenses, createdBy, createdOn);
         if (luceneSearch) {
-            Map<String, Set<String>> filterMap = getFilterMap(categories, componentType, languages, softwarePlatforms,
-                    operatingSystems, vendors, mainLicenses, createdBy, createdOn);
             if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
                 Set<String> values = CommonUtils.splitToSet(name);
                 values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
                         .collect(Collectors.toSet());
                 filterMap.put(Component._Fields.NAME.getFieldName(), values);
             }
-            allComponents.addAll(componentService.refineSearch(filterMap, sw360User));
+            paginatedComponents = componentService.refineSearch(filterMap, sw360User, pageable);
         } else {
-            if (name != null && !name.isEmpty()) {
-                allComponents.addAll(componentService.searchComponentByName(params.get("name")));
+            if (name != null && !name.isEmpty() && filterMap.isEmpty()) {
+                paginatedComponents = componentService.searchComponentByExactNamePaginated(sw360User, name, pageable);
+            } else if (filterMap.isEmpty()) {
+                paginatedComponents = componentService.getRecentComponentsSummaryWithPagination(sw360User, pageable);
             } else {
                 allComponents.addAll(componentService.getComponentsForUser(sw360User));
-            }
-            Map<String, Set<String>> restrictions = getFilterMap(categories, componentType, languages,
-                    softwarePlatforms, operatingSystems, vendors, mainLicenses, createdBy, createdOn);
-            if (!restrictions.isEmpty()) {
                 allComponents = new ArrayList<>(allComponents.stream()
-                        .filter(filterComponentMap(restrictions)).toList());
+                        .filter(filterComponentMap(filterMap)).toList());
             }
         }
 
-        PaginationResult<Component> paginationResult = restControllerHelper.createPaginationResult(request, pageable,
-                allComponents, SW360Constants.TYPE_COMPONENT);
+        PaginationResult<Component> paginationResult;
+        if (paginatedComponents != null) {
+            allComponents.addAll(paginatedComponents.values().iterator().next());
+            int totalCount = Math.toIntExact(paginatedComponents.keySet().stream()
+                    .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));
+            paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                    request, pageable, allComponents, SW360Constants.TYPE_COMPONENT, totalCount);
+        } else {
+            paginationResult = restControllerHelper.createPaginationResult(request, pageable,
+                    allComponents, SW360Constants.TYPE_COMPONENT);
+        }
 
         CollectionModel resources = getFilteredComponentResources(fields, allDetails, sw360User, paginationResult);
         return new ResponseEntity<>(resources, HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -27,6 +27,7 @@ import org.eclipse.sw360.datahandler.thrift.components.ClearingReport;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentDTO;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
@@ -40,6 +41,8 @@ import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -69,6 +72,13 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
     public List<Component> getComponentsForUser(User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.getComponentSummary(sw360User);
+    }
+
+    public Map<PaginationData, List<Component>> getRecentComponentsSummaryWithPagination(User sw360User,
+                                                                                         Pageable pageable) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        PaginationData pageData = pageableToPaginationData(pageable);
+        return sw360ComponentClient.getRecentComponentsSummaryWithPagination(sw360User, pageData);
     }
 
     public Release getReleaseById(String id, User sw360User) {
@@ -184,9 +194,11 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         }
     }
 
-    public List<Component> searchComponentByName(String name) throws TException {
+    public Map<PaginationData, List<Component>> searchComponentByExactNamePaginated(
+            User sw360User, String name, Pageable pageable
+    ) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        return sw360ComponentClient.searchComponentForExport(name.toLowerCase(), false);
+        return sw360ComponentClient.searchComponentByExactNamePaginated(sw360User, name.toLowerCase(Locale.ROOT), pageableToPaginationData(pageable));
     }
 
     public List<Release> getReleasesByComponentId(String id,User user) throws TException {
@@ -211,7 +223,7 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
             Set<Attachment> attachments = getAttachmentForClearingReport(release);
             if (!attachments.equals(Collections.emptySet())) {
                 Set<Attachment> attachmentsAccepted = getAttachmentsStatusAccept(attachments);
-                if(attachmentsAccepted.size() != 0) {
+                if(!attachmentsAccepted.isEmpty()) {
                     clearingReport.setClearingReportStatus(ClearingReportStatus.DOWNLOAD);
                     clearingReport.setAttachments(attachmentsAccepted);
                     releaseLink.setClearingReport(clearingReport);
@@ -247,9 +259,8 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
 
     private Boolean checkStatusAttachment(Release release){
         final Set<Attachment> attachments = release.getAttachments();
-        boolean checkStatusAttachment = attachments.stream().anyMatch(attachment ->
+        return attachments.stream().anyMatch(attachment ->
                 CheckStatus.ACCEPTED.equals(attachment.getCheckStatus()));
-        return checkStatusAttachment;
     }
 
     private ComponentService.Iface getThriftComponentClient() throws TTransportException {
@@ -339,7 +350,6 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
      *
      * @param componentId Ids of Component
      * @return int                    Number of projects
-     * @throws TException
      */
     public int countProjectsByComponentId(String componentId, User sw360user) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
@@ -348,9 +358,10 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         return projectService.countProjectsByReleaseIds(releaseIds);
     }
 
-    public List<Component> refineSearch(Map<String, Set<String>> filterMap, User sw360User) throws TException {
+    public Map<PaginationData, List<Component>> refineSearch(Map<String, Set<String>> filterMap, User sw360User, Pageable pageable) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        return sw360ComponentClient.refineSearchAccessibleComponents(null, filterMap, sw360User);
+        PaginationData pageData = pageableToPaginationData(pageable);
+        return sw360ComponentClient.refineSearchAccessibleComponents(null, filterMap, sw360User, pageData);
     }
 
     /**
@@ -400,5 +411,32 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         }
 
         return releases;
+    }
+
+    /**
+     * Converts a Pageable object to a PaginationData object.
+     *
+     * @param pageable the Pageable object to convert
+     * @return a PaginationData object representing the pagination information
+     */
+    private static PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
+        ComponentSortColumn column = ComponentSortColumn.BY_CREATEDON;
+        boolean ascending = false;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            column = switch (property) {
+                case "created" -> ComponentSortColumn.BY_CREATEDON;
+                case "name" -> ComponentSortColumn.BY_NAME;
+                case "vendor" -> ComponentSortColumn.BY_VENDOR;
+                case "license" -> ComponentSortColumn.BY_MAINLICENSE;
+                case "type" -> ComponentSortColumn.BY_TYPE;
+                default -> column; // Default to BY_CREATEDON if no match
+            };
+            ascending = order.isAscending();
+        }
+        return new PaginationData().setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -218,7 +218,7 @@ public class RestControllerHelper<T> {
 
     public PaginationResult<T> paginationResultFromPaginatedList(HttpServletRequest request, Pageable pageable,
                                                                  List<T> resources, String resourceType, int totalCount)
-            throws ResourceClassNotFoundException {
+            throws ResourceClassNotFoundException, PaginationParameterException {
         if (!requestContainsPaging(request)) {
             request.setAttribute(PAGINATION_PARAM_PAGE, pageable.getPageNumber());
             request.setAttribute(PAGINATION_PARAM_PAGE_ENTRIES, pageable.getPageSize());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -26,6 +26,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
@@ -123,7 +124,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             HttpServletRequest request,
             @Parameter(description = "Fetch all details of the moderation request")
             @RequestParam(value = "allDetails", required = false) boolean allDetails
-    ) throws TException, ResourceClassNotFoundException, URISyntaxException {
+    ) throws TException, ResourceClassNotFoundException, URISyntaxException, PaginationParameterException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         List<ModerationRequest> moderationRequests = sw360ModerationRequestService.getRequestsByModerator(sw360User, pageable);
 
@@ -187,7 +188,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             @RequestParam(value = "state", defaultValue = "open", required = true) String state,
             @Parameter(description = "Fetch all details of the moderation request.")
             @RequestParam(value = "allDetails", required = false) boolean allDetails
-    ) throws TException, URISyntaxException, ResourceClassNotFoundException {
+    ) throws TException, URISyntaxException, ResourceClassNotFoundException, PaginationParameterException {
         List<String> stateOptions = new ArrayList<>();
         stateOptions.add("open");
         stateOptions.add("closed");
@@ -344,7 +345,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
             HttpServletRequest request
-    ) throws TException, URISyntaxException, ResourceClassNotFoundException {
+    ) throws TException, URISyntaxException, ResourceClassNotFoundException, PaginationParameterException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData =
                 sw360ModerationRequestService.getRequestsByRequestingUser(sw360User, pageable);
@@ -363,7 +364,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
     private ResponseEntity<CollectionModel<ModerationRequest>> getModerationResponseEntity(
             Pageable pageable, HttpServletRequest request, boolean allDetails,
             Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData
-    ) throws ResourceClassNotFoundException, URISyntaxException {
+    ) throws ResourceClassNotFoundException, URISyntaxException, PaginationParameterException {
         List<ModerationRequest> moderationRequests = new ArrayList<>();
         int totalCount = 0;
         if (!CommonUtils.isNullOrEmptyMap(modRequestsWithPageData)) {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -98,8 +99,16 @@ public class ComponentTest extends TestIntegrationBase {
         component.setCreatedBy("admin@sw360.org");
         componentList.add(component);
 
+        Map<PaginationData, List<Component>> paginationMap = Collections.singletonMap(
+                new PaginationData().setRowsPerPage(10).setDisplayStart(0).setTotalRowCount(componentList.size()),
+                componentList
+        );
+
         Mockito.doReturn(componentList).when(componentServiceMock)
                 .getComponentsForUser(any());
+
+        Mockito.doReturn(paginationMap).when(componentServiceMock)
+                .getRecentComponentsSummaryWithPagination(any(), any());
 
         User user = TestHelper.getTestUser();
 
@@ -189,8 +198,12 @@ public class ComponentTest extends TestIntegrationBase {
 
     @Test
     public void should_get_all_components_empty_list() throws IOException, TException {
-        Mockito.doReturn(new ArrayList<>()).when(this.componentServiceMock)
-                .getComponentsForUser(any());
+        Mockito.doReturn(Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(10).setDisplayStart(0).setTotalRowCount(0),
+                        new ArrayList<>()
+                ))
+                .when(componentServiceMock)
+                .getRecentComponentsSummaryWithPagination(any(), any());
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
                 new TestRestTemplate().exchange("http://localhost:" + port + "/api/components",
@@ -204,8 +217,12 @@ public class ComponentTest extends TestIntegrationBase {
 
     @Test
     public void should_get_all_components_wrong_page() throws IOException, TException {
-        Mockito.doThrow(ResourceNotFoundException.class).when(this.componentServiceMock)
-                .getComponentsForUser(any());
+        Mockito.doReturn(Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(10).setDisplayStart(0).setTotalRowCount(0),
+                        new ArrayList<>()
+                ))
+                .when(componentServiceMock)
+                .getRecentComponentsSummaryWithPagination(any(), any());
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
                 new TestRestTemplate().exchange("http://localhost:" + port + "/api/components?page=5&page_entries=10",

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -308,14 +308,29 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         given(this.componentServiceMock.getComponentsForUser(any())).willReturn(componentList);
         given(this.sw360ReportServiceMock.getComponentBuffer(any(),anyBoolean())).willReturn(ByteBuffer.allocate(10000));
         given(this.componentServiceMock.getRecentComponents(any())).willReturn(componentList);
-        given(this.componentServiceMock.refineSearch(any(), any())).willReturn(componentList);
+        given(this.componentServiceMock.refineSearch(any(), any(), any()))
+                .willReturn(Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(componentList.size()).setDisplayStart(0).setTotalRowCount(componentList.size()),
+                        componentList)
+                );
         given(this.componentServiceMock.getComponentSubscriptions(any())).willReturn(componentList);
         given(this.componentServiceMock.getMyComponentsForUser(any())).willReturn(componentList);
         given(this.componentServiceMock.getComponentForUserById(eq("17653524"), any())).willReturn(angularComponent);
         given(this.componentServiceMock.getComponentForUserById(eq("98745"), any())).willReturn(testComponent);
         given(this.componentServiceMock.getProjectsByComponentId(eq("17653524"), any())).willReturn(projectList);
         given(this.componentServiceMock.getUsingComponentsForComponent(eq("17653524"), any())).willReturn(usedByComponent);
-        given(this.componentServiceMock.searchComponentByName(eq(angularComponent.getName()))).willReturn(componentListByName);
+        given(this.componentServiceMock.searchComponentByExactNamePaginated(any(), eq(angularComponent.getName()), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(componentListByName.size()).setDisplayStart(0).setTotalRowCount(componentListByName.size()),
+                        componentListByName.stream().toList()
+                )
+        );
+        given(this.componentServiceMock.getRecentComponentsSummaryWithPagination(any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(componentListByName.size()).setDisplayStart(0).setTotalRowCount(componentListByName.size()),
+                        componentListByName.stream().toList()
+                )
+        );
         given(this.componentServiceMock.deleteComponent(eq(angularComponent.getId()), any())).willReturn(RequestStatus.SUCCESS);
         given(this.componentServiceMock.searchByExternalIds(eq(externalIds), any())).willReturn((new HashSet<>(componentList)));
         given(this.componentServiceMock.convertToEmbeddedWithExternalIds(eq(angularComponent))).willReturn(
@@ -717,13 +732,20 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
                         links(
-                                linkWithRel("curies").description("Curies are used for online documentation")
+                                linkWithRel("curies").description("Curies are used for online documentation"),
+                                linkWithRel("first").description("Link to first page"),
+                                linkWithRel("last").description("Link to last page")
                         ),
                         responseFields(
                                 subsectionWithPath("_embedded.sw360:components.[]name").description("The name of the component"),
                                 subsectionWithPath("_embedded.sw360:components.[]componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
                                 subsectionWithPath("_embedded.sw360:components").description("An array of <<resources-components, Components resources>>"),
-                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
+                                fieldWithPath("page").description("Additional paging information"),
+                                fieldWithPath("page.size").description("Number of components per page"),
+                                fieldWithPath("page.totalElements").description("Total number of all existing components"),
+                                fieldWithPath("page.totalPages").description("Total number of pages"),
+                                fieldWithPath("page.number").description("Number of the current page")
                         )));
     }
 


### PR DESCRIPTION
> Please provide a summary of your changes here.

Make the `/components` endpoint queries DB side paginated instead of application side. It should make the endpoint more performant as it does not load all data.

### How To Test?
1. Try to fetch paginated responses from `/components` endpoint.
2. Query for components with `/components?luceneSearch=true`
3. Query for exact component name with `/components?luceneSearch=false&name=<name>`

### Known issue (issue to be created)
1. The query where `/components?luceneSearch=false` is called and fields other than `name` are filtered, is not optimized.
2. The query `/components?luceneSearch=false&name=<name>` returns total number of records as if no filter were applied. This can be confusing.

### Checklist
Depends on #3198 