### PR TITLE
feat(report) : show release name under acknowledgement in readmeoss file.

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -772,7 +772,7 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
         setText(document.createParagraph().createRun(), "Please note the following license conditions and copyright " +
                 "notices applicable to Open Source Software and/or other components (or parts thereof):");
         addNewLines(document, 0);
-        Map<String, Set<String>> sortedAcknowledgement = getAcknowledgement(projectLicenseInfoResults,
+        Map<String, Map<String, Set<String>>> sortedAcknowledgement = getAcknowledgement(projectLicenseInfoResults,
                 excludeReleaseVersion);
         for (LicenseInfoParsingResult parsingResult : projectLicenseInfoResults) {
             addReleaseTitle(document, parsingResult, excludeReleaseVersion);
@@ -799,18 +799,28 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
         addPageBreak(document);
     }
 
-    private void addAcknowledgement(XWPFDocument document, Set<String> acknowledgements) {
-        if (CollectionUtils.isNotEmpty(acknowledgements)) {
+    private void addAcknowledgement(XWPFDocument document, Map<String, Set<String>> acknowledgements) {
+        if (acknowledgements!=null && !acknowledgements.isEmpty()) {
             XWPFRun ackRun = document.createParagraph().createRun();
-            addFormattedText(ackRun, "Acknowledgement", FONT_SIZE, true);
-            for (String acknowledgement : acknowledgements) {
-                setText(document.createParagraph().createRun(), nullToEmptyString(acknowledgement));
+            addFormattedText(ackRun, "Acknowledgements:", FONT_SIZE, true);
+            for (Map.Entry<String, Set<String>> entry : acknowledgements.entrySet()) {
+                String licenseName = entry.getKey();
+                Set<String> acknowledgementSet = entry.getValue();
+                if (!acknowledgementSet.isEmpty()) {
+                    // Print license name as heading
+                    XWPFRun licenseRun = document.createParagraph().createRun();
+                    addFormattedText(licenseRun, licenseName + ":", FONT_SIZE, true);
+                    // Print each acknowledgement under the license name
+                    for (String acknowledgement : acknowledgementSet) {
+                        setText(document.createParagraph().createRun(), nullToEmptyString(acknowledgement));
+                    }
+                }
             }
             addNewLines(document, 1);
         }
     }
 
-    private SortedMap<String, Set<String>> getAcknowledgement(
+    private SortedMap<String, Map<String, Set<String>>> getAcknowledgement(
             Collection<LicenseInfoParsingResult> projectLicenseInfoResults, boolean excludeReleaseVersion) {
 
         Map<Boolean, List<LicenseInfoParsingResult>> partitionedResults = projectLicenseInfoResults.stream()

--- a/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -133,20 +133,24 @@
 
                     #if(${acknowledgements.get($releaseName)})
                         Acknowledgements:<br/>
-                            #set($acks = [])
-                            #set($acks = $acknowledgements.get($releaseName))
+                        #set($licenseAckMap = $acknowledgements.get($releaseName))
     <pre class="acknowledgements">
+#foreach($licenseName in $licenseAckMap.keySet())
+    <strong>$esc.xml($licenseName)</strong><br/>
+    #set($acks = $licenseAckMap.get($licenseName))
 #foreach($ack in ${acks})
-    #set($containsLink = $ack.matches($anchorRegEx))
-    #set($containsScript = $ack.matches($scriptRegEx))
-    #set($ackAsHtml = $esc.xml($ack))
-    #if($containsLink && !$containsScript)
-        #set($ackAsHtml = $ack)
-    #end
-$ackAsHtml
-#end
-    </pre>
-                    #end
+     #set($containsLink = $ack.matches($anchorRegEx))
+     #set($containsScript = $ack.matches($scriptRegEx))
+     #set($ackAsHtml = $esc.xml($ack))
+     #if($containsLink && !$containsScript)
+     #set($ackAsHtml = $ack)
+     #end
+     $ackAsHtml<br/>
+     #end
+     #end
+         </pre>
+                #end
+
 
                     Licenses:<br/>
                     #set($licenses = [])


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Closes #3392 

### How To Test?
Current Scenario : 

### Example BusyBox 1.35.0
Current Display of Acknowledgments
**Acknowledgements**

derived from the RSA Data Security, Inc. MD5 Message-Digest Algorithm

To the extent files may be licensed under BSD-3-Clause or GPL-2.0, in this context BSD-3-Clause license has been chosen. This shall not restrict the freedom of other users to choose either BSD-3-Clause or GPL-2.0 license.

This product includes software developed by the University of California, Berkeley and its contributors.

This product includes software developed by the University of California, Lawrence Berkeley Laboratory and its contributors.

New Display of Acknowledgments -- Requirement.
**Acknowledgements**

**RSA-MD5 license**
derived from the RSA Data Security, Inc. MD5 Message-Digest Algorithm

**Dual license - BSD-3-Clause or GPL-2.0**
To the extent files may be licensed under BSD-3-Clause or GPL-2.0, in this context BSD-3-Clause license has been chosen. This shall not restrict the freedom of other users to choose either BSD-3-Clause or GPL-2.0 license.

**BSD-4-Clause-UC**
This product includes software developed by the University of California, Berkeley and its contributors.

**BSD-4-Clause-Shortened**
This product includes software developed by the University of California, Lawrence Berkeley Laboratory and its contributors.

Sample URL : 

http://localhost:8080/resource/api/reports?projectId=<projectId>&module=licenseInfo&variant=DISCLOSURE&generatorClassName=XhtmlGenerator

generatorClassName : XhtmlGenerator/DocxGenerator (Both scenario should be validated).


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
