### PR TITLE
fix(rest): Add shortname field to license REST API response.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -1019,6 +1019,7 @@ public class RestControllerHelper<T> {
     public License convertToEmbeddedLicense(License license) {
         License embeddedLicense = new License();
         embeddedLicense.setId(license.getId());
+        embeddedLicense.setShortname(license.getShortname());
         embeddedLicense.setFullname(license.getFullname());
         embeddedLicense.setChecked(license.isChecked());
         embeddedLicense.setLicenseType(license.getLicenseType());


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Closes #3579 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
use url: http://localhost:8080/resource/api/licenses?page=0&size=2

response should come like below: 
{
  "_embedded": {
    "sw360:licenses": [
      {
        "checked": true,
        "shortName": "Apache-2.0",
        "fullName": "Apache License 2.0",
        "_links": {
          "self": {
            "href": "http://localhost:8080/resource/api/licenses/Apache-2.0"
          }
        }
      }
    ]
  }
}

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
