### PR TITLE
fix(rest) : Check vendor usage before delete

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -41,7 +41,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
@@ -175,7 +174,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
     public ResponseEntity<?> deleteVendor(
             @Parameter(description = "The id of the vendor to be deleted.")
             @PathVariable("id") String id
-    ) {
+    ) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Vendor sw360Vendor = vendorService.getVendorById(id);
         if (sw360Vendor == null) {
@@ -184,9 +183,8 @@ public class VendorController implements RepresentationModelProcessor<Repository
         RequestStatus requestStatus = vendorService.deleteVendorByid(id, sw360User);
         if (requestStatus == RequestStatus.SUCCESS) {
             return new ResponseEntity<>("Vendor with full name " + sw360Vendor.getFullname() + " deleted successfully.", HttpStatus.OK);
-        } else {
-            throw new BadRequestClientException("Vendor with full name " + sw360Vendor.getFullname() + " cannot be deleted.");
         }
+        throw new BadRequestClientException("Vendor with full name " + sw360Vendor.getFullname() + " cannot be deleted.");
     }
 
     @Operation(


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 
Closes : #3294 


### How To Test?
Before the PR
1. Create a Vendor and use it in a release/component/project.
2. Delete the Vendor from REST API.
3. Linked element cannot be loaded as the deleted Vendor ID is still associated.

After the PR : 
1. Create a Vendor and use it in a release/component/project.
2. Delete the Vendor from REST API.
3.  Linked element should be loaded as the deleted Vendor ID is unset from the release.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
