### PR TITLE
feat(resourceserver): Add endpoint to fetch linked packages for a release

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Siemens AG, 2017-2018.
+ * Copyright Sandip Mandal<sandipmandal02.sm@gmail.com>, 2026.
  * Copyright Bosch Software Innovations GmbH, 2017.
  * Part of the SW360 Portal Project.
  *
@@ -1644,4 +1645,22 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return usageInformation;
     }
 
+    /**
+     * Get linked packages for a release
+     */
+    public List<org.eclipse.sw360.datahandler.thrift.packages.Package> getLinkedPackagesForRelease(String releaseId, User user) throws TException {
+        Release release = getReleaseForUserById(releaseId, user);
+
+        if (release.getPackageIds() == null || release.getPackageIds().isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        try {
+            org.eclipse.sw360.datahandler.thrift.packages.PackageService.Iface packageClient =
+                new ThriftClients().makePackageClient();
+            return packageClient.getPackageWithReleaseByPackageIds(release.getPackageIds());
+        } catch (TTransportException e) {
+            throw new TException("Unable to get package client", e);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds a new REST endpoint to fetch packages linked to a release with pagination and lightweight serverside filtering.
It allows consumers to retrieve only the relevant linked packages instead of fetching all packages and filtering client side.

No new dependencies were added.


## Issue

Issue: #3439


### Suggest Reviewer

@GMishx 
@deo002 

### How To Test?

1. Create or identify a release with linked packages.
2. Call the endpoint via Swagger UI or curl:

```
GET /releases/{id}/linkedPackages?page=0&size=20
```

3. Test optional filters, for example:

```
GET /releases/{id}/linkedPackages?vendor=apache&name=http&licenseIds=MIT,Apache-2.0
```



### Checklist

Must:

* [x] All related issues are referenced in commit messages and in PR
