### PR TITLE
fix(security): Remove password hash from user CSV export

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
@@ -343,8 +343,7 @@ public class Sw360ImportExportService {
         List<User> users = userClient.getAllUsers();
 
         List<String> headers = Arrays.asList(
-                "GivenName", "Lastname", "Email", "Department", "UserGroup", "GID", "PasswdHash", "wantsMailNotification"
-        );
+                "GivenName", "Lastname", "Email", "Department", "UserGroup", "GID", "wantsMailNotification");
 
         List<Iterable<String>> csvRows = new ArrayList<>();
 
@@ -356,7 +355,6 @@ public class Sw360ImportExportService {
             row.add(user.getDepartment() != null ? user.getDepartment() : "");
             row.add(user.getUserGroup() != null ? user.getUserGroup().toString() : "");
             row.add(user.getExternalid() != null ? user.getExternalid() : "");
-            row.add(user.getPassword() != null ? user.getPassword() : "");
             row.add(user.isSetWantsMailNotification() ? "True" : "False");
 
             csvRows.add(row);


### PR DESCRIPTION
Fixes #3649
## Description

The user export functionality (`/api/importExport/downloadUsers`) includes bcrypt password hashes in the exported CSV file. This unnecessarily exposes credential data that could be used for offline cracking attempts.

## Changes Made

- Removed `PasswdHash` from CSV headers 
- Removed `user.getPassword()` from row data 

## Before
<img width="1902" height="1031" alt="image" src="https://github.com/user-attachments/assets/fa53c7c1-9529-4d21-966f-8e1ad8e2ac3f" />
<img width="1055" height="177" alt="image" src="https://github.com/user-attachments/assets/d5a12450-0e5a-417c-9554-0882aa48836d" />

## After
<img width="824" height="187" alt="image" src="https://github.com/user-attachments/assets/06368673-0ca4-47a1-8159-acd2e90fcfc0" />

## How to Test
- Login as admin user
- Navigate to Admin → Users
- Click "Download Users" button
- Open the CSV file and verify PasswdHash column is no longer present
