### PR TITLE
fix(Component): Move comment field form requestParam to requestBody

### DIFF
--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -407,6 +407,9 @@ struct ComponentDTO {
     51: optional string mailinglist,
     52: optional string wiki,
     53: optional string blog,
+
+    // Moderation comment passed during PATCH request (not persisted on Component)
+    90: optional string comment,
 }
 
 struct ReleaseLink{

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -652,6 +652,7 @@ public class JacksonCustomizations {
                 "licenseIdsSize",
                 "licenseIdsIterator",
                 "createdBy",
+                "comment",
                 "setId",
                 "setRevision",
                 "setType",
@@ -672,6 +673,7 @@ public class JacksonCustomizations {
                 "setVcs",
                 "setPackageManager",
                 "setRelease",
+                "setComment",
                 "createdByIsSet",
                 "createdOnIsSet",
                 "versionIsSet",
@@ -693,6 +695,7 @@ public class JacksonCustomizations {
                 "homepageUrlIsSet",
                 "hashIsSet",
                 "packageManagerIsSet",
+                "commentIsSet",
                 "typeIsSet"
         })
         static abstract class PackageMixin extends Package {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -308,7 +308,7 @@ public class ComponentTest extends TestIntegrationBase {
                         HttpMethod.PATCH,
                         new HttpEntity<>(body, headers),
                         String.class);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -331,6 +331,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                 )
         );
         given(this.componentServiceMock.deleteComponent(eq(angularComponent.getId()), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.componentServiceMock.updateComponent(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.componentServiceMock.searchByExternalIds(eq(externalIds), any())).willReturn((new HashSet<>(componentList)));
         given(this.componentServiceMock.convertToEmbeddedWithExternalIds(eq(angularComponent))).willReturn(
                 new Component("Angular")


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


## Summary of Changes

- Optimized `patchComponent()` method in ComponentController with request body to have comment instead of param
- Added input validation for null/empty component ID and DTO


## 2) How to Test

Test the API using the  `PATCH /api/components/{id}` 

Issue: 
https://github.com/eclipse-sw360/sw360/issues/3454

### Suggest Reviewer
@GMishx  @amritkv 

