### PR TITLE
fix(rest) : FilenameChanges for ComponentReport Download from Mail-URL

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -133,6 +133,9 @@ public class SW360ReportService {
                         SW360Utils.getCreatedOn());
             }
             break;
+        case SW360Constants.COMPONENTS:
+            documentName = String.format("components-%s.xlsx", SW360Utils.getCreatedOn());
+            break;
         case SW360Constants.LICENSES:
             documentName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
             break;


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: 

Closes : #3633 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Login -> Redirect to component page -> Click export components/components with releases -> Should recieve an email -> Download the file from URL generated from Mail.

After this fix - report should be with expected name of a file.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
