### PR TITLE
docs(readme): update Java, Maven, and Thrift versions based on pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ If you intend to develop over SW360, few steps are needed as equal you need have
 requirements
 
 * Base build requirements
-  * Java 11
-  * Maven 3.8.7
+  * Java 21
+  * Maven 4.0.0
   * pre-commit
-  * thrift 0.16.0 runtime
+  * thrift 0.20.0 runtime
   * Python environment ( to [pre-commit](https://pre-commit.com/) ) - SW360 use Eclipse formatting rules
   through [Spotless maven plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven)
 
-If you can't install thrift 0.16 runtime, you will need the following requirements:
+If you can't install thrift 0.20 runtime, you will need the following requirements:
 
 * C++ dev environment
 * cmake


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> Updated README.md to reflect the versions actually defined in pom.xml.
Java 11→21, Maven 3.8.7→4.0.0, Thrift 0.16→0.20
> * Did you add or update any new dependencies that are required for your change?
NA

Issue: 
README.md lists outdated versions (Java 11, Maven 3.8.7, Thrift 0.16) which do not match the actual versions used in the pom.xml, causing potential confusion for developers setting up the project.
