### PR TITLE
feat(rest) : Endpoint to fetch UsageInfo for release merge

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -1957,4 +1957,48 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                 sw360User);
         return new ResponseEntity<>(requestStatus, HttpStatus.OK);
     }
+
+    @Operation(
+            summary = "Get usage information for release merge.",
+            description = "Get usage information for release merge including projects, attachment usages, releases, release vulnerabilities, and project ratings. " +
+                    "This information helps determine the impact of merging a release.",
+            tags = {"Releases"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", description = "Usage information for the release.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(
+                                                    example = """
+                                                        {
+                                                          "projects": 5,
+                                                          "attachmentUsages": 3,
+                                                          "releases": 2,
+                                                          "releaseVulnerabilities": 1,
+                                                          "projectRatings": 4
+                                                        }
+                                                        """
+                                            ))
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "404", description = "Release not found"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500", description = "Internal server error, while processing the request."
+                    )
+
+            }
+    )
+    @RequestMapping(value = RELEASES_URL + "/{id}/usageInformationForMerge", method = RequestMethod.GET)
+    public ResponseEntity<Map<String, Object>> getUsageInformationForReleaseMerge(
+            @Parameter(description = "The ID of the release.")
+            @PathVariable("id") String releaseId
+    ) throws TException {
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        restControllerHelper.throwIfSecurityUser(user);
+        Map<String, Integer> usageInfo = releaseService.getUsageInformationForReleaseMerge(releaseId, user);
+        Map<String, Object> result = new HashMap<>(usageInfo);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

New API to get info about affected data while merging releases

Issue: Closes : #3536 

### How To Test?

1. URL : http://localhost:8080/resource/api/releases/{releaseId}/usageInformationForMerge
2. Sample Response : 
    {
      "projects": 2,
      "attachmentUsages": 3,
      "projectRatings": 0,
      "releaseVulnerabilities": 0,
      "releases": 0
    }

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
