### PR TITLE
feat(project): use DB side pagination

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -12,7 +12,6 @@ package org.eclipse.sw360.datahandler.db;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.common.annotations.VisibleForTesting;
@@ -24,7 +23,6 @@ import com.google.gson.JsonObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
-import org.eclipse.sw360.common.utils.BackendUtils;
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.cyclonedx.CycloneDxBOMExporter;
 import org.eclipse.sw360.cyclonedx.CycloneDxBOMImporter;
@@ -232,6 +230,14 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return repository.searchByName(name, user);
     }
 
+    public Map<PaginationData, List<Project>> searchProjectByNamePrefixPaginated(User user, String name, PaginationData pageData) {
+        return repository.searchProjectByNamePrefixPaginated(user, name, pageData);
+    }
+
+    public Map<PaginationData, List<Project>> searchProjectByExactNamePaginated(User user, String name, PaginationData pageData) {
+        return repository.searchProjectByExactNamePaginated(user, name, pageData);
+    }
+
     /////////////////////////////
     // CREATE CLEARING REQUEST //
     /////////////////////////////
@@ -346,7 +352,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             Boolean projectResponsible = userRoles.get(Project._Fields.PROJECT_RESPONSIBLE.toString());
             Boolean securityResponsible = userRoles.get(Project._Fields.SECURITY_RESPONSIBLES.toString());
 
-            myProjectsFull = myProjectsFull.stream().filter(ProjectPermissions.isVisible(user)::test)
+            myProjectsFull = myProjectsFull.stream().filter(ProjectPermissions.isVisible(user))
                     .filter(project -> {
                         if (creator != null && creator && project.getCreatedBy().equals(userEmail)) {
                             return true;

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -21,15 +21,13 @@ import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectData;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.jetbrains.annotations.NotNull;
 
 import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
 import com.ibm.cloud.cloudant.v1.model.PostFindOptions;
-import com.ibm.cloud.cloudant.v1.model.PostViewOptions;
-import com.ibm.cloud.cloudant.v1.model.ViewResult;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 
@@ -162,6 +160,13 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
                     "  }" +
                     "}";
 
+    private static final String BY_NAME_LOWER_VIEW =
+            "function(doc) {" +
+                    "  if (doc.type == 'project') {" +
+                    "    emit(doc.name.toLowerCase(), doc._id);" +
+                    "  }" +
+                    "}";
+
     private static final String BY_TAG_VIEW =
             "function(doc) {" +
                     "  if (doc.type == 'project') {" +
@@ -261,6 +266,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         super(Project.class, db, new ProjectSummary());
         Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
         views.put("byname", createMapReduce(BY_NAME_VIEW, null));
+        views.put("bynamelower", createMapReduce(BY_NAME_LOWER_VIEW, null));
         views.put("bygroup", createMapReduce(BY_GROUP_VIEW, null));
         views.put("bytag", createMapReduce(BY_TAG_VIEW, null));
         views.put("bytype", createMapReduce(BY_TYPE_VIEW, null));
@@ -279,6 +285,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         createIndex("byName", new String[] {"name"}, db);
         createIndex("byDesc", new String[] {"description"}, db);
         createIndex("byProjectResponsible", new String[] {"projectResponsible"}, db);
+        createIndex("byCreatedOn", new String[] {"createdOn"}, db);
     }
 
     public List<Project> searchByName(String name, User user, SummaryType summaryType) {
@@ -383,7 +390,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
     public Map<PaginationData, List<Project>> getAccessibleProjectsSummary(User user, PaginationData pageData) {
         final int rowsPerPage = pageData.getRowsPerPage();
         final boolean ascending = pageData.isAscending();
-        final int sortColumnNo = pageData.getSortColumnNumber();
+        final ProjectSortColumn sortBy = ProjectSortColumn.findByValue(pageData.getSortColumnNumber());
         final String requestingUserEmail = user.getEmail();
         final String userBU = getBUFromOrganisation(user.getDepartment());
         List<Project> projects = new ArrayList<>();
@@ -443,38 +450,36 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
             qb.limit(rowsPerPage);
         }
         qb.skip(pageData.getDisplayStart());
-        PostViewOptions.Builder queryView = null;
-        switch (sortColumnNo) {
-            case 0:
-                qb.useIndex(Collections.singletonList("byName"))
-                        .addSort(Collections.singletonMap("name", ascending ? "asc" : "desc"));
-                query = qb.build();
-                break;
-            case 1:
+        String queryViewName = null;
+
+        switch (sortBy) {
+            case ProjectSortColumn.BY_DESCRIPTION:
                 qb.useIndex(Collections.singletonList("byDesc"))
                         .addSort(Collections.singletonMap("description", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
-            case 2:
+            case ProjectSortColumn.BY_RESPONSIBLE:
                 qb.useIndex(Collections.singletonList("byProjectResponsible"))
                         .addSort(Collections.singletonMap("projectResponsible", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
-            case 3:
-            case 4:
-                queryView = getConnector().getPostViewQueryBuilder(Project.class, "byState");
+            case ProjectSortColumn.BY_CREATEDON:
+                qb.useIndex(Collections.singletonList("byCreatedOn"))
+                        .addSort(Collections.singletonMap("createdOn", ascending ? "asc" : "desc"));
+                query = qb.build();
+            case ProjectSortColumn.BY_STATE:
+                queryViewName = "byState";
                 break;
-            default:
+            case null:
+            default: // By default, sort by name
+                qb.useIndex(Collections.singletonList("byName"))
+                        .addSort(Collections.singletonMap("name", ascending ? "asc" : "desc"));
+                query = qb.build();
                 break;
         }
         try {
-            if (queryView != null) {
-                PostViewOptions request = queryView.limit(rowsPerPage).skip(pageData.getDisplayStart())
-                        .descending(!ascending).includeDocs(true).build();
-                ViewResult response = getConnector().getPostViewQueryResponse(request);
-                if (response != null) {
-                    projects = getPojoFromViewResponse(response);
-                }
+            if (queryViewName != null) {
+                projects = queryViewPaginated(queryViewName, pageData);
             } else {
                 projects = getConnector().getQueryResult(query, Project.class);
             }
@@ -505,6 +510,20 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
 
     public List<Project> searchByName(String name, User user) {
         return searchByName(name, user, SummaryType.SUMMARY);
+    }
+
+    public Map<PaginationData, List<Project>> searchProjectByNamePrefixPaginated(User user, String name, PaginationData pageData) {
+        Map<PaginationData, List<Project>> result = Maps.newHashMap();
+        Set<String> searchIds = queryForIdsByPrefixPaginated("byname", name, pageData);
+        result.put(pageData, makeSummaryFromFullDocs(SummaryType.SUMMARY, filterAccessibleProjectsByIds(user, searchIds)));
+        return result;
+    }
+
+    public Map<PaginationData, List<Project>> searchProjectByExactNamePaginated(User user, String name, PaginationData pageData) {
+        Map<PaginationData, List<Project>> result = Maps.newHashMap();
+        List<Project> projects = queryViewPaginated("bynamelower", name, pageData);
+        result.put(pageData, makeSummaryWithPermissionsFromFullDocs(SummaryType.SUMMARY, projects, user));
+        return result;
     }
 
     public Set<String> getGroups() {
@@ -587,7 +606,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         Set<Project> accessibleProjects = filterAccessibleProjectsByIds(user, searchIds);
         return getProjectData(accessibleProjects);
     }
-    
+
     private ProjectData getProjectData(Set<Project> accessibleProjects) {
         int totalSize = accessibleProjects.size();
         ProjectData projectData = new ProjectData();

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -94,6 +94,11 @@ public class ProjectHandler implements ProjectService.Iface {
     }
 
     @Override
+    public Map<PaginationData, List<Project>> refineSearchPageable(String text, Map<String, Set<String>> subQueryRestrictions, User user, PaginationData paginationData) throws TException {
+        return searchHandler.search(text, subQueryRestrictions, user, paginationData);
+    }
+
+    @Override
     public List<Project> getMyProjects(User user, Map<String, Boolean> userRoles) throws TException {
         assertNotNull(user);
         assertNotEmpty(user.getEmail());
@@ -127,6 +132,22 @@ public class ProjectHandler implements ProjectService.Iface {
         assertUser(user);
 
         return handler.searchByName(name, user);
+    }
+
+    @Override
+    public Map<PaginationData, List<Project>> searchProjectByNamePrefixPaginated(User user, String name, PaginationData pageData) throws TException {
+        assertNotEmpty(name);
+        assertUser(user);
+
+        return handler.searchProjectByNamePrefixPaginated(user, name, pageData);
+    }
+
+    @Override
+    public Map<PaginationData, List<Project>> searchProjectByExactNamePaginated(User user, String name, PaginationData pageData) throws TException {
+        assertNotEmpty(name);
+        assertUser(user);
+
+        return handler.searchProjectByExactNamePaginated(user, name, pageData);
     }
 
     @Override
@@ -216,7 +237,7 @@ public class ProjectHandler implements ProjectService.Iface {
         assertId(id);
 
         Project project = handler.getProjectById(id, user);
-        handler.addSelectLogs(project, user); 
+        handler.addSelectLogs(project, user);
         assertNotNull(project);
 
         return project;
@@ -328,7 +349,7 @@ public class ProjectHandler implements ProjectService.Iface {
 
         return handler.updateProject(project, user, forceUpdate);
     }
-    
+
     public RequestStatus updateProjectFromModerationRequest(Project projectAdditions, Project projectDeletions, User user) {
         return handler.updateProjectFromAdditionsAndDeletions(projectAdditions, projectDeletions, user);
     }
@@ -344,7 +365,7 @@ public class ProjectHandler implements ProjectService.Iface {
 
         return handler.deleteProject(id, user);
     }
-    
+
     @Override
     public RequestStatus deleteProjectWithForceFlag(String id, User user, boolean forceDelete) throws TException {
         assertId(id);
@@ -396,7 +417,7 @@ public class ProjectHandler implements ProjectService.Iface {
             throws TException {
         return handler.fillClearingStateSummaryIncludingSubprojects(projects, user);
     }
-    
+
     @Override
     public Project fillClearingStateSummaryIncludingSubprojectsForSingleProject(Project project, User user)
             throws TException {
@@ -505,7 +526,7 @@ public class ProjectHandler implements ProjectService.Iface {
         assertNotNull(projectId);
         return handler.getClearingStateInformationForListView(projectId,user,false);
     }
-    
+
     @Override
     public List<Map<String, String>> getAccessibleClearingStateInformationForListView(String projectId,User user) throws SW360Exception {
         assertNotNull(projectId);

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -12,8 +12,6 @@ package org.eclipse.sw360.datahandler.cloudantclient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -40,7 +38,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -428,17 +425,22 @@ public class DatabaseConnectorCloudant {
     }
 
     public <T> PostViewOptions.Builder getPostViewQueryBuilder(
-            @NotNull Class<T> type, String queryName) {
+            @NotNull Class<T> type, String viewName) {
         return new PostViewOptions.Builder()
                 .db(this.dbName)
                 .ddoc(type.getSimpleName())
-                .view(queryName);
+                .view(viewName);
     }
 
     public ViewResult getPostViewQueryResponse(PostViewOptions options) {
-        return this.instance.getClient().postView(options)
-                .execute()
-                .getResult();
+        try {
+            return this.instance.getClient().postView(options)
+                    .execute()
+                    .getResult();
+        } catch (ServiceResponseException e) {
+            log.error("Unable to run query on view {}. Check response: {}", options.view(), e.getMessage());
+            throw new RuntimeException("Something went wrong. Please try again later.", e);
+        }
     }
 
     public InputStream getAttachment(String docId, String attachmentName) {
@@ -754,7 +756,7 @@ public class DatabaseConnectorCloudant {
         }
     }
 
-    private <T> boolean isInstanceOfOAuthClientEntity(T doc) {    
+    private <T> boolean isInstanceOfOAuthClientEntity(T doc) {
         return doc.getClass().getSimpleName().equals("OAuthClientEntity");
     }
 

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -12,7 +12,6 @@ package org.eclipse.sw360.datahandler.cloudantclient;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -25,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TFieldIdEnum;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -49,7 +49,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class DatabaseRepositoryCloudantClient<T> {
 
-    protected final Logger log = LogManager.getLogger(DatabaseConnectorCloudant.class);
+    protected final Logger log = LogManager.getLogger(DatabaseRepositoryCloudantClient.class);
     private static final char HIGH_VALUE_UNICODE_CHARACTER = '\uFFF0';
 
     private final Class<T> type;
@@ -156,6 +156,47 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryView(query);
     }
 
+    public List<T> queryViewPaginated(String viewName, String startKey, String endKey, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, viewName)
+                .descending(!ascending)
+                .includeDocs(true);
+
+        if (ascending) {
+            query.startKey(startKey)
+                    .endKey(endKey);
+        } else {
+            query.startKey(endKey)
+                    .endKey(startKey);
+        }
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryViewPaginated(query.build(), pageData);
+    }
+
+    public List<T> queryViewPaginated(String viewName, String key, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, viewName)
+                .descending(!ascending)
+                .keys(Collections.singletonList(key))
+                .includeDocs(true);
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryViewPaginated(query.build(), pageData);
+    }
+
     public List<T> queryView(String viewName, String key) {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, viewName)
                 .keys(Collections.singletonList(key))
@@ -169,12 +210,38 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryView(query);
     }
 
+    public List<T> queryViewPaginated(String viewName, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, viewName)
+                .descending(!ascending)
+                .includeDocs(true);
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryViewPaginated(query.build(), pageData);
+    }
+
     public Set<String> queryForIds(PostViewOptions query) {
         ViewResult response = this.connector.getPostViewQueryResponse(query);
         HashSet<String> ids = new HashSet<>();
         for (ViewResultRow row : response.getRows()) {
             ids.add(row.getId());
         }
+        return ids;
+    }
+
+    public Set<String> queryForIdsPaginated(PostViewOptions query, PaginationData pageData) {
+        ViewResult response = this.connector.getPostViewQueryResponse(query);
+        HashSet<String> ids = new HashSet<>();
+        for (ViewResultRow row : response.getRows()) {
+            ids.add(row.getId());
+        }
+        pageData.setTotalRowCount(response.getTotalRows());
         return ids;
     }
 
@@ -200,8 +267,16 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryView(viewName, key, key + HIGH_VALUE_UNICODE_CHARACTER);
     }
 
+    public List<T> queryByPrefixPaginated(String viewName, String key, PaginationData pageData) {
+        return queryViewPaginated(viewName, key, key + HIGH_VALUE_UNICODE_CHARACTER, pageData);
+    }
+
     public Set<String> queryForIdsByPrefix(String viewName, String prefix) {
         return queryForIds(viewName, prefix, prefix + HIGH_VALUE_UNICODE_CHARACTER);
+    }
+
+    public Set<String> queryForIdsByPrefixPaginated(String viewName, String prefix, PaginationData pageData) {
+        return queryForIdsPaginated(viewName, prefix, prefix + HIGH_VALUE_UNICODE_CHARACTER, pageData);
     }
 
     public Set<String> queryForIdsAsValueByPrefix(String viewName, String prefix) {
@@ -216,6 +291,29 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryForIds(query);
     }
 
+    public Set<String> queryForIdsPaginated(String queryName, String startKey, String endKey, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, queryName)
+                .descending(!ascending);
+
+        if (ascending) {
+            query.startKey(startKey)
+                    .endKey(endKey);
+        } else {
+            query.startKey(endKey)
+                    .endKey(startKey);
+        }
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryForIdsPaginated(query.build(), pageData);
+    }
+
     public Set<String> queryForIdsAsValue(String queryName, String startKey, String endKey) {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, queryName)
                 .startKey(startKey)
@@ -228,6 +326,22 @@ public class DatabaseRepositoryCloudantClient<T> {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, queryName)
                 .keys(Collections.singletonList(key)).build();
         return queryForIds(query);
+    }
+
+    public Set<String> queryForIdsPaginated(String queryName, String key, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, queryName)
+                .keys(Collections.singletonList(key))
+                .descending(!ascending);
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        return queryForIdsPaginated(query.build(), pageData);
     }
 
     public Set<String> queryForIdsAsComplexValue(String queryName, String... keys) {
@@ -279,6 +393,18 @@ public class DatabaseRepositoryCloudantClient<T> {
         try {
             ViewResult response = getConnector().getPostViewQueryResponse(req);
             docList = getPojoFromViewResponse(response);
+        } catch (ServiceResponseException e) {
+            log.warn("Error in getting documents", e);
+        }
+        return docList;
+    }
+
+    public List<T> queryViewPaginated(PostViewOptions req, PaginationData pageData) {
+        List<T> docList = Lists.newArrayList();
+        try {
+            ViewResult response = getConnector().getPostViewQueryResponse(req);
+            docList = getPojoFromViewResponse(response);
+            pageData.setTotalRowCount(response.getTotalRows());
         } catch (ServiceResponseException e) {
             log.warn("Error in getting documents", e);
         }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -32,6 +33,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -117,11 +119,44 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     }
 
     /**
+     * Search with lucene with pagination support
+     */
+    public <T> Map<PaginationData, List<T>> searchView(
+            Class<T> type, String indexName, String queryString,
+            PaginationData pageData, String sortColumn, boolean sortAscending
+    ) {
+        Map<PaginationData, List<String>> idMap = searchIds(type, indexName, queryString,
+                pageData, sortColumn, sortAscending);
+
+        PaginationData respPageData = idMap.keySet().iterator().next();
+        List<T> collections = connector.get(type, idMap.values().iterator().next());
+
+        return Collections.singletonMap(respPageData, collections);
+    }
+
+    /**
      * Search with lucene using the previously declared search function only for ids
      */
     public <T> List<String> searchIds(Class<T> type, String indexName, String queryString) {
         NouveauResult queryNouveauResult = searchView(indexName, queryString, false);
         return getIdsFromResult(queryNouveauResult);
+    }
+
+    /**
+     * Search with lucene for ids with pagination support.
+     */
+    public <T> Map<PaginationData, List<String>> searchIds(
+            Class<T> type, String indexName, String queryString,
+            PaginationData pageData, String sortColumn, boolean sortAscending
+    ) {
+        NouveauResult queryNouveauResult = searchView(indexName, queryString,
+                false, pageData, sortColumn, sortAscending);
+        if (queryNouveauResult != null) {
+            pageData.setTotalRowCount(queryNouveauResult.getTotalHits());
+        } else {
+            pageData.setTotalRowCount(0);
+        }
+        return Collections.singletonMap(pageData, getIdsFromResult(queryNouveauResult));
     }
 
     /**
@@ -183,6 +218,19 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return callLuceneDirectly(indexName, queryString, includeDocs);
     }
 
+    /**
+     * Search with lucene with pagination support
+     */
+    private @Nullable NouveauResult searchView(String indexName, String queryString, boolean includeDocs,
+                                               PaginationData pageData, String sortColumn,
+                                               boolean sortAscending) {
+        if (isNullOrEmpty(queryString)) {
+            return null;
+        }
+
+        return callLuceneDirectly(indexName, queryString, includeDocs, pageData, sortColumn, sortAscending);
+    }
+
     private @Nullable NouveauResult callLuceneDirectly(String indexName, String queryString, boolean includeDocs) {
         NouveauQuery query = new NouveauQuery(queryString);
         query.setIncludeDocs(includeDocs);
@@ -195,6 +243,53 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             log.error("Nouveau query failed: {}", e.getResponseBody(), e);
         }
         return null;
+    }
+
+    private @Nullable NouveauResult callLuceneDirectly(String indexName, String queryString, boolean includeDocs,
+                                                       @NotNull PaginationData pageData, String sortColumn,
+                                                       boolean sortAscending) {
+        final int limit = pageData.getRowsPerPage() > 0 ? pageData.getRowsPerPage() : DatabaseSettings.LUCENE_SEARCH_LIMIT;
+        final int requiredPage = pageData.getDisplayStart() / limit;
+
+        NouveauQuery query = new NouveauQuery(queryString);
+        query.setIncludeDocs(includeDocs);
+        if (sortColumn != null && !sortColumn.isEmpty()) {
+            query.setSort(sortAscending ? sortColumn : "-" + sortColumn);
+        } else {
+            query.setSort(null);
+        }
+        query.setLimit(limit);
+
+        int currentPage = 0;
+        String bookmark = "";
+        String previousBookmark = "";
+        NouveauResult result = null;
+        try {
+            do {
+                if (!bookmark.isEmpty()) {
+                    query.reset();
+                    query.setBookmark(bookmark);
+                    previousBookmark = bookmark;
+                }
+                result = queryNouveau(indexName, query);
+                bookmark = result.getBookmark();
+                currentPage += 1;
+            } while (moreResultsAvailable(result, previousBookmark) && currentPage <= requiredPage);
+        } catch (ServiceResponseException e) {
+            log.error("Nouveau query failed: {}", e.getResponseBody(), e);
+        }
+        return result;
+    }
+
+    /**
+     * Check if there are more results available based on the current result and bookmark.
+     * @param result The result of the previous query.
+     * @param bookmark The bookmark from the previous query.
+     * @return True if there are more results available, false otherwise.
+     */
+    private boolean moreResultsAvailable(NouveauResult result, String bookmark) {
+        return result != null && result.getHits() != null && !result.getHits().isEmpty()
+                && !bookmark.equals(result.getBookmark());
     }
 
     /////////////////////////
@@ -226,9 +321,26 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     public <T> List<T> searchViewWithRestrictions(Class<T> type, String indexName,
                                                   String text,
                                                   final @NotNull Map<String, Set<String>> subQueryRestrictions) {
+        String query = convertToRestrictiveQuery(type, text, subQueryRestrictions);
+
+        return searchView(type, indexName, query);
+    }
+
+    /**
+     * Search the database for a given string and types, with pagination support.
+     */
+    public <T> Map<PaginationData, List<T>> searchViewWithRestrictions(
+            Class<T> type, String indexName, String text,
+            final @NotNull Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData, String sortColumn, boolean sortAscending
+    ) {
+        String query = convertToRestrictiveQuery(type, text, subQueryRestrictions);
+        return searchView(type, indexName, query, pageData, sortColumn, sortAscending);
+    }
+
+    private static <T> @NotNull String convertToRestrictiveQuery(Class<T> type, String text, @NotNull Map<String, Set<String>> subQueryRestrictions) {
         List <String> subQueries = new ArrayList<>();
         for (Map.Entry<String, Set<String>> restriction : subQueryRestrictions.entrySet()) {
-
             final Set<String> filterSet = restriction.getValue();
 
             if (!filterSet.isEmpty()) {
@@ -246,9 +358,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             // get all packages with name field and then negate with releaseId field to find orphan packages
             subQueries.add("(name:*) NOT (releaseId:*)");
         }
-        String query = AND.join(subQueries);
-
-        return searchView(type, indexName, query);
+        return AND.join(subQueries);
     }
 
     private static @NotNull String formatSubquery(@NotNull Set<String> filterSet, final String fieldName) {

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
@@ -41,7 +41,14 @@ public class ResourceListController<T> {
 
     public PaginationResult<T> getPaginationResultFromPaginatedList(List<T> resources,
                                                                     PaginationOptions<T> paginationOptions,
-                                                                    int totalCount) {
+                                                                    int totalCount) throws PaginationParameterException {
+        if (resources.isEmpty()) {
+            if (paginationOptions.getPageNumber() == 0) {
+                return new PaginationResult<>(resources, 0, paginationOptions);
+            } else {
+                throw new PaginationParameterException(PAGINATION_PARAMETER_EXCEPTION_MESSAGE);
+            }
+        }
         return new PaginationResult<>(this.sortList(resources, paginationOptions.getSortComparator()),
                 totalCount, paginationOptions);
     }

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -81,6 +81,17 @@ enum ProjectClearingState {
     CLOSED = 2,
 }
 
+enum ProjectSortColumn {
+    BY_CREATEDON = -1,
+    BY_VENDOR = 0,
+    BY_NAME = 1,
+    BY_MAINLICENSE = 2,
+    BY_TYPE = 3,
+    BY_DESCRIPTION = 4,
+    BY_RESPONSIBLE = 5,
+    BY_STATE = 6,
+}
+
 struct ProjectProjectRelationship {
     1: required ProjectRelationship projectRelationship,
     2: optional bool enableSvm = true;
@@ -374,9 +385,25 @@ service ProjectService {
     list<Project> refineSearch(1: string text, 2: map<string,set<string>>  subQueryRestrictions, 3: User user);
 
     /**
+     * returns a list of projects which match `text` and the
+     * `subQueryRestrictions` and are visible to the `user`. The request is pageable
+     */
+    map<PaginationData, list<Project>> refineSearchPageable(1: string text, 2: map<string,set<string>>  subQueryRestrictions, 3: User user, 4: PaginationData pageData);
+
+    /**
      * list of projects which are visible to the `user` and match the `name`
      */
     list<Project> searchByName(1: string name, 2: User user);
+
+    /**
+     * Get Projects with name prefix and paginated
+     **/
+    map<PaginationData, list<Project>> searchProjectByNamePrefixPaginated(1: User user, 2: string name, 3: PaginationData pageData);
+
+    /**
+     * Get Projects with exact name and paginated
+     **/
+    map<PaginationData, list<Project>> searchProjectByExactNamePaginated(1: User user, 2: string name, 3: PaginationData pageData);
 
     /**
      * project data which are visible to the `user` and match the `group`
@@ -387,7 +414,7 @@ service ProjectService {
      * project data which are visible to the `user` and match the `tag`
      */
     ProjectData searchByTag(1: string tag, 2: User user) throws (1: SW360Exception exp);
- 
+
     /**
      * project data which are visible to the `user` and match the `type`
      */
@@ -532,7 +559,7 @@ service ProjectService {
      * Visibility of any of the projects in the tree for the given user is currently not considered.
      */
     list<Project> fillClearingStateSummaryIncludingSubprojects(1: list<Project> projects, 2: User user);
-    
+
     Project fillClearingStateSummaryIncludingSubprojectsForSingleProject(1: Project project, 2: User user);
 
     /**
@@ -641,7 +668,7 @@ service ProjectService {
      * get clearing state information for list view
      */
     list<map<string,string>> getClearingStateInformationForListView(1:string projectId, 2: User user) throws (1: SW360Exception exp);
-    
+
     /**
      * get accessible clearing state information for list view
      */

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -218,7 +218,7 @@ public class RestControllerHelper<T> {
 
     public PaginationResult<T> paginationResultFromPaginatedList(HttpServletRequest request, Pageable pageable,
                                                                  List<T> resources, String resourceType, int totalCount)
-            throws ResourceClassNotFoundException {
+            throws ResourceClassNotFoundException, PaginationParameterException {
         if (!requestContainsPaging(request)) {
             request.setAttribute(PAGINATION_PARAM_PAGE, pageable.getPageNumber());
             request.setAttribute(PAGINATION_PARAM_PAGE_ENTRIES, pageable.getPageSize());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -26,6 +26,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
@@ -123,7 +124,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             HttpServletRequest request,
             @Parameter(description = "Fetch all details of the moderation request")
             @RequestParam(value = "allDetails", required = false) boolean allDetails
-    ) throws TException, ResourceClassNotFoundException, URISyntaxException {
+    ) throws TException, ResourceClassNotFoundException, URISyntaxException, PaginationParameterException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         List<ModerationRequest> moderationRequests = sw360ModerationRequestService.getRequestsByModerator(sw360User, pageable);
 
@@ -187,7 +188,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             @RequestParam(value = "state", defaultValue = "open", required = true) String state,
             @Parameter(description = "Fetch all details of the moderation request.")
             @RequestParam(value = "allDetails", required = false) boolean allDetails
-    ) throws TException, URISyntaxException, ResourceClassNotFoundException {
+    ) throws TException, URISyntaxException, ResourceClassNotFoundException, PaginationParameterException {
         List<String> stateOptions = new ArrayList<>();
         stateOptions.add("open");
         stateOptions.add("closed");
@@ -344,7 +345,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
             HttpServletRequest request
-    ) throws TException, URISyntaxException, ResourceClassNotFoundException {
+    ) throws TException, URISyntaxException, ResourceClassNotFoundException, PaginationParameterException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData =
                 sw360ModerationRequestService.getRequestsByRequestingUser(sw360User, pageable);
@@ -363,7 +364,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
     private ResponseEntity<CollectionModel<ModerationRequest>> getModerationResponseEntity(
             Pageable pageable, HttpServletRequest request, boolean allDetails,
             Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData
-    ) throws ResourceClassNotFoundException, URISyntaxException {
+    ) throws ResourceClassNotFoundException, URISyntaxException, PaginationParameterException {
         List<ModerationRequest> moderationRequests = new ArrayList<>();
         int totalCount = 0;
         if (!CommonUtils.isNullOrEmptyMap(modRequestsWithPageData)) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -56,6 +56,7 @@ import org.eclipse.sw360.datahandler.thrift.ClearingRequestPriority;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestType;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
@@ -274,11 +275,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         boolean isSearchByName = name != null && !name.isEmpty();
         List<Project> sw360Projects = new ArrayList<>();
+        Map<PaginationData, List<Project>> paginatedProjects = null;
 
+        Map<String, Set<String>> filterMap = getFilterMap(tag, projectType, group, version, projectResponsible, projectState, projectClearingState,
+                additionalData);
         if (luceneSearch) {
-            Map<String, Set<String>> filterMap = getFilterMap(tag, projectType, group, version, projectResponsible, projectState, projectClearingState,
-                    additionalData);
-
             if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
                 Set<String> values = CommonUtils.splitToSet(name);
                 values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
@@ -286,22 +287,20 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 filterMap.put(Project._Fields.NAME.getFieldName(), values);
             }
 
-            sw360Projects.addAll(projectService.refineSearch(filterMap, sw360User));
+            paginatedProjects = projectService.refineSearch(filterMap, sw360User, pageable);
         } else {
-            if (isSearchByName) {
-                sw360Projects.addAll(projectService.searchProjectByName(name, sw360User));
+            if (isSearchByName && filterMap.isEmpty()) {
+                paginatedProjects = projectService.searchProjectByExactNamePaginated(sw360User, name, pageable);
+            } else if (filterMap.isEmpty()) {
+                paginatedProjects = projectService.getProjectsForUser(sw360User, pageable);
             } else {
                 sw360Projects.addAll(projectService.getProjectsSummaryForUserWithoutPagination(sw360User));
-            }
-            Map<String, Set<String>> restrictions = getFilterMap(tag, projectType, group, version, projectResponsible, projectState, projectClearingState,
-                    additionalData);
-            if (!restrictions.isEmpty()) {
                 sw360Projects = new ArrayList<>(sw360Projects.stream()
-                        .filter(filterProjectMap(restrictions)).toList());
+                        .filter(filterProjectMap(filterMap)).toList());
             }
         }
         return getProjectResponse(pageable, allDetails, request, sw360User,
-                sw360Projects);
+                sw360Projects, paginatedProjects);
     }
 
     private Map<String, Set<String>> getFilterMap(String tag, String projectType, String group, String version, String projectResponsible,
@@ -337,10 +336,19 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     @NotNull
     private ResponseEntity<CollectionModel<EntityModel<Project>>> getProjectResponse(
             Pageable pageable, boolean allDetails, HttpServletRequest request, User sw360User,
-            List<Project> sw360Projects
+            List<Project> sw360Projects, Map<PaginationData, List<Project>> paginatedProjects
     ) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException {
-        PaginationResult<Project> paginationResult = restControllerHelper.createPaginationResult(request, pageable,
-                sw360Projects, SW360Constants.TYPE_PROJECT);
+        PaginationResult<Project> paginationResult;
+        if (paginatedProjects != null) {
+            sw360Projects.addAll(paginatedProjects.values().iterator().next());
+            int totalCount = Math.toIntExact(paginatedProjects.keySet().stream()
+                    .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));
+            paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                    request, pageable, sw360Projects, SW360Constants.TYPE_PROJECT, totalCount);
+        } else {
+            paginationResult = restControllerHelper.createPaginationResult(request, pageable,
+                    sw360Projects, SW360Constants.TYPE_PROJECT);
+        }
 
         List<EntityModel<Project>> projectResources = new ArrayList<>();
         Consumer<Project> consumer = p -> {
@@ -357,7 +365,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             projectResources.add(embeddedProjectResource);
         };
 
-        paginationResult.getResources().stream().forEach(consumer);
+        paginationResult.getResources().forEach(consumer);
 
         CollectionModel resources;
         if (projectResources.isEmpty()) {
@@ -424,7 +432,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         sw360Projects = projectService.getWithFilledClearingStatus(sw360Projects, clearingState);
 
         return getProjectResponse(pageable, allDetails, request, sw360User,
-                sw360Projects);
+                sw360Projects, null);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -61,6 +61,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
@@ -74,6 +75,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.Link;
 import org.springframework.security.access.AccessDeniedException;
@@ -153,13 +155,14 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public static final ImmutableSet<ObligationStatusInfo._Fields> SET_OF_LICENSE_OBLIGATION_FIELDS = ImmutableSet
             .of(ObligationStatusInfo._Fields.COMMENT, ObligationStatusInfo._Fields.STATUS);
 
-    public Set<Project> getProjectsForUser(User sw360User, Pageable pageable) throws TException {
+    public Map<PaginationData, List<Project>> getProjectsForUser(User sw360User, Pageable pageable) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        PaginationData pageData = new PaginationData().setDisplayStart((int) pageable.getOffset())
-                .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(0);
-        Map<PaginationData, List<Project>> pageDtToProjects = sw360ProjectClient
+        PaginationData pageData = pageableToPaginationData(pageable, null, null);
+        Map<PaginationData, List<Project>> resp = sw360ProjectClient
                 .getAccessibleProjectsSummaryWithPagination(sw360User, pageData);
-        return new HashSet<>(pageDtToProjects.entrySet().iterator().next().getValue());
+        PaginationData respPagination = resp.keySet().iterator().next();
+        respPagination.setTotalRowCount(sw360ProjectClient.getMyAccessibleProjectCounts(sw360User));
+        return resp;
     }
 
     public List<Project> getProjectsSummaryForUserWithoutPagination(User sw360User) throws TException {
@@ -873,9 +876,13 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return sw360ProjectClient.fillClearingStateSummaryIncludingSubprojectsForSingleProject(sw360Project, sw360User);
     }
 
-    public List<Project> searchProjectByName(String name, User sw360User) throws TException {
+    public Map<PaginationData, List<Project>> searchProjectByExactNamePaginated(
+            User sw360User, String name, Pageable pageable
+    ) throws TException {
         final ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        return sw360ProjectClient.searchByName(name, sw360User);
+        name = name.replaceAll("\"", "");
+        return sw360ProjectClient.searchProjectByExactNamePaginated(sw360User, name.toLowerCase(Locale.ROOT),
+                pageableToPaginationData(pageable, null, null));
     }
 
     public List<Project> searchProjectByGroup(String group, User sw360User) throws TException {
@@ -1153,9 +1160,12 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         }
     }
 
-    public List<Project> refineSearch(Map<String, Set<String>> filterMap, User sw360User) throws TException {
+    public Map<PaginationData, List<Project>> refineSearch(Map<String, Set<String>> filterMap, User sw360User, Pageable pageable) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        return sw360ProjectClient.refineSearch(null, filterMap, sw360User);
+        PaginationData pageData = pageableToPaginationData(pageable,
+                // Can be sorted on name and createdOn, but using different default value for score sorting
+                ProjectSortColumn.BY_TYPE, true);
+        return sw360ProjectClient.refineSearchPageable(null, filterMap, sw360User, pageData);
     }
 
     public void copyLinkedObligationsForClonedProject(Project createDuplicateProject, Project sw360Project, User user)
@@ -1787,5 +1797,45 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return true;
         }).collect(Collectors.toList());
         return releases;
+    }
+
+    /**
+     * Converts a Pageable object to a PaginationData object.
+     *
+     * @param pageable the Pageable object to convert
+     * @return a PaginationData object representing the pagination information
+     */
+    private static PaginationData pageableToPaginationData(
+            @NotNull Pageable pageable, ProjectSortColumn defaultSort, Boolean defaultAscending
+    ) {
+        ProjectSortColumn column = ProjectSortColumn.BY_NAME;
+        boolean ascending = true;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            column = switch (property) {
+                case "created" -> ProjectSortColumn.BY_CREATEDON;
+                case "name" -> ProjectSortColumn.BY_NAME;
+                case "vendor" -> ProjectSortColumn.BY_VENDOR;
+                case "license" -> ProjectSortColumn.BY_MAINLICENSE;
+                case "type" -> ProjectSortColumn.BY_TYPE;
+                case "desc" -> ProjectSortColumn.BY_DESCRIPTION;
+                case "resp" -> ProjectSortColumn.BY_RESPONSIBLE;
+                case "state" -> ProjectSortColumn.BY_STATE;
+                default -> column; // Default to BY_NAME if no match
+            };
+            ascending = order.isAscending();
+        } else {
+            if (defaultSort != null) {
+                column = defaultSort;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
+        }
+
+        return new PaginationData().setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.rest.resourceserver.integration;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
@@ -28,6 +29,7 @@ import org.springframework.http.*;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -44,10 +46,10 @@ public class ProjectTest extends TestIntegrationBase {
     @MockBean
     private Sw360ProjectService projectServiceMock;
 
+    private final Set<Project> projectList = new HashSet<>();
+
     @Before
     public void before() throws TException {
-        Set<Project> projectList = new HashSet<>();
-
         // Create sample projects
         Project project1 = new Project();
         project1.setId("p001");
@@ -72,7 +74,12 @@ public class ProjectTest extends TestIntegrationBase {
         projectList.add(project1);
         projectList.add(project2);
 
-        given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(projectList);
+        given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(projectList.size()).setDisplayStart(0).setTotalRowCount(projectList.size()),
+                        projectList.stream().toList()
+                )
+        );
         given(this.projectServiceMock.getProjectsSummaryForUserWithoutPagination(any())).willReturn(projectList.stream().toList());
 
         User user = new User();
@@ -97,7 +104,13 @@ public class ProjectTest extends TestIntegrationBase {
     }
 
     @Test
-    public void should_get_all_projects_paginated() throws IOException {
+    public void should_get_all_projects_paginated() throws IOException, TException {
+        given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(1).setDisplayStart(0).setTotalRowCount(projectList.size()),
+                        Collections.singletonList(projectList.iterator().next())
+                )
+        );
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
                 new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?page=0&page_entries=1",

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.ClearingRequestType;
 import org.eclipse.sw360.datahandler.thrift.CycloneDxComponentType;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.ObligationStatus;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
@@ -598,7 +599,12 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.sw360ReportServiceMock.getDocumentName(any(), any(), any())).willReturn(projectName);
         given(this.sw360ReportServiceMock.getProjectBuffer(any(),anyBoolean(),any())).willReturn(ByteBuffer.allocate(10000));
         given(this.sw360ReportServiceMock.getProjectReleaseSpreadSheetWithEcc(any(),any())).willReturn(ByteBuffer.allocate(10000));
-        given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(projectList);
+        given(this.projectServiceMock.getProjectsForUser(any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(projectList.size()).setDisplayStart(0).setTotalRowCount(projectList.size()),
+                        projectList.stream().toList()
+                )
+        );
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), any())).willReturn(project);
         given(this.projectServiceMock.getProjectsSummaryForUserWithoutPagination(any())).willReturn(projectList.stream().toList());
         given(this.projectServiceMock.getProjectForUserById(eq(project2.getId()), any())).willReturn(project2);
@@ -629,11 +635,21 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.getProjectForUserById(eq(SPDXProject.getId()), any())).willReturn(SPDXProject);
         given(this.projectServiceMock.getProjectForUserById(eq(cycloneDXProject.getId()), any())).willReturn(cycloneDXProject);
         given(this.projectServiceMock.searchLinkingProjects(eq(project.getId()), any())).willReturn(usedByProjectList);
-        given(this.projectServiceMock.searchProjectByName(any(), any())).willReturn(projectListByName);
+        given(this.projectServiceMock.searchProjectByExactNamePaginated(any(), any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(projectListByName.size()).setDisplayStart(0).setTotalRowCount(projectListByName.size()),
+                        projectListByName.stream().toList()
+                )
+        );
         given(this.projectServiceMock.searchProjectByTag(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.searchProjectByType(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.searchProjectByGroup(any(), any())).willReturn(new ArrayList<Project>(projectList));
-        given(this.projectServiceMock.refineSearch(any(), any())).willReturn(projectListByName);
+        given(this.projectServiceMock.refineSearch(any(), any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(projectListByName.size()).setDisplayStart(0).setTotalRowCount(projectListByName.size()),
+                        projectListByName.stream().toList()
+                )
+        );
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(false))).willReturn(releaseIds);
         given(this.projectServiceMock.getReleaseIds(eq(project9.getId()), any(), eq(true))).willReturn(releaseIds2);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(true))).willReturn(releaseIdsTransitive);


### PR DESCRIPTION
> Please provide a summary of your changes here.

Make the `/projects` endpoint queries DB side paginated instead of application side. It should make the endpoint more performant as it does not load all data.
(Similar to #3199)

### How To Test?
1. Try to fetch paginated responses from `/projects` endpoint.
2. Query for components with `/projects?luceneSearch=true`
3. Query for exact component name with `/projects?luceneSearch=false&name=<name>`

### Known issue (issue to be created)
1. The query where `/projects?luceneSearch=false` is called and fields other than `name` are filtered, is not optimized.
2. The query `/projects?luceneSearch=false&name=<name>` returns total number of records as if no filter were applied. This can be confusing.

### Checklist
Depends on #3198 