### PR TITLE
fix(docker): use new ubuntu-nobel for thrift

### DIFF
--- a/third-party/thrift/Dockerfile
+++ b/third-party/thrift/Dockerfile
@@ -13,7 +13,7 @@
 #--------------------------------------------------------------------------------------------------
 # Thrift
 # Ubuntu Noble image
-FROM ubuntu@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS build
+FROM ubuntu@sha256:985be7c735afdf6f18aaa122c23f87d989c30bba4e9aa24c8278912aac339a8d AS build
 
 ARG BASEDIR="/build"
 ARG DESTDIR="/"


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Fix the version of Ubuntu Nobel image used to create thrift container.