### PR TITLE
feat(rest): Api endpoint to retrieve package usage count

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -220,7 +220,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
             "function(doc) {" +
                     "  if (doc.type == 'project' && doc.packageIds) {" +
                     "    for(var i in doc.packageIds) {" +
-                    "      emit(doc.packageIds[i], doc._id);" +
+                    "      emit(i, doc._id);" +
                     "    }" +
                     "  }" +
                     "}";

--- a/rest/resource-server/src/docs/asciidoc/packages.adoc
+++ b/rest/resource-server/src/docs/asciidoc/packages.adoc
@@ -135,3 +135,44 @@ include::{snippets}/should_document_delete_package/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_delete_package/http-response.adoc[]
+
+
+[[resources-package-usage]]
+==== Get Package Usage Information
+
+A `GET` request to `/api/packages/{id}/usage` will get the usage information for a specific package, including whether the package is being used and the count of projects using it.
+
+===== Path parameters
+[cols="2,1,2"]
+|===
+|Name |Type |Description
+
+|id
+|String
+|The ID of the package to check usage for
+|===
+
+===== Response structure
+[cols="2,1,2"]
+|===
+|Path |Type |Description
+
+|count
+|Number
+|Number of projects using this package
+
+|isUsed
+|Boolean
+|Flag indicating if the package is used in any project
+|===
+
+===== Example request
+include::{snippets}/should_document_get_package_usage/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_package_usage/http-response.adoc[]
+
+===== Error response
+When the package is not found:
+
+include::{snippets}/should_document_get_package_usage_not_found/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1888,4 +1888,21 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return new PaginationData().setDisplayStart((int) pageable.getOffset())
                 .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
     }
+
+    public int getProjectCountByPackageId(String packageId) throws TException {
+        ThriftClients thriftClients = new ThriftClients();
+        ProjectService.Iface projectClient = thriftClients.makeProjectClient();
+        int count;
+        try {
+            count = projectClient.getProjectCountByPackageId(packageId);
+        } catch (SW360Exception sw360Exp) {
+            if (sw360Exp.getErrorCode() == 404) {
+                throw new ResourceNotFoundException("Requested Package Id Not Found");
+            }
+            else {
+                throw sw360Exp;
+            }
+        }
+        return count;
+    }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? https://github.com/eclipse-sw360/sw360/issues/3418
> * Did you add or update any new dependencies that are required for your change? No

Closes https://github.com/eclipse-sw360/sw360/issues/3418

### Suggest Reviewer
> @GMishx @amritkv 

### How To Test?
API : GET 
URL : http://localhost:8080/resource/api/packages/{id}/usage
Path Variable : id= packageId
Response : 
{
  "count": 1,
  "isUsed": true
}



### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
