### PR TITLE
fix(vulnerability): default sort with lastUpdated

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
@@ -339,18 +339,19 @@ public class Sw360VulnerabilityService {
      * @return a PaginationData object representing the pagination information
      */
     private static PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
-        VulnerabilitySortColumn column = VulnerabilitySortColumn.BY_EXTERNALID;
+        VulnerabilitySortColumn column = VulnerabilitySortColumn.BY_LASTUPDATED;
         boolean ascending = false;
 
         if (pageable.getSort().isSorted()) {
             Sort.Order order = pageable.getSort().iterator().next();
             String property = order.getProperty();
             column = switch (property) {
+                case "externalId" -> VulnerabilitySortColumn.BY_EXTERNALID;
                 case "title" -> VulnerabilitySortColumn.BY_TITLE;
                 case "cvss" -> VulnerabilitySortColumn.BY_WEIGHTING;
                 case "publishDate" -> VulnerabilitySortColumn.BY_PUBLISHDATE;
                 case "lastUpdateDate" -> VulnerabilitySortColumn.BY_LASTUPDATED;
-                default -> column; // Default to BY_EXTERNALID if no match
+                default -> column; // Default to BY_LASTUPDATED if no match
             };
             ascending = order.isAscending();
         }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Default vulnerabilities to be sorted by `lastUpdated`