### PR TITLE
Fix: CycloneDX BOM import dropping CPE, PURL, and repository data

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -619,7 +619,7 @@ public class CycloneDxBOMImporter {
 
                 for (org.cyclonedx.model.Component bomComp : entry.getValue()) {
                     Set<String> licenses = getLicenseFromBomComponent(bomComp);
-                    Release release = createRelease(bomComp.getVersion(), comp, licenses);
+                    Release release = createRelease(bomComp, comp, licenses);
                     if (CommonUtils.isNullEmptyOrWhitespace(release.getVersion()) ) {
                         log.error("release version is not present in SBoM for component: " + comp.getName());
                         invalidReleases.add(comp.getName());


### PR DESCRIPTION
While working with CycloneDX BOM imports, I noticed that releases created via the default import path were missing CPE, PURL, and repository information, even though these fields were present in the BOM and the import itself completed successfully.

## What was happening
Under the default configuration (`package.portlet.enabled = true`), the import flow goes through `importAllComponentsAsPackages()`.  
In this path, the release was being created using a simplified `createRelease(String version, …)` overload.

Because only the version string was passed, important metadata from the BOM — specifically CPE, PURL, and repository — was never applied to the release. This happened silently, with no errors or warnings.

Other import paths in the same class already use the full `createRelease(Component bomComp, …)` overload and correctly preserve this data.

## Root cause
A wrong method overload was called during release creation:
- `bomComp.getVersion()` was passed instead of the full CycloneDX component
- Java method resolution routed the call to the stripped-down overload
- As a result, CPE, PURL, and repository fields were dropped

## Fix
Changed the release creation call to pass the full CycloneDX component, aligning this code path with the other import flows in the same file.

This is a one-line change and does not affect any other behavior.

## Impact
- CPE IDs are now preserved for vulnerability matching
- PURLs are retained for cross-tool package identification
- Repository URLs are correctly stored for provenance and license workflows
- No behavior change outside the default CycloneDX package import path

## Notes
Happy to adjust or extend this if there’s a preferred way to handle this in the importer.
