### PR TITLE
feat(project): Add clearingRequestId to getAllProjects endpoint response

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -881,6 +881,7 @@ public class RestControllerHelper<T> {
         embeddedProject.setBusinessUnit(project.getBusinessUnit());
         embeddedProject.setEnableSvm(project.isEnableSvm());
         embeddedProject.setType(null);
+        embeddedProject.setClearingRequestId(project.getClearingRequestId());
         return embeddedProject;
     }
 


### PR DESCRIPTION
Added `clearingRequestId` in the response `/projects` endpoint as it is needed for displaying CR modal in React UI. 

https://github.com/eclipse-sw360/sw360-frontend/issues/960

endpoint : http://localhost:8080/resource/api/projects

<img width="433" height="69" alt="image" src="https://github.com/user-attachments/assets/7962b1b1-5065-4459-afaa-73e82e6e8094" />