### PR TITLE
Prevent deletion of attachments shared by multiple releases.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1218,8 +1218,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 Component oldComponent = componentRepository.get(componentId);
                 Component updatedComponent = updateReleaseDependentFieldsForComponentId(componentId, user);
                 // clean up attachments in database
-                attachmentConnector.deleteAttachmentDifference(nullToEmptySet(actual.getAttachments()),
+                Set<String> idsToBeDeleted = attachmentConnector.getAttachentContentIdsToBeDeleted(nullToEmptySet(actual.getAttachments()),
                         nullToEmptySet(release.getAttachments()));
+                Set<String> idsInUse = attachmentDatabaseHandler.getAttachmentsByIds(idsToBeDeleted).stream().map(Attachment::getAttachmentContentId).collect(Collectors.toSet());
+                attachmentConnector.deleteAttachmentsByIds(idsToBeDeleted.stream().filter(id->!idsInUse.contains(id)).collect(Collectors.toSet()));
                 // update linked packages
                 updateLinkedPackages(CommonUtils.nullToEmptySet(actual.getPackageIds()), CommonUtils.nullToEmptySet(release.getPackageIds()), release.getId(), user);
                 sendMailNotificationsForReleaseUpdate(release, user.getEmail());

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnector.java
@@ -81,7 +81,7 @@ public class AttachmentConnector extends AttachmentStreamConnector {
         deleteAttachmentsByIds(attachmentContentIds);
     }
 
-    private void deleteAttachmentsByIds(Collection<String> attachmentContentIds) {
+    public void deleteAttachmentsByIds(Collection<String> attachmentContentIds) {
         connector.deleteIds(attachmentContentIds);
     }
 


### PR DESCRIPTION
**Description:**
This PR fixes an issue where deleting an attachment from one release could inadvertently affect other releases that share the same attachment.

- Before deleting an attachment, the system now checks all releases/project/components for references to the same attachmentContentId.

- Single-release attachments are deleted normally.

**To Test:**

- Verify that attachments shared by multiple releases are not deleted in the database.

- Verify delete operations via REST API for releases.
