### PR TITLE
fix(Release): listing the source files names for the license in release.

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -41,6 +41,7 @@ import javax.xml.xpath.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -161,7 +162,14 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
         Set<String> files = new HashSet<String>();
         String sourceFiles = findNamedSubelement(node, SOURCE_FILES_ELEMENT_NAME).map(AbstractCLIParser::normalizeEscapedXhtml).orElse(null);
         if (CommonUtils.isNotNullEmptyOrWhitespace(sourceFiles)) {
-            files.addAll(Arrays.asList(sourceFiles.split(" ")));
+            // Parse comma-separated files and join them with newlines, store as single entry
+            String joinedFiles = Arrays.stream(sourceFiles.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.joining("\n"));
+            if (!joinedFiles.isEmpty()) {
+                files.add(joinedFiles);
+            }
         }
         return new LicenseNameWithText()
                 .setLicenseText(findNamedSubelement(node, LICENSE_CONTENT_ELEMENT_NAME)


### PR DESCRIPTION
Closes #3337 

Description: With this PR, the source files that were previously missing for certain licenses will now be visible.

<img width="1141" height="523" alt="image" src="https://github.com/user-attachments/assets/d0f7f0af-dddb-421b-b9c8-6e5543a909bf" />


