### PR TITLE
fix(sbom): add support for older CycloneDX XML/JSON format

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/spdx/document/SpdxDocumentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/spdx/document/SpdxDocumentDatabaseHandler.java
@@ -14,9 +14,9 @@ import com.ibm.cloud.cloudant.v1.Cloudant;
 
 import org.apache.logging.log4j.core.util.UuidUtil;
 import org.apache.thrift.TException;
-import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.parsers.JsonParser;
 import org.cyclonedx.parsers.XmlParser;
+import org.cyclonedx.model.Bom;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
@@ -401,8 +401,8 @@ public class SpdxDocumentDatabaseHandler {
                 if (extension.equalsIgnoreCase(XML_FILE_EXTENSION)) {
                     try {
                         XmlParser xmlParser = new XmlParser();
-                        List<ParseException> xmlErrors = xmlParser.validate(tempFile);
-                        return xmlErrors == null || xmlErrors.isEmpty();
+                        Bom bom = xmlParser.parse(tempFile);
+                        return bom != null && bom.getMetadata() != null;
                     } catch (Exception e) {
                         log.debug("Not a valid CycloneDX XML file: {}", e.getMessage());
                         return false;
@@ -410,20 +410,19 @@ public class SpdxDocumentDatabaseHandler {
                 } else if (extension.equalsIgnoreCase(JSON_FILE_EXTENSION)) {
                     try {
                         JsonParser jsonParser = new JsonParser();
-                        List<ParseException> jsonErrors = jsonParser.validate(tempFile);
-                        return jsonErrors == null || jsonErrors.isEmpty();
+                        Bom bom = jsonParser.parse(tempFile);
+                        return bom != null && bom.getMetadata() != null;
                     } catch (Exception e) {
                         log.debug("Not a valid CycloneDX JSON file: {}", e.getMessage());
                         return false;
                     }
                 }
             }
-
-            return false;
         } finally {
             if (tempFile.exists()) {
                 tempFile.delete();
             }
         }
+        return false;
     }
 }


### PR DESCRIPTION
This PR enhances the SBOM file import functionality to support older versions of CycloneDX in both .xml and .json formats (v1.1, v1.2, v1.3, etc.).

Previously, the import process rejected valid SBOM files using older CycloneDX schemas. With this update:

- .xml and .json files with schema versions like 1.1, 1.2, 1.3 are now validated and accepted correctly.
- SPDX import logic remains untouched.


Testing:
- Navigate to the SBOM import section.
- Upload CycloneDX .xml or .json files with schema version 1.1, 1.2, 1.3.
- Ensure the import succeeds and shows correct results.