### PR TITLE
feat(rest) : Avoid multiple entries of same license in ReadMeOSS generated from SW360 for html download.

### DIFF
--- a/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -195,7 +195,9 @@ $copyrightAsHtml
 
     #if($allLicenseNamesWithTexts.size() > 0)
         <ul id="licenseTexts" style="list-style-type:none">
-        #foreach($license in $allLicenseNamesWithTexts)
+        #foreach($entry in $allLicenseNamesWithTexts.entrySet())
+            #set($license = $entry.value)
+            #set($licenseIds = $entry.getKey())
             #set($licenseName = "&lt;no license name available&gt;")
             #if($license.licenseName)
                 #set($licenseName = $esc.xml($license.licenseName))
@@ -212,7 +214,7 @@ $copyrightAsHtml
                 #end
             #end
 
-            #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
+            #set($licenseId = $licenseIds)
             <li id="licenseTextItem$licenseId">
                 <h3>$licenseId: $licenseName<a class="top" href="#releaseHeader">&#8679;</a></h3>
     <pre class="licenseText" id="licenseText$licenseId">

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -62,6 +62,7 @@ public class XhtmlGeneratorTest {
     static String L1 = "L1";
     static String L2 = "L2";
     static String t1 = "first row\nsecond row";
+    static String t2 = "first row\nsecond row 2";
     static String T1 = "T1";
     static String T2 = "T2";
     static String releaseName = "myrelease";
@@ -78,7 +79,7 @@ public class XhtmlGeneratorTest {
         li.setCopyrights(copyrights);
 
         LicenseNameWithText lnt1 = new LicenseNameWithText().setLicenseName(l1).setLicenseText(t1);
-        LicenseNameWithText lnt2 = new LicenseNameWithText().setLicenseName(l2).setLicenseText(t1);
+        LicenseNameWithText lnt2 = new LicenseNameWithText().setLicenseName(l2).setLicenseText(t2);
         Set<LicenseNameWithText> licenseNameWithTexts = new HashSet<>(Arrays.asList(lnt1, lnt2));
 
         li.setLicenseNamesWithTexts(licenseNameWithTexts);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: 

Closes : #3196 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Sample URL : 

http://localhost:8080/resource/api/reports?projectId=6f3fe36085b49ea07ef51bec50000f6b&module=licenseInfo&variant=DISCLOSURE&generatorClassName=XhtmlGenerator

Sample output in attachment: 

![image](https://github.com/user-attachments/assets/7e6dbaaa-a33b-4a6a-8d56-16178920ff5d)

If the Content for (Example : Apache-2.0 and Apache-2.0) different releases are same, then on clicking of that link both redirect  to same content. 
Example as in Screenshot, for reactComp2 1.0 -> Apache 2.0(3) and reactComp3 1.0 -> Apache 2.0(3) on click of those links both redirect to same licenseText in the document.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
