### PR TITLE
fix(backend) : Merged release updation failure in restricted projects.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1819,10 +1819,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         ProjectService.Iface projectClient = new ThriftClients().makeProjectClient();
 
         final String userEmail = sessionUser.getEmail();
-        Set<Project> projects = projectClient.searchByReleaseId(mergeSourceId, sessionUser);
+        Set<Project> projects = projectRepository.searchByReleaseId(mergeSourceId);
         for(Project project : projects) {
             // retrieve full document, other method only retrieves summary
-            project = projectClient.getProjectById(project.getId(), sessionUser);
+            project = projectClient.getProjectByIdIgnoringVisibility(project.getId());
             Project projectBefore=project.deepCopy();
             ProjectReleaseRelationship relationship = project.getReleaseIdToUsage().remove(mergeSourceId);
             // if the target release is also linked, keep this one, do not overwrite
@@ -1830,7 +1830,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 project.putToReleaseIdToUsage(mergeTargetId, relationship);
             }
             updateModifiedFields(project, userEmail);
-            projectClient.updateProject(project, sessionUser);
+            projectClient.updateProjectWithForceFlag(project, sessionUser, true);
 
             dbHandlerUtil.addChangeLogs(project, projectBefore, userEmail, Operation.UPDATE,
                     attachmentConnector, Lists.newArrayList(), mergeTargetId, Operation.MERGE_RELEASE);

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -341,6 +341,12 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return project;
     }
 
+    public Project getProjectByIdIgnoringVisibility(String id) throws SW360Exception {
+        Project project = repository.get(id);
+        assertNotNull(project);
+        return project;
+    }
+
     ////////////////////////////
     // ADD INDIVIDUAL OBJECTS //
     ////////////////////////////

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -260,6 +260,14 @@ public class ProjectHandler implements ProjectService.Iface {
     }
 
     @Override
+    public Project getProjectByIdIgnoringVisibility(String id) throws SW360Exception {
+        assertId(id);
+        Project project = handler.getProjectByIdIgnoringVisibility(id);
+        assertNotNull(project);
+        return project;
+    }
+
+    @Override
     public List<Project> getProjectsById(List<String> id, User user) throws TException {
         assertUser(user);
         assertNotNull(id);

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -472,6 +472,12 @@ service ProjectService {
     Project getProjectById(1: string id, 2: User user) throws (1: SW360Exception exp);
 
     /**
+      * get a project by id based on id irrespective of its visibility for the user
+      * (part of project CRUD support)
+      */
+    Project getProjectByIdIgnoringVisibility(1: string id) throws (1: SW360Exception exp);
+
+    /**
      * get multiple projects by id, if they are visible to the user
      * (part of project CRUD support)
      */


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
Close : #3534 

> * Did you add or update any new dependencies that are required for your change?
No

Issue: #3534 


### How To Test?

1. Create the following releases:
- release1: 1.2.1
- release2: 1.2.1
- release3: 1.2
2. Merge release1 and release2.
3. After merging, you will have a new release named 1.2.1_restricted.
4. Assign 1.2.1_restricted to a restricted project that should not be accessible to any clearing admin.
5. Log in as a clearing admin who does not have access to the project that contains 1.2.1_restricted, and attempt to merge 1.2.1_restricted into release 1.2.
6. Before applying the fix, the restricted release 1.2.1_restricted will still appear on the project, even though it has already been merged into release 1.2.
7. With the fix applied, this incorrect behavior is resolved, and the release information reflects the merge correctly.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
