### PR TITLE
feat(keycloak): set externalId on sync

### DIFF
--- a/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/service/Sw360KeycloakAdminEventService.java
+++ b/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/service/Sw360KeycloakAdminEventService.java
@@ -32,6 +32,7 @@ public class Sw360KeycloakAdminEventService {
 	private static final String REALM = "sw360";
 
 	private static final String CUSTOM_ATTR_DEPARTMENT = "Department";
+	private static final String CUSTOM_ATTR_EXTERNAL_ID = "externalId";
 
 	public Sw360KeycloakAdminEventService(Sw360UserService sw360UserService, ObjectMapper objectMapper, KeycloakSession keycloakSession) {
 		this.objectMapper = objectMapper;
@@ -142,6 +143,7 @@ public class Sw360KeycloakAdminEventService {
 		user.setGivenname(userEntity.getFirstName());
 		user.setLastname(userEntity.getLastName());
 		setDepartment(userEntity, user);
+		setExternalId(userEntity, user);
 		setUserGroup(userEntity, user);
 		return user;
 	}
@@ -166,6 +168,16 @@ public class Sw360KeycloakAdminEventService {
 			user.setDepartment(department);
 		}, () -> {
 			user.setDepartment("Unknown");
+		});
+	}
+
+	private static void setExternalId(UserEntity userEntity, User user) {
+		Map<String, List<String>> userAttributes = userEntity.getAttributes();
+		Optional.ofNullable(userAttributes.get(CUSTOM_ATTR_EXTERNAL_ID)).ifPresentOrElse((d) -> {
+			String externalId = d.stream().findFirst().get();
+			user.setExternalid(externalId);
+		}, () -> {
+			user.setExternalid("N/A");
 		});
 	}
 }

--- a/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/service/Sw360KeycloakUserEventService.java
+++ b/keycloak/event-listeners/src/main/java/org/eclipse/sw360/keycloak/event/listener/service/Sw360KeycloakUserEventService.java
@@ -24,7 +24,9 @@ public class Sw360KeycloakUserEventService {
 	private static final Logger log = Logger.getLogger(Sw360KeycloakUserEventService.class);
 	public static final String USERNAME = "username";
 	public static final String DEPARTMENT = "Department";
+	public static final String EXTERNAL_ID = "externalId";
 	public static final String DEFAULT_DEPARTMENT = "DEPARTMENT";
+	public static final String DEFAULT_EXTERNAL_ID = "N/A";
 
 
 	private final Sw360UserService userService;
@@ -106,15 +108,23 @@ public class Sw360KeycloakUserEventService {
 		user.setGivenname(userModel.getFirstName());
 		user.setLastname(userModel.getLastName());
 		mapSetDepartment(userModel, user);
+		mapSetExternalId(userModel, user);
 		return user;
 	}
 
 	private void mapSetDepartment(UserModel userModel, User user) {
 		log.debug("User Model Attributes" + userModel.getAttributes());
 		List<String> departments = userModel.getAttributes().getOrDefault(DEPARTMENT, Collections.singletonList(DEFAULT_DEPARTMENT));
-		String department = departments.stream().findFirst().get();
+		String department = departments.getFirst();
 		String parentDepartment = sanitizeDepartment(department);
 		user.setDepartment(parentDepartment);
+	}
+
+	private void mapSetExternalId(UserModel userModel, User user) {
+		log.debug("User Model Attributes" + userModel.getAttributes());
+		List<String> externalIds = userModel.getAttributes().getOrDefault(EXTERNAL_ID, Collections.singletonList(DEFAULT_EXTERNAL_ID));
+		String externalId = externalIds.getFirst();
+		user.setExternalid(sanitizeExternalId(externalId));
 	}
 
 	/**
@@ -129,6 +139,14 @@ public class Sw360KeycloakUserEventService {
 			departmentSanitized= department.trim().split("\\s+")[0];
 		}
 		return departmentSanitized;
+	}
+
+	private String sanitizeExternalId(String externalId) {
+		String externalIdSanitized = null;
+		if (externalId != null) {
+			externalIdSanitized= externalId.trim();
+		}
+		return externalIdSanitized;
 	}
 
 	private boolean checkExistenceOfUserInSw360DB(User user) {


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Sync user's `externalId` attribute with KeyCloak. Continuation of #3194 

### How To Test?
Setup KeyCloak and login as a user having `externalId` attribute.