### PR TITLE
fix(Project): LicenseClearing count to follow camelCasing

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2951,8 +2951,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         int approvedCount = clearingInfo.approved;
         try {
             JsonObject row = new JsonObject();
-            row.addProperty("Release Count", releaseCount);
-            row.addProperty("Approved Count", approvedCount);
+            row.addProperty("releaseCount", releaseCount);
+            row.addProperty("approvedCount", approvedCount);
             response.getWriter().write(row.toString());
         } catch (IOException e) {
             throw new SW360Exception(e.getMessage());
@@ -2985,7 +2985,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 int approvedCount = clearingInfo.approved;
 
                 JsonObject row = new JsonObject();
-                row.addProperty("totalCount", releaseCount);
+                row.addProperty("releaseCount", releaseCount);
                 row.addProperty("approvedCount", approvedCount);
                 result.add(proj.getId(), row);
             }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2472,8 +2472,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
                        responseFields(
-                               fieldWithPath("Release Count").description("Total count of releases of a project including sub-projects releases"),
-                               fieldWithPath("Approved Count").description("Approved license clearing state releases")
+                               fieldWithPath("releaseCount").description("Total count of releases of a project including sub-projects releases"),
+                               fieldWithPath("approvedCount").description("Approved license clearing state releases")
                        )));
     }
 


### PR DESCRIPTION
Fixes inconsistency in below endpoints : 

`GET /projects/{id}/licenseClearingCount` (used in homepage) returns {'Release Count': xx, 'Approved Count': xx}
`POST /projects/licenseClearingCount` returns (used in projects page) {totalCount: xx, approvedCount: xx}

This PR makes the response consistent and follows camelCasing in the `GET /projects/{id}/licenseClearingCount` response.

Issue : https://github.com/eclipse-sw360/sw360-frontend/issues/1417

