### PR TITLE
feat(ci): use couchdb as actions service

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,6 +38,15 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-24.04
 
+    services:
+      couchdb:
+        image: couchdb:3
+        ports:
+          - 5984:5984
+        env:
+          COUCHDB_USER: ${{ env.COUCHDB_USER }}
+          COUCHDB_PASSWORD: ${{ env.COUCHDB_PASSWORD }}
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -51,9 +60,6 @@ jobs:
         run: |
           chmod +x .github/testForLicenseHeaders.sh
           bash .github/testForLicenseHeaders.sh
-
-      - name: Setup CouchDB
-        run: scripts/startCouchdbForTests.sh
 
       - name: Update properties with DB credentials
         run: |

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
@@ -753,8 +753,8 @@ public class VulnerabilityTest extends TestIntegrationBase {
         given(this.releaseServiceMock.getReleaseForUserById(eq("release666"), any()))
                 .willReturn(release);
 
-        // Mock service to throw HttpMessageNotReadableException
-        doThrow(new HttpMessageNotReadableException("Invalid message format"))
+        // Mock service to throw BadRequestClientException
+        doThrow(new BadRequestClientException("Invalid message format"))
                 .when(vulnerabilityServiceMock).createUpdateDeleteVulnerabilityReleaseRelation(any(), any(), any());
 
         HttpHeaders headers = getHeaders(port);
@@ -858,4 +858,4 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
         assertTrue("Response should contain INTERNAL_SERVER_ERROR status", response.getBody().contains("\"status\" : 500"));
     }
-} 
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Use couchdb container as an action service instead of running it on same container.