### PR TITLE
fix(rest): add vendor existence validation in getReleases endpoint

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -140,6 +140,9 @@ public class VendorController implements RepresentationModelProcessor<Repository
             @Parameter(description = "The id of the vendor to get.")
             @PathVariable("id") String id
     ) throws SW360Exception {
+        if(vendorService.getVendorById(id) == null){
+            throw new ResourceNotFoundException("Vendor with id " + id + " not found.");
+        }
         try {
             Set<Release> releases = vendorService.getAllReleaseList(id);
             List<EntityModel<Release>> resources = new ArrayList<>();


### PR DESCRIPTION
 this PR fixes a critical API inconsistency in the `VendorController.getReleases()` method. Previously, the endpoint would return `204 No Content` for non-existent vendor IDs, making it impossible for clients to distinguish between "vendor exists but has no releases" and "vendor doesn't exist".

close Issue: #3205
