### PR TITLE
ci: cancel stale PR workflow runs using concurrency

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,6 +25,10 @@ on:
       - .github/thrift_container.yml
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   COUCHDB_USER: sw360
   COUCHDB_PASSWORD: sw360fossie
@@ -55,7 +59,6 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: webiny/action-conventional-commits@faccb24fc2550dd15c0390d944379d2d8ed9690e # v1.3.1
-
 
       - name: Verify license headers
         run: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,12 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
+
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -23,5 +28,6 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2

--- a/.github/workflows/sw360_container.yml
+++ b/.github/workflows/sw360_container.yml
@@ -20,12 +20,15 @@ on:
   pull_request:
     paths:
       - 'Dockerfile'
-
   push:
     branches:
       - main
     paths-ignore:
       - '**.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -112,7 +115,6 @@ jobs:
           context: .
           target: sw360
           push: true
-          #platforms: linux/amd64,linux/arm64
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR introduces concurrency at the workflow level for GitHub Actions triggered by pull requests so that when new commits are pushed to the same pull request, any running CI jobs older than the new ones are automatically cancelled. This ensures that there are no stale results for the CI and that only the latest commit is verified, while leaving all other workflows (such as scheduled, push-only, and CodeQL/Scorecard scans) unaffected.