### PR TITLE
fix(attachment): Prioritize attachment filename from request body

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -227,7 +227,10 @@ public class Sw360AttachmentService {
     }
 
     public Attachment uploadAttachment(MultipartFile file, Attachment newAttachment, User sw360User) throws IOException, TException {
-        String fileName = file.getOriginalFilename(); // TODO: shouldn't the fileName be taken from newAttachment?
+        String attachmentFilename = newAttachment.getFilename();
+        String fileName = (attachmentFilename != null && !attachmentFilename.isEmpty())
+                ? attachmentFilename
+                : file.getOriginalFilename();
         String contentType = file.getContentType();
         final AttachmentContent attachmentContent = makeAttachmentContent(fileName, contentType);
 


### PR DESCRIPTION
## Summary
When uploading attachments, now prefer the filename specified in the 
attachment metadata (if provided) over the multipart file's original filename.

## Changes
- [Sw360AttachmentService.java](cci:7://file:///c:/Users/airaj/OneDrive/Desktop/gsoc/sw360/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java:0:0-0:0): Modified [uploadAttachment()](cci:1://file:///c:/Users/airaj/OneDrive/Desktop/gsoc/sw360/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java:228:4-268:5) method

## Behavior
- If `attachment.filename` is provided in request body: use it
- Otherwise: fallback to `file.getOriginalFilename()`

This allows API clients to specify custom filenames when uploading attachments,
which is useful when:
- The original filename contains special characters
- A different filename is desired for organization
- Renaming files during programmatic uploads

## Related Issue
Resolves TODO comment at line 230 of Sw360AttachmentService.java