### PR TITLE
fix(rest): prevent silent data loss in obligation update

### DIFF
--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -314,8 +314,8 @@ public class LicenseDatabaseHandler {
      * @return ID of the added obligations.
      */
     public String updateObligation(@NotNull Obligation oblig, User user) throws SW360Exception {
-        if (!PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)){
-            return null;
+        if (!PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)) {
+            throw new SW360Exception("User should be at least " + UserGroup.CLEARING_ADMIN);
         }
         Obligation oldObligation = getObligationsById(oblig.getId());
         // Setting the revision to avoid the document update conflict exception
@@ -339,7 +339,7 @@ public class LicenseDatabaseHandler {
      */
     public String addObligationElements(@NotNull ObligationElement obligationElement, User user) throws SW360Exception {
         if (!PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)) {
-            return null;
+            throw new SW360Exception("User should be at least " + UserGroup.CLEARING_ADMIN);
         }
         prepareObligationElement(obligationElement);
         // check existed obligation element
@@ -361,7 +361,7 @@ public class LicenseDatabaseHandler {
      */
     public String addObligationNodes(@NotNull ObligationNode obligationNode, User user) throws SW360Exception {
         if (!PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)) {
-            return null;
+            throw new SW360Exception("User should be at least " + UserGroup.CLEARING_ADMIN);
         }
         prepareObligationNode(obligationNode);
         // check existed node


### PR DESCRIPTION
## Prevent silent obligation node data loss on update

### What’s broken

`Sw360ObligationService.updateObligation()` unconditionally overwrites an obligation’s node with the return value of `addNodes()`.

`addNodes()` can return `null` (permission denied, malformed JSON, unexpected structure). When that happens, the existing node tree is **silently wiped**, persisted, and the REST API still returns HTTP 200.

This causes **permanent obligation data loss** and broken compliance exports.

### Why this matters

Obligation nodes are core compliance data. Losing them silently breaks trust in SW360 and can impact legal/compliance decisions.

This is a **regression** introduced by commit `16a36f1cf`.

### Fix

Fail fast if `addNodes()` returns `null`:

* Do **not** mutate or persist the obligation
* Return an error instead of reporting success

### Impact

Prevents silent data corruption and restores atomic, predictable obligation updates.

Low-risk, minimal change, failure cases only.
