### PR TITLE
fix(pagination): use correct sort column

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -162,6 +162,8 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
             "  } " +
             "}";
 
+    private static final String COMPONENT_BY_ALL_IDX = "ComponentByAllIdx";
+
     public ComponentRepository(DatabaseConnectorCloudant db, ReleaseRepository releaseRepository, VendorRepository vendorRepository) {
         super(Component.class, db, new ComponentSummary(releaseRepository, vendorRepository));
         Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
@@ -184,7 +186,7 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
         views.put("byVCSLowercase", createMapReduce(BY_VCS_LOWERCASE, null));
         initStandardDesignDocument(views, db);
 
-        createIndex("compByAll", new String[] {
+        createIndex(COMPONENT_BY_ALL_IDX, "compByAll", new String[] {
                 Component._Fields.NAME.getFieldName(),
                 Component._Fields.CATEGORIES.getFieldName(),
                 Component._Fields.COMPONENT_TYPE.getFieldName(),
@@ -333,7 +335,7 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
 
         PostFindOptions.Builder qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("compByAll"));
+                .useIndex(Collections.singletonList(COMPONENT_BY_ALL_IDX));
 
         List<Component> components = getConnector().getQueryResultPaginated(
                 qb, Component.class, pageData, sortSelector

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -103,24 +103,6 @@ public class ComponentSearchHandler {
 
     public Map<PaginationData, List<Component>> searchAccessibleComponents(String text, final Map<String,
             Set<String>> subQueryRestrictions, User user, @Nonnull PaginationData pageData) {
-        ResourceComparatorGenerator<Component> resourceComparatorGenerator = new ResourceComparatorGenerator<>();
-        ComponentSortColumn sortBy = ComponentSortColumn.findByValue(pageData.getSortColumnNumber());
-        Comparator<Component> comparator;
-
-        try {
-            comparator = switch (sortBy) {
-                case ComponentSortColumn.BY_NAME ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_COMPONENT, "name");
-                case ComponentSortColumn.BY_CREATEDON ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_COMPONENT, "createdOn");
-                case ComponentSortColumn.BY_TYPE ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_COMPONENT, "componentType");
-                case null, default -> null; // only two sortable fields, sort by score
-            };
-        } catch (ResourceClassNotFoundException e) {
-            comparator = null;
-        }
-
         Map<PaginationData, List<Component>> resultComponentList = connector
                 .searchViewWithRestrictions(Component.class,
                         luceneSearchView.getIndexName(), text, subQueryRestrictions,
@@ -131,10 +113,7 @@ public class ComponentSearchHandler {
 
         componentList = componentList.stream().filter(component ->
                 makePermission(component, user).isActionAllowed(RequestedAction.READ))
-                .collect(Collectors.toList());
-        if (comparator != null) {
-            componentList.sort(comparator);
-        }
+                .toList();
 
         return Collections.singletonMap(respPageData, componentList);
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -254,7 +254,12 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
                     "  }" +
                     "}";
 
-    public static Joiner spaceJoiner = Joiner.on(" ");
+    private static final String PROJECT_BY_NAME_IDX = "ProjectByNameIdx";
+    private static final String PROJECT_BY_DESC_IDX = "ProjectByDescIdx";
+    private static final String PROJECT_BY_RESPONSIBLE_IDX = "ProjectByResponsibleIdx";
+    private static final String PROJECT_BY_CREATED_ON_IDX = "ProjectByCreatedOnIdx";
+    private static final String PROJECT_BY_ALL_IDX = "ProjectByAllIdx";
+    public static final String PAGINATION_IDX = "PaginationIdx";
 
     public ProjectRepository(DatabaseConnectorCloudant db) {
         super(Project.class, db, new ProjectSummary());
@@ -275,12 +280,18 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         views.put("myfullprojectscount", createMapReduce(MY_ACCESSIBLE_PROJECTS_COUNT, "_count"));
         views.put("myfullprojectscountca", createMapReduce(ACCESSIBLE_PROJECTS_COUNT_FOR_CA_AND_ABOVE, "_count"));
         initStandardDesignDocument(views, db);
-        createIndex("byName", new String[] {"name"}, db);
-        createIndex("byDesc", new String[] {"description"}, db);
-        createIndex("byProjectResponsible", new String[] {"projectResponsible"}, db);
-        createIndex("byCreatedOn", new String[] {"createdOn"}, db);
+        createIndex(PROJECT_BY_NAME_IDX, "byName",
+                new String[] {Project._Fields.TYPE.getFieldName(), Project._Fields.NAME.getFieldName()}, db);
+        createIndex(PROJECT_BY_DESC_IDX, "byDesc",
+                new String[] {Project._Fields.TYPE.getFieldName(), Project._Fields.DESCRIPTION.getFieldName()}, db);
+        createIndex(PROJECT_BY_RESPONSIBLE_IDX, "byProjectResponsible",
+                new String[] {Project._Fields.TYPE.getFieldName(), Project._Fields.PROJECT_RESPONSIBLE.getFieldName()}, db);
+        createIndex(PROJECT_BY_CREATED_ON_IDX, "byCreatedOn",
+                new String[] {Project._Fields.TYPE.getFieldName(), Project._Fields.CREATED_ON.getFieldName()}, db);
+        createIndex(PAGINATION_IDX, "byTypePagination",
+                new String[] {"type", "_id"}, db);
 
-        createIndex("projByAll", new String[] {
+        createIndex(PROJECT_BY_ALL_IDX, "projByAll", new String[] {
                 Project._Fields.NAME.getFieldName(),
                 Project._Fields.TAG.getFieldName(),
                 Project._Fields.PROJECT_TYPE.getFieldName(),
@@ -407,19 +418,19 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
 
         switch (sortBy) {
             case ProjectSortColumn.BY_DESCRIPTION:
-                qb.useIndex(Collections.singletonList("byDesc"));
+                qb.useIndex(Collections.singletonList(PROJECT_BY_DESC_IDX));
                 break;
             case ProjectSortColumn.BY_RESPONSIBLE:
-                qb.useIndex(Collections.singletonList("byProjectResponsible"));
+                qb.useIndex(Collections.singletonList(PROJECT_BY_RESPONSIBLE_IDX));
                 break;
             case ProjectSortColumn.BY_CREATEDON:
-                qb.useIndex(Collections.singletonList("byCreatedOn"));
+                qb.useIndex(Collections.singletonList(PROJECT_BY_CREATED_ON_IDX));
             case ProjectSortColumn.BY_STATE:
                 queryViewName = "byState";
                 break;
             case null:
             default: // By default, sort by name
-                qb.useIndex(Collections.singletonList("byName"));
+                qb.useIndex(Collections.singletonList(PROJECT_BY_NAME_IDX));
                 break;
         }
         try {
@@ -480,7 +491,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
 
         PostFindOptions.Builder qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("projByAll"));
+                .useIndex(Collections.singletonList(PROJECT_BY_ALL_IDX));
 
         List<Project> projects = getConnector().getQueryResultPaginated(
                 qb, Project.class, pageData, sortSelector
@@ -605,8 +616,9 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         final Map<String, Object> isAModerator = elemMatch("moderators", requestingUserEmail);
         final Map<String, Object> isAContributor = elemMatch("contributors", requestingUserEmail);
         final Map<String, Object> meAndModerator_visibility_Selector = eq("visbility", "ME_AND_MODERATORS");
+        final List<Map<String, Object>> checkUserInProjectFields = List.of(createdBySelector, isAProjectResponsible, isALeadArchitect, isAModerator, isAContributor);
         final Map<String, Object> isUserBelongToMeAndModerator = and(List.of(meAndModerator_visibility_Selector,
-                or(List.of(createdBySelector, isAProjectResponsible, isALeadArchitect, isAModerator, isAContributor))));
+                or(checkUserInProjectFields)));
 
         final Map<String, Object> buAndModerator_visibility_Selector = eq("visbility", "BUISNESSUNIT_AND_MODERATORS");
         final Map<String, Object> userBuSelector = eq("businessUnit", userBU);
@@ -625,7 +637,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
                 buSelectors.add(eq("businessUnit", secondaryBU));
             }
         }
-        buSelectors.add(isUserBelongToMeAndModerator);
+        buSelectors.addAll(checkUserInProjectFields);
         buSelectors.add(userBuSelector);
         isUserBelongToBuAndModerator = and(List.of(buAndModerator_visibility_Selector, or(buSelectors)));
 
@@ -647,10 +659,16 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
             } else {
                 innerRestrictions.add(isUserBelongToBuAndModerator);
             }
+            // If there are subQuery, then "and" them other restrictions
             if (!subQueryRestrictions.isEmpty()) {
-                innerRestrictions.add(getQueryFromRestrictions(subQueryRestrictions));
+                finalSelector = and(List.of(
+                        typeSelector,
+                        getQueryFromRestrictions(subQueryRestrictions),
+                        or(innerRestrictions)
+                ));
+            } else {
+                finalSelector = and(List.of(typeSelector, or(innerRestrictions)));
             }
-            finalSelector = and(List.of(typeSelector, or(innerRestrictions)));
         }
         return finalSelector;
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -99,21 +99,6 @@ public class ProjectSearchHandler {
     }
 
     public Map<PaginationData, List<Project>> search(String text, final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
-        ResourceComparatorGenerator<Project> resourceComparatorGenerator = new ResourceComparatorGenerator<>();
-        ProjectSortColumn sortBy = ProjectSortColumn.findByValue(pageData.getSortColumnNumber());
-        Comparator<Project> comparator;
-        try {
-            comparator = switch (sortBy) {
-                case ProjectSortColumn.BY_NAME ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_PROJECT, "name");
-                case ProjectSortColumn.BY_CREATEDON ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_PROJECT, "createdOn");
-                case null, default -> null; // only two sortable fields, sort by score
-            };
-        } catch (ResourceClassNotFoundException e) {
-            comparator = null;
-        }
-
         Map<PaginationData, List<Project>> resultProjectList = connector
                 .searchViewWithRestrictions(Project.class,
                         luceneSearchView.getIndexName(), text, subQueryRestrictions,
@@ -122,10 +107,7 @@ public class ProjectSearchHandler {
         PaginationData respPageData = resultProjectList.keySet().iterator().next();
         List<Project> projectList = resultProjectList.values().iterator().next();
 
-        projectList = projectList.stream().filter(ProjectPermissions.isVisible(user)).collect(Collectors.toList());
-        if (comparator != null) {
-            projectList.sort(comparator);
-        }
+        projectList = projectList.stream().filter(ProjectPermissions.isVisible(user)).toList();
 
         return Collections.singletonMap(respPageData, projectList);
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -175,6 +175,9 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
                     "  } " +
                     "}";
 
+    private static final String RELEASE_BY_ALL_IDX = "ReleaseByAllIdx";
+    private static final String RELEASE_BY_ATTACHMENT_TYPE_IDX = "ReleaseByAttachmentTypeIdx";
+
     public ReleaseRepository(DatabaseConnectorCloudant db, VendorRepository vendorRepository) {
         super(Release.class, db, new ReleaseSummary(vendorRepository));
         Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
@@ -199,13 +202,13 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
         views.put("byCreatorGroup", createMapReduce(BY_CREATOR_DEPARTMENT_VIEW, null));
         initStandardDesignDocument(views, db);
 
-        createIndex("releaseByAll", new String[] {
+        createIndex(RELEASE_BY_ALL_IDX, "releaseByAll", new String[] {
                 Release._Fields.NAME.getFieldName(),
                 Release._Fields.CREATED_ON.getFieldName(),
                 Release._Fields.VERSION.getFieldName()
         }, db);
 
-        createIndex("releaseByAttachmentType", new String[] {
+        createIndex(RELEASE_BY_ATTACHMENT_TYPE_IDX, "releaseByAttachmentType", new String[] {
                 Release._Fields.TYPE.getFieldName(),
                 Release._Fields.CLEARING_STATE.getFieldName(),
                 Release._Fields.ATTACHMENTS.getFieldName() + "." + Attachment._Fields.ATTACHMENT_TYPE.getFieldName()
@@ -230,7 +233,7 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
 
         PostFindOptions.Builder qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("releaseByAll"));
+                .useIndex(Collections.singletonList(RELEASE_BY_ALL_IDX));
 
         List<Release> releases = getConnector().getQueryResultPaginated(
                 qb, Release.class, pageData, sortSelector
@@ -256,7 +259,7 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
 
         PostFindOptions.Builder qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("releaseByAttachmentType"));
+                .useIndex(Collections.singletonList(RELEASE_BY_ATTACHMENT_TYPE_IDX));
 
         List<Release> releases = getConnector().getQueryResultPaginated(
                 qb, Release.class, pageData, sortSelector

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
@@ -11,8 +11,6 @@ package org.eclipse.sw360.datahandler.db;
 
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.eq;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.and;
-import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.exists;
-import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.or;
 
 import org.eclipse.sw360.components.summary.UserSummary;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
@@ -116,6 +114,15 @@ public class UserRepository extends SummaryAwareRepository<User> {
             "  }" +
             "}";
 
+    private static final String USER_BY_EMAIL_IDX = "UserByEmailIdx";
+    private static final String USER_BY_DEPARTMENT_IDX = "UserByDepartmentIdx";
+    private static final String USER_BY_FIRST_NAME_IDX = "UserByFirstNameIdx";
+    private static final String USER_BY_LAST_NAME_IDX = "UserByLastNameIdx";
+    private static final String USER_BY_ACTIVE_STATUS_IDX = "UserByActiveStatusIdx";
+    private static final String USER_BY_GROUP_IDX = "UserByGroupIdx";
+    private static final String USER_BY_SECONDARY_DEPT_IDX = "UserBySecondaryDeptIdx";
+    private static final String USER_BY_ALL_IDX = "UserByAllIdx";
+
     public UserRepository(DatabaseConnectorCloudant databaseConnector) {
         super(User.class, databaseConnector, new UserSummary());
         Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
@@ -129,15 +136,16 @@ public class UserRepository extends SummaryAwareRepository<User> {
         views.put("find_by_secondaryDepartments", createMapReduce(FIND_BY_SECONDARY_DEPARTMENT, null));
         views.put("userEmails", createMapReduce(USERS_ALL_EMAIL_VIEW, null));
         initStandardDesignDocument(views, databaseConnector);
-        createIndex("byEmailUser", new String[] {"email"}, databaseConnector);
-        createIndex("byDepartment", new String[] {"department"}, databaseConnector);
-        createIndex("byFirstName", new String[] {"givenname"}, databaseConnector);
-        createIndex("byLastName", new String[] {"lastname"}, databaseConnector);
-        createIndex("byActiveStatus", new String[] {"deactivated"}, databaseConnector);
-        createIndex("byUserGroup", new String[] {"userGroup"}, databaseConnector);
-        createIndex("bySecondaryDepartmentsAndRoles", new String[] {"secondaryDepartmentsAndRoles"}, databaseConnector);
+        createIndex(USER_BY_EMAIL_IDX, "byEmailUser", new String[] {"email"}, databaseConnector);
+        createIndex(USER_BY_DEPARTMENT_IDX, "byDepartment", new String[] {"department"}, databaseConnector);
+        createIndex(USER_BY_FIRST_NAME_IDX, "byFirstName", new String[] {"givenname"}, databaseConnector);
+        createIndex(USER_BY_LAST_NAME_IDX, "byLastName", new String[] {"lastname"}, databaseConnector);
+        createIndex(USER_BY_ACTIVE_STATUS_IDX, "byActiveStatus", new String[] {"deactivated"}, databaseConnector);
+        createIndex(USER_BY_GROUP_IDX, "byUserGroup", new String[] {"userGroup"}, databaseConnector);
+        createIndex(USER_BY_SECONDARY_DEPT_IDX,
+                "bySecondaryDepartmentsAndRoles", new String[] {"secondaryDepartmentsAndRoles"}, databaseConnector);
 
-        createIndex("usersByAll", new String[] {
+        createIndex(USER_BY_ALL_IDX, "usersByAll", new String[] {
                 User._Fields.GIVENNAME.getFieldName(),
                 User._Fields.LASTNAME.getFieldName(),
                 User._Fields.DEPARTMENT.getFieldName(),
@@ -204,7 +212,7 @@ public class UserRepository extends SummaryAwareRepository<User> {
 
         PostFindOptions.Builder qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("usersByAll"));
+                .useIndex(Collections.singletonList(USER_BY_ALL_IDX));
 
         List<User> users = getConnector().getQueryResultPaginated(
                 qb, User.class, pageData, sortSelector
@@ -246,9 +254,9 @@ public class UserRepository extends SummaryAwareRepository<User> {
                 .selector(typeSelector);
 
         if (sortBy == UserSortColumn.BY_STATUS) {
-            qb.useIndex(Collections.singletonList("byActiveStatus"));
+            qb.useIndex(Collections.singletonList(USER_BY_ACTIVE_STATUS_IDX));
         } else {
-            qb.useIndex(Collections.singletonList("usersByAll"));
+            qb.useIndex(Collections.singletonList(USER_BY_ALL_IDX));
         }
 
         try {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
@@ -105,41 +105,8 @@ public class UserSearchHandler {
     }
 
     public Map<PaginationData, List<User>> search(String text, final Map<String, Set<String>> subQueryRestrictions, @Nonnull PaginationData pageData) {
-        ResourceComparatorGenerator<User> resourceComparatorGenerator = new ResourceComparatorGenerator<>();
-        UserSortColumn sortBy = UserSortColumn.findByValue(pageData.getSortColumnNumber());
-        Comparator<User> comparator;
-
-        try {
-            comparator = switch (sortBy) {
-                case UserSortColumn.BY_GIVENNAME ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_USER, User._Fields.GIVENNAME.getFieldName());
-                case UserSortColumn.BY_LASTNAME ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_USER, User._Fields.LASTNAME.getFieldName());
-                case UserSortColumn.BY_EMAIL ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_USER, User._Fields.EMAIL.getFieldName());
-                case UserSortColumn.BY_STATUS ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_USER, User._Fields.DEACTIVATED.getFieldName());
-                case UserSortColumn.BY_DEPARTMENT ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_USER, User._Fields.DEPARTMENT.getFieldName());
-                case UserSortColumn.BY_ROLE ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_USER, User._Fields.USER_GROUP.getFieldName());
-                case null, default -> null; // sort by score
-            };
-        } catch (ResourceClassNotFoundException e) {
-            comparator = null;
-        }
-
-        Map<PaginationData, List<User>> resultUserList = connector
-                .searchViewWithRestrictions(User.class,
-                        luceneUserSearchView.getIndexName(), text, subQueryRestrictions,
-                        pageData, null, pageData.isAscending());
-
-        PaginationData respPageData = resultUserList.keySet().iterator().next();
-        List<User> usersList = resultUserList.values().iterator().next();
-        if (comparator != null) {
-            usersList.sort(comparator);
-        }
-
-        return Collections.singletonMap(respPageData, usersList);
+        return connector.searchViewWithRestrictions(User.class,
+                luceneUserSearchView.getIndexName(), text, subQueryRestrictions,
+                pageData, null, pageData.isAscending());
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
@@ -67,44 +67,13 @@ public class VulnerabilitySearchHandler {
     }
 
     public Map<PaginationData, List<Vulnerability>> search(String searchText, PaginationData pageData) {
-        ResourceComparatorGenerator<Vulnerability> resourceComparatorGenerator = new ResourceComparatorGenerator<>();
-        VulnerabilitySortColumn sortBy = VulnerabilitySortColumn.findByValue(pageData.getSortColumnNumber());
-        Comparator<Vulnerability> comparator;
-
-        try {
-            comparator = switch (sortBy) {
-                case VulnerabilitySortColumn.BY_EXTERNALID ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_VULNERABILITY, Vulnerability._Fields.EXTERNAL_ID.getFieldName());
-                case VulnerabilitySortColumn.BY_TITLE ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_VULNERABILITY, Vulnerability._Fields.TITLE.getFieldName());
-                case VulnerabilitySortColumn.BY_WEIGHTING ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_VULNERABILITY, Vulnerability._Fields.CVSS.getFieldName());
-                case VulnerabilitySortColumn.BY_PUBLISHDATE ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_VULNERABILITY, Vulnerability._Fields.PUBLISH_DATE.getFieldName());
-                case VulnerabilitySortColumn.BY_LASTUPDATED ->
-                        resourceComparatorGenerator.generateComparator(SW360Constants.TYPE_VULNERABILITY, Vulnerability._Fields.LAST_UPDATE_DATE.getFieldName());
-                case null, default -> null; // sort by score
-            };
-        } catch (ResourceClassNotFoundException e) {
-            comparator = null;
-        }
-
         Map<String, Set<String>> subQueryRestrictions = Map.of(
                 Vulnerability._Fields.TITLE.getFieldName(), Collections.singleton(searchText),
                 Vulnerability._Fields.EXTERNAL_ID.getFieldName(), Collections.singleton(searchText)
         );
 
-        Map<PaginationData, List<Vulnerability>> resultVulnList = connector
-                .searchViewWithRestrictions(Vulnerability.class, luceneSearchView.getIndexName(),
-                        null, subQueryRestrictions,
-                        pageData, null, pageData.isAscending());
-
-        PaginationData respPageData = resultVulnList.keySet().iterator().next();
-        List<Vulnerability> vulnerabilityList = resultVulnList.values().iterator().next();
-        if (comparator != null) {
-            vulnerabilityList.sort(comparator);
-        }
-
-        return Collections.singletonMap(respPageData, vulnerabilityList);
+        return connector.searchViewWithRestrictions(Vulnerability.class,
+                luceneSearchView.getIndexName(), null, subQueryRestrictions,
+                pageData, null, pageData.isAscending());
     }
 }

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
@@ -76,6 +76,15 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
             "    }" +
             "}";
 
+    private static final String MR_BY_MODERATORS_IDX = "MrByModeratorsIdx";
+    private static final String MR_BY_DATE_IDX = "MrByDateIdx";
+    private static final String MR_BY_COMPONENT_TYPE_IDX = "MrByComponentTypeIdx";
+    private static final String MR_BY_DOCUMENT_NAME_IDX = "MrByDocumentNameIdx";
+    private static final String MR_BY_USERS_IDX = "MrByUsersIdx";
+    private static final String MR_BY_DEPARTMENT_IDX = "MrByDepartmentIdx";
+    private static final String MR_BY_MODERATION_STATE_IDX = "MrByModerationStateIdx";
+    private static final String MR_BY_DOCUMENT_ID_IDX = "MrByDocumentIdIdx";
+
     public ModerationRequestRepository(DatabaseConnectorCloudant db) {
         super(ModerationRequest.class, db, new ModerationRequestSummary());
         Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
@@ -84,15 +93,14 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         views.put("countByModerationState", createMapReduce(COUNTBYMODERATIONSTATE, "_count"));
         views.put("countByRequester", createMapReduce(COUNTBYREQUESTER, "_count"));
         initStandardDesignDocument(views, db);
-        createIndex("byModerators", new String[] {"moderators"}, db);
-        createIndex("byDate", new String[] {"timestamp"}, db);
-        createIndex("byComponentType", new String[] {"componentType"}, db);
-        createIndex("byDocumentName", new String[] {"documentName"}, db);
-        createIndex("byUsers", new String[] {"requestingUser"}, db);
-        createIndex("byDepartment", new String[] {"requestingUserDepartment"}, db);
-        createIndex("byModerationState", new String[] {"moderationState"}, db);
-        createIndex("byId", new String[] {"_id"}, db);
-        createIndex("byDocumentId", new String[] {"documentId"}, db);
+        createIndex(MR_BY_MODERATORS_IDX, "byModerators", new String[] {"moderators"}, db);
+        createIndex(MR_BY_DATE_IDX, "byDate", new String[] {"timestamp"}, db);
+        createIndex(MR_BY_COMPONENT_TYPE_IDX, "byComponentType", new String[] {"componentType"}, db);
+        createIndex(MR_BY_DOCUMENT_NAME_IDX, "byDocumentName", new String[] {"documentName"}, db);
+        createIndex(MR_BY_USERS_IDX, "byUsers", new String[] {"requestingUser"}, db);
+        createIndex(MR_BY_DEPARTMENT_IDX, "byDepartment", new String[] {"requestingUserDepartment"}, db);
+        createIndex(MR_BY_MODERATION_STATE_IDX, "byModerationState", new String[] {"moderationState"}, db);
+        createIndex(MR_BY_DOCUMENT_ID_IDX, "byDocumentId", new String[] {"documentId"}, db);
     }
 
     public List<ModerationRequest> getRequestsByDocumentId(String documentId) {
@@ -101,7 +109,7 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         final Map<String, Object> finalSelector = and(List.of(typeSelector, filterByModeratorSelector));
         PostFindOptions qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("byDocumentId"))
+                .useIndex(Collections.singletonList(MR_BY_DOCUMENT_ID_IDX))
                 .build();
         List<ModerationRequest> mrs = getConnector().getQueryResult(qb, ModerationRequest.class);
         return mrs;
@@ -113,7 +121,7 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         final Map<String, Object> finalSelector = and(List.of(typeSelector, filterByModeratorSelector));
         PostFindOptions qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("byModerators"))
+                .useIndex(Collections.singletonList(MR_BY_MODERATORS_IDX))
                 .build();
         List<ModerationRequest> mrs = getConnector().getQueryResult(qb, ModerationRequest.class);
         return makeSummaryFromFullDocs(SummaryType.SHORT, mrs);
@@ -130,7 +138,7 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
                 .selector(finalSelector)
                 .limit(rowsPerPage)
                 .skip(skip)
-                .useIndex(Collections.singletonList("byDate"))
+                .useIndex(Collections.singletonList(MR_BY_DATE_IDX))
                 .addSort(Collections.singletonMap("timestamp", ascending ? "asc" : "desc"))
                 .build();
         return getConnector().getQueryResult(qb, ModerationRequest.class);
@@ -175,37 +183,37 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         qb.skip(pageData.getDisplayStart());
         switch (sortColumnNo) {
             case -1, 5:
-                qb.useIndex(Collections.singletonList("byModerators"))
+                qb.useIndex(Collections.singletonList(MR_BY_MODERATORS_IDX))
                         .addSort(Collections.singletonMap("moderators", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
             case 0:
-                qb.useIndex(Collections.singletonList("byDate"))
+                qb.useIndex(Collections.singletonList(MR_BY_DATE_IDX))
                         .addSort(Collections.singletonMap("timestamp", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
             case 1:
-                qb.useIndex(Collections.singletonList("byComponentType"))
+                qb.useIndex(Collections.singletonList(MR_BY_COMPONENT_TYPE_IDX))
                         .addSort(Collections.singletonMap("componentType", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
             case 2:
-                qb.useIndex(Collections.singletonList("byDocumentName"))
+                qb.useIndex(Collections.singletonList(MR_BY_DOCUMENT_NAME_IDX))
                         .addSort(Collections.singletonMap("documentName", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
             case 3:
-                qb.useIndex(Collections.singletonList("byUsers"))
+                qb.useIndex(Collections.singletonList(MR_BY_USERS_IDX))
                         .addSort(Collections.singletonMap("requestingUser", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
             case 4:
-                qb.useIndex(Collections.singletonList("byDepartment"))
+                qb.useIndex(Collections.singletonList(MR_BY_DEPARTMENT_IDX))
                         .addSort(Collections.singletonMap("requestingUserDepartment", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
             case 6:
-                qb.useIndex(Collections.singletonList("byModerationState"))
+                qb.useIndex(Collections.singletonList(MR_BY_MODERATION_STATE_IDX))
                         .addSort(Collections.singletonMap("moderationState", ascending ? "asc" : "desc"));
                 query = qb.build();
                 break;
@@ -255,7 +263,7 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         final Map<String, Object> finalSelector = and(List.of(typeSelector, filterByModeratorSelector));
         PostFindOptions.Builder qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
-                .useIndex(Collections.singletonList("byUsers"));
+                .useIndex(Collections.singletonList(MR_BY_USERS_IDX));
         List<ModerationRequest> mrs = getConnector().getQueryResult(qb.build(), ModerationRequest.class);
         return makeSummaryFromFullDocs(SummaryType.SHORT, mrs);
     }
@@ -271,7 +279,7 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
                 .selector(finalSelector)
                 .limit(rowsPerPage)
                 .skip(skip)
-                .useIndex(Collections.singletonList("byUsers"))
+                .useIndex(Collections.singletonList(MR_BY_USERS_IDX))
                 .addSort(Collections.singletonMap("timestamp", ascending ? "asc" : "desc"));
 
         List<ModerationRequest> modReqs = Lists.newArrayList();

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -73,7 +73,8 @@ public class DatabaseRepositoryCloudantClient<T> {
         return mrBuilder.build();
     }
 
-    public void createIndex(String indexName, String[] fields, DatabaseConnectorCloudant db) {
+    public void createIndex(String ddocId, String indexName, String[] fields,
+                            DatabaseConnectorCloudant db) {
         IndexDefinition.Builder indexDefinitionBuilder = new IndexDefinition.Builder();
         for (String fieldName : fields) {
             IndexField field = new IndexField.Builder()
@@ -82,7 +83,8 @@ public class DatabaseRepositoryCloudantClient<T> {
             indexDefinitionBuilder.addFields(field);
         }
 
-        db.createIndex(indexDefinitionBuilder.build(), indexName, "json");
+        db.createIndex(indexDefinitionBuilder.build(), ddocId, indexName,
+                "json");
     }
 
     protected DatabaseConnectorCloudant getConnector() {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -436,10 +436,10 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
             Sort.Order order = pageable.getSort().iterator().next();
             String property = order.getProperty();
             column = switch (property) {
-                case "created" -> ComponentSortColumn.BY_CREATEDON;
+                case "createdOn" -> ComponentSortColumn.BY_CREATEDON;
                 case "name" -> ComponentSortColumn.BY_NAME;
-                case "vendor" -> ComponentSortColumn.BY_VENDOR;
-                case "license" -> ComponentSortColumn.BY_MAINLICENSE;
+                case "vendorNames" -> ComponentSortColumn.BY_VENDOR;
+                case "mainLicenseIds" -> ComponentSortColumn.BY_MAINLICENSE;
                 case "type" -> ComponentSortColumn.BY_TYPE;
                 default -> column; // Default to BY_CREATEDON if no match
             };

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1818,13 +1818,13 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             Sort.Order order = pageable.getSort().iterator().next();
             String property = order.getProperty();
             column = switch (property) {
-                case "created" -> ProjectSortColumn.BY_CREATEDON;
+                case "createdOn" -> ProjectSortColumn.BY_CREATEDON;
                 case "name" -> ProjectSortColumn.BY_NAME;
                 case "vendor" -> ProjectSortColumn.BY_VENDOR;
                 case "license" -> ProjectSortColumn.BY_MAINLICENSE;
                 case "type" -> ProjectSortColumn.BY_TYPE;
-                case "desc" -> ProjectSortColumn.BY_DESCRIPTION;
-                case "resp" -> ProjectSortColumn.BY_RESPONSIBLE;
+                case "description" -> ProjectSortColumn.BY_DESCRIPTION;
+                case "projectResponsible" -> ProjectSortColumn.BY_RESPONSIBLE;
                 case "state" -> ProjectSortColumn.BY_STATE;
                 default -> column; // Default to BY_NAME if no match
             };

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -160,8 +160,6 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         PaginationData pageData = pageableToPaginationData(pageable, null, null);
         Map<PaginationData, List<Project>> resp = sw360ProjectClient
                 .getAccessibleProjectsSummaryWithPagination(sw360User, pageData);
-        PaginationData respPagination = resp.keySet().iterator().next();
-        respPagination.setTotalRowCount(sw360ProjectClient.getMyAccessibleProjectCounts(sw360User));
         return resp;
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -283,7 +283,7 @@ public class Sw360UserService {
      */
     private static PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
         UserSortColumn column = UserSortColumn.BY_GIVENNAME;
-        boolean ascending = false;
+        boolean ascending = true;
 
         if (pageable.getSort().isSorted()) {
             Sort.Order order = pageable.getSort().iterator().next();
@@ -291,9 +291,9 @@ public class Sw360UserService {
             column = switch (property) {
                 case "lastname" -> UserSortColumn.BY_LASTNAME;
                 case "email" -> UserSortColumn.BY_EMAIL;
-                case "status" -> UserSortColumn.BY_STATUS;
+                case "deactivated" -> UserSortColumn.BY_STATUS;
                 case "department" -> UserSortColumn.BY_DEPARTMENT;
-                case "role" -> UserSortColumn.BY_ROLE;
+                case "primaryRoles" -> UserSortColumn.BY_ROLE;
                 default -> column; // Default to BY_GIVENNAME if no match
             };
             ascending = order.isAscending();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
@@ -347,9 +347,9 @@ public class Sw360VulnerabilityService {
             String property = order.getProperty();
             column = switch (property) {
                 case "title" -> VulnerabilitySortColumn.BY_TITLE;
-                case "weighting" -> VulnerabilitySortColumn.BY_WEIGHTING;
-                case "publishdate" -> VulnerabilitySortColumn.BY_PUBLISHDATE;
-                case "lastupdated" -> VulnerabilitySortColumn.BY_LASTUPDATED;
+                case "cvss" -> VulnerabilitySortColumn.BY_WEIGHTING;
+                case "publishDate" -> VulnerabilitySortColumn.BY_PUBLISHDATE;
+                case "lastUpdateDate" -> VulnerabilitySortColumn.BY_LASTUPDATED;
                 default -> column; // Default to BY_EXTERNALID if no match
             };
             ascending = order.isAscending();


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

1. Correct pagination sort property names to use actual column names.
2. Remove custom sorting as it is already done by `org.eclipse.sw360.datahandler.resourcelists.ResourceListController#getPaginationResultFromPaginatedList` to avoid duplicate efforts.

### How To Test?
Check if sorting still works as expected in following endpoints.
1. /projects
2. /components
3. /users
4. /vulnerabilities