### PR TITLE
chore(rest): Remove outdated TODO comment from Sw360AuthenticationProvider

### DIFF
--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthenticationProvider.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthenticationProvider.java
@@ -38,8 +38,6 @@ public class Sw360AuthenticationProvider implements AuthenticationProvider {
     @Value("${sw360.test-user-password}")
     private String testUserPassword;
 
-    // TODO Thomas Maier 15-12-2017
-    // Use Sw360GrantedAuthority from authorization server
     private final String GRANTED_AUTHORITY_READ = "READ";
     private final String GRANTED_AUTHORITY_WRITE = "WRITE";
 


### PR DESCRIPTION
Remove 7-year-old TODO comment from test security provider.
The hardcoded authority strings are intentional for this mock authentication provider used in tests.