### PR TITLE
fix: Exception Swallowing in UserRepository

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
@@ -259,11 +259,9 @@ public class UserRepository extends SummaryAwareRepository<User> {
             qb.useIndex(Collections.singletonList(USER_BY_ALL_IDX));
         }
 
-        try {
-            users = getConnector().getQueryResultPaginated(qb, User.class, pageData, sortSelector);
-        } catch (Exception e) {
-            log.error("Error getting users", e);
-        }
+        users = getConnector().getQueryResultPaginated(
+                qb, User.class, pageData, sortSelector
+        );
         result.put(pageData, users);
         return result;
     }


### PR DESCRIPTION
## Issue
Fixes a critical bug where database exceptions were swallowed in `UserRepository`.

## Summary
This PR resolves an issue where the `queryViewWithPagination` method in `UserRepository.java` was catching generic `Exception`s and returning an empty result set instead of propagating the error.

This behavior masked critical database failures (such as connection issues or query errors), causing the application to return **HTTP 200 OK with “0 results”** instead of correctly reporting an **HTTP 500 Internal Server Error**.

##  Solution
The implementation was updated to ensure proper error propagation:

- Removed the `try-catch` block wrapping the `getQueryResultPaginated` call.
- Ensured runtime exceptions from the database layer propagate up the stack.
- Allowed errors to be handled by the global exception handler or caller.
- Fixed indentation of the affected line.
- No new dependencies were added.

## Suggested Reviewers
- @GMishx
- @deo002

## How to Test
1. Review the changes in `UserRepository.java` and verify that the `try-catch` block has been removed.
2. Ensure the code compiles successfully:
   ```bash
   mvn compile -pl backend/common