### PR TITLE
Fix/vcs hosts config validation (#3653)

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -87,8 +87,8 @@ public class SW360ConfigsDatabaseHandler {
             .put(SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, getOrDefault(configContainer, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, SW360Constants.DEFAULT_DOMAIN_PATTERN_SKIP_FOR_SOURCECODE))
             .put(RELEASE_FRIENDLY_URL, getOrDefault(configContainer, RELEASE_FRIENDLY_URL, "http://localhost:3000/components/releases/detail/releaseId"))
             .put(COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, getOrDefault(configContainer, COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, ""))
-                .put(VCS_HOSTS, getOrDefault(configContainer, VCS_HOSTS, ""))
-                .put(NON_PKG_MANAGED_COMPS_PROP, getOrDefault(configContainer, NON_PKG_MANAGED_COMPS_PROP, ""))
+                .put(VCS_HOSTS, getOrDefault(configContainer, VCS_HOSTS, "[]"))
+                .put(NON_PKG_MANAGED_COMPS_PROP, getOrDefault(configContainer, NON_PKG_MANAGED_COMPS_PROP, "[]"))
             .build();
         putInMemory(ConfigFor.SW360_CONFIGURATION, configMap);
     }
@@ -143,8 +143,11 @@ public class SW360ConfigsDatabaseHandler {
     }
 
     private boolean isValidSet(String value) {
-        if (value == null || value.isEmpty()) {
-            return false; // Null or empty string is not a valid set
+        if (value == null) {
+            return false; // Null is not a valid set
+        }
+        if (value.isEmpty()) {
+            return true; // Empty string is valid (treated as empty array for backwards compatibility)
         }
         try {
             JSONArray obj = new JSONArray(value);


### PR DESCRIPTION
Solves #3653 
Issue: Updating any configuration in the Admin → Configurations page fails with the error: Invalid config: [vcs.hosts : ]

### Root Cause
The vcs.hosts configuration has conflicting default value and validation logic:


Default value : ""
Validation : Expects valid JSON array like [] 


### How To Test?

1. Go to Admin → Configurations
2. Toggle any setting (e.g., SPDX Document)
3. Click "Update Backend Configurations"
4. See error: Invalid config: [vcs.hosts : ]

### Recommended Fix
Change the default value in backend from "" to "[]"

## Before screenshot
<img width="1903" height="1028" alt="image" src="https://github.com/user-attachments/assets/6ae3a31e-b72e-43c9-8797-a2bf14b275b7" />
## After screenshot
<img width="1901" height="733" alt="image" src="https://github.com/user-attachments/assets/91747167-cb08-464c-b3d3-c5419ebea75e" />
