### PR TITLE
fix(utils): check CR date is equals or after

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -286,7 +286,7 @@ public class SW360Utils {
             LocalDate currLocalDate = LocalDate.parse(currRequestedClearingDate, format);
             LocalDate requestedLocalDate = LocalDate.parse(newRequestedClearingDate, format);
 
-            return requestedLocalDate.isAfter(currLocalDate);
+            return requestedLocalDate.isEqual(currLocalDate) || requestedLocalDate.isAfter(currLocalDate);
         } catch (DateTimeParseException e) {
             return false;
         }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

In `isValidDate()`, check if dates are equals or after creating an `>=` check.

### How To Test?
Modify a clearing request and send the `requestedClearingDate` with same value as current CR.