### PR TITLE
Fix NPE During License Info Generation; Support Projects With and Without Linked Projects

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1197,7 +1197,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         String parentProjectKey = sw360Project.getName() + " " + sw360Project.getVersion();
         vulnerabilitiesMap.put(parentProjectKey, parentProjectVulnerabilities);
 
-        if (!sw360Project.getLinkedProjects().isEmpty()) {
+        if (sw360Project.getLinkedProjects() != null && !sw360Project.getLinkedProjects().isEmpty()) {
             for (String linkedProjectId : sw360Project.getLinkedProjects().keySet()) {
                 Project linkedProject = projectService.getProjectForUserById(linkedProjectId, sw360User);
                 List<VulnerabilityDTO> linkedProjectVulnerabilities = vulnerabilityService.getVulnerabilitiesByProjectId(linkedProjectId, sw360User);
@@ -2089,7 +2089,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 	}
 
     public Map<String, Integer> countMap(Collection<AttachmentType> attachmentTypes, UsageData filter, Project project, User sw360User, String id) throws TException {
-        boolean projectWithSubProjects = !project.getLinkedProjects().isEmpty();
+        boolean projectWithSubProjects = project.getLinkedProjects() != null && !project.getLinkedProjects().isEmpty();
         List<ProjectLink> mappedProjectLinks =
                 (!SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP)
                         ? projectService.createLinkedProjects(project,
@@ -2122,7 +2122,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             )
             @RequestParam(value = "filter", required = false) String filter,
             @Parameter(description = "Get the transitive releases.")
-            @RequestParam(value = "transitive", required = true) boolean transitive
+            @RequestParam(value = "transitive", required = false, defaultValue = "false") boolean transitive
     ) throws TException {
 
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();


### PR DESCRIPTION
This PR fixes a NullPointerException that occurred during license info generation for projects that had linkedProjects set to null.
**Key Enhancements:**
Safely handles both cases

- Projects with linked projects.

- Projects without any linked projects

**Improved the /attachmentUsage API:**

- Made the transitive query parameter is now optional with a default value (false) to prevent 400 Bad Request.

**Bug Fixed:**
NPE when generating license info for projects with null linkedProjects.