### PR TITLE
fix(sbom-import): handle invalid VCS URLs in SBOM-import

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -106,6 +106,7 @@ public class CycloneDxBOMImporter {
     private static final String PROJECT_ID = "projectId";
     private static final String PROJECT_NAME = "projectName";
     private static final String REDIRECTED_VCS = "redirectedVCS";
+    public static final String INVALID_VCS_COMPONENT = "invalidVcsComponent";
     private static final Predicate<ExternalReference.Type> typeFilter = Type.VCS::equals;
 
     private final ProjectDatabaseHandler projectDatabaseHandler;
@@ -434,6 +435,7 @@ public class CycloneDxBOMImporter {
         final Set<String> duplicateComponents = new HashSet<>();
         final Set<String> duplicateReleases = new HashSet<>();
         final Set<String> invalidReleases = new HashSet<>();
+        final Set<String> invalidVcsComponents = new HashSet<>();
         final Map<String, ProjectReleaseRelationship> releaseRelationMap = CommonUtils.isNullOrEmptyMap(project.getReleaseIdToUsage()) ? new HashMap<>() : project.getReleaseIdToUsage();
         countMap.put(COMP_CREATION_COUNT_KEY, 0); countMap.put(COMP_REUSE_COUNT_KEY, 0);
         countMap.put(REL_CREATION_COUNT_KEY, 0); countMap.put(REL_REUSE_COUNT_KEY, 0);
@@ -458,6 +460,10 @@ public class CycloneDxBOMImporter {
                     } else {
                         compReuseCount++;
                     }
+                } else if (AddDocumentRequestStatus.INVALID_INPUT.equals(compAddSummary.getRequestStatus())) {
+                    log.warn("Invalid VCS URL for component: " + comp.getName());
+                    invalidVcsComponents.add(comp.getName()+ " (" + comp.getVcs() + ")");
+                    continue;
                 } else {
                     // in case of more than 1 duplicate found, then continue and show error message in UI.
                     log.warn("found multiple components: " + comp.getName());
@@ -537,6 +543,7 @@ public class CycloneDxBOMImporter {
         messageMap.put(DUPLICATE_COMPONENT, String.join(JOINER, duplicateComponents));
         messageMap.put(DUPLICATE_RELEASE, String.join(JOINER, duplicateReleases));
         messageMap.put(INVALID_RELEASE, String.join(JOINER, invalidReleases));
+        messageMap.put(INVALID_VCS_COMPONENT, String.join(JOINER, invalidVcsComponents));
         messageMap.put(PROJECT_ID, project.getId());
         messageMap.put(PROJECT_NAME, SW360Utils.getVersionedName(project.getName(), project.getVersion()));
         messageMap.put(COMP_CREATION_COUNT_KEY, String.valueOf(compCreationCount));
@@ -553,6 +560,7 @@ public class CycloneDxBOMImporter {
         final Set<String> duplicatePackages = new HashSet<>();
         final Set<String> invalidReleases = new HashSet<>();
         final Set<String> invalidPackages = new HashSet<>();
+        final Set<String> invalidVcsComponents = new HashSet<>();
         final Map<String, ProjectReleaseRelationship> releaseRelationMap = CommonUtils.isNullOrEmptyMap(project.getReleaseIdToUsage()) ? new HashMap<>() : project.getReleaseIdToUsage();
         final Set<String> projectPkgIds = CommonUtils.isNullOrEmptyCollection(project.getPackageIds()) ? new HashSet<>() : project.getPackageIds();
         countMap.put(REL_CREATION_COUNT_KEY, 0); countMap.put(REL_REUSE_COUNT_KEY, 0);
@@ -587,6 +595,10 @@ public class CycloneDxBOMImporter {
                     comp.setId(compAddSummary.getId());
                     String existingCompName = getComponetNameById(comp.getId(), user);
                     comp.setName(existingCompName);
+                } else if (AddDocumentRequestStatus.INVALID_INPUT.equals(compAddSummary.getRequestStatus())) {
+                    log.warn("Invalid VCS URL for component: " + comp.getName());
+                    invalidVcsComponents.add(comp.getName() + " (" + comp.getVcs() + ")");
+                    continue;
                 } else {
                     // in case of more than 1 duplicate found, then continue and show error message in UI.
                     log.warn("found multiple components: " + comp.getName());
@@ -713,6 +725,7 @@ public class CycloneDxBOMImporter {
         messageMap.put(INVALID_RELEASE, String.join(JOINER, invalidReleases));
         messageMap.put(REDIRECTED_VCS, String.join(JOINER, repositoryURL.getRedirectedUrls()));
         messageMap.put(INVALID_PACKAGE, String.join(JOINER, invalidPackages));
+        messageMap.put(INVALID_VCS_COMPONENT, String.join(JOINER, invalidVcsComponents));
         messageMap.put(PROJECT_ID, project.getId());
         messageMap.put(PROJECT_NAME, SW360Utils.getVersionedName(project.getName(), project.getVersion()));
         messageMap.put(REL_CREATION_COUNT_KEY, String.valueOf(relCreationCount));

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -466,7 +466,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 }
                 return addDocumentRequestSummary;
             }
-            if (!CommonUtils.isValidUrl(vcsUrl)) {
+            if (!isValidUrl(vcsUrl)) {
                 log.error("Invalid VCS URL: " + vcsUrl);
                 return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT);
             }


### PR DESCRIPTION
**Description:**
This PR enhances the CycloneDX SBOM import process by adding robust handling for invalid or missing VCS URLs in SBOM components.

- Validation of VCS URLs during SBOM parsing to detect invalid or malformed entries.

- Prevents creation of components with invalid VCS values and categorizes them as invalid VCS components.

- Aggregates and returns import result details, including counts and lists of invalid components, duplicate components, releases, and packages.

- Maintains compatibility with existing CycloneDX import logic.

- Ensures better feedback to users via import result summaries.

**Test it by:**
- Importing SBOM with valid and invalid VCS URLs (CycloneDX XML).

- Verify import results and JSON summary output in Postman.


