### PR TITLE
feat(vulnerabilities): search on title or CVE

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -94,7 +94,7 @@ public class ComponentSearchHandler {
     }
 
     public List<Component> search(String text, final Map<String, Set<String>> subQueryRestrictions ){
-        return connector.searchViewWithRestrictions(Component.class, luceneSearchView.getIndexName(),
+        return connector.searchViewWithRestrictionsWithAnd(Component.class, luceneSearchView.getIndexName(),
                 text, subQueryRestrictions);
     }
 
@@ -102,7 +102,7 @@ public class ComponentSearchHandler {
             Set<String>> subQueryRestrictions, User user, @Nonnull PaginationData pageData) {
         String sortColumn = getSortColumnName(pageData);
         Map<PaginationData, List<Component>> resultComponentList = connector
-                .searchViewWithRestrictions(Component.class,
+                .searchViewWithRestrictionsWithAnd(Component.class,
                         luceneSearchView.getIndexName(), text, subQueryRestrictions,
                         pageData, sortColumn, pageData.isAscending());
 
@@ -118,7 +118,7 @@ public class ComponentSearchHandler {
 
     public List<Component> searchWithAccessibility(String text, final Map<String, Set<String>> subQueryRestrictions,
                                                    User user) {
-        List<Component> resultComponentList = connector.searchViewWithRestrictions(Component.class,
+        List<Component> resultComponentList = connector.searchViewWithRestrictionsWithAnd(Component.class,
                 luceneSearchView.getIndexName(), text, subQueryRestrictions);
         for (Component component : resultComponentList) {
             makePermission(component, user).fillPermissionsInOther(component);

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -74,7 +74,7 @@ public class ModerationSearchHandler {
     }
 
     public List<ModerationRequest> search(String text, final Map<String, Set<String>> subQueryRestrictions ) {
-        return connector.searchViewWithRestrictions(ModerationRequest.class, luceneSearchView.getIndexName(),
+        return connector.searchViewWithRestrictionsWithAnd(ModerationRequest.class, luceneSearchView.getIndexName(),
                 text, subQueryRestrictions);
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
@@ -14,14 +14,12 @@ import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
-import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,7 +84,7 @@ public class PackageSearchHandler {
     }
 
     public List<Package> searchPackagesWithRestrictions(String text, final Map<String , Set<String>> subQueryRestrictions) {
-        return connector.searchViewWithRestrictions(Package.class, luceneSearchView.getIndexName(),
+        return connector.searchViewWithRestrictionsWithAnd(Package.class, luceneSearchView.getIndexName(),
                 text, subQueryRestrictions);
     }
 
@@ -97,7 +95,7 @@ public class PackageSearchHandler {
 
     public List<Package> searchAccessiblePackages(String text, final Map<String,
             Set<String>> subQueryRestrictions, User user ){
-        List<Package> resultPackageList = connector.searchViewWithRestrictions(Package.class,
+        List<Package> resultPackageList = connector.searchViewWithRestrictionsWithAnd(Package.class,
                 luceneSearchView.getIndexName(), text, subQueryRestrictions);
         return resultPackageList;
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -111,7 +111,7 @@ public class ProjectSearchHandler {
     public Map<PaginationData, List<Project>> search(String text, final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
         String sortColumn = getSortColumnName(pageData);
         Map<PaginationData, List<Project>> resultProjectList = connector
-                .searchViewWithRestrictions(Project.class,
+                .searchViewWithRestrictionsWithAnd(Project.class,
                         luceneSearchView.getIndexName(), text, subQueryRestrictions,
                         pageData, sortColumn, pageData.isAscending());
 
@@ -134,7 +134,7 @@ public class ProjectSearchHandler {
     }
 
     public List<Project> search(String text, final Map<String, Set<String>> subQueryRestrictions) {
-        return connector.searchViewWithRestrictions(Project.class, luceneSearchView.getIndexName(),
+        return connector.searchViewWithRestrictionsWithAnd(Project.class, luceneSearchView.getIndexName(),
                 text, subQueryRestrictions);
     }
 
@@ -149,7 +149,7 @@ public class ProjectSearchHandler {
             projectsByReleaseIds = connector.searchProjectViewWithRestrictionsAndFilter(luceneSearchView.getIndexName(),
                     null, filterMap, user);
         } else {
-            projectsByReleaseIds = connector.searchViewWithRestrictions(Project.class, luceneSearchView.getIndexName(),
+            projectsByReleaseIds = connector.searchViewWithRestrictionsWithAnd(Project.class, luceneSearchView.getIndexName(),
                     null, filterMap);
         }
         return new HashSet<>(projectsByReleaseIds);

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -75,7 +75,7 @@ public class ReleaseSearchHandler {
     public Map<PaginationData, List<Release>> search(String searchText, PaginationData pageData) {
         String sortColumn = getSortColumnName(pageData);
         Map<PaginationData, List<Release>> resultReleaseList = connector
-                .searchViewWithRestrictions(Release.class,
+                .searchViewWithRestrictionsWithAnd(Release.class,
                         luceneSearchView.getIndexName(), null,
                         Map.of(Release._Fields.NAME.getFieldName(),
                                 Collections.singleton(prepareWildcardQuery(searchText))

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
@@ -111,7 +111,7 @@ public class UserSearchHandler {
 
     public Map<PaginationData, List<User>> search(String text, final Map<String, Set<String>> subQueryRestrictions, @Nonnull PaginationData pageData) {
         String sortColumn = getSortColumnName(pageData);
-        return connector.searchViewWithRestrictions(User.class,
+        return connector.searchViewWithRestrictionsWithAnd(User.class,
                 luceneUserSearchView.getIndexName(), text, subQueryRestrictions,
                 pageData, sortColumn, pageData.isAscending());
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.datahandler.db;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
@@ -23,6 +24,7 @@ import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,10 +38,22 @@ public class VulnerabilitySearchHandler {
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
+    private static final String CVE_REFERENCES_TO_TEXT = """
+            function cveRefsToTextIndex(references, indexName) {
+              for (ref in references) {
+                if (typeof(references[ref]) == 'object' && references[ref]['type'] == 'cveReference') {
+                  let refString = 'CVE-' + references[ref]['year'] + '-' + references[ref]['number'];
+                  index('text', indexName, refString, {'store': true});
+                }
+              }
+            }
+            """;
+
     private static final NouveauIndexDesignDocument luceneSearchView
             = new NouveauIndexDesignDocument("vulnerabilities",
             new NouveauIndexFunction(
                     "function(doc) {" +
+                            CVE_REFERENCES_TO_TEXT +
                             "  if(doc.type == 'vulnerability') {" +
                             "    if (typeof(doc.externalId) == 'string' && doc.externalId.length > 0) {" +
                             "      index('text', 'externalId', doc.externalId, {'store': true});" +
@@ -62,6 +76,7 @@ public class VulnerabilitySearchHandler {
                             "    if(doc.cvss && typeof(doc.cvss) == 'number') {"+
                             "      index('double', 'cvss', doc.cvss);"+
                             "    }" +
+                            "    cveRefsToTextIndex(doc.cveReferences, 'cveReferences');" +
                             "  }" +
                             "}"));
 
@@ -78,15 +93,19 @@ public class VulnerabilitySearchHandler {
         connector.addDesignDoc(searchView);
     }
 
-    public Map<PaginationData, List<Vulnerability>> search(String searchText, PaginationData pageData) {
-        Map<String, Set<String>> subQueryRestrictions = Map.of(
-                Vulnerability._Fields.TITLE.getFieldName(), Collections.singleton(searchText),
-                Vulnerability._Fields.EXTERNAL_ID.getFieldName(), Collections.singleton(searchText)
-        );
+    public Map<PaginationData, List<Vulnerability>> search(String searchText, String cveId, PaginationData pageData) {
+        Map<String, Set<String>> subQueryRestrictions = new HashMap<>();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
+            subQueryRestrictions.put(Vulnerability._Fields.TITLE.getFieldName(), Collections.singleton(searchText));
+            subQueryRestrictions.put(Vulnerability._Fields.EXTERNAL_ID.getFieldName(), Collections.singleton(searchText));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(cveId)) {
+            subQueryRestrictions.put(Vulnerability._Fields.CVE_REFERENCES.getFieldName(), Collections.singleton(cveId));
+        }
 
         String sortColumn = getSortColumnName(pageData);
 
-        return connector.searchViewWithRestrictions(Vulnerability.class,
+        return connector.searchViewWithRestrictionsWithOr(Vulnerability.class,
                 luceneSearchView.getIndexName(), null, subQueryRestrictions,
                 pageData, sortColumn, pageData.isAscending());
     }

--- a/backend/vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
+++ b/backend/vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
@@ -333,12 +333,18 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
     }
 
     @Override
-    public Map<PaginationData, List<Vulnerability>> searchVulnerabilities(String searchText, User user, PaginationData pageData) throws TException {
+    public Map<PaginationData, List<Vulnerability>> searchVulnerabilities(
+            String searchText, String cveId, User user, PaginationData pageData
+    ) throws TException {
         if (!PermissionUtils.isUserAtLeast(UserGroup.USER, user)) {
             return Collections.singletonMap(pageData, Collections.emptyList());
         }
 
-        return vulnerabilitySearchHandler.search(searchText, pageData);
+        if (CommonUtils.isNullEmptyOrWhitespace(searchText) && CommonUtils.isNullEmptyOrWhitespace(cveId)) {
+            throw new SW360Exception("No search input provided.").setErrorCode(400);
+        }
+
+        return vulnerabilitySearchHandler.search(searchText, cveId, pageData);
     }
 
     @Override

--- a/libraries/datahandler/src/main/thrift/vulnerabilities.thrift
+++ b/libraries/datahandler/src/main/thrift/vulnerabilities.thrift
@@ -291,10 +291,10 @@ service VulnerabilityService {
     map<PaginationData, list<Vulnerability>> getVulnerabilities(1: User user, 2: PaginationData pageData);
 
     /**
-      * returns a list with all vulnerabilities matching searchText in the SW360 database if the user is valid
-      * returns empty list if user is not valid
+      * returns a list with all vulnerabilities matching searchText or CVE ID in the SW360 database if the user
+      * is valid returns empty list if user is not valid
       **/
-    map<PaginationData, list<Vulnerability>> searchVulnerabilities(1: string searchText, 2: User user, 3: PaginationData pageData);
+    map<PaginationData, list<Vulnerability>> searchVulnerabilities(1: string searchText, 2: string cveId, 3: User user, 4: PaginationData pageData);
 
       /**
        * returns a list with the latest vulnerabilities in the SW360 database if the user is valid

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
@@ -75,12 +75,17 @@ public class Sw360VulnerabilityService {
         }
     }
 
-    public Map<PaginationData, List<Vulnerability>> searchVulnerabilities(String searchText, User sw360User, Pageable pageable) {
+    public Map<PaginationData, List<Vulnerability>> searchVulnerabilities(
+            String searchText, String cveId, User sw360User, Pageable pageable
+    ) {
         try {
             VulnerabilityService.Iface sw360VulnerabilityClient = getThriftVulnerabilityClient();
             PaginationData pageData = pageableToPaginationData(pageable);
-            return sw360VulnerabilityClient.searchVulnerabilities(searchText, sw360User, pageData);
+            return sw360VulnerabilityClient.searchVulnerabilities(searchText, cveId, sw360User, pageData);
         } catch (TException e) {
+            if ((e instanceof SW360Exception) && (((SW360Exception) e).getErrorCode() == 400)) {
+                throw new BadRequestClientException("Search parameters cannot be empty.");
+            }
             throw new RuntimeException(e);
         }
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -112,16 +112,18 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     )
     @GetMapping(value = VULNERABILITIES_URL)
     public ResponseEntity<CollectionModel<EntityModel<VulnerabilityApiDTO>>> getVulnerabilities(
-            @Parameter(description = "Search text")
+            @Parameter(description = "Filter for External Id or Title")
             @RequestParam(value = "search", required = false) String searchText,
+            @Parameter(description = "Filter for CVE ID")
+            @RequestParam(value = "cveId", required = false) String cveId,
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
             HttpServletRequest request
     ) throws URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Map<PaginationData, List<Vulnerability>> paginatedVulnerabilities = null;
-        if (!CommonUtils.isNullEmptyOrWhitespace(searchText)) {
-            paginatedVulnerabilities = vulnerabilityService.searchVulnerabilities(searchText, user, pageable);
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) || CommonUtils.isNotNullEmptyOrWhitespace(cveId)) {
+            paginatedVulnerabilities = vulnerabilityService.searchVulnerabilities(searchText, cveId, user, pageable);
         } else {
             paginatedVulnerabilities = vulnerabilityService.getVulnerabilities(user, pageable);
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
@@ -192,7 +192,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
         paginationData.setTotalRowCount(1);
         searchPaginatedResults.put(paginationData, searchResults);
 
-        given(this.vulnerabilityServiceMock.searchVulnerabilities(eq("test"), any(), any())).willReturn(searchPaginatedResults);
+        given(this.vulnerabilityServiceMock.searchVulnerabilities(eq("test"), any(), any(), any())).willReturn(searchPaginatedResults);
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

1. In `/vulnerabilities` endpoints, allow search via title, external id or CVE ID.
2. Split the function `searchViewWithRestrictions()` with two kind of joins or type `AND` and `OR` allowing services to choose either based on query requirements.

### How To Test?
1. Try searching vulnerabilities based on external ID, or title via the `search` parameter.
2. Try searching vulnerabilities based on CVE ID via the `cveId` parameter.
3. Try  searching vulnerabilities based on external ID, or title and CVE ID via the `search` and `cveId` parameters.