### PR TITLE
feat(search): add sorting index for lucene search

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/common/utils/SearchUtils.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/utils/SearchUtils.java
@@ -61,6 +61,7 @@ public class SearchUtils {
             "    }" +
             "    if (result.trim().length > 0) {" +
             "      index('text', indexName, result.trim(), {'store': true});" +
+            "      index('string', indexName + '_sort', result.trim());" +
             "    }" +
             "  }";
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -14,10 +14,7 @@ import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
-import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceComparatorGenerator;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
@@ -30,11 +27,9 @@ import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
@@ -66,9 +61,11 @@ public class ComponentSearchHandler {
                 "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');" +
                 "    if(doc.componentType && typeof(doc.componentType) == 'string' && doc.componentType.length > 0) {" +
                 "      index('text', 'componentType', doc.componentType, {'store': true});" +
+                "      index('string', 'componentType_sort', doc.componentType);" +
                 "    }" +
                 "    if(doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
                 "      index('text', 'name', doc.name, {'store': true});"+
+                "      index('string', 'name_sort', doc.name);"+
                 "    }" +
                 "    if(doc.createdBy && typeof(doc.createdBy) == 'string' && doc.createdBy.length > 0) {" +
                 "      index('text', 'createdBy', doc.createdBy, {'store': true});"+
@@ -103,10 +100,11 @@ public class ComponentSearchHandler {
 
     public Map<PaginationData, List<Component>> searchAccessibleComponents(String text, final Map<String,
             Set<String>> subQueryRestrictions, User user, @Nonnull PaginationData pageData) {
+        String sortColumn = getSortColumnName(pageData);
         Map<PaginationData, List<Component>> resultComponentList = connector
                 .searchViewWithRestrictions(Component.class,
                         luceneSearchView.getIndexName(), text, subQueryRestrictions,
-                        pageData, null, pageData.isAscending());
+                        pageData, sortColumn, pageData.isAscending());
 
         PaginationData respPageData = resultComponentList.keySet().iterator().next();
         List<Component> componentList = resultComponentList.values().iterator().next();
@@ -119,12 +117,29 @@ public class ComponentSearchHandler {
     }
 
     public List<Component> searchWithAccessibility(String text, final Map<String, Set<String>> subQueryRestrictions,
-                                                   User user ){
+                                                   User user) {
         List<Component> resultComponentList = connector.searchViewWithRestrictions(Component.class,
                 luceneSearchView.getIndexName(), text, subQueryRestrictions);
         for (Component component : resultComponentList) {
             makePermission(component, user).fillPermissionsInOther(component);
         }
         return resultComponentList;
+    }
+
+    /**
+     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
+     * `_sort` suffix) for text indexes.
+     * @param pageData Pagination Data from the request.
+     * @return Sort column name. Defaults to createdOn
+     */
+    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
+        return switch (ComponentSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ComponentSortColumn.BY_NAME -> "name_sort";
+            case ComponentSortColumn.BY_VENDOR -> "vendorNames_sort";
+            case ComponentSortColumn.BY_MAINLICENSE -> "mainLicenseIds_sort";
+            case ComponentSortColumn.BY_TYPE -> "componentType_sort";
+            case null -> "createdOn";
+            default -> "createdOn";
+        };
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -13,11 +13,8 @@ import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
-import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceComparatorGenerator;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
@@ -26,9 +23,9 @@ import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -55,18 +52,26 @@ public class ProjectSearchHandler {
                 "    }" +
                 "    if(doc.projectType !== undefined && doc.projectType != null && doc.projectType.length >0) {" +
                 "      index('text', 'projectType', doc.projectType, {'store': true});" +
+                "      index('string', 'projectType_sort', doc.projectType);" +
                 "    }" +
                 "    if(doc.projectResponsible !== undefined && doc.projectResponsible != null && doc.projectResponsible.length >0) {" +
                 "      index('text', 'projectResponsible', doc.projectResponsible, {'store': true});" +
+                "      index('string', 'projectResponsible_sort', doc.projectResponsible);" +
                 "    }" +
                 "    if(doc.name !== undefined && doc.name != null && doc.name.length >0) {" +
                 "      index('text', 'name', doc.name, {'store': true});" +
+                "      index('string', 'name_sort', doc.name);" +
+                "    }" +
+                "    if(doc.description !== undefined && doc.description != null && doc.description.length >0) {" +
+                "      index('text', 'description', doc.description, {'store': true});" +
+                "      index('string', 'description_sort', doc.description);" +
                 "    }" +
                 "    if(doc.version !== undefined && doc.version != null && doc.version.length >0) {" +
                 "      index('string', 'version', doc.version, {'store': true});" +
                 "    }" +
                 "    if(doc.state !== undefined && doc.state != null && doc.state.length >0) {" +
                 "      index('text', 'state', doc.state, {'store': true});" +
+                "      index('string', 'state_sort', doc.state);" +
                 "    }" +
                 "    if(doc.clearingState) {" +
                 "      index('text', 'clearingState', doc.clearingState, {'store': true});" +
@@ -77,6 +82,11 @@ public class ProjectSearchHandler {
                 "    arrayToStringIndex(doc.additionalData, 'additionalData');" +
                 "    if(doc.releaseRelationNetwork !== undefined && doc.releaseRelationNetwork != null && doc.releaseRelationNetwork.length > 0) {" +
                 "      index('text', 'releaseRelationNetwork', doc.releaseRelationNetwork, {'store': true});" +
+                "    }" +
+                "    if(doc.createdOn && doc.createdOn.length) {"+
+                "      var dt = new Date(doc.createdOn);"+
+                "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
+                "      index('double', 'createdOn', Number(formattedDt), {'store': true});"+
                 "    }" +
                 "}")
                     .setFieldAnalyzer(
@@ -99,10 +109,11 @@ public class ProjectSearchHandler {
     }
 
     public Map<PaginationData, List<Project>> search(String text, final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        String sortColumn = getSortColumnName(pageData);
         Map<PaginationData, List<Project>> resultProjectList = connector
                 .searchViewWithRestrictions(Project.class,
                         luceneSearchView.getIndexName(), text, subQueryRestrictions,
-                        pageData, null, pageData.isAscending());
+                        pageData, sortColumn, pageData.isAscending());
 
         PaginationData respPageData = resultProjectList.keySet().iterator().next();
         List<Project> projectList = resultProjectList.values().iterator().next();
@@ -154,5 +165,25 @@ public class ProjectSearchHandler {
         values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery).collect(Collectors.toSet());
         filterMap.put(Project._Fields.RELEASE_RELATION_NETWORK.getFieldName(), values);
         return filterMap;
+    }
+
+    /**
+     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
+     * `_sort` suffix) for text indexes.
+     * @param pageData Pagination Data from the request.
+     * @return Sort column name. Defaults to name_sort
+     */
+    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
+        return switch (ProjectSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ProjectSortColumn.BY_CREATEDON -> "createdOn";
+//            case ProjectSortColumn.BY_VENDOR -> "vendor_sort";
+//            case ProjectSortColumn.BY_MAINLICENSE -> "license_sort";
+            case ProjectSortColumn.BY_TYPE -> "projectType_sort";
+            case ProjectSortColumn.BY_DESCRIPTION -> "description_sort";
+            case ProjectSortColumn.BY_RESPONSIBLE -> "projectResponsible_sort";
+            case ProjectSortColumn.BY_STATE -> "state_sort";
+            case null -> "name_sort";
+            default -> "name_sort";
+        };
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -15,10 +15,12 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseSortColumn;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -43,9 +45,16 @@ public class ReleaseSearchHandler {
                 "  if(doc.type == 'release') {" +
                 "    if (doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
                 "      index('text', 'name', doc.name, {'store': true});" +
+                "      index('string', 'name_sort', doc.name);" +
                 "    }" +
                 "    if (doc.version && typeof(doc.version) == 'string' && doc.version.length > 0) {" +
                 "      index('text', 'version', doc.version, {'store': true});" +
+                "      index('string', 'version_sort', doc.version);" +
+                "    }" +
+                "    if(doc.createdOn && doc.createdOn.length) {"+
+                "      var dt = new Date(doc.createdOn);"+
+                "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
+                "      index('double', 'createdOn', Number(formattedDt), {'store': true});"+
                 "    }" +
                 "    index('text', 'id', doc._id, {'store': true});" +
                 "  }" +
@@ -64,17 +73,33 @@ public class ReleaseSearchHandler {
     }
 
     public Map<PaginationData, List<Release>> search(String searchText, PaginationData pageData) {
+        String sortColumn = getSortColumnName(pageData);
         Map<PaginationData, List<Release>> resultReleaseList = connector
                 .searchViewWithRestrictions(Release.class,
                         luceneSearchView.getIndexName(), null,
                         Map.of(Release._Fields.NAME.getFieldName(),
                                 Collections.singleton(prepareWildcardQuery(searchText))
                         ),
-                        pageData, null, pageData.isAscending());
+                        pageData, sortColumn, pageData.isAscending());
 
         PaginationData respPageData = resultReleaseList.keySet().iterator().next();
         List<Release> releaseList = resultReleaseList.values().iterator().next();
 
         return Collections.singletonMap(respPageData, releaseList);
+    }
+
+    /**
+     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
+     * `_sort` suffix) for text indexes.
+     * @param pageData Pagination Data from the request.
+     * @return Sort column name. Defaults to createdOn
+     */
+    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
+        return switch (ReleaseSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ReleaseSortColumn.BY_NAME -> "name_sort";
+            case ReleaseSortColumn.BY_VERSION -> "version_sort";
+            case null -> "createdOn";
+            default -> "createdOn";
+        };
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
@@ -12,10 +12,7 @@ package org.eclipse.sw360.datahandler.db;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
-import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceComparatorGenerator;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserSortColumn;
@@ -25,12 +22,11 @@ import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareFuzzyQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 
@@ -57,22 +53,31 @@ public class UserSearchHandler {
     private static final NouveauIndexDesignDocument luceneUserSearchView
         = new NouveauIndexDesignDocument("usersearch",
             new NouveauIndexFunction("function(doc) {" +
+                OBJ_ARRAY_TO_STRING_INDEX +
                 "    if (!doc.type || doc.type != 'user') return;" +
                 "    if (doc.givenname && typeof(doc.givenname) == 'string' && doc.givenname.length > 0) {" +
                 "      index('text', 'givenname', doc.givenname, {'store': true});" +
+                "      index('string', 'givenname_sort', doc.givenname);" +
                 "    }" +
                 "    if (doc.lastname && typeof(doc.lastname) == 'string' && doc.lastname.length > 0) {" +
                 "      index('text', 'lastname', doc.lastname, {'store': true});" +
+                "      index('string', 'lastname_sort', doc.lastname);" +
                 "    }" +
                 "    if (doc.email && typeof(doc.email) == 'string' && doc.email.length > 0) {" +
                 "      index('text', 'email', doc.email, {'store': true});" +
+                "      index('string', 'email_sort', doc.email);" +
                 "    }" +
                 "    if (doc.userGroup && typeof(doc.userGroup) == 'string' && doc.userGroup.length > 0) {" +
                 "      index('text', 'userGroup', doc.userGroup, {'store': true});" +
                 "    }" +
                 "    if (doc.department && typeof(doc.department) == 'string' && doc.department.length > 0) {" +
                 "      index('text', 'department', doc.department, {'store': true});" +
+                "      index('string', 'department_sort', doc.department);" +
                 "    }" +
+                "    if (doc.deactivated && typeof(doc.deactivated) == 'boolean') {" +
+                "      index('double', 'deactivated', doc.deactivated ? 0 : 1);" +
+                "    }" +
+                "    arrayToStringIndex(doc.primaryRoles, 'primaryroles');" +
                 "}"));
 
     private final NouveauLuceneAwareDatabaseConnector connector;
@@ -105,8 +110,27 @@ public class UserSearchHandler {
     }
 
     public Map<PaginationData, List<User>> search(String text, final Map<String, Set<String>> subQueryRestrictions, @Nonnull PaginationData pageData) {
+        String sortColumn = getSortColumnName(pageData);
         return connector.searchViewWithRestrictions(User.class,
                 luceneUserSearchView.getIndexName(), text, subQueryRestrictions,
-                pageData, null, pageData.isAscending());
+                pageData, sortColumn, pageData.isAscending());
+    }
+
+    /**
+     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
+     * `_sort` suffix) for text indexes.
+     * @param pageData Pagination Data from the request.
+     * @return Sort column name. Defaults to givenname_sort
+     */
+    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
+        return switch (UserSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case UserSortColumn.BY_LASTNAME -> "lastname_sort";
+            case UserSortColumn.BY_EMAIL -> "email_sort";
+            case UserSortColumn.BY_STATUS -> "deactivated";
+            case UserSortColumn.BY_DEPARTMENT -> "department_sort";
+            case UserSortColumn.BY_ROLE -> "primaryroles_sort";
+            case null -> "givenname_sort";
+            default -> "givenname_sort";
+        };
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
@@ -12,10 +12,7 @@ package org.eclipse.sw360.datahandler.db;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
-import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
-import org.eclipse.sw360.datahandler.resourcelists.ResourceComparatorGenerator;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilitySortColumn;
@@ -23,9 +20,9 @@ import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,9 +43,24 @@ public class VulnerabilitySearchHandler {
                             "  if(doc.type == 'vulnerability') {" +
                             "    if (typeof(doc.externalId) == 'string' && doc.externalId.length > 0) {" +
                             "      index('text', 'externalId', doc.externalId, {'store': true});" +
+                            "      index('string', 'externalId_sort', doc.externalId);" +
                             "    }" +
                             "    if (typeof(doc.title) == 'string' && doc.title.length > 0) {" +
                             "      index('text', 'title', doc.title, {'store': true});" +
+                            "      index('string', 'title_sort', doc.title);" +
+                            "    }" +
+                            "    if(doc.lastUpdateDate && doc.lastUpdateDate.length) {"+
+                            "      var dt = new Date(doc.lastUpdateDate);"+
+                            "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
+                            "      index('double', 'lastUpdateDate', Number(formattedDt));"+
+                            "    }" +
+                            "    if(doc.publishDate && doc.publishDate.length) {"+
+                            "      var dt = new Date(doc.publishDate);"+
+                            "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
+                            "      index('double', 'publishDate', Number(formattedDt));"+
+                            "    }" +
+                            "    if(doc.cvss && typeof(doc.cvss) == 'number') {"+
+                            "      index('double', 'cvss', doc.cvss);"+
                             "    }" +
                             "  }" +
                             "}"));
@@ -72,8 +84,27 @@ public class VulnerabilitySearchHandler {
                 Vulnerability._Fields.EXTERNAL_ID.getFieldName(), Collections.singleton(searchText)
         );
 
+        String sortColumn = getSortColumnName(pageData);
+
         return connector.searchViewWithRestrictions(Vulnerability.class,
                 luceneSearchView.getIndexName(), null, subQueryRestrictions,
-                pageData, null, pageData.isAscending());
+                pageData, sortColumn, pageData.isAscending());
+    }
+
+    /**
+     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
+     * `_sort` suffix) for text indexes.
+     * @param pageData Pagination Data from the request.
+     * @return Sort column name. Defaults to lastUpdateDate
+     */
+    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
+        return switch (VulnerabilitySortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case VulnerabilitySortColumn.BY_EXTERNALID -> "externalId_sort";
+            case VulnerabilitySortColumn.BY_TITLE -> "title_sort";
+            case VulnerabilitySortColumn.BY_WEIGHTING -> "cvss";
+            case VulnerabilitySortColumn.BY_PUBLISHDATE -> "publishDate";
+            case null -> "lastUpdateDate";
+            default -> "lastUpdateDate";
+        };
     }
 }


### PR DESCRIPTION
> Please provide a summary of your changes here.

Add new `string` type index which can be used for sorting for `text` type indexes.

As per [Nouveau docs](https://docs.couchdb.org/en/stable/ddocs/nouveau.html#field-types), `text` indexes are great for searching but cannot be used for sorting. On the other hand, `string` indexes are bad for searching but can be used for sorting.

This PR creates a `string` index for `text` indexes with `_sort` suffix to be used for sorting whenever making a lucene search. Index searches are already sorted.

### How To Test?
Search for a component or a project with `luceneSearch=true` and different allowed sorting columns.