### PR TITLE
fix(rest) : Project Obligation should have default status "Open"

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -64,6 +64,7 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.ObligationStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
@@ -3110,6 +3111,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     releaseIdToAcceptedCLI, releases, sw360User);
             for (Map.Entry<String, ObligationStatusInfo> entry : obligationStatusMap.entrySet()) {
                 ObligationStatusInfo statusInfo = entry.getValue();
+                if(statusInfo.getStatus() == null){
+                    statusInfo.setStatus(ObligationStatus.OPEN);
+                }
                 Set<Release> limitedSet = releaseService
                         .getReleasesForUserByIds(statusInfo.getReleaseIdToAcceptedCLI().keySet());
                 statusInfo.setReleases(limitedSet);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: 

Closes #3501 

### How To Test?

1. Trigger the URL /resource/api/projects/{id}/licenseObligations
2. The data received should have status key with value 
3. If status has no value, by default "Open" should be available in the response. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
