### PR TITLE
feat(rest): Get license clearing counts based on clearing status

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2928,6 +2928,39 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     }
 
     @Operation(
+            description = "Get license  clearing details counts for `Clearing Detail` field " +
+                    "at Administration tab of project detail page.",
+            tags = {"Projects"}
+    )
+    @RequestMapping(value = PROJECTS_URL + "/{id}/clearingDetailsCount", method = RequestMethod.GET)
+    public void getlicenseClearingDetailsCount(
+            HttpServletResponse response ,
+            @Parameter(description = "Project ID", example = "376521")
+            @PathVariable("id") String id
+    ) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        restControllerHelper.throwIfSecurityUser(sw360User);
+        Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+
+        Project proj = projectService.getClearingInfo(sw360Project, sw360User);
+        ReleaseClearingStateSummary clearingInfo = proj.getReleaseClearingStateSummary();
+        int releaseCount = clearingInfo.newRelease + clearingInfo.sentToClearingTool + clearingInfo.underClearing + clearingInfo.reportAvailable + clearingInfo.approved;
+
+        try {
+            JsonObject row = new JsonObject();
+            row.addProperty("newClearing",clearingInfo.newRelease);
+            row.addProperty("underClearing",clearingInfo.underClearing);
+            row.addProperty("sentToClearingTool",clearingInfo.sentToClearingTool);
+            row.addProperty("reportAvailable",clearingInfo.reportAvailable);
+            row.addProperty("approved",clearingInfo.approved);
+            row.addProperty("totalReleases", releaseCount);
+            response.getWriter().write(row.toString());
+        } catch (IOException e) {
+            throw new SW360Exception(e.getMessage());
+        }
+    }
+
+    @Operation(
             description = "Get license obligations data from license database.",
             tags = {"Projects"}
     )

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2478,6 +2478,24 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_document_get_license_clearing_details_count() throws Exception {
+        this.mockMvc.perform(get("/api/projects/" + project.getId()+ "/clearingDetailsCount")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON)
+                        .contentType(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("newClearing").description("Number of new releases for clearing"),
+                                fieldWithPath("underClearing").description("Number of releases under clearing"),
+                                fieldWithPath("sentToClearingTool").description("Number of releases sent to clearing tool"),
+                                fieldWithPath("reportAvailable").description("Number of releases with report available"),
+                                fieldWithPath("approved").description("Number of approved license clearing state"),
+                                fieldWithPath("totalReleases").description("Total count of releases of a project including sub-projects releases")
+                        )));
+    }
+
+    @Test
     public void should_document_create_summary_administration() throws Exception {
         mockMvc.perform(get("/api/projects/" + project.getId()+ "/summaryAdministration")
                         .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/3421*)
> * Did you add or update any new dependencies that are required for your change? No

Closes #3421

### Suggest Reviewer
> @GMishx , @amritkv 

### How To Test?
API
GET  : http://localhost:8080/resource/api/projects/{id}/clearingDetailsCount

Response:
{
  "newClearing": 245,
  "underClearing": 0,
  "sentToClearingTool": 0,
  "reportAvailable": 0,
  "approved": 0,
  "totalReleases": 245
}



