### PR TITLE
chore(datahandler): migrate deprecated APIs

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/common/utils/RepositoryURL.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/utils/RepositoryURL.java
@@ -115,8 +115,8 @@ public class RepositoryURL {
         URL url;
         HttpURLConnection connection = null;
         try {
-            url = new URL(urlString);
-        } catch (MalformedURLException e) {
+            url = new URI(urlString).toURL();
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             log.error("Invalid URL format: {}", e.getMessage());
             return urlString;
         }
@@ -133,7 +133,7 @@ public class RepositoryURL {
                     connection.disconnect();
 
                     // Resolve relative URLs
-                    url = new URL(url, newUrl);
+                    url = url.toURI().resolve(newUrl).toURL();
 
                     if (!"https".equalsIgnoreCase(url.getProtocol())) {
                         log.error("Insecure redirection to non-HTTPS URL: {}", url);
@@ -146,7 +146,7 @@ public class RepositoryURL {
                     connection.disconnect();
                     break;
                 }
-            } catch (IOException e) {
+            } catch (IOException | URISyntaxException | IllegalArgumentException e) {
                 log.error("Error during redirection handling: {}", e.getMessage());
                 return urlString;
             }
@@ -159,7 +159,7 @@ public class RepositoryURL {
         }
 
         if (redirectCount == 0 || redirectCount >= redirectionLimit) {
-            if (redirectCount >= Integer.parseInt(VCS_REDIRECTION_LIMIT)) {
+            if (redirectCount >= redirectionLimit) {
                 log.error("Exceeded maximum redirect limit. Returning original URL.");
             }
             return urlString;
@@ -175,7 +175,7 @@ public class RepositoryURL {
         return connection;
     }
 
-    public Set<String> getRiderctedUrls(){
+    public Set<String> getRedirectedUrls(){
         return redirectedUrls;
     }
 

--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -12,10 +12,6 @@ package org.eclipse.sw360.cyclonedx;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.Predicate;
@@ -286,7 +282,7 @@ public class CycloneDxBOMImporter {
                         // all components does not have VCS, so return & show appropriate error in UI
                         messageMap.put(INVALID_COMPONENT, String.join(JOINER, componentsWithoutVcs));
                         messageMap.put(INVALID_PACKAGE, String.join(JOINER, invalidPackages));
-                        messageMap.put(REDIRECTED_VCS, String.join(JOINER, repositoryURL.getRiderctedUrls()));
+                        messageMap.put(REDIRECTED_VCS, String.join(JOINER, repositoryURL.getRedirectedUrls()));
                         messageMap.put(DUPLICATE_PACKAGE, String.join(JOINER, duplicatePackages));
                         messageMap.put(SW360Constants.MESSAGE,
                                 String.format("VCS information is missing for <b>%s</b> / <b>%s</b> Components!",
@@ -715,7 +711,7 @@ public class CycloneDxBOMImporter {
         messageMap.put(DUPLICATE_RELEASE, String.join(JOINER, duplicateReleases));
         messageMap.put(DUPLICATE_PACKAGE, String.join(JOINER, duplicatePackages));
         messageMap.put(INVALID_RELEASE, String.join(JOINER, invalidReleases));
-        messageMap.put(REDIRECTED_VCS, String.join(JOINER, repositoryURL.getRiderctedUrls()));
+        messageMap.put(REDIRECTED_VCS, String.join(JOINER, repositoryURL.getRedirectedUrls()));
         messageMap.put(INVALID_PACKAGE, String.join(JOINER, invalidPackages));
         messageMap.put(PROJECT_ID, project.getId());
         messageMap.put(PROJECT_NAME, SW360Utils.getVersionedName(project.getName(), project.getVersion()));

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
@@ -906,27 +906,27 @@ public class DatabaseHandlerUtil {
     private static ObjectMapper initAndGetObjectMapper() {
         if (mapper == null) {
             mapper = new ObjectMapper();
-            mapper.addMixInAnnotations(Attachment.class, AttachmentMixin.class);
-            mapper.addMixInAnnotations(ObligationStatusInfo.class, ObligationStatusInfoMixin.class);
-            mapper.addMixInAnnotations(ClearingInformation.class, ClearingInformationMixin.class);
-            mapper.addMixInAnnotations(COTSDetails.class, COTSDetailsMixin.class);
-            mapper.addMixInAnnotations(EccInformation.class, EccInformationMixin.class);
-            mapper.addMixInAnnotations(Vendor.class, VendorMixin.class);
-            mapper.addMixInAnnotations(Repository.class, RepositoryMixin.class);
-            mapper.addMixInAnnotations(ProjectProjectRelationship.class, ProjectProjectRelationshipMixin.class);
-            mapper.addMixInAnnotations(ProjectReleaseRelationship.class, ProjectReleaseRelationshipMixin.class);
-            mapper.addMixInAnnotations(CheckSum.class, CheckSumMixin.class);
-            mapper.addMixInAnnotations(Annotations.class, AnnotationsMixin.class);
-            mapper.addMixInAnnotations(ExternalDocumentReferences.class, ExternalDocumentReferencesMixin.class);
-            mapper.addMixInAnnotations(Creator.class, CreatorMixin.class);
-            mapper.addMixInAnnotations(OtherLicensingInformationDetected.class, OtherLicensingInformationDetectedMixin.class);
-            mapper.addMixInAnnotations(PackageVerificationCode.class, PackageVerificationCodeMixin.class);
-            mapper.addMixInAnnotations(ExternalReference.class, ExternalReferenceMixin.class);
-            mapper.addMixInAnnotations(RelationshipsBetweenSPDXElements.class, RelationshipsBetweenSPDXElementsMixin.class);
-            mapper.addMixInAnnotations(SnippetInformation.class, SnippetInformationMixin.class);
-            mapper.addMixInAnnotations(SnippetRange.class, SnippetRangeMixin.class);
-            mapper.addMixInAnnotations(Obligation.class, ObligationMixin.class);
-            mapper.addMixInAnnotations(LicenseType.class, LicenseTypeMixin.class);
+            mapper.addMixIn(Attachment.class, AttachmentMixin.class);
+            mapper.addMixIn(ObligationStatusInfo.class, ObligationStatusInfoMixin.class);
+            mapper.addMixIn(ClearingInformation.class, ClearingInformationMixin.class);
+            mapper.addMixIn(COTSDetails.class, COTSDetailsMixin.class);
+            mapper.addMixIn(EccInformation.class, EccInformationMixin.class);
+            mapper.addMixIn(Vendor.class, VendorMixin.class);
+            mapper.addMixIn(Repository.class, RepositoryMixin.class);
+            mapper.addMixIn(ProjectProjectRelationship.class, ProjectProjectRelationshipMixin.class);
+            mapper.addMixIn(ProjectReleaseRelationship.class, ProjectReleaseRelationshipMixin.class);
+            mapper.addMixIn(CheckSum.class, CheckSumMixin.class);
+            mapper.addMixIn(Annotations.class, AnnotationsMixin.class);
+            mapper.addMixIn(ExternalDocumentReferences.class, ExternalDocumentReferencesMixin.class);
+            mapper.addMixIn(Creator.class, CreatorMixin.class);
+            mapper.addMixIn(OtherLicensingInformationDetected.class, OtherLicensingInformationDetectedMixin.class);
+            mapper.addMixIn(PackageVerificationCode.class, PackageVerificationCodeMixin.class);
+            mapper.addMixIn(ExternalReference.class, ExternalReferenceMixin.class);
+            mapper.addMixIn(RelationshipsBetweenSPDXElements.class, RelationshipsBetweenSPDXElementsMixin.class);
+            mapper.addMixIn(SnippetInformation.class, SnippetInformationMixin.class);
+            mapper.addMixIn(SnippetRange.class, SnippetRangeMixin.class);
+            mapper.addMixIn(Obligation.class, ObligationMixin.class);
+            mapper.addMixIn(LicenseType.class, LicenseTypeMixin.class);
         }
         return mapper;
     }
@@ -1119,4 +1119,3 @@ public class DatabaseHandlerUtil {
         return tempFile;
     }
 }
-

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SvmConnector.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SvmConnector.java
@@ -11,13 +11,13 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.ByteArrayBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.ssl.SSLContexts;
 import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
@@ -99,8 +99,8 @@ public class SvmConnector {
 
             SSLContext sslcontext = SSLContexts
                     .custom()
-                    .useProtocol("TLSv1.2")
-                    .loadTrustMaterial(trustStore)
+                    .setProtocol("TLSv1.2")
+                    .loadTrustMaterial(trustStore, null)
                     .loadKeyMaterial(keyStore, KEY_STORE_PASSPHRASE)
                     .build();
 

--- a/backend/cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImpl.java
+++ b/backend/cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasource/CveSearchApiImpl.java
@@ -22,9 +22,10 @@ import org.apache.logging.log4j.Logger;
 import java.io.BufferedReader;
 import java.lang.reflect.Type;
 import java.io.*;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,10 +51,12 @@ public class CveSearchApiImpl implements CveSearchApi {
 
     private <T> T getParsedContentFor(String query, Function<BufferedReader,T> parser) throws IOException {
         log.debug("Execute query: " + query);
-        try(InputStream is = new URL(query).openStream();
-            InputStreamReader inputStreamReader = new InputStreamReader(is, Charset.forName("UTF-8"));
+        try(InputStream is = new URI(query).toURL().openStream();
+            InputStreamReader inputStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
             BufferedReader content = new BufferedReader(inputStreamReader)) {
             return parser.apply(content);
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
         }
     }
 

--- a/backend/cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchDataTestHelper.java
+++ b/backend/cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasource/CveSearchDataTestHelper.java
@@ -12,7 +12,8 @@
 package org.eclipse.sw360.cvesearch.datasource;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,11 +38,11 @@ public class CveSearchDataTestHelper {
 
     public static boolean isUrlReachable(String url) {
         try {
-            final URLConnection connection = new URL(url).openConnection();
+            final URLConnection connection = new URI(url).toURL().openConnection();
             connection.setConnectTimeout(CONNECT_TIMEOUT);
             connection.connect();
             return true;
-        } catch (final IOException e) {
+        } catch (final IOException | URISyntaxException | IllegalArgumentException e) {
             return false;
         }
     }

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyRestConfig.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyRestConfig.java
@@ -20,7 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
@@ -97,8 +98,8 @@ public class FossologyRestConfig {
         String url = newConfig.getConfigKeyToValues().get(CONFIG_KEY_URL).stream().findFirst().orElseThrow(
                 () -> new IllegalStateException("The new FOSSology REST configuration does not contain a URL."));
         try {
-            new URL(url);
-        } catch (MalformedURLException e) {
+            new URI(url).toURL();
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             throw new IllegalStateException("The new FOSSology REST configuration does not contain a valid URL.");
         }
 

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
@@ -433,7 +433,7 @@ public class FossologyRestClient {
                 return reportResource.getInputStream();
             } else {
                 log.error("Failed to download report for reportId {}. HTTP status: {}",
-                        reportId, responseEntity.getStatusCodeValue());
+                        reportId, responseEntity.getStatusCode());
                 return null;
             }
         } catch (RestClientException e) {

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -470,7 +470,7 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
         CTColor colour = CTColor.Factory.newInstance();
         colour.setVal("0000FF");
         // Set the color using XWPFRun
-        XWPFRun run = new XWPFRun(ctr, null);
+        XWPFRun run = new XWPFRun(ctr, (IRunBody)null);
         run.setColor("0000FF"); // Set the color to blue
         ctrpr.addNewU().setVal(STUnderline.SINGLE);
         ctrpr.addNewSz().setVal(BigInteger.valueOf(18L));

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -213,7 +213,7 @@ public class DocxUtils {
 
     public static void removeParagraph(XWPFDocument document, String paragraphText) {
         XWPFParagraph paragraphToDelete = document.getParagraphs().stream()
-                .filter(p -> StringUtils.equalsIgnoreCase(paragraphText, p.getParagraphText()))
+                .filter(p -> paragraphText.equalsIgnoreCase(p.getParagraphText()))
                 .findFirst().orElse(null);
         if (paragraphToDelete != null) {
             document.removeBodyElement(document.getPosOfParagraph(paragraphToDelete));

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -19,6 +19,8 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
 import org.apache.jena.util.XMLChar;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -117,14 +119,14 @@ public class SPDXParserTools {
                 if (Util.splitNamespaceXML(label) == label.length()) {
                     try {
                         label = URLDecoder.decode(label, StandardCharsets.UTF_8);
-                        URL url = new URL(label);
+                        URL url = new URI(label).toURL();
                         if (null != url.getRef()) {
                             return url.getRef();
                         } else {
                             String path = url.getPath();
                             return path.substring(path.lastIndexOf('/') + 1);
                         }
-                    } catch (MalformedURLException e) {
+                    } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
                         return "";
                     }
                 }

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
@@ -13,7 +13,6 @@ package org.eclipse.sw360.licenseinfo;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
@@ -22,6 +21,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.licenseinfo.parsers.AttachmentContentProvider;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.HashMap;
@@ -80,10 +80,12 @@ public class TestHelper {
             return store.get(attachmentContentId);
         }
 
-        public AttachmentContentStore put(String filename, String fileContent) throws TException {
+        public AttachmentContentStore put(String filename, String fileContent) throws TException, IOException {
             AttachmentContent attachmentContent = makeAttachmentContent(filename);
             store.put(attachmentContent.getId(), attachmentContent);
-            when(connectorMock.getAttachmentStream(eq(attachmentContent), any(), any())).thenReturn(new ReaderInputStream(new StringReader(fileContent)));
+            when(connectorMock.getAttachmentStream(eq(attachmentContent), any(), any())).thenReturn(
+                    ReaderInputStream.builder().setReader(new StringReader(fileContent)).get()
+            );
             return this;
         }
 

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
@@ -106,28 +106,36 @@ public class CLIParserTest {
 
     @Test
     public void testIsApplicableTo() throws Exception {
-        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(CLI_TESTFILE)).get()
+        );
         assertTrue(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnIncorrectRootElement() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
+        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader("<wrong-root/>")).get()
+        );
         assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnMalformedXML() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
+        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader("this is not an xml file")).get()
+        );
         assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testGetCLI() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(CLI_TESTFILE)).get()
+        );
         LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project()).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
@@ -144,7 +152,9 @@ public class CLIParserTest {
     @Test
     public void testGetCLIObligations() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(CLI_TESTFILE)).get()
+        );
         ObligationParsingResult oblRes = parser.getObligations(cliAttachment, new User(), new Project());
         assertThat(oblRes.getStatus(), is(ObligationInfoRequestStatus.SUCCESS));
         assertThat(oblRes.getObligationsAtProjectSize(), is(2));
@@ -157,13 +167,13 @@ public class CLIParserTest {
     @Test
     public void testGetCLIFailsOnMalformedXML() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE.replaceAll("</Content>", "</Broken>"))));
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(CLI_TESTFILE.replaceAll("</Content>", "</Broken>"))).get()
+        );
         LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project()).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res, LicenseInfoRequestStatus.FAILURE);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.FAILURE));
         assertThat(res.getLicenseInfo(), notNullValue());
         assertThat(res.getLicenseInfo().getFilenames(), contains("a.xml"));
-
     }
-
 }

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/OSADLObligationConnector.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/OSADLObligationConnector.java
@@ -46,7 +46,7 @@ public class OSADLObligationConnector extends ObligationConnector {
     protected String getText(String licenseId) {
         String obligationURL = generateURL(licenseId);
 		try {
-			URL url = new URL(obligationURL);
+			URL url = new URI(obligationURL).toURL();
 			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 			int responseCode = conn.getResponseCode();
 			if (responseCode != HttpURLConnection.HTTP_OK) {
@@ -63,7 +63,7 @@ public class OSADLObligationConnector extends ObligationConnector {
 			}
 			in.close();
 			return buffer.toString();
-		} catch (IOException e) {
+		} catch (IOException | URISyntaxException | IllegalArgumentException e) {
 			log.error("Could not get OSADL License for: " + licenseId);
 			return null;
 		}

--- a/backend/utils/src/main/java/org/eclipse/sw360/UtilsEntryPoint.java
+++ b/backend/utils/src/main/java/org/eclipse/sw360/UtilsEntryPoint.java
@@ -54,7 +54,7 @@ public class UtilsEntryPoint {
     private static CommandLine parseArgs(String[] args) throws ParseException {
         Options options = getOptions();
 
-        return new BasicParser().parse(options, args, true);
+        return new DefaultParser().parse(options, args, true);
     }
 
     private static void printHelp() {

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/common/SVMUtils.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/common/SVMUtils.java
@@ -17,6 +17,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import static org.apache.log4j.Logger.getLogger;
@@ -30,9 +32,9 @@ public class SVMUtils {
 
     private SVMUtils(){}
 
-    public static String prepareJSONRequestAndGetResponse(String url) throws IOException {
-        StringBuffer json = new StringBuffer();
-        URL url_ = new URL(url);
+    public static String prepareJSONRequestAndGetResponse(String url) throws IOException, URISyntaxException {
+        StringBuilder json = new StringBuilder();
+        URL url_ = new URI(url).toURL();
         log.debug("Call URL: "+url);
         HttpURLConnection conn = (HttpURLConnection) url_.openConnection();
         conn.setRequestMethod("GET");

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandler.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandler.java
@@ -35,6 +35,7 @@ import com.github.cliftonlabs.json_simple.Jsoner;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -659,7 +660,7 @@ public class SVMSyncHandler<T extends TBase> {
                 }
                 return vulIds;
 
-            } catch (IOException | RuntimeException e){
+            } catch (IOException | RuntimeException | URISyntaxException e){
                 String message = "Failed to get vulnerabilities for component "+componentVmId+" from SMV";
                 log.error(message, e);
                 return Collections.emptySet();

--- a/clients/client/src/main/java/org/eclipse/sw360/clients/adapter/SW360AttachmentUtils.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/adapter/SW360AttachmentUtils.java
@@ -175,7 +175,7 @@ public class SW360AttachmentUtils {
      */
     public static String calculateHash(Path file, MessageDigest digest) {
         try (DigestInputStream din = new DigestInputStream(Files.newInputStream(file), digest)) {
-            IOUtils.copy(din, NullOutputStream.NULL_OUTPUT_STREAM);
+            IOUtils.copy(din, NullOutputStream.INSTANCE);
         } catch (IOException e) {
             throw new SW360ClientException("Could not calculate hash for file " + file, e);
         }

--- a/clients/client/src/main/java/org/eclipse/sw360/clients/config/SW360ClientConfig.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/config/SW360ClientConfig.java
@@ -131,8 +131,8 @@ public final class SW360ClientConfig {
                     Validate.notEmpty(clientId, "Undefined client ID"),
                     Validate.notEmpty(clientPassword, "Undefined client password"),
                     Validate.notEmpty(token, "Undefined token"),
-                    Validate.notNull(httpClient),
-                    Validate.notNull(mapper));
+                    Validate.notNull(httpClient, "HTTP client cannot be null"),
+                    Validate.notNull(mapper, "Object Mapper cannot be null"));
         }
         return new SW360ClientConfig(
                 URI.create(stripTrailingSeparator(Validate.notEmpty(restURL, "Undefined REST URL"))),
@@ -142,8 +142,8 @@ public final class SW360ClientConfig {
                 Validate.notEmpty(clientId, "Undefined client ID"),
                 Validate.notEmpty(clientPassword, "Undefined client password"),
                 token,
-                Validate.notNull(httpClient),
-                Validate.notNull(mapper));
+                Validate.notNull(httpClient, "HTTP client cannot be null"),
+                Validate.notNull(mapper, "Object Mapper cannot be null"));
     }
 
     /**
@@ -220,7 +220,7 @@ public final class SW360ClientConfig {
     }
 
     public String getToken() {
-        if (StringUtils.isBlank(token) || StringUtils.equalsIgnoreCase(token, "none")){
+        if (StringUtils.isBlank(token) || "none".equalsIgnoreCase(token)){
               return "";
         }
         return token;

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 /**
  * <p>
@@ -42,7 +42,7 @@ class NewRequestBodyBuilderImpl implements RequestBodyBuilder {
      */
     public NewRequestBodyBuilderImpl(ObjectMapper mapper) {
         this.mapper = mapper;
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
     }
 
     @Override

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/RequestBodyBuilderImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/RequestBodyBuilderImpl.java
@@ -12,7 +12,7 @@ package org.eclipse.sw360.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
@@ -55,7 +55,7 @@ class RequestBodyBuilderImpl implements RequestBodyBuilder {
      */
     public RequestBodyBuilderImpl(ObjectMapper mapper) {
         this.mapper = mapper;
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
     }
 
     @Override

--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/utils/HttpUtils.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/utils/HttpUtils.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -285,9 +286,11 @@ public final class HttpUtils {
                 return mapper.readValue(response.bodyStream(), resultClass);
             } else {
                 try {
-                    return resultClass.newInstance();
-                } catch (InstantiationException | IllegalAccessException e) {
+                    return resultClass.getDeclaredConstructor().newInstance();
+                } catch (InstantiationException | IllegalAccessException | NoSuchMethodException e) {
 
+                } catch (InvocationTargetException e) {
+                    throw new RuntimeException(e);
                 }
                 return null;
             }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -36,7 +36,8 @@ import org.jetbrains.annotations.NotNull;
 import java.io.*;
 import java.lang.reflect.Array;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -59,7 +60,8 @@ public class CommonUtils {
 
     private static final Ordering<String> CASE_INSENSITIVE_ORDERING = Ordering.from(String.CASE_INSENSITIVE_ORDER);
 
-    public static final CSVFormat sw360CsvFormat = CSVFormat.RFC4180.withQuote('\'').withEscape('\\').withIgnoreSurroundingSpaces(true).withQuoteMode(QuoteMode.ALL);
+    public static final CSVFormat sw360CsvFormat = CSVFormat.RFC4180
+            .builder().setQuote('\'').setEscape('\\').setIgnoreSurroundingSpaces(true).setQuoteMode(QuoteMode.ALL).get();
 
     private static final Splitter COMMA_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
@@ -414,19 +416,22 @@ public class CommonUtils {
     }
 
     public static boolean isValidUrl(String url) {
+        if (isNullOrEmpty(url)) {
+            return false;
+        }
         try {
-            return !isNullOrEmpty(new URL(url).getHost());
-        } catch (MalformedURLException e) {
+            return !isNullOrEmpty(new URI(url).toURL().getHost());
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             return false;
         }
     }
 
     public static String getTargetNameOfUrl(String url) {
         try {
-            String path = new URL(url).getPath();
+            String path = new URI(url).toURL().getPath();
             String fileName = FilenameUtils.getName(path);
             return !isNullOrEmpty(fileName) ? fileName : path;
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             return "";
         }
     }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ImportCSV.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ImportCSV.java
@@ -39,16 +39,16 @@ public class ImportCSV {
     /**
      * reads a CSV file and returns its content as a list of CSVRecord
      *
-     * @param in
+     * @param in Stream to read the CSV file from
      * @return list of records
      */
     public static List<CSVRecord> readAsCSVRecords(InputStream in) {
         List<CSVRecord> records = null;
 
         try (Reader reader = new InputStreamReader(in);
-             CSVParser parser = new CSVParser(reader, CommonUtils.sw360CsvFormat)) {
+             CSVParser parser = CSVParser.parse(reader, CommonUtils.sw360CsvFormat)) {
             records = parser.getRecords();
-            records.remove(0); // Remove header
+            records.removeFirst(); // Remove header
         } catch (IOException e) {
             log.error("Error parsing CSV File!", e);
         }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -25,6 +25,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import com.google.gson.Gson;
+import org.apache.maven.api.model.Model;
+import org.apache.maven.model.v4.MavenStaxReader;
 import org.apache.thrift.protocol.TType;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.ProjectProjectRelationshipMixin;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
@@ -53,14 +55,13 @@ import org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.Doc
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.thrift.TEnum;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityService;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -399,13 +400,13 @@ public class SW360Utils {
     }
 
     public static String getSW360Version() {
-        final MavenXpp3Reader reader = new MavenXpp3Reader();
+        final MavenStaxReader reader = new MavenStaxReader();
         try (InputStreamReader iStreamReader = new InputStreamReader(
                 SW360Utils.class.getResourceAsStream(SW360Constants.DATA_HANDLER_POM_FILE_PATH))) {
             Model model = reader.read(iStreamReader);
             return model.getVersion();
         } catch (Exception e) {
-            log.error("Error while getting SW360 version information: "+ e);
+            log.error("Error while getting SW360 version information: {}", String.valueOf(e));
             return SW360Constants.NA;
         }
     }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloader.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloader.java
@@ -15,6 +15,8 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -27,10 +29,10 @@ public class AttachmentContentDownloader {
      *
      * @todo setup DI and move timeout to a member
      */
-    public InputStream download(AttachmentContent attachmentContent, Duration timeout) throws IOException {
+    public InputStream download(AttachmentContent attachmentContent, Duration timeout) throws IOException, URISyntaxException {
         int millisTimeout = ((Number) timeout.toMillis()).intValue();
 
-        URL remoteURL = new URL(attachmentContent.getRemoteUrl());
+        URL remoteURL = new URI(attachmentContent.getRemoteUrl()).toURL();
         URLConnection urlConnection = remoteURL.openConnection();
 
         urlConnection.setConnectTimeout(millisTimeout);

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -171,7 +172,7 @@ public class AttachmentStreamConnector {
 
         try {
             downloadStream = attachmentContentDownloader.download(attachmentContent, downloadTimeout);
-        } catch (IOException e) {
+        } catch (IOException | URISyntaxException | IllegalArgumentException e) {
             String msg = "Cannot download attachment " + attachmentContent.getId() + " from URL";
             log.error(msg, e);
             throw new SW360Exception(msg);

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
@@ -49,6 +49,8 @@ import org.eclipse.sw360.datahandler.thrift.vmcomponents.VMComponentService;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityService;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Properties;
 
@@ -142,7 +144,7 @@ public class ThriftClients {
 
         try {
             if (BACKEND_PROXY_URL != null) {
-                URL proxyUrl = new URL(BACKEND_PROXY_URL);
+                URL proxyUrl = new URI(BACKEND_PROXY_URL).toURL();
                 HttpHost proxy = new HttpHost(proxyUrl.getProtocol(), proxyUrl.getHost(), proxyUrl.getPort());
                 DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
                 CloseableHttpClient httpClient = HttpClients.custom().setRoutePlanner(routePlanner).build();
@@ -153,8 +155,8 @@ public class ThriftClients {
             thriftClient.setConnectTimeout(THRIFT_CONNECTION_TIMEOUT);
             thriftClient.setReadTimeout(THRIFT_READ_TIMEOUT);
         } catch (TTransportException e) {
-            log.error("cannot connect to backend on " + destinationAddress, e);
-        } catch (MalformedURLException e) {
+            log.error("cannot connect to backend on {}", destinationAddress, e);
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
             log.error("cannot connect via http proxy (REASON:MalformedURLException) to thrift backend", e);
         }
         return new TCompactProtocol(thriftClient);

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
@@ -270,8 +270,8 @@ public class TestUtils {
 
     public static void assumeCanConnectTo(String url) {
         try {
-            new URL(url).openConnection().getInputStream().close();
-        } catch (IOException e) {
+            new URI(url).toURL().openConnection().getInputStream().close();
+        } catch (IOException | URISyntaxException e) {
             assumeNoException(e);
         }
     }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -76,8 +76,8 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
             final ByteArrayOutputStream out = new ByteArrayOutputStream();
             workbook.write(out);
             stream = new ByteArrayInputStream(out.toByteArray());
-        }finally{
-            workbook.dispose();
+        } finally {
+            workbook.close();
         }
         return stream;
     }
@@ -116,7 +116,7 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
                 outputStream.close();
             }
         } finally {
-            workbook.dispose();
+            workbook.close();
         }
         return file.getPath();
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -8,13 +8,12 @@ import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.SBOM_IMPORT_E
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -160,7 +159,7 @@ public class SW360ReportService {
                 String projectPath = projectclient.getReportInEmail(user, withLinkedReleases, projectId);
                 String backendURL = base + "api/reports/download?user=" + user.getEmail() + "&module=projects"
                         + "&extendedByReleases=" + withLinkedReleases + "&projectId=" + projectId + "&token=";
-                URL emailURL = new URL(backendURL + projectPath);
+                URL emailURL = new URI(backendURL + projectPath).toURL();
                 if (!CommonUtils.isNullEmptyOrWhitespace(projectPath)) {
                     sendExportSpreadsheetSuccessMail(emailURL.toString(), user.getEmail());
                 }
@@ -186,7 +185,7 @@ public class SW360ReportService {
                 String componentPath = componentclient.getComponentReportInEmail(sw360User, withLinkedReleases);
                 String backendURL = base + "api/reports/download?user=" + sw360User.getEmail() + "&module=components"
                         + "&extendedByReleases=" + withLinkedReleases + "&token=";
-                URL emailURL = new URL(backendURL + componentPath);
+                URL emailURL = new URI(backendURL + componentPath).toURL();
                 if (!CommonUtils.isNullEmptyOrWhitespace(componentPath)) {
                     sendComponentExportSpreadsheetSuccessMail(emailURL.toString(), sw360User.getEmail());
                 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
@@ -17,8 +17,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.common.exceptions.UnauthorizedUserException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -139,12 +139,12 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 	 *
 	 * @param email the email of the user
 	 * @param sw360User the user object fetched from the user service
-	 * @throws UnauthorizedUserException if the user is deactivated or not available
+	 * @throws BadCredentialsException if the user is deactivated or not available
 	 */
 	private static void validateUser(String email, User sw360User) {
 		if (email != null && CommonUtils.isNotNullEmptyOrWhitespace(email)) {
 			if (sw360User == null || sw360User.isDeactivated()) {
-				throw new UnauthorizedUserException(USER_IS_DEACTIVATED_OR_NOT_AVAILABLE);
+				throw new BadCredentialsException(USER_IS_DEACTIVATED_OR_NOT_AVAILABLE);
 			}
 		}
 	}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/keycloak/KeycloakAccessTokenConverter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/keycloak/KeycloakAccessTokenConverter.java
@@ -22,15 +22,11 @@ import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.JwtAccessTokenConverterConfigurer;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.oauth2.common.exceptions.UnauthorizedUserException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.DefaultAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Map;
 
 @Profile("!SECURITY_MOCK")
 @Component
@@ -93,7 +89,7 @@ public class KeycloakAccessTokenConverter extends DefaultAccessTokenConverter im
             String userEmailStr = userEmail.toString();
             User sw360User = userService.getUserByEmail(userEmailStr);
             if (sw360User == null || sw360User.isDeactivated()) {
-                throw new UnauthorizedUserException("User is deactivated");
+                throw new BadCredentialsException("User is deactivated");
             }
         }
 

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360XSSRequestWrapper.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360XSSRequestWrapper.java
@@ -125,7 +125,7 @@ public class Sw360XSSRequestWrapper extends HttpServletRequestWrapper {
 			return arrayNode;
 		} else if (input.isObject()) {
 			ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
-			input.fields().forEachRemaining(entry -> objectNode.set(entry.getKey(), sanitizeInput(entry.getValue())));
+			input.properties().forEach(entry -> objectNode.set(entry.getKey(), sanitizeInput(entry.getValue())));
 			return objectNode;
 		} else {
 			return input;


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Migrate deprecated APIs:
1. Change from `URL(String)` to `URI(String).toURL()`.
2. Get builder from `CSVFormat.RFC4180` to change parameters.
3. Change from `MavenXpp3Reader` to `MavenStaxReader` from v4 of Maven.
4. Migrate Jackson `addMixInAnnotations` to `addMixIn`.
5. Replace `UnauthorizedUserException` with `BadCredentialsException`.

### How To Test?
Check build logs.