### PR TITLE
fix(wsimport): Remove extra whitespace before method call

### DIFF
--- a/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftUploader.java
+++ b/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftUploader.java
@@ -235,7 +235,7 @@ public class ThriftUploader {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        if (releases.size() != libraryList .size()) {
+        if (releases.size() != libraryList.size()) {
             LOGGER.warn("expected to get " + libraryList.size() + " different ids of releases but got " + releases.size());
         } else {
             LOGGER.info("The expected number of releases was imported or already found in database.");


### PR DESCRIPTION
## Summary
Fix code style issue in ThriftUploader.java.

## Changes
- Line 238: `libraryList .size()` → `libraryList.size()`

