### PR TITLE
fix(script): Adding missing documentation for 062_update_packagids_to_map-py

### DIFF
--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -115,6 +115,10 @@ To migrate it is recommended to do this in the following order:
 - `060_migrate_project_dependency_network.py`
 - `061_add_modifiedBy_modifiedOn_project.py`
 
+### 18.0.0 -> 20.0.0
+
+- `062_update_packagIds_to_map.py`
+
 ## Optional usage
 - `009_overwrite_release_name_with_component_name.py`
 - `010_repair_missing_vendorId_links_in_releases.py`


### PR DESCRIPTION

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue : https://github.com/eclipse-sw360/sw360/issues/3339
Backend Related PR : https://github.com/eclipse-sw360/sw360/pull/3338

Issue: 

### Suggest Reviewer
> @GMishx 

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
