### PR TITLE
fix(rest): Restructuring of the response to Delete a License Type API.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -553,7 +553,35 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     @Operation(
             summary = "Delete a specific license type.",
             description = "Delete a specific license type.",
-            tags = {"Licenses"}
+            tags = {"Licenses"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", description = "License type deleted successfully.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(
+                                                    example = """
+                                                    {
+                                                        "status": "SECCESS",
+                                                        "message": "License type deleted successfully."
+                                                    }
+                                                    """
+                                            ))
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "403", description = "User does not have permission to delete license type."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404", description = "License type with the given ID was not found."
+                    ),
+                    @ApiResponse(
+                            responseCode = "409", description = "Cannot delete license type because it is currently in use."
+                    ),
+                    @ApiResponse(
+                            responseCode = "500", description = "Unexpected error occurred while deleting license type."
+                    )
+            }
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @RequestMapping(value = LICENSE_TYPES_URL + "/{id}", method = RequestMethod.DELETE)
@@ -564,29 +592,25 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus status = licenseService.deleteLicenseType(id, sw360User);
 
-        Map<String, String> response = new HashMap<>();
-        response.put("status", status.name());
-
         switch (status) {
-        case SUCCESS:
-            Map<String, String> successResponse = new HashMap<>();
-            successResponse.put("status", status.name());
-            successResponse.put("message", "License type deleted successfully.");
-            return ResponseEntity.ok(successResponse);
+            case SUCCESS:
+                Map<String, String> successResponse = new HashMap<>();
+                successResponse.put("status", status.name());
+                successResponse.put("message", "License type deleted successfully.");
+                return ResponseEntity.ok(successResponse);
 
-        case IN_USE:
-            throw new HttpClientErrorException(HttpStatus.CONFLICT,
-                    "Cannot delete license type because it is currently in use.");
+            case IN_USE:
+                throw new HttpClientErrorException(HttpStatus.CONFLICT,
+                        "Cannot delete license type because it is currently in use.");
 
-        case ACCESS_DENIED:
-            throw new AccessDeniedException("User does not have permission to delete license type.");
+            case ACCESS_DENIED:
+                throw new AccessDeniedException("User does not have permission to delete license type.");
 
-        case INVALID_INPUT:
-            throw new ResourceNotFoundException("License type with the given ID was not found.");
+            case INVALID_INPUT:
+                throw new ResourceNotFoundException("License type with the given ID was not found.");
 
-        default:
-            throw new RuntimeException("Unexpected error occurred while deleting license type.");
+            default:
+                throw new RuntimeException("Unexpected error occurred while deleting license type.");
         }
     }
 }
- 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -47,6 +47,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -54,6 +55,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
@@ -562,6 +564,29 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus status = licenseService.deleteLicenseType(id, sw360User);
 
-        return ResponseEntity.ok("License type deleted successfully: " + status.name());
+        Map<String, String> response = new HashMap<>();
+        response.put("status", status.name());
+
+        switch (status) {
+        case SUCCESS:
+            Map<String, String> successResponse = new HashMap<>();
+            successResponse.put("status", status.name());
+            successResponse.put("message", "License type deleted successfully.");
+            return ResponseEntity.ok(successResponse);
+
+        case IN_USE:
+            throw new HttpClientErrorException(HttpStatus.CONFLICT,
+                    "Cannot delete license type because it is currently in use.");
+
+        case ACCESS_DENIED:
+            throw new AccessDeniedException("User does not have permission to delete license type.");
+
+        case INVALID_INPUT:
+            throw new ResourceNotFoundException("License type with the given ID was not found.");
+
+        default:
+            throw new RuntimeException("Unexpected error occurred while deleting license type.");
+        }
     }
 }
+ 


### PR DESCRIPTION
…sponse

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Closes #3192


### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test
Delete: http://localhost:8080/resource/api/licenseTypes/5c2f90c4f15d2c92a91ff880c00021
First, create a License Type and then assign it to a License. After that, try to delete the License Type using its ID — it will not be allowed because it is in use. However, if the License Type is not assigned to any License, you will be able to delete it.
![image](https://github.com/user-attachments/assets/056f35e2-6b8f-4189-8253-b7b88f1a02fe)

![image](https://github.com/user-attachments/assets/c5f55d41-5fa7-40f1-ba0c-26a83a992801)

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
