### PR TITLE
refactor(rest): Replace logging anti-patterns with proper Log4j2 logging

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/key/KeyManager.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/key/KeyManager.java
@@ -20,6 +20,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,8 @@ import com.nimbusds.jose.jwk.RSAKey;
 
 @Component
 public class KeyManager {
+
+    private static final Logger log = LogManager.getLogger(KeyManager.class);
 
     @Value("${jwt.secretkey:sw360SecretKey}")
     private String secretKey;
@@ -48,20 +52,10 @@ public class KeyManager {
     private static KeyStore loadKeyStore(String keystoreFile, String password) throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
         KeyStore keyStore = KeyStore.getInstance("JKS");
         keyStore.load(null, null);
-        FileInputStream fileInputStream = null;
-        try {
-            fileInputStream = new FileInputStream(keystoreFile);
+        try (FileInputStream fileInputStream = new FileInputStream(keystoreFile)) {
             keyStore.load(fileInputStream, password.toCharArray());
         } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            if (fileInputStream != null) {
-                try {
-                    fileInputStream.close();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
+            log.error("Error loading keystore from {}", keystoreFile, e);
         }
         return keyStore;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -257,7 +257,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 selectedData.add(stringResult);
             }
         }
-        System.out.println("Resulting string: " + selectedData);
+        log.debug("Resulting string: {}", selectedData);
         return selectedData;
     }
 


### PR DESCRIPTION
## Summary
Replaces logging anti-patterns and modernizes resource handling in REST modules.
## Problem
- `e.printStackTrace()` bypasses logging framework, making errors invisible in log files
- Manual resource handling (try-finally) is error-prone vs try-with-resources
- Debug `System.out.println()` left in production code
## Changes
### KeyManager.java
- Added Log4j2 logger
- Replaced 2× `e.printStackTrace()` with `log.error()`
- Modernized to try-with-resources (Java 7+)
### Sw360ProjectService.java
- Replaced `System.out.println()` with `log.debug()`
## Impact
- Errors captured in log files for debugging
- Resource handling follows modern Java best practices
- Debug output controlled via log configuration
- No functional changes