### PR TITLE
Fix incorrect error message in importOsadlInformation() method #3670

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -294,7 +294,7 @@ public class Sw360LicenseService {
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             return sw360LicenseClient.importAllOSADLLicenses(sw360User);
         } else {
-            throw new BadRequestClientException("Unable to import All Spdx license. User is not admin");
+            throw new BadRequestClientException("Unable to import All OSADL license obligations. User is not admin");
         }
     }
 


### PR DESCRIPTION
Fixes #3670 - Incorrect error message in importOsadlInformation() method
### What was changed
- Changed error message from "Unable to import All Spdx license" to "Unable to import All OSADL license obligations"
- Corrects terminology to accurately reflect that this method handles OSADL license obligations, not SPDX licenses
### Location
File: rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
Line: ~297
### Testing
- This is a simple string change that improves error message accuracy
- No functional changes to the method behavior
- Error message now correctly describes the operation being blocked
