### PR TITLE
feat(ImportCDX): remove VCS URL redirection logic

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -108,7 +108,6 @@ public class CycloneDxBOMImporter {
     private static final String INVALID_PACKAGE = "invalidPkg";
     private static final String PROJECT_ID = "projectId";
     private static final String PROJECT_NAME = "projectName";
-    private static final String REDIRECTED_VCS = "redirectedVCS";
     public static final String INVALID_VCS_COMPONENT = "invalidVcsComponent";
     private static final Predicate<ExternalReference.Type> typeFilter = Type.VCS::equals;
 
@@ -299,8 +298,6 @@ public class CycloneDxBOMImporter {
                         // all components does not have VCS, so return & show appropriate error in UI
                         messageMap.put(INVALID_COMPONENT, String.join(JOINER, componentsWithoutVcs));
                         messageMap.put(INVALID_PACKAGE, String.join(JOINER, invalidPackages));
-                        messageMap.put(REDIRECTED_VCS, String.join(JOINER, repositoryURL.getRedirectedUrls()));
-                        messageMap.put(DUPLICATE_PACKAGE, String.join(JOINER, duplicatePackages));
                         messageMap.put(SW360Constants.MESSAGE,
                                 String.format("VCS information is missing for <b>%s</b> / <b>%s</b> Components!",
                                         componentsCount - vcsCount, componentsCount));
@@ -811,7 +808,6 @@ public class CycloneDxBOMImporter {
         messageMap.put(DUPLICATE_RELEASE, String.join(JOINER, duplicateReleases));
         messageMap.put(DUPLICATE_PACKAGE, String.join(JOINER, duplicatePackages));
         messageMap.put(INVALID_RELEASE, String.join(JOINER, invalidReleases));
-        messageMap.put(REDIRECTED_VCS, String.join(JOINER, repositoryURL.getRedirectedUrls()));
         messageMap.put(NON_PKG_MANAGED_COMP_WITHOUT_VCS, String.join(JOINER, nonPkgManagedCompWithoutVCS));
         messageMap.put(INVALID_PACKAGE, String.join(JOINER, invalidPackages));
         messageMap.put(INVALID_VCS_COMPONENT, String.join(JOINER, invalidVcsComponents));

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -88,8 +88,6 @@ public class SW360ConfigsDatabaseHandler {
             .put(RELEASE_FRIENDLY_URL, getOrDefault(configContainer, RELEASE_FRIENDLY_URL, "http://localhost:3000/components/releases/detail/releaseId"))
             .put(COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, getOrDefault(configContainer, COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, ""))
                 .put(VCS_HOSTS, getOrDefault(configContainer, VCS_HOSTS, ""))
-                .put(VCS_REDIRECTION_LIMIT, getOrDefault(configContainer, VCS_REDIRECTION_LIMIT, String.valueOf(SW360Constants.VCS_REDIRECTION_LIMIT)))
-                .put(VCS_REDIRECTION_TIMEOUT_LIMIT, getOrDefault(configContainer, VCS_REDIRECTION_TIMEOUT_LIMIT, String.valueOf(SW360Constants.VCS_REDIRECTION_TIMEOUT_LIMIT)))
                 .put(NON_PKG_MANAGED_COMPS_PROP, getOrDefault(configContainer, NON_PKG_MANAGED_COMPS_PROP, ""))
             .build();
         putInMemory(ConfigFor.SW360_CONFIGURATION, configMap);
@@ -208,9 +206,7 @@ public class SW360ConfigsDatabaseHandler {
                     -> configValue != null;
 
             // validate int value
-            case ATTACHMENT_DELETE_NO_OF_DAYS,
-                 VCS_REDIRECTION_LIMIT,
-                 VCS_REDIRECTION_TIMEOUT_LIMIT
+            case ATTACHMENT_DELETE_NO_OF_DAYS
                     -> isIntegerValue(configValue);
 
             // validate string in enum

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -65,8 +65,6 @@ public class SW360ConfigKeys {
 
     //Properties used by the RepositoryURL class to handle VCS from SBOM
     public static final String VCS_HOSTS = "vcs.hosts";
-    public static final String VCS_REDIRECTION_LIMIT = "vcs.redirection.limit";
-    public static final String VCS_REDIRECTION_TIMEOUT_LIMIT = "vcs.redirection.timeout.limit";
     public static final String NON_PKG_MANAGED_COMPS_PROP = "non.pkg.managed.comps.prop";
 
     // Properties purely used by UI

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -120,9 +120,6 @@ public class SW360Constants {
     public static final String SRC_ATTACHMENT_DOWNLOAD_LOCATION;
     public static final String PREFERRED_CLEARING_DATE_LIMIT;
 
-    public static final String VCS_REDIRECTION_LIMIT = "5";
-    public static final String VCS_REDIRECTION_TIMEOUT_LIMIT = "5000";
-
     public static final String COMPONENTS = "components";
     public static final String PROJECTS = "projects";
     public static final String LICENSES = "licenses";


### PR DESCRIPTION
- VCS redirection during import causes duplicate components to be created in SW360, as a new component would be created if the VCS of an existing component now points to a new location.
- Feedback regarding the urls redirected is given after the new component has been created, leaving no room for corrections, which depletes transparency between the SBOM being imported and the components being created in SW360.
- The SRC upload service of SW360 uploads the latest source even for old VCS URLs, removing the need to have the latest VCS URL.
