### PR TITLE
test(restdocs): add unit test for downloadUsers endpoint in ImportExp…

### DIFF
--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ImportExportSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ImportExportSpecTest.java
@@ -55,6 +55,7 @@ public class ImportExportSpecTest extends TestRestDocsSpecBase {
         Mockito.doNothing().when(importExportService).getDownloadReleaseSample(any(), any());
         Mockito.doNothing().when(importExportService).getDownloadReleaseLink(any(), any());
         Mockito.doNothing().when(importExportService).getComponentDetailedExport(any(), any());
+        Mockito.doNothing().when(importExportService).getDownloadUsers(any(), any());
     }
 
     @Test
@@ -101,5 +102,14 @@ public class ImportExportSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(get("/api/importExport/downloadComponent")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON)).andExpect(status().isOk());
+    }
+
+    @Test
+    public void should_document_get_download_users() throws Exception {
+        mockMvc.perform(get("/api/importExport/downloadUsers")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept("text/plain"))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document());
     }
 }


### PR DESCRIPTION
This PR adds the missing UT in the complete sw360 REST endpoints.

Summary: After checking all the endpoints and their corresponding UT's, we have identified one endpoint lacks a UT. So added the UT for /importExport/downloadUsers endpoint.

detailed test report doc : https://docs.google.com/document/d/1VUX2_XYo920uC6iY2QKBrCleMTZB_6LpbBDKGDyoTvg/edit?tab=t.0#heading=h.frz01aqik1uh

Issue: test coverage

Suggest Reviewer
@GMishx

How To Test?
The CI pipelines should pass and that should be enough as there are no changes in the source code.



### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
