### PR TITLE
fix: Thread safety race-condition in ProjectDatabaseHandler

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -110,7 +110,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     private static final boolean WITH_ALL_RELEASES = true;
     private static final boolean WITH_ROOT_RELEASES_ONLY = false;
 
-    private ExecutorService projectExecutor;
+
 
     private final ProjectRepository repository;
     private final ProjectVulnerabilityRatingRepository pvrRepository;
@@ -2293,8 +2293,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     protected List<ReleaseLink> convertReleaseNodesToReleaseLinksParallel(List<ReleaseNode> releaseNodes, String projectId, User user) {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
-
         final List<Callable<ReleaseLink>> callableTasksToConvertReleaseNodes = new ArrayList<>();
         releaseNodes.forEach(releaseNode -> {
             Callable<ReleaseLink> convertToReleaseLink = () ->
@@ -2303,12 +2301,10 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         });
 
         List<Future<ReleaseLink>> releaseLinksFuture;
-        try {
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
             releaseLinksFuture = executor.invokeAll(callableTasksToConvertReleaseNodes);
         } catch (InterruptedException e) {
             throw new RuntimeException("Error when convert releaseLink: " + e.getMessage());
-        } finally {
-            executor.shutdown();
         }
 
         AtomicInteger index = new AtomicInteger();
@@ -2331,34 +2327,34 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         projectOrigin.put(projectId, SW360Utils.printName(projectById));
         LinkedHashMap<String, String> releaseOrigin = new LinkedHashMap<>();
         Map<String, ProjectProjectRelationship> linkedProjects = projectById.getLinkedProjects();
-        projectExecutor = Executors.newFixedThreadPool(5);
         String releaseNetwork = projectById.getReleaseRelationNetwork();
         List<ReleaseNode> listReleaseLinkJson;
-        if (releaseNetwork != null) {
-            try {
-                listReleaseLinkJson = mapper.readValue(releaseNetwork, new TypeReference<List<ReleaseNode>>() {
-                });
-                flattenLinkedReleaseOfRelease(listReleaseLinkJson, projectOrigin, releaseOrigin, clearingStatusList, user, isInaccessibleLinkMasked);
-            } catch (JsonProcessingException e) {
-                log.error("JsonProcessingException: " + e);
+        try (ExecutorService projectExecutor = Executors.newVirtualThreadPerTaskExecutor()) {
+            if (releaseNetwork != null) {
+                try {
+                    listReleaseLinkJson = mapper.readValue(releaseNetwork, new TypeReference<List<ReleaseNode>>() {
+                    });
+                    flattenLinkedReleaseOfRelease(listReleaseLinkJson, projectOrigin, releaseOrigin, clearingStatusList, user, isInaccessibleLinkMasked, projectExecutor);
+                } catch (JsonProcessingException e) {
+                    log.error("JsonProcessingException: " + e);
+                }
             }
-        }
 
-        if (linkedProjects != null && !linkedProjects.isEmpty()) {
-            try {
-                flattenDependencyNetworkForLinkedProject(linkedProjects, projectOrigin, releaseOrigin, clearingStatusList,
-                        user, isInaccessibleLinkMasked);
-            } catch (WrappedException.WrappedSW360Exception exception) {
-                throw new SW360Exception(exception.getCause());
+            if (linkedProjects != null && !linkedProjects.isEmpty()) {
+                try {
+                    flattenDependencyNetworkForLinkedProject(linkedProjects, projectOrigin, releaseOrigin, clearingStatusList,
+                            user, isInaccessibleLinkMasked, projectExecutor);
+                } catch (WrappedException.WrappedSW360Exception exception) {
+                    throw new SW360Exception(exception.getCause());
+                }
             }
         }
-        projectExecutor.shutdown();
         return clearingStatusList;
     }
 
     private void flattenLinkedReleaseOfRelease(List<ReleaseNode>  listReleaseLinkJson,
                                                LinkedHashMap<String, String> projectOrigin, LinkedHashMap<String, String> releaseOrigin,
-                                               List<Map<String, String>> clearingStatusList, User user, boolean isInaccessibleLinkMasked) {
+                                               List<Map<String, String>> clearingStatusList, User user, boolean isInaccessibleLinkMasked, ExecutorService projectExecutor) {
         final List<Callable<Void>> callables = new ArrayList<>();
         listReleaseLinkJson.forEach(rl -> {
             Callable<Void> callableTask = () -> {
@@ -2376,7 +2372,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                     Map<String, String> row = createReleaseCSRow(relation, projectMailLineState, rel, clearingStatusList, user, comment);
                     if (CommonUtils.isNotEmpty(listLinkedRelease)) {
                         flattenLinkedReleaseOfRelease(listLinkedRelease, projectOrigin, cpReleaseOrigin,
-                                clearingStatusList, user, isInaccessibleLinkMasked);
+                                clearingStatusList, user, isInaccessibleLinkMasked, projectExecutor);
                     }
                     cpReleaseOrigin.remove(releaseId);
                     row.put("projectOrigin", String.join(" -> ", projectOrigin.values()));
@@ -2399,7 +2395,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     private void flattenDependencyNetworkForLinkedProject(Map<String, ProjectProjectRelationship> linkedProjects,
                                                           LinkedHashMap<String, String> projectOrigin, LinkedHashMap<String, String> releaseOrigin,
-                                                          List<Map<String, String>> clearingStatusList, User user, boolean isInaccessibleLinkMasked) throws WrappedException.WrappedSW360Exception {
+                                                          List<Map<String, String>> clearingStatusList, User user, boolean isInaccessibleLinkMasked, ExecutorService projectExecutor) throws WrappedException.WrappedSW360Exception {
 
         linkedProjects.entrySet().stream().forEach(lp -> wrapSW360Exception(() -> {
             String projId = lp.getKey();
@@ -2417,7 +2413,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 try {
                     listReleaseLinkJson = mapper.readValue(releaseNetwork, new TypeReference<List<ReleaseNode>>() {
                     });
-                    flattenLinkedReleaseOfRelease(listReleaseLinkJson, projectOrigin, releaseOrigin, clearingStatusList, user, isInaccessibleLinkMasked);
+                    flattenLinkedReleaseOfRelease(listReleaseLinkJson, projectOrigin, releaseOrigin, clearingStatusList, user, isInaccessibleLinkMasked, projectExecutor);
                 } catch (JsonProcessingException e) {
                     log.error("JsonProcessingException: " + e);
                 }
@@ -2426,7 +2422,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             if (subprojects != null && !subprojects.isEmpty()) {
                 try {
                     flattenDependencyNetworkForLinkedProject(subprojects, projectOrigin, releaseOrigin, clearingStatusList,
-                            user, isInaccessibleLinkMasked);
+                            user, isInaccessibleLinkMasked, projectExecutor);
                 } catch (WrappedException.WrappedSW360Exception exception) {
                     throw new SW360Exception(exception.getCause());
                 }


### PR DESCRIPTION
##  Issue
Fixes a critical thread-safety race condition in `ProjectDatabaseHandler`.


##  Summary
This PR resolves a concurrency bug caused by a shared `ExecutorService` (`projectExecutor`) being declared as an instance field while being initialized and shut down inside the `getClearingStateForDependencyNetworkListView` method.

Under concurrent requests, this led to race conditions where:
- One request could overwrite the executor reference used by another.
- An executor could be shut down while still in use by a different request.

This resulted in intermittent `RejectedExecutionException` failures under load.


##  Solution
The implementation was updated to ensure proper thread isolation per request:

- Removed the shared `projectExecutor` instance field.
- Introduced a method-local `ExecutorService`, scoped to each request.
- Updated helper methods to accept the executor explicitly:
  - `flattenLinkedReleaseOfRelease`
  - `flattenDependencyNetworkForLinkedProject`
- Ensured proper lifecycle management of the executor within the method.
- No new dependencies were added.


## Suggested Reviewers
- @GMishx
- @deo002
- @amritkv 

##  How to Test
1. Review the changes in `ProjectDatabaseHandler.java` and verify:
   - `projectExecutor` is no longer an instance field.
   - A local `ExecutorService` is created per request.
   - The executor is correctly passed to helper methods.
2. Run the following command:
   ```bash
   mvn compile -pl backend/common