### PR TITLE
docs(licenseinfo): better excp for wrong generator

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -25,8 +25,8 @@ import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
 import org.eclipse.sw360.datahandler.common.WrappedException.WrappedTException;
 import org.eclipse.sw360.datahandler.db.AttachmentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
-import org.eclipse.sw360.datahandler.db.DatabaseHandlerUtil;
 import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -1011,7 +1011,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         assertNotNull(generatorClassname);
         return outputGenerators.stream()
                 .filter(outputGenerator -> generatorClassname.equals(outputGenerator.getClass().getSimpleName()))
-                .findFirst().orElseThrow(() -> new TException("Unknown output generator: " + generatorClassname));
+                .findFirst().orElseThrow(() -> new SW360Exception("Unknown output generator: " + generatorClassname));
     }
 
     protected OutputGenerator<?> getOutputGeneratorByClassnameAndVariant(String generatorClassname, OutputFormatVariant generatorVariant) throws TException {
@@ -1020,7 +1020,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         return outputGenerators.stream()
                 .filter(outputGenerator -> generatorClassname.equals(outputGenerator.getClass().getSimpleName()))
                 .filter(outputGenerator -> generatorVariant.equals(outputGenerator.getOutputVariant()))
-                .findFirst().orElseThrow(() -> new TException("Unknown output generator: " + generatorClassname));
+                .findFirst().orElseThrow(() -> new SW360Exception("Unknown output generator: " + generatorClassname + " or variant: " + generatorVariant));
     }
 
     private LicenseInfoParsingResult getLicenseInfoForAttachment(Release release, Attachment attachment, User user)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
@@ -19,6 +19,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
@@ -27,6 +28,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -43,6 +45,8 @@ public class Sw360LicenseInfoService {
         try {
             LicenseInfoService.Iface sw360LicenseInfoClient = getThriftLicenseInfoClient();
             return sw360LicenseInfoClient.getOutputFormatInfoForGeneratorClass(generatorClassName);
+        } catch (SW360Exception e) {
+            throw new BadRequestClientException(e.getWhy(), e);
         } catch (TException e) {
             throw new RuntimeException(e);
         }
@@ -61,6 +65,8 @@ public class Sw360LicenseInfoService {
             }
             return sw360LicenseInfoClient.getLicenseInfoFile(project, sw360User, generatorClassNameWithVariant,
                     selectedReleaseAndAttachmentIds, excludedLicenses, externalIds, fileName);
+        } catch (SW360Exception e) {
+            throw new BadRequestClientException(e.getWhy(), e);
         } catch (TException e) {
             throw new RuntimeException(e);
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1525,8 +1525,16 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             summary = "Download license info for the project.",
-            description = "Set the request parameter `&template=<TEMPLATE_NAME>` for variant `REPORT` to choose " +
-                    "specific template.",
+            description = """
+                    Set the request parameter `&template=<TEMPLATE_NAME>` for variant `REPORT` to choose \
+                    specific template.
+
+                    Combination of `generatorClassName` and `variant` possible are:
+
+                    When `variant` is `DISCLOSURE`, `generatorClassName` can be one of: \
+                    `TextGenerator`, `XhtmlGenerator` or `DISCLOSURE`.
+                    When `variant` is `REPORT`, `generatorClassName` can be one of: \
+                    `DocxGenerator`.""",
             tags = {"Projects"}
     )
     @RequestMapping(value = PROJECTS_URL + "/{id}/licenseinfo", method = RequestMethod.GET)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -82,7 +82,15 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
 
     @Operation(
             summary = "Generate the reports.",
-            description = "Generate the reports.",
+            description = """
+                    Generate the reports.
+
+                    Combination of `generatorClassName` and `variant` possible are:
+
+                    When `variant` is `DISCLOSURE`, `generatorClassName` can be one of: \
+                    `TextGenerator`, `XhtmlGenerator` or `DISCLOSURE`.
+                    When `variant` is `REPORT`, `generatorClassName` can be one of: \
+                    `DocxGenerator`.""",
             tags = {"Reports"}
     )
     @GetMapping(value = REPORTS_URL)


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Throw better exceptions when the `generatorClassName` or `variant` is wrong while generating LicenseInfo report.

Also update the documentation for possible combinations of `generatorClassName` and `variant` in OpenAPI docs.

### How To Test?
1. Check if the documentation is clear.
2. Check if bad request is thrown if generator or variant is wrong.