### PR TITLE
fix(obligation): fix the pagination /obligations

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
@@ -10,18 +10,28 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import com.google.common.base.Joiner;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationSortColumn;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
@@ -33,15 +43,24 @@ public class ObligationSearchHandler {
     private static final NouveauIndexDesignDocument luceneSearchView
         = new NouveauIndexDesignDocument("obligations",
             new NouveauIndexFunction(
-                "function(doc) {" +
-                "    if(!doc.type || doc.type != 'obligation') return;" +
-                "    if(doc.title !== undefined && doc.title != null && doc.title.length >0) {" +
-                "      index('text', 'title', doc.title, {'store': true});" +
-                "    }" +
-                "    if(doc.text !== undefined && doc.text != null && doc.text.length >0) {" +
-                "      index('text', 'text', doc.text, {'store': true});" +
-                "    }" +
-                "}"));
+                """
+                function(doc) {
+                    if(!doc.type || doc.type != 'obligation') return;
+                    if(doc.title !== undefined && doc.title != null && doc.title.length >0) {
+                      index('text', 'title', doc.title, {'store': true});
+                      index('string', 'title_sort', doc.title);
+                    }
+                    if(doc.text !== undefined && doc.text != null && doc.text.length >0) {
+                      index('text', 'text', doc.text, {'store': true});
+                      index('string', 'text_sort', doc.text);
+                    }
+                    if(doc.obligationLevel !== undefined && doc.obligationLevel != null && doc.obligationLevel.length >0) {
+                      index('text', 'obligationLevel', doc.obligationLevel, {'store': true});
+                      index('string', 'obligationLevel_sort', doc.obligationLevel);
+                    }
+                }
+                """
+                ));
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
@@ -60,5 +79,77 @@ public class ObligationSearchHandler {
     public List<Obligation> search(String searchText) {
         return connector.searchView(Obligation.class, luceneSearchView.getIndexName(),
                 prepareWildcardQuery(searchText));
+    }
+
+    /**
+     * Search for Obligations in paginated manner based on searchText in title
+     * or text or obligationLevel.
+     * @param searchText      Text to search
+     * @param obligationLevel Obligation level to filter
+     * @param pageData        Pagination data
+     * @return Paginated filtered obligations list.
+     */
+    public Map<PaginationData, List<Obligation>> searchWithPagination(
+            String searchText, ObligationLevel obligationLevel, PaginationData pageData
+    ) {
+        String sortColumn = getSortColumnName(pageData);
+
+        Map<String, Map<String, Set<String>>> restrictions = new HashMap<>();
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
+            Map<String, Set<String>> textFilter = new HashMap<>();
+
+            String queryString = prepareWildcardQuery(searchText);
+            textFilter.put(
+                    Obligation._Fields.TITLE.getFieldName(),
+                    Collections.singleton(queryString));
+            textFilter.put(
+                    Obligation._Fields.TEXT.getFieldName(),
+                    Collections.singleton(queryString));
+
+            restrictions.put("OR", textFilter);
+        }
+
+        if (obligationLevel != null) {
+            Map<String, Set<String>> levelFilter = new HashMap<>();
+            levelFilter.put(
+                    Obligation._Fields.OBLIGATION_LEVEL.getFieldName(),
+                    Collections.singleton(obligationLevel.toString())
+            );
+
+            restrictions.put("AND", levelFilter);
+        }
+
+        List<String> queryFilters = NouveauLuceneAwareDatabaseConnector.createComplexQuery(
+                Obligation.class, null, restrictions
+        );
+
+        final Joiner AND = Joiner.on(" AND ");
+
+        String finalQuery = AND.join(queryFilters);
+
+        Map<PaginationData, List<Obligation>> resultObligationList = connector
+                .searchView(Obligation.class,
+                        luceneSearchView.getIndexName(), finalQuery,
+                        pageData, sortColumn, pageData.isAscending());
+
+        PaginationData respPageData = resultObligationList.keySet().iterator().next();
+        List<Obligation> obligationList = resultObligationList.values().iterator().next();
+
+        return Collections.singletonMap(respPageData, obligationList);
+    }
+
+    /**
+     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
+     * `_sort` suffix) for text indexes.
+     * @param pageData Pagination Data from the request.
+     * @return Sort column name. Defaults to title
+     */
+    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
+        return switch (ObligationSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ObligationSortColumn.BY_TEXT -> "text_sort";
+            case ObligationSortColumn.BY_LEVEL -> "obligationLevel_sort";
+            case null, default -> "title_sort";
+        };
     }
 }

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -1468,4 +1468,11 @@ public class LicenseDatabaseHandler {
 
         return jsonObject.toString();
     }
+
+    public Map<PaginationData, List<Obligation>> getObligationsPaginated(PaginationData pageData) {
+        if (pageData == null) {
+            throw new IllegalArgumentException("PaginationData cannot be null");
+        }
+        return obligRepository.getObligationsPaginated(pageData);
+    }
 }

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/TodoRepository.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/TodoRepository.java
@@ -9,14 +9,19 @@
  */
 package org.eclipse.sw360.licenses.db;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 
 import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationSortColumn;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * CRUD access for the Obligation class
@@ -28,11 +33,50 @@ public class TodoRepository extends DatabaseRepositoryCloudantClient<Obligation>
 
     private static final String ALL = "function(doc) { if (doc.type == 'obligation') emit(null, doc._id) }";
 
+    private static final String BY_LOWERCASE_OBLIGATION_TITLE_VIEW =
+            "function(doc) {" +
+                    "  if (doc.type == 'obligation' && doc.title != null) {" +
+                    "    emit(doc.title.toLowerCase(), doc._id);" +
+                    "  } " +
+                    "}";
+
+    private static final String BY_LOWERCASE_OBLIGATION_TEXT_VIEW =
+            "function(doc) {" +
+                    "  if (doc.type == 'obligation' && doc.text != null) {" +
+                    "    emit(doc.text.toLowerCase(), doc._id);" +
+                    "  } " +
+                    "}";
+
+    private static final String BY_LOWERCASE_OBLIGATION_LEVEL_VIEW =
+            "function(doc) {" +
+                    "  if (doc.type == 'obligation' && doc.obligationLevel != null) {" +
+                    "    emit(doc.obligationLevel.toLowerCase(), doc._id);" +
+                    "  } " +
+                    "}";
+
     public TodoRepository(DatabaseConnectorCloudant db) {
         super(db, Obligation.class);
         Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
         views.put("all", createMapReduce(ALL, null));
+        views.put("obligationbytitle", createMapReduce(BY_LOWERCASE_OBLIGATION_TITLE_VIEW, null));
+        views.put("obligationbytext", createMapReduce(BY_LOWERCASE_OBLIGATION_TEXT_VIEW, null));
+        views.put("obligationbylevel", createMapReduce(BY_LOWERCASE_OBLIGATION_LEVEL_VIEW, null));
         initStandardDesignDocument(views, db);
     }
 
+    public Map<PaginationData, List<Obligation>> getObligationsPaginated(PaginationData pageData) {
+        String viewName = getViewFromPagination(pageData);
+
+        List<Obligation> obligations = queryViewPaginated(viewName, pageData, false);
+
+        return Collections.singletonMap(pageData, obligations);
+    }
+
+    private static @NotNull String getViewFromPagination(PaginationData pageData) {
+        return switch (ObligationSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ObligationSortColumn.BY_TEXT -> "obligationbytext";
+            case ObligationSortColumn.BY_LEVEL -> "obligationbylevel";
+            case null, default -> "obligationbytitle";
+        };
+    }
 }

--- a/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.db.ObligationSearchHandler;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
@@ -31,6 +32,7 @@ import org.apache.thrift.TException;
 import java.nio.ByteBuffer;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.io.IOException;
 
@@ -401,5 +403,15 @@ public class LicenseHandler implements LicenseService.Iface {
             return handler.getLicenseSummary();
         }
         return handler.searchLicense(searchText);
+    }
+
+    @Override
+    public Map<PaginationData, List<Obligation>> searchObligationTextPaginated(
+            String searchText, ObligationLevel obligationLevel, PaginationData pageData
+    ) {
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) || obligationLevel != null) {
+            return obligationSearchHandler.searchWithPagination(searchText, obligationLevel, pageData);
+        }
+        return handler.getObligationsPaginated(pageData);
     }
 }

--- a/libraries/datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/datahandler/src/main/thrift/licenses.thrift
@@ -24,6 +24,7 @@ typedef sw360.CustomProperties CustomProperties
 typedef sw360.RequestSummary RequestSummary
 typedef sw360.Quadratic Quadratic
 typedef sw360.SW360Exception SW360Exception
+typedef sw360.PaginationData PaginationData
 typedef i32 int
 
 
@@ -46,6 +47,12 @@ enum ObligationElementStatus {
     UPDATED = 0,
     DEFINED = 1
     UNDEFINED = 2
+}
+
+enum ObligationSortColumn {
+    BY_TITLE = 0,
+    BY_TEXT = 1,
+    BY_LEVEL = 2
 }
 
 struct Obligation {
@@ -386,4 +393,9 @@ service LicenseService {
      * Search licenses by shortname or fullname
      */
     list<License> searchLicense(1: string searchText);
+
+    /**
+     * Search obligations by title or text with pagination
+     */
+    map<PaginationData, list<Obligation>> searchObligationTextPaginated(1: string searchText, 2: ObligationLevel obligationLevel, 3: PaginationData pageData);
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
@@ -23,9 +23,9 @@ import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
@@ -54,7 +54,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
@@ -79,7 +79,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             tags = {"Obligations"}
     )
     @RequestMapping(value = OBLIGATION_URL, method = RequestMethod.GET)
-    public ResponseEntity<CollectionModel> getObligations(
+    public ResponseEntity<CollectionModel<EntityModel<Obligation>>> getObligations(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
             HttpServletRequest request,
@@ -88,36 +88,41 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             @RequestParam(value = "obligationLevel", required = false) String obligationLevel,
             @Parameter(description = "Search obligations by title or text", required = false)
             @RequestParam(value = "search", required = false) String searchKeyWord
-    ) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException {
+    ) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException, SW360Exception {
 
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
-        List<Obligation> obligations;
-        if (!CommonUtils.isNullEmptyOrWhitespace(obligationLevel)) {
-            obligations = obligationService.getObligations().stream()
-                    .filter(obligation -> obligationLevel.equalsIgnoreCase(obligation.getObligationLevel().toString()))
-                    .collect(Collectors.toList());
+        List<Obligation> obligations = new ArrayList<>();
+        Map<PaginationData, List<Obligation>> paginatedObligations =
+                obligationService.getObligationsFiltered(searchKeyWord, obligationLevel, pageable);
+
+        PaginationResult<Obligation> paginationResult;
+        if (paginatedObligations != null && !paginatedObligations.isEmpty()) {
+            obligations.addAll(paginatedObligations.values().iterator().next());
+            int totalCount = Math.toIntExact(paginatedObligations.keySet().stream()
+                    .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));
+            paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                    request, pageable, obligations, SW360Constants.TYPE_OBLIGATION, totalCount);
         } else {
-            obligations = obligationService.getObligations();
+            paginationResult = restControllerHelper.createPaginationResult(request, pageable,
+                    obligations, SW360Constants.TYPE_OBLIGATION);
         }
-        if(!CommonUtils.isNullEmptyOrWhitespace(searchKeyWord)){
-            filterObligationBasedOnSearchKey(searchKeyWord, obligations);
-        }
-        PaginationResult<Obligation> paginationResult = restControllerHelper.createPaginationResult(request, pageable, obligations, SW360Constants.TYPE_OBLIGATION);
+
         List<EntityModel<Obligation>> obligationResources = new ArrayList<>();
-        paginationResult.getResources().stream()
+        paginationResult.getResources()
                 .forEach(obligation -> {
                     Obligation embeddedObligation = restControllerHelper.convertToEmbeddedObligation(obligation);
-                    EntityModel<Obligation> licenseResource = EntityModel.of(embeddedObligation);
-                    obligationResources.add(licenseResource);
+                    obligationResources.add(EntityModel.of(embeddedObligation));
                 });
-        CollectionModel resources;
-        if (obligationResources.size() == 0) {
-            resources = restControllerHelper.emptyPageResource(License.class, paginationResult);
+        CollectionModel<EntityModel<Obligation>> resources;
+        if (obligationResources.isEmpty()) {
+            resources = restControllerHelper.emptyPageResource(Obligation.class, paginationResult);
         } else {
             resources = restControllerHelper.generatePagesResource(paginationResult, obligationResources);
         }
-        return new ResponseEntity<>(resources, HttpStatus.OK);
+
+        HttpStatus status = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
+        return new ResponseEntity<>(resources, status);
     }
 
     private void filterObligationBasedOnSearchKey(String searchKeyWord, List<Obligation> obligations) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
@@ -13,45 +13,33 @@ package org.eclipse.sw360.rest.resourceserver.obligation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TCompactProtocol;
-import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationNode;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class Sw360ObligationService {
-    @Value("${sw360.thrift-server-url:http://localhost:8080}")
-    private String thriftServerUrl;
-
-    public List<Obligation> getObligations() {
-        List<Obligation> obligations;
-        try {
-            LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
-            obligations = sw360LicenseClient.getObligations();
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
-        if (obligations != null) {
-            return obligations.stream().map(o -> o.setNode(null)).toList();
-        }
-        return null;
-    }
-
     public Obligation getObligationById(String obligationId, User user) {
         LicenseService.Iface sw360LicenseClient = null;
         Obligation obligation = null;
@@ -94,9 +82,8 @@ public class Sw360ObligationService {
     }
 
     private LicenseService.Iface getThriftLicenseClient() throws TTransportException {
-        THttpClient thriftClient = new THttpClient(thriftServerUrl + "/licenses/thrift");
-        TProtocol protocol = new TCompactProtocol(thriftClient);
-        return new LicenseService.Client(protocol);
+        ThriftClients thriftClients = new ThriftClients();
+        return thriftClients.makeLicenseClient();
     }
 
     public Obligation updateObligation(Obligation obligation, User sw360User) {
@@ -136,5 +123,60 @@ public class Sw360ObligationService {
             throw new RuntimeException(e);
         }
         return obligationElements;
+    }
+
+    public Map<PaginationData, List<Obligation>> getObligationsFiltered(String searchText, String obligationLevel,
+                                                                        Pageable pageable) throws SW360Exception {
+        ObligationLevel level = null;
+        try {
+            if (!CommonUtils.isNullEmptyOrWhitespace(obligationLevel)) {
+                level = ObligationLevel.valueOf(obligationLevel);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestClientException("Illegal value for obligationLevel: " + obligationLevel, e);
+        }
+        try {
+            LicenseService.Iface licenseClient = getThriftLicenseClient();
+            PaginationData pageData = pageableToPaginationData(pageable,
+                    ObligationSortColumn.BY_TITLE, true);
+            return licenseClient.searchObligationTextPaginated(searchText, level, pageData);
+        } catch (TException e) {
+            throw new SW360Exception("Unable to fetch Obligations.");
+        }
+    }
+
+
+    /**
+     * Converts a Pageable object to a PaginationData object.
+     *
+     * @param pageable the Pageable object to convert
+     * @return a PaginationData object representing the pagination information
+     */
+    private static PaginationData pageableToPaginationData(
+            @NotNull Pageable pageable, ObligationSortColumn defaultSort, Boolean defaultAscending
+    ) {
+        ObligationSortColumn column = ObligationSortColumn.BY_TITLE;
+        boolean ascending = true;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            column = switch (property) {
+                case "text" -> ObligationSortColumn.BY_TEXT;
+                case "level" -> ObligationSortColumn.BY_LEVEL;
+                default -> column; // Default to BY_NAME if no match
+            };
+            ascending = order.isAscending();
+        } else {
+            if (defaultSort != null) {
+                column = defaultSort;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
+        }
+
+        return new PaginationData().setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
@@ -11,6 +11,7 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
@@ -88,8 +89,15 @@ public class ObligationTest extends TestIntegrationBase {
 
         obligationList = Arrays.asList(obligation1, obligation2);
 
+        PaginationData pageData = new PaginationData();
+        pageData.setSortColumnNumber(0);
+        pageData.setDisplayStart(0);
+        pageData.setRowsPerPage(obligationList.size());
+        pageData.setTotalRowCount(obligationList.size());
+        pageData.setAscending(true);
+
         // Setup service mocks
-        given(obligationServiceMock.getObligations()).willReturn(obligationList);
+        given(obligationServiceMock.getObligationsFiltered(any(), any(), any())).willReturn(Map.of(pageData, obligationList));
         given(obligationServiceMock.getObligationById(eq(obligation1.getId()), any())).willReturn(obligation1);
         given(obligationServiceMock.getObligationById(eq(obligation2.getId()), any())).willReturn(obligation2);
         given(obligationServiceMock.deleteObligation(eq(obligation1.getId()), any())).willReturn(RequestStatus.SUCCESS);
@@ -315,7 +323,7 @@ public class ObligationTest extends TestIntegrationBase {
     public void should_handle_exception_in_get_obligations() throws IOException, TException {
         // Mock service to throw exception
         doThrow(new RuntimeException("Failed to get obligations"))
-                .when(obligationServiceMock).getObligations();
+                .when(obligationServiceMock).getObligationsFiltered(any(), any(), any());
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ObligationSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ObligationSpecTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
@@ -81,7 +82,15 @@ public class ObligationSpecTest extends TestRestDocsSpecBase {
         obligationList.add(obligation);
         obligationList.add(obligation2);
 
-        given(this.obligationServiceMock.getObligations()).willReturn(obligationList);
+        PaginationData pageData = new PaginationData();
+        pageData.setSortColumnNumber(0);
+        pageData.setDisplayStart(0);
+        pageData.setRowsPerPage(obligationList.size());
+        pageData.setTotalRowCount(obligationList.size());
+        pageData.setAscending(true);
+
+        // Setup service mocks
+        given(this.obligationServiceMock.getObligationsFiltered(any(), any(), any())).willReturn(Map.of(pageData, obligationList));
         given(this.obligationServiceMock.getObligationById(eq(obligation.getId()), any())).willReturn(obligation);
         given(this.obligationServiceMock.deleteObligation(eq(obligation.getId()), any())).willReturn(RequestStatus.SUCCESS);
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(


### PR DESCRIPTION
Fix the pagination and search for the `/obligations` endpoint.

The sorting is allowed for `text`, `level`, `title`.

Closes #3568
Closes #3569

### How To Test?
Check the issue to make calls with pagination and text filter.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
