### PR TITLE
fix: update broken documentation link in Docker README (#3555)

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -133,7 +133,7 @@ So any external docker image can connect to internal couchdb  through this netwo
 ### Post setup configuration
 
 * Please read this page after you have initial screen:
- [SW360 Initial Setup Configuration](https://eclipse.dev/sw360/docs/deployment/)
+[SW360 Initial Setup Configuration](https://eclipse.dev/sw360/docs/deployment/legacy/deploy-liferay7.3/)
 
 ## Fossology
 


### PR DESCRIPTION
## Description
Fixes #3555 

Replaced the broken "SW360 Initial Setup Configuration" link that was leading to a 404 error page.

## Changes
- Updated link from `https://eclipse.org/...` to `https://eclipse.dev/sw360/docs/deployment/`
- The new link points to the current SW360 deployment documentation

## Testing
- Verified the new link works and points to valid documentation
-  Checked the documentation content is relevant to post-setup configuration

## Related Issue
Closes #3555