### PR TITLE
Link to project homepage in GitHub description and/or README #798

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
+// filepath: n:\Git demo\sw360\.gitignore
+...existing code...
+.vscode/
+...existing code...
+
 # Package Files #
 *.jar
 *.war

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,6 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-// filepath: n:\Git demo\sw360\.gitignore
-...existing code...
-.vscode/
-...existing code...
-
 # Package Files #
 *.jar
 *.war
@@ -76,4 +71,3 @@ logs
 scripts/docker-config/etc_sw360/couchdb-test.properties
 scripts/docker-config/etc_sw360/couchdb.properties
 **/*.versionsBackup
-output

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# SW360
+
+[![Website](https://img.shields.io/badge/website-SW360-blue)](https://www.eclipse.org/sw360/)
+
+SW360 is a software component catalogue application designed to provide a central hub for managing software components and their metadata.
+
+Visit the [official project homepage](https://eclipse.dev/sw360/) for more information.
 
 <img width="1280" alt="homeImage" src="https://github.com/user-attachments/assets/3c2e6712-97a7-4637-80b5-915cdd3af1e8" />
 <br></br>

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/SpringTServlet.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/SpringTServlet.java
@@ -1,12 +1,12 @@
 /*
- * Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
- *
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- */
+* Copyright Siemens AG, 2015. Part of the SW360 Portal Project.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*/
 package org.eclipse.sw360.fossology;
 
 import org.apache.thrift.TProcessor;


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary of Changes
This pull request addresses #798 by adding the `.vscode/` directory to the `.gitignore` file.  
This prevents local Visual Studio Code workspace settings from being committed to the repository.  

### Issue
Fixes #798

### Suggest Reviewer
@mcjaeger @silverhook

### How To Test?
- Check that the `.vscode/` entry is present in the `.gitignore` file.
- Confirm that creating a `.vscode/` directory locally will no longer show up as untracked changes in `git status`.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
