### PR TITLE
fix(CDXImport): Trim VCS URLs before processing

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -149,7 +149,7 @@ public class CycloneDxBOMImporter {
                         .filter(ref -> ExternalReference.Type.VCS.equals(ref.getType()))
                         .map(ExternalReference::getUrl)
                         .filter(CommonUtils::isNotNullEmptyOrWhitespace)
-                        .map(repositoryURL::processURL)
+                        .map(url->repositoryURL.processURL(url.trim()))
                         .map(url -> new AbstractMap.SimpleEntry<>(url, comp)))
                 .collect(Collectors.groupingBy(
                         AbstractMap.SimpleEntry::getKey,


### PR DESCRIPTION
**Description:**
Space characters in the VCS URL of SBOM are getting encoded to "plus" due to URL encoding. The VCS URL is to be trimmed before processing.

