### PR TITLE
fix(rest): correct OSADL license obligations error message

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -294,7 +294,7 @@ public class Sw360LicenseService {
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             return sw360LicenseClient.importAllOSADLLicenses(sw360User);
         } else {
-            throw new BadRequestClientException("Unable to import All Spdx license. User is not admin");
+            throw new BadRequestClientException("Unable to import All OSADL license obligations. User is not admin");
         }
     }
 


### PR DESCRIPTION
### Summary
This pull request fixes an incorrect error message in `Sw360LicenseService`.
The message previously referred to **SPDX licenses**, whereas the affected code path concerns **OSADL license obligations**.
The wording has been corrected to avoid confusion for users and administrators.

### Issue
Closes #3670 

### Checklist
- [x] All related issues are referenced in commit messages and in PR
