### PR TITLE
feat(AttachmentUsages): Save existing attachment usages of sub-project at parent project level

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -90,6 +90,7 @@ public class SW360ConfigsDatabaseHandler {
                 .put(VCS_HOSTS, getOrDefault(configContainer, VCS_HOSTS, "[]"))
                 .put(NON_PKG_MANAGED_COMPS_PROP, getOrDefault(configContainer, NON_PKG_MANAGED_COMPS_PROP, ""))
                 .put(REST_API_TOKEN_LENGTH, getOrDefault(configContainer, REST_API_TOKEN_LENGTH, "20"))
+                .put(INHERIT_ATTACHMENT_USAGES, getOrDefault(configContainer, INHERIT_ATTACHMENT_USAGES, "false"))
             .build();
         putInMemory(ConfigFor.SW360_CONFIGURATION, configMap);
     }
@@ -199,6 +200,7 @@ public class SW360ConfigsDatabaseHandler {
                  DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD,
                  IS_BULK_RELEASE_DELETING_ENABLED,
                  IS_PACKAGE_PORTLET_ENABLED,
+                 INHERIT_ATTACHMENT_USAGES,
                  IS_ADMIN_PRIVATE_ACCESS_ENABLED,
                  UI_CLEARING_TEAM_UNKNOWN_ENABLED,
                  UI_CUSTOM_WELCOME_PAGE_GUIDELINE,

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -60,6 +60,8 @@ public class SW360ConfigKeys {
     public static final String PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE = "package.portlet.write.access.usergroup";
     // This property is used to create URLs in Doc reports
     public static final String RELEASE_FRIENDLY_URL = "release.friendly.url";
+    //This property is used to inherit attachmentUsages of subproject by default
+    public static final String INHERIT_ATTACHMENT_USAGES = "inherit.attachment.usages";
 
     public static final String IS_ADMIN_PRIVATE_ACCESS_ENABLED = "admin.private.project.access.enabled";
 
@@ -125,7 +127,7 @@ public class SW360ConfigKeys {
             COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, AUTO_SET_ECC_STATUS, MAIL_REQUEST_FOR_PROJECT_REPORT,
             MAIL_REQUEST_FOR_COMPONENT_REPORT, IS_BULK_RELEASE_DELETING_ENABLED,
             DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, IS_FORCE_UPDATE_ENABLED, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE,
-            TOOL_NAME, TOOL_VENDOR, IS_PACKAGE_PORTLET_ENABLED, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE,
+            TOOL_NAME, TOOL_VENDOR, IS_PACKAGE_PORTLET_ENABLED, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, INHERIT_ATTACHMENT_USAGES,
             RELEASE_FRIENDLY_URL, IS_ADMIN_PRIVATE_ACCESS_ENABLED, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, VCS_HOSTS,
             NON_PKG_MANAGED_COMPS_PROP, REST_API_TOKEN_LENGTH,
             UI_CLEARING_TEAMS, UI_CLEARING_TEAM_UNKNOWN_ENABLED, UI_COMPONENT_CATEGORIES,


### PR DESCRIPTION
**Description**

1. Attachment Usages saved at a project should be preserved and transferred to the project it is being linked to.
2. This saves the user the effort of making selections at each sub-project level again.
3. Attachment usages are crucial to generate readme oss.
