### PR TITLE
docs: clarify build requirements for partial builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ git clone https://github.com/eclipse-sw360/sw360.git
 cd sw360
 pip install pre-commit
 pre-commit install
+
+### Note on build requirements
+
+Please note that even partial or module-level Maven builds require deploy-related
+properties to be set due to enforced build rules.
+
+At a minimum, the `base.deploy.dir` property must be provided, otherwise the build
+will fail with a Maven Enforcer error.
+
+This applies even when building individual modules (for example, `libraries`).
+
 ```
 
 **Step 2**: Build the code


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

 This PR clarifies the build requirements for contributors.

While setting up SW360 locally, I noticed that even partial or module-level Maven
builds fail unless deploy-related properties (such as `base.deploy.dir`) are provided.
This requirement was not clearly documented.

This change adds a short note in the Build section to help new contributors avoid
confusion during setup
 
Closes #3577

### Suggest Reviewer
     @amritkv , @GMishx


### How To Test?
 This is a documentation-only change.
Reviewers can verify the update by reading the Build section in the README.
No additional tests were required.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
