### PR TITLE
feat(REST): Add includeSubproject parameter to licenseInfo

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1559,6 +1559,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "includeAllAttachments", required = false ) boolean includeAllAttachments,
             @Parameter(description = "Exclude release version from the license info file")
             @RequestParam(value = "excludeReleaseVersion", required = false, defaultValue = "false") boolean excludeReleaseVersion,
+            @Parameter(description = "Include subprojects")
+            @RequestParam(value = "includeSubprojects", required = false, defaultValue = "true") boolean includeSubprojects,
             HttpServletResponse response
     ) throws TException, IOException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -1568,10 +1570,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         if (includeAllAttachments) {
             mappedProjectLinks = projectService.createLinkedProjects(sw360Project,
-                    projectService.filterAndSortAllAttachments(SW360Constants.INITIAL_LICENSE_INFO_ATTACHMENT_TYPES), true, sw360User);
+                    projectService.filterAndSortAllAttachments(SW360Constants.INITIAL_LICENSE_INFO_ATTACHMENT_TYPES), true, includeSubprojects, sw360User);
         } else {
             mappedProjectLinks = projectService.createLinkedProjects(sw360Project,
-                    projectService.filterAndSortAttachments(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES), true, sw360User);
+                    projectService.filterAndSortAttachments(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES), true, includeSubprojects, sw360User);
         }
 
         List<AttachmentUsage> attchmntUsg = attachmentService.getAttachemntUsages(id);
@@ -2103,7 +2105,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         List<ProjectLink> mappedProjectLinks =
                 (!SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP)
                         ? projectService.createLinkedProjects(project,
-                        projectService.filterAndSortAttachments(attachmentTypes), true, sw360User)
+                        projectService.filterAndSortAttachments(attachmentTypes), true, true, sw360User)
                         : projectService.createLinkedProjectsWithAllReleases(project,
                         projectService.filterAndSortAttachments(attachmentTypes), true, sw360User);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -238,7 +238,7 @@ public class SW360ReportService {
                 : null;
 
         List<ProjectLink> mappedProjectLinks = projectService.createLinkedProjects(sw360Project,
-                projectService.filterAndSortAttachments(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES), true, sw360User);
+                projectService.filterAndSortAttachments(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES), true, true, sw360User);
 
         List<AttachmentUsage> attchmntUsg = attachmentService.getAttachemntUsages(id);
 


### PR DESCRIPTION
**Description**

- Configure the inclusion of subprojects while generating license info for a project.
- Set to true by default to preserve existing behavior.