### PR TITLE
fix(rest): Map vcs field correctly in component update request

### DIFF
--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -408,6 +408,7 @@ struct ComponentDTO {
     51: optional string mailinglist,
     52: optional string wiki,
     53: optional string blog,
+    54: optional string vcs,
 
     // Moderation comment passed during PATCH request (not persisted on Component)
     90: optional string comment,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -767,6 +767,7 @@ public class RestControllerHelper<T> {
         component.setWiki(componentDTO.getWiki());
         component.setBlog(componentDTO.getBlog());
         component.setAttachments(componentDTO.getAttachments());
+        component.setVcs(componentDTO.getVcs());
 
         return component;
     }


### PR DESCRIPTION
This PR adds backend support for updating the vcs field via the REST API.
- Enabled proper persistence of VCS updates coming from REST update requests

This change unblocks testing and ensures the frontend VCS update functionality (https://github.com/eclipse-sw360/sw360-frontend/pull/1379) works as expected.