### PR TITLE
fix(REST):null error in license info

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1596,7 +1596,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         mappedProjectLinks.forEach(projectLink -> wrapTException(() ->
                 projectLink.getLinkedReleases().stream().filter(ReleaseLink::isSetAttachments).forEach(releaseLink -> {
                     String releaseLinkId = releaseLink.getId();
-                    Set<String> excludedLicenseIds = releaseIdToExcludedLicenses.get(Source.releaseId(releaseLinkId));
+                    Set<String> excludedLicenseIds = releaseIdToExcludedLicenses.
+                            getOrDefault(Source.releaseId(releaseLinkId),new HashSet<>());
 
                     if (!selectedReleaseAndAttachmentIds.containsKey(releaseLinkId)) {
                         selectedReleaseAndAttachmentIds.put(releaseLinkId, new HashMap<>());


### PR DESCRIPTION
**Description**

- Occurs due to the same attachmentContentId being used by more than one release.
-  In this case, the "save attachment usages" button saves only one such release's attachmentContentId, ignoring the other.
- This causes null pointer exception when fetching the ignored release's id from the releaseIdToExcludedLicenses map.