### PR TITLE
fix(rest): Correct Swagger UI API request URL path

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
@@ -175,6 +176,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     public OpenAPI customOpenAPI() {
         String restVersionString = getRestVersion();
         return new OpenAPI()
+                .addServersItem(new Server().url("/resource/api").description("SW360 REST API Server"))
                 .components(new Components()
                         .addSecuritySchemes("tokenAuth",
                                 new SecurityScheme().type(SecurityScheme.Type.APIKEY).name("Authorization")


### PR DESCRIPTION
Fixes #3660
## Issue: 
When using Swagger UI to test REST API calls, the generated request URLs are incorrect. The URLs are missing the /api prefix in the path, causing 403 Forbidden errors.

Actual : `resource/<apiName>` Expected : `resource/api/<apiName>`

This issue occurs because SpringDoc/OpenAPI does not automatically detect the Spring Data REST base path configuration.

## Solution
Added explicit server URL configuration in the OpenAPI bean to tell Swagger UI the correct base path:
`.addServersItem(new Server().url("/resource/api").description("SW360 REST API Server"))`


Steps to Verify

1. Open Swagger UI: http://localhost:8080/resource/swagger-ui/index.html
2. Authorize with valid credentials
3. Expand any API (e.g., Projects → GET /projects)
4. Click "Try it out" → "Execute"
5. Verify the Request URL contains /resource/api/ prefix
6. Verify the API returns a successful response (200 OK)

Screenshots:
Before:
<img width="1438" height="882" alt="image" src="https://github.com/user-attachments/assets/0cd467b8-01cb-4ea5-b74f-68b441d0c15f" />
After
<img width="1459" height="852" alt="image" src="https://github.com/user-attachments/assets/03d12f6d-3334-4844-a8b8-e23fb33883ef" />
