### PR TITLE
fix(docker): fix version to mentioned tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # is triggered by buildkit images
 
 # 3-eclipse-temurin-21
-FROM maven@sha256:42f00a9b0a9e04389ba857b2a69ba47fe11d1d47f7565edd65c45bbbd6b1e639 AS sw360build
+FROM maven@sha256:486d196b0422fee4f8508e032321bf4c8f27f607b138278a3ceb758117e17219 AS sw360build
 
 ARG COUCHDB_HOST=localhost
 
@@ -81,7 +81,7 @@ COPY --from=sw360build /sw360_tomcat_webapps /sw360_tomcat_webapps
 # Runtime image
 
 # 11-jre21-temurin-noble
-FROM tomcat@sha256:2b3894dce12e0f4b81e972269143f44781c7ed490379fe3f8d38b0b56c8a6792 AS sw360
+FROM tomcat@sha256:a024567d3b7e960f3c11c55b6366d052fd176aeea36dbb90d6537e0c32a4d699 AS sw360
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Fix version of image tags (maven and tomcat) to mentioned version in comment. Dependabot has updated them to the latest version.