### PR TITLE
bug(spdx): fixed spdx import format

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -1,6 +1,7 @@
 /*
  * Copyright Siemens AG, 2017-2018.
  * Copyright Bosch Software Innovations GmbH, 2017.
+ * Copyright Ritankar Saha <ritankar.saha786@gmail.com>, 2025.
  * Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
@@ -455,10 +456,12 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @RequestMapping(value = LICENSES_URL + "/import/SPDX", method = RequestMethod.POST)
-    public ResponseEntity importSPDX() throws TException {
+    public ResponseEntity<RequestSummary> importSPDX() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        licenseService.importSpdxInformation(sw360User);
-        return new ResponseEntity<>(HttpStatus.OK);
+        RequestSummary requestSummary = licenseService.importSpdxInformation(sw360User);
+        requestSummary.setMessage("SPDX license has imported successfully");
+        HttpStatus status = HttpStatus.OK;
+        return new ResponseEntity<>(requestSummary, status);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
- *
+ * Copyright Ritankar Saha <ritankar.saha786@gmail.com>, 2025.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -226,10 +226,11 @@ public class Sw360LicenseService {
         TProtocol protocol = new TCompactProtocol(thriftClient);
         return new LicenseService.Client(protocol);
     }
-    public void importSpdxInformation(User sw360User) throws TException {
+    public RequestSummary importSpdxInformation(User sw360User) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             RequestSummary allSPDXLicenseStatus = sw360LicenseClient.importAllSpdxLicenses(sw360User);
+            return allSPDXLicenseStatus;
         } else {
             throw new BadRequestClientException("Unable to import All Spdx license. User is not admin");
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -120,7 +120,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         given(this.licenseServiceMock.updateWhitelist(any(),any(),any())).willReturn(RequestStatus.SUCCESS);
         Mockito.doNothing().when(licenseServiceMock).deleteLicenseById(any(), any());
         Mockito.doNothing().when(licenseServiceMock).deleteAllLicenseInfo(any());
-        Mockito.doNothing().when(licenseServiceMock).importSpdxInformation(any());
+        given(this.licenseServiceMock.importSpdxInformation(any())).willReturn(requestSummary);
         Mockito.doNothing().when(licenseServiceMock).getDownloadLicenseArchive(any(), any(), any());
         Mockito.doNothing().when(licenseServiceMock).uploadLicense(any(), any(), anyBoolean(), anyBoolean());
         given(this.licenseServiceMock.deleteLicenseType(any(), any())).willReturn(RequestStatus.SUCCESS);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary 

- on hitting endpoint /licences/import/SPDX returns 200 with a response body.

Issue: #3249 

### Suggest Reviewer
@GMishx 
@amritkv 
@rudra-superrr 

### How To Test?
- can test via swagger or curl after build
- tested via curl 


Curl Command -- 
```bash
curl -v --max-time 30 -X 'POST' \
    'http://127.0.0.1:8080/resource/api/licenses/import/SPDX' \
    -H 'accept: application/json' \
    -H 'Content-Type: application/json' \
    -H 'Authorization: Basic YWRtaW5Ac3czNjAub3JnOjEyMzQ1' \
    -d '{}'
```

Output Response Body --
```bash
{
  "requestStatus" : "SUCCESS",
  "totalAffectedElements" : 699,
  "totalElements" : 699,
  "message" : "SPDX license has imported successfully",
  "setTotalAffectedElements" : false,
  "setTotalElements" : false,
  "setMessage" : true,
  "setRequestStatus" : true
* Connection #0 to host 127.0.0.1 left intact
```

Fixes #3249 

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
