### PR TITLE
fix(rest): correct OSADL obligations import error message

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -294,7 +294,7 @@ public class Sw360LicenseService {
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             return sw360LicenseClient.importAllOSADLLicenses(sw360User);
         } else {
-            throw new BadRequestClientException("Unable to import All Spdx license. User is not admin");
+            throw new BadRequestClientException("Unable to import All OSADL license obligations. User is not admin");
         }
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)
> Correct the non-admin error message thrown by importOsadlInformation() so it references OSADL license obligations (not SPDX).
> * Fixes the incorrect wording reported in #3670.
> * No new or updated dependencies.
Issue: Fixes #3670
Suggest Reviewer
> @eclipse-sw360/committers
How To Test?
> 1. Call the REST endpoint that triggers OSADL import as a non-admin user.
> 2. Verify the API returns HTTP 400 with message: Unable to import All OSADL license obligations. User is not admin.
> 3. Call the same endpoint as an admin user and verify the import proceeds (no BadRequest).
Checklist
Must:
[x] All related issues are referenced in commit messages and in PR