### PR TITLE
refactor(rest): migrate RequestMapping(method=...) to composed mappin…

### DIFF
--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/SpringTServlet.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/SpringTServlet.java
@@ -12,8 +12,9 @@ package org.eclipse.sw360.fossology;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.eclipse.sw360.projects.Sw360ThriftServlet;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,13 +31,13 @@ public class SpringTServlet extends Sw360ThriftServlet {
         super(processor, protocolFactory);
     }
 
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         super.doPost(request, response);
     }
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         super.doGet(request, response);

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -28,10 +28,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.eclipse.sw360.rest.authserver.security.key.KeyManager;
@@ -61,7 +63,7 @@ public class OAuthClientController {
     @Autowired
     private OAuthClientRepository repo;
 
-    @RequestMapping(method = RequestMethod.GET, path = "")
+    @GetMapping(path = "")
     public ResponseEntity<List<OAuthClientResource>> getAllClients() {
         List<OAuthClientResource> clientResources;
 
@@ -75,7 +77,7 @@ public class OAuthClientController {
         return new ResponseEntity<List<OAuthClientResource>>(clientResources, HttpStatus.OK);
     }
 
-    @RequestMapping(method = RequestMethod.POST, path = "", consumes = "application/json", produces = "application/json")
+    @PostMapping(path = "", consumes = "application/json", produces = "application/json")
     public ResponseEntity<?> createOrUpdateClient(@RequestBody OAuthClientResource clientResource) {
         OAuthClientEntity clientEntity = null;
 
@@ -107,7 +109,7 @@ public class OAuthClientController {
                 new OAuthClientResource(repo.getByClientId(clientEntity.getClientId())), HttpStatus.OK);
     }
 
-    @RequestMapping(method = RequestMethod.DELETE, path = "/{clientId}", consumes = "application/json", produces = "application/json")
+    @DeleteMapping(path = "/{clientId}", consumes = "application/json", produces = "application/json")
     public ResponseEntity<?> deleteClient(@PathVariable("clientId") String clientId) {
         OAuthClientEntity clientEntity = null;
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
@@ -23,8 +23,7 @@ import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +53,7 @@ public class AttachmentCleanUpController implements RepresentationModelProcessor
             description = "Cleanup all the unused attachments.",
             tags = {"Admin"}
     )
-    @RequestMapping(value = ATTACHMENT_CLEANUP_URL + "/deleteAll", method = RequestMethod.DELETE)
+    @DeleteMapping(value = ATTACHMENT_CLEANUP_URL + "/deleteAll")
     public ResponseEntity<RequestSummary> cleanUpAttachment() throws TException  {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = attachmentCleanUpService.cleanUpAttachments(sw360User);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
@@ -40,8 +40,7 @@ import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -126,7 +125,7 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
             description = "Make a test call and check the FOSSology server connection.",
             tags = {"Admin"}
     )
-    @RequestMapping(value = FOSSOLOGY_URL + "/reServerConnection", method = RequestMethod.GET)
+    @GetMapping(value = FOSSOLOGY_URL + "/reServerConnection")
     public ResponseEntity<?> checkServerConnection() {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         sw360FossologyAdminServices.serverConnection(sw360User);
@@ -158,7 +157,7 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
             )
     }
     )
-    @RequestMapping(value = FOSSOLOGY_URL + "/configData", method = RequestMethod.GET)
+    @GetMapping(value = FOSSOLOGY_URL + "/configData")
     public ResponseEntity<?> getConnectionConfigurationData()throws TException {
         Map<String, Object> configData = new HashMap<>();
         try {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
@@ -126,7 +126,10 @@ public class AttachmentController implements RepresentationModelProcessor<Reposi
             description = "Create an attachment.",
             tags = {"Attachments"}
     )
-    @RequestMapping(value = ATTACHMENTS_URL , method = RequestMethod.POST, consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(
+            value = ATTACHMENTS_URL,
+            consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE}
+    )
     public ResponseEntity<CollectionModel<EntityModel<Attachment>>> createAttachment(
             @Parameter(description = "List of files to attach",
                     schema = @Schema(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
@@ -51,9 +51,8 @@ import org.springframework.hateoas.server.core.Relation;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -96,7 +95,7 @@ public class ChangeLogController implements RepresentationModelProcessor<Reposit
                     ),
             }
     )
-    @RequestMapping(value = CHANGE_LOG_URL + "/document/{id}", method = RequestMethod.GET)
+    @GetMapping(value = CHANGE_LOG_URL + "/document/{id}")
     public ResponseEntity getChangeLogForDocument(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -96,7 +96,7 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "Get a clearing request by id.",
             tags = {"ClearingRequest"}
     )
-    @RequestMapping(value = CLEARING_REQUEST_URL + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = CLEARING_REQUEST_URL + "/{id}")
     public ResponseEntity<EntityModel<ClearingRequest>> getClearingRequestById(
             @Parameter(description = "id of the clearing request")
             @PathVariable("id") String docId
@@ -114,7 +114,7 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "Get the ClearingRequest based on the project id.",
             tags = {"ClearingRequest"}
     )
-    @RequestMapping(value = CLEARING_REQUEST_URL + "/project/{id}", method = RequestMethod.GET)
+    @GetMapping(value = CLEARING_REQUEST_URL + "/project/{id}")
     public ResponseEntity<EntityModel<ClearingRequest>> getClearingRequestByProjectId(
             @Parameter(description = "id of the project")
             @PathVariable("id") String projectId
@@ -165,7 +165,7 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "List all clearing requests visible to user",
             tags = {"ClearingRequest"}
     )
-    @RequestMapping(value = CLEARING_REQUESTS_URL, method = RequestMethod.GET)
+    @GetMapping(value = CLEARING_REQUESTS_URL)
     public ResponseEntity<CollectionModel<?>> getClearingRequests(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -295,7 +295,7 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             tags = {"ClearingRequest"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = CLEARING_REQUEST_URL + "/{id}/comments", method = RequestMethod.POST)
+    @PostMapping(value = CLEARING_REQUEST_URL + "/{id}/comments")
     public ResponseEntity<?> addComment(
             @Parameter(description = "ID of the clearing request")
             @PathVariable("id") String crId,
@@ -348,7 +348,7 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "Update a clearing request by id.",
             tags = {"ClearingRequest"}
     )
-    @RequestMapping(value = CLEARING_REQUEST_URL + "/{id}", method = RequestMethod.PATCH)
+    @PatchMapping(value = CLEARING_REQUEST_URL + "/{id}")
     public ResponseEntity<HalResource<ClearingRequest>> patchClearingRequest(
             @Parameter(description = "id of the clearing request")
             @PathVariable("id") String id,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -145,7 +145,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "List all of the service's components.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL, method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL)
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getComponents(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -255,7 +255,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all the resources where the component is used.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/usedBy" + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/usedBy" + "/{id}")
     public ResponseEntity<CollectionModel<EntityModel>> getUsedByResourceDetails(
             @Parameter(description = "The id of the component.")
             @PathVariable("id") String id
@@ -288,7 +288,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get a single component by its id.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/{id}")
     public ResponseEntity<EntityModel<Component>> getComponent(
             @Parameter(description = "The id of the component to be retrieved.")
             @PathVariable("id") String id
@@ -305,7 +305,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Return 5 of the service's most recently created components.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/recentComponents", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/recentComponents")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getRecentComponent() throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         List<Component> sw360Components = componentService.getRecentComponents(user);
@@ -325,7 +325,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "List all of the service's mysubscriptions components.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/mySubscriptions", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/mySubscriptions")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getMySubscriptions() throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         List<Component> sw360Components = componentService.getComponentSubscriptions(user);
@@ -346,7 +346,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Subscribes or unsubscribes the user to a specified component based on their current subscription status.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{id}/subscriptions", method = RequestMethod.POST)
+    @PostMapping(value = COMPONENTS_URL + "/{id}/subscriptions")
     public ResponseEntity<String> toggleComponentSubscription(
             @Parameter(description = "The ID of the component.")
             @PathVariable("id") String componentId
@@ -371,7 +371,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get components by external ID.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/searchByExternalIds", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/searchByExternalIds")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> searchByExternalIds(
             @Parameter(
                     description = "The external IDs of the components to be retrieved.",
@@ -399,7 +399,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                     @ApiResponse(responseCode = "404", description = "Component not found")
             }
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{id}", method = RequestMethod.PATCH)
+    @PatchMapping(value = COMPONENTS_URL + "/{id}")
     public ResponseEntity<EntityModel<Component>> patchComponent(
             @Parameter(description = "The id of the component to be updated.")
             @PathVariable("id") String id,
@@ -473,7 +473,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Delete existing components by ids.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{ids}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = COMPONENTS_URL + "/{ids}")
     public ResponseEntity<List<MultiStatus>> deleteComponents(
             @Parameter(description = "The ids of the components to be deleted.")
             @PathVariable("ids") List<String> idsToDelete,
@@ -506,7 +506,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Create a new component.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL, method = RequestMethod.POST)
+    @PostMapping(value = COMPONENTS_URL)
     public ResponseEntity<EntityModel<Component>> createComponent(
             @Parameter(description = "The component to be created.")
             @RequestBody Component component
@@ -549,7 +549,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all attachment information of a component.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{id}/attachments", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/{id}/attachments")
     public ResponseEntity<CollectionModel<EntityModel<Attachment>>> getComponentAttachments(
             @Parameter(description = "The id of the component.")
             @PathVariable("id") String id
@@ -566,7 +566,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all releases of a component.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{id}/releases", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/{id}/releases")
     public ResponseEntity<CollectionModel<ReleaseLink>> getReleaseLinksByComponentId(
             @Parameter(description = "The id of the component.")
             @PathVariable("id") String id
@@ -583,7 +583,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Update attachment info a component.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{id}/attachment/{attachmentId}", method = RequestMethod.PATCH)
+    @PatchMapping(value = COMPONENTS_URL + "/{id}/attachment/{attachmentId}")
     public ResponseEntity<EntityModel<Attachment>> patchComponentAttachmentInfo(
             @Parameter(description = "The id of the component.")
             @PathVariable("id") String id,
@@ -639,7 +639,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             },
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{componentId}/attachments", method = RequestMethod.POST, consumes = {"multipart/mixed", "multipart/form-data"})
+    @PostMapping(value = COMPONENTS_URL + "/{componentId}/attachments", consumes = {"multipart/mixed", "multipart/form-data"})
     public ResponseEntity<HalResource> addAttachmentToComponent(
             @Parameter(description = "The id of the component.")
             @PathVariable("componentId") String componentId,
@@ -681,7 +681,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             },
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/{componentId}/attachments/{attachmentId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @GetMapping(value = COMPONENTS_URL + "/{componentId}/attachments/{attachmentId}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void downloadAttachmentFromComponent(
             @Parameter(description = "The id of the component.")
             @PathVariable("componentId") String componentId,
@@ -843,7 +843,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all components associated to the user.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/mycomponents", method = RequestMethod.GET)
+    @GetMapping(value = COMPONENTS_URL + "/mycomponents")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getMyComponents(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -1031,7 +1031,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             },
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/import/SBOM", method = RequestMethod.POST, consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = COMPONENTS_URL + "/import/SBOM", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> importSBOM(
             @Parameter(description = "Type of SBOM being uploaded.",
                     schema = @Schema(type = "string", allowableValues = {"SPDX"})
@@ -1085,7 +1085,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             },
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/prepareImport/SBOM", method = RequestMethod.POST, consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = COMPONENTS_URL + "/prepareImport/SBOM", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> prepareImportSBOM(
             @Parameter(description = "Type of SBOM being uploaded.",
                     schema = @Schema(type = "string", allowableValues = {"SPDX"})
@@ -1132,7 +1132,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Merge source component into target component.",
             tags = {"Components"}
     )
-    @RequestMapping(value = COMPONENTS_URL + "/mergecomponents", method = RequestMethod.PATCH)
+    @PatchMapping(value = COMPONENTS_URL + "/mergecomponents")
     public ResponseEntity<RequestStatus> mergeComponents(
             @Parameter(description = "The id of the merge target component.")
             @RequestParam(value = "mergeTargetId", required = true) String mergeTargetId,
@@ -1207,7 +1207,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                     )
             }
     )
-    @RequestMapping(value = COMPONENTS_URL + "/splitComponents", method = RequestMethod.PATCH)
+    @PatchMapping(value = COMPONENTS_URL + "/splitComponents")
     public ResponseEntity<RequestStatus> splitComponents(
             @Parameter(description = "Source and target components.",
                     schema = @Schema(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
@@ -36,12 +36,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
@@ -181,7 +179,7 @@ public class SW360ConfigurationsController implements RepresentationModelProcess
                     )
             )
     })
-    @RequestMapping(value = SW360_CONFIG_URL + "/container/{configFor}", method = RequestMethod.GET)
+    @GetMapping(value = SW360_CONFIG_URL + "/container/{configFor}")
     public ResponseEntity<Map<String, String>> getConfigForContainer(
             @Parameter(description = "The container for which the configuration is requested.",
                     required = true, schema = @Schema(
@@ -247,9 +245,10 @@ public class SW360ConfigurationsController implements RepresentationModelProcess
                     )
             )
     })
-    @RequestMapping(value = SW360_CONFIG_URL + "/container/{configFor}",
-            method = RequestMethod.PATCH,
-            consumes = {MediaType.APPLICATION_JSON_VALUE})
+    @PatchMapping(
+            value = SW360_CONFIG_URL + "/container/{configFor}",
+            consumes = {MediaType.APPLICATION_JSON_VALUE}
+    )
     public ResponseEntity<?> updateSW360ConfigurationsForContainer(
             @Parameter(description = "The container for which the configuration is requested.",
                     required = true, schema = @Schema(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/DatabaseSanitationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/DatabaseSanitationController.java
@@ -30,8 +30,7 @@ import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -88,7 +87,7 @@ public class DatabaseSanitationController  implements RepresentationModelProcess
             @ApiResponse(responseCode = "403", description = "User is not Admin."),
             @ApiResponse(responseCode = "500", description = "Internal server error."),
     })
-    @RequestMapping(value = DATABASESANITATION_URL + "/searchDuplicate", method = RequestMethod.GET)
+    @GetMapping(value = DATABASESANITATION_URL + "/searchDuplicate")
     public ResponseEntity<Map<String, Map<String, List<String>>>> searchDuplicateIdentifiers()throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Map<String, Map<String, List<String>>> resource = dataSanitationService.duplicateIdentifiers(sw360User);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
@@ -34,9 +34,10 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -72,7 +73,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Manually active the service.",
             tags = {"Departments"}
     )
-    @RequestMapping(value = DEPARTMENT_URL + "/manuallyactive", method = RequestMethod.POST)
+    @PostMapping(value = DEPARTMENT_URL + "/manuallyactive")
     public ResponseEntity<RequestSummary> importDepartmentManually() throws SW360Exception {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         return processAction(sw360User);
@@ -92,7 +93,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Schedule import.",
             tags = {"Departments"}
     )
-    @RequestMapping(value = DEPARTMENT_URL + "/scheduleImport", method = RequestMethod.POST)
+    @PostMapping(value = DEPARTMENT_URL + "/scheduleImport")
     public ResponseEntity<Map<String, String>> scheduleImportDepartment() throws SW360Exception {
         try {
             User user = restControllerHelper.getSw360UserFromAuthentication();
@@ -121,7 +122,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
     @Operation(summary = "Unschedule Department Import",
             description = "Cancels the scheduled import task for the department.",
             tags = {"Departments"})
-    @RequestMapping(value = DEPARTMENT_URL + "/unscheduleImport", method = RequestMethod.POST)
+    @PostMapping(value = DEPARTMENT_URL + "/unscheduleImport")
     public ResponseEntity<Map<String, String>> unScheduleImportDepartment() throws SW360Exception {
 
         try {
@@ -144,7 +145,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Updates the department folder path configuration.",
             tags = {"Departments"}
     )
-    @RequestMapping(value = DEPARTMENT_URL + "/writePathFolder", method = RequestMethod.POST)
+    @PostMapping(value = DEPARTMENT_URL + "/writePathFolder")
     public ResponseEntity<String> updatePath(
             @Parameter(description = "The path of the folder")
             @RequestParam String pathFolder
@@ -163,7 +164,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Get information about importing the department (import path folder, interval, last run time, next run time, and whether the scheduler is started or not)",
             tags = {"Departments"}
     )
-    @RequestMapping(value = DEPARTMENT_URL + "/importInformation", method = RequestMethod.GET)
+    @GetMapping(value = DEPARTMENT_URL + "/importInformation")
     public ResponseEntity<Map<String, Object>> getImportInformation() throws TException {
         final User user = restControllerHelper.getSw360UserFromAuthentication();
         return new ResponseEntity<>(departmentService.getImportInformation(user), HttpStatus.OK);
@@ -174,7 +175,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Get log file list",
             tags = {"Departments"}
     )
-    @RequestMapping(value = DEPARTMENT_URL + "/logFiles", method = RequestMethod.GET)
+    @GetMapping(value = DEPARTMENT_URL + "/logFiles")
     public ResponseEntity<Set<String>> getLogFileList() throws TException {
         return new ResponseEntity<>(departmentService.getLogFileList(), HttpStatus.OK);
     }
@@ -184,7 +185,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Get log file content by date",
             tags = {"Departments"}
     )
-    @RequestMapping(value = DEPARTMENT_URL + "/logFileContent", method = RequestMethod.GET)
+    @GetMapping(value = DEPARTMENT_URL + "/logFileContent")
     public ResponseEntity<List<String>> getLogFileContentByDate(
             @RequestParam(value = "date") String date
     ) throws TException {
@@ -193,7 +194,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
 
     @Operation(summary = "Fetch a list of members' emails from each department.",
             description = "Fetch a list of members' emails from each department.", tags = {"Users"})
-    @RequestMapping(value = DEPARTMENT_URL + "/members", method = RequestMethod.GET)
+    @GetMapping(value = DEPARTMENT_URL + "/members")
     public ResponseEntity<Map<String, List<String>>> getMembersEmailsOfSecondaryDepartments(
             @Parameter(description = "departmentName") @RequestParam(value = "departmentName", required = false) String departmentName
     ) {
@@ -205,7 +206,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
 
     @Operation(summary = "Update members of a secondary department.",
             description = "Update members of a secondary department.", tags = {"Users"})
-    @RequestMapping(value = DEPARTMENT_URL + "/members", method = RequestMethod.PATCH)
+    @PatchMapping(value = DEPARTMENT_URL + "/members")
     public ResponseEntity<Map<String, List<String>>> updateMembersOfSecondaryDepartment(
             @Parameter(description = "Department name") @RequestParam(value = "departmentName", required = false) String departmentName,
             @Parameter(description = "New email list of members in department") @RequestBody List<String> emailsList

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
@@ -41,8 +41,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -203,9 +202,11 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
                     @Parameter(name = "Content-Type", in = ParameterIn.HEADER, required = true, description = "The content type of the request. Supported values: multipart/mixed or multipart/form-data.")
             }
     )
-    @RequestMapping(value = IMPORTEXPORT_URL + "/uploadComponent", method = RequestMethod.POST, consumes = {
-            MediaType.MULTIPART_MIXED_VALUE,
-            MediaType.MULTIPART_FORM_DATA_VALUE }, produces = { MediaType.APPLICATION_JSON_VALUE })
+    @PostMapping(
+            value = IMPORTEXPORT_URL + "/uploadComponent",
+            consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE}
+    )
     public ResponseEntity<RequestSummary> uploadComponentCsv(
             @Parameter(description = "The component csv file to be uploaded.")
             @RequestParam("componentFile") MultipartFile file,
@@ -225,9 +226,11 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
                     @Parameter(name = "Content-Type", in = ParameterIn.HEADER, required = true,  description = "The content type of the request. Supported values: multipart/mixed or multipart/form-data."),
             }
     )
-    @RequestMapping(value = IMPORTEXPORT_URL + "/uploadRelease", method = RequestMethod.POST, consumes = {
-            MediaType.MULTIPART_MIXED_VALUE,
-            MediaType.MULTIPART_FORM_DATA_VALUE }, produces = { MediaType.APPLICATION_JSON_VALUE })
+    @PostMapping(
+            value = IMPORTEXPORT_URL + "/uploadRelease",
+            consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE}
+    )
     public ResponseEntity<RequestSummary> uploadReleaseCsv(
             @Parameter(description = "The release csv file to be uploaded.")
             @RequestParam("releaseFile") MultipartFile file,
@@ -247,9 +250,11 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
                     @Parameter(name = "Content-Type", in = ParameterIn.HEADER, required = true,  description = "The content type of the request. Supported values: multipart/mixed or multipart/form-data."),
             }
     )
-    @RequestMapping(value = IMPORTEXPORT_URL + "/componentAttachment", method = RequestMethod.POST, consumes = {
-            MediaType.MULTIPART_MIXED_VALUE,
-            MediaType.MULTIPART_FORM_DATA_VALUE }, produces = { MediaType.APPLICATION_JSON_VALUE })
+    @PostMapping(
+            value = IMPORTEXPORT_URL + "/componentAttachment",
+            consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE}
+    )
     public ResponseEntity<RequestSummary> uploadComponentAttachment(
             @Parameter(description = "The component attachment csv file to be uploaded.")
             @RequestParam("attachmentFile") MultipartFile file,
@@ -270,7 +275,7 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = IMPORTEXPORT_URL + "/downloadUsers", method = RequestMethod.GET, produces = { MediaType.TEXT_PLAIN_VALUE })
+    @GetMapping(value = IMPORTEXPORT_URL + "/downloadUsers", produces = {MediaType.TEXT_PLAIN_VALUE})
     public void downloadUsers(HttpServletResponse response) throws SW360Exception {
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -321,9 +326,11 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('ADMIN')")
-    @RequestMapping(value = IMPORTEXPORT_URL + "/usersCsv", method = RequestMethod.POST,
+    @PostMapping(
+            value = IMPORTEXPORT_URL + "/usersCsv",
             consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
-            produces = {MediaType.APPLICATION_JSON_VALUE})
+            produces = {MediaType.APPLICATION_JSON_VALUE}
+    )
     public ResponseEntity<RequestSummary> uploadUsersCsv(
             @Parameter(
                     description = "The users CSV file to be uploaded. " +

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -59,11 +59,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
@@ -107,7 +108,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "List all of the service's licenses. Supports quick filtering.",
             tags = {"Licenses"}
     )
-    @RequestMapping(value = LICENSES_URL, method = RequestMethod.GET)
+    @GetMapping(value = LICENSES_URL)
     public ResponseEntity<CollectionModel<License>> getLicenses(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -147,7 +148,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "List all obligations of a license.",
             tags = {"Licenses"}
     )
-    @RequestMapping(value = LICENSES_URL + "/{id}/obligations", method = RequestMethod.GET)
+    @GetMapping(value = LICENSES_URL + "/{id}/obligations")
     public ResponseEntity<CollectionModel<EntityModel<Obligation>>> getObligationsByLicenseId(
             @PathVariable("id") String id
     ) throws TException {
@@ -168,7 +169,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "List all of the service's licenseTypes.",
             tags = {"Licenses"}
     )
-    @RequestMapping(value = LICENSE_TYPES_URL, method = RequestMethod.GET)
+    @GetMapping(value = LICENSE_TYPES_URL)
     public ResponseEntity<CollectionModel<EntityModel<LicenseType>>> getLicenseTypes(
             @Parameter(description = "The search license type text.")
             @RequestParam(value = "search", required = false) String searchElem) throws TException {
@@ -195,7 +196,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "Get a specific license.",
             tags = {"Licenses"}
     )
-    @RequestMapping(value = LICENSES_URL + "/{id:.+}", method = RequestMethod.GET)
+    @GetMapping(value = LICENSES_URL + "/{id:.+}")
     public ResponseEntity<EntityModel<License>> getLicense(
             @Parameter(description = "The id of the license.")
             @PathVariable("id") String id
@@ -213,7 +214,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/{id:.+}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = LICENSES_URL + "/{id:.+}")
     public ResponseEntity deleteLicense(
             @Parameter(description = "The id of the license.")
             @PathVariable("id") String id
@@ -229,7 +230,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL, method = RequestMethod.POST)
+    @PostMapping(value = LICENSES_URL)
     public ResponseEntity<EntityModel<License>> createLicense(
             @Parameter(description = "The license to be created.")
             @RequestBody License license
@@ -270,7 +271,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
                     description = "Reject license update due to: an already checked license is not allowed" +
                             " to become unchecked again")
     })
-    @RequestMapping(value = LICENSES_URL + "/{id}", method = RequestMethod.PATCH)
+    @PatchMapping(value = LICENSES_URL + "/{id}")
     public ResponseEntity<EntityModel<License>> updateLicense(
             @Parameter(description = "The id of the license.")
             @PathVariable("id") String id,
@@ -312,7 +313,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             ),
             @ApiResponse(responseCode = "500", description = "Update Whitelist to Obligation Fail!")
     })
-    @RequestMapping(value = LICENSES_URL+ "/{id}/whitelist", method = RequestMethod.PATCH)
+    @PatchMapping(value = LICENSES_URL+ "/{id}/whitelist")
     public ResponseEntity<EntityModel<License>> updateWhitelist(
             @Parameter(description = "ID of the license.")
             @PathVariable("id") String licenseId,
@@ -375,7 +376,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             )
     })
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/{id}/obligations", method = RequestMethod.POST)
+    @PostMapping(value = LICENSES_URL + "/{id}/obligations")
     public ResponseEntity linkObligation(
             @Parameter(description = "The id of the license.")
             @PathVariable("id") String id,
@@ -405,7 +406,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             )
     })
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/{id}/obligations", method = RequestMethod.PATCH)
+    @PatchMapping(value = LICENSES_URL + "/{id}/obligations")
     public ResponseEntity unlinkObligation(
             @Parameter(description = "The id of the license.")
             @PathVariable("id") String id,
@@ -460,7 +461,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/deleteAll", method = RequestMethod.DELETE)
+    @DeleteMapping(value = LICENSES_URL + "/deleteAll")
     public ResponseEntity deleteAllLicense() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         licenseService.deleteAllLicenseInfo(sw360User);
@@ -473,7 +474,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/import/SPDX", method = RequestMethod.POST)
+    @PostMapping(value = LICENSES_URL + "/import/SPDX")
     public ResponseEntity<RequestSummary> importSPDX() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = licenseService.importSpdxInformation(sw360User);
@@ -491,7 +492,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/downloadLicenses", method = RequestMethod.GET, produces = "application/zip")
+    @GetMapping(value = LICENSES_URL + "/downloadLicenses", produces = "application/zip")
     public void downloadLicenseArchive(
             HttpServletRequest request,
             HttpServletResponse response
@@ -507,7 +508,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "Upload license archive.",
             tags = {"Licenses"}
     )
-    @RequestMapping(value = LICENSES_URL + "/upload", method = RequestMethod.POST, consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = LICENSES_URL + "/upload", consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> uploadLicenses(
             @Parameter(description = "The license archive file to be uploaded.")
             @RequestParam("licenseFile") MultipartFile file,
@@ -532,7 +533,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSES_URL + "/import/OSADL", method = RequestMethod.POST)
+    @PostMapping(value = LICENSES_URL + "/import/OSADL")
     public ResponseEntity<RequestSummary> importOsadlInfo() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = licenseService.importOsadlInformation(sw360User);
@@ -557,7 +558,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
                     }
             )
     })
-    @RequestMapping(value = LICENSES_URL + "/addLicenseType", method = RequestMethod.POST)
+    @PostMapping(value = LICENSES_URL + "/addLicenseType")
     public ResponseEntity<RequestStatus> createLicenseType(
             @Parameter(description = "The license type name.")
             @RequestParam(value = "licenseType", required = true) String licenseType,
@@ -603,7 +604,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = LICENSE_TYPES_URL + "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = LICENSE_TYPES_URL + "/{id}")
     public ResponseEntity deleteLicenseType(
             @Parameter(description = "The id of the license type.")
             @PathVariable("id") String id

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -114,7 +114,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             description = "List all of the service's moderation requests.",
             tags = {"Moderation Requests"}
     )
-    @RequestMapping(value = MODERATION_REQUEST_URL, method = RequestMethod.GET)
+    @GetMapping(value = MODERATION_REQUEST_URL)
     public ResponseEntity<CollectionModel<ModerationRequest>> getModerationRequests(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -140,7 +140,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             description = "Get a single moderation request by id.",
             tags = {"Moderation Requests"}
     )
-    @RequestMapping(value = MODERATION_REQUEST_URL + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = MODERATION_REQUEST_URL + "/{id}")
     public ResponseEntity<HalResource<Map<String, Object>>> getModerationRequestById(
             @Parameter(description = "The id of the moderation request to be retrieved.")
             @PathVariable String id
@@ -177,7 +177,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             description = "List all the ModerationRequest visible to the user based on the state and  respond with MR where user is a moderator",
             tags = {"Moderation Requests"}
     )
-    @RequestMapping(value = MODERATION_REQUEST_URL + "/byState", method = RequestMethod.GET)
+    @GetMapping(value = MODERATION_REQUEST_URL + "/byState")
     public ResponseEntity<CollectionModel<ModerationRequest>> getModerationRequestsByState(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -254,7 +254,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
                     )}
             )}
     )
-    @RequestMapping(value = MODERATION_REQUEST_URL + "/{id}", method = RequestMethod.PATCH)
+    @PatchMapping(value = MODERATION_REQUEST_URL + "/{id}")
     public ResponseEntity<HalResource<Map<String, String>>> updateModerationRequestById(
             @Parameter(description = "The id of the moderation request to be updated.")
             @PathVariable String id,
@@ -581,7 +581,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
                 }
             )
         })
-    @RequestMapping(value = MODERATION_REQUEST_URL + "/validate", method = RequestMethod.POST)
+    @PostMapping(value = MODERATION_REQUEST_URL + "/validate")
     public ResponseEntity<String> validateModerationRequest(
             @Parameter(description = "Entity type", example = "PROJECT",
                     schema = @Schema(allowableValues = {"PROJECT", "COMPONENT", "RELEASE"}))
@@ -635,7 +635,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
             tags = {"Moderation Requests"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = MODERATION_REQUEST_URL + "/delete", method = RequestMethod.DELETE)
+    @DeleteMapping(value = MODERATION_REQUEST_URL + "/delete")
     public ResponseEntity<?> deleteModerationRequest(
             @Parameter(description = "List of moderation request IDs to delete")
             @RequestBody List<String> ids

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
@@ -78,7 +78,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "List all of the service's obligations.",
             tags = {"Obligations"}
     )
-    @RequestMapping(value = OBLIGATION_URL, method = RequestMethod.GET)
+    @GetMapping(value = OBLIGATION_URL)
     public ResponseEntity<CollectionModel<EntityModel<Obligation>>> getObligations(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -137,7 +137,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "Get an obligation by id.",
             tags = {"Obligations"}
     )
-    @RequestMapping(value = OBLIGATION_URL + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = OBLIGATION_URL + "/{id}")
     public ResponseEntity<EntityModel<Obligation>> getObligation(
             @Parameter(description = "The id of the obligation to be retrieved.")
             @PathVariable("id") String id
@@ -159,7 +159,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             tags = {"Obligations"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = OBLIGATION_URL, method = RequestMethod.POST)
+    @PostMapping(value = OBLIGATION_URL)
     public ResponseEntity<HalResource<Obligation>> createObligation(
             @Parameter(description = "The obligation to be created.")
             @RequestBody Obligation obligation
@@ -181,7 +181,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             tags = {"Obligations"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = OBLIGATION_URL + "/{ids}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = OBLIGATION_URL + "/{ids}")
     public ResponseEntity<List<MultiStatus>> deleteObligations(
             @Parameter(description = "The ids of the obligations to be deleted.")
             @PathVariable("ids") List<String> idsToDelete
@@ -284,7 +284,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "Get all Obligation Nodes from the server to render Obligations.",
             tags = {"Obligations"}
     )
-    @RequestMapping(value = OBLIGATION_URL + "/nodes", method = RequestMethod.GET)
+    @GetMapping(value = OBLIGATION_URL + "/nodes")
     public ResponseEntity<CollectionModel<ObligationNode>> getObligationNodes() {
         List<ObligationNode> obligationNodes = obligationService.getObligationNodes();
         return new ResponseEntity<>(CollectionModel.of(obligationNodes), HttpStatus.OK);
@@ -295,7 +295,7 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "Get all Obligation Elements from the server to render Obligation suggestions.",
             tags = {"Obligations"}
     )
-    @RequestMapping(value = OBLIGATION_URL + "/elements", method = RequestMethod.GET)
+    @GetMapping(value = OBLIGATION_URL + "/elements")
     public ResponseEntity<CollectionModel<ObligationElement>> getObligationElements() {
         List<ObligationElement> obligationNodes = obligationService.getObligationElements();
         return new ResponseEntity<>(CollectionModel.of(obligationNodes), HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
@@ -109,7 +109,7 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             tags = {"Packages"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = PACKAGES_URL, method = RequestMethod.POST)
+    @PostMapping(value = PACKAGES_URL)
     public ResponseEntity<EntityModel<Package>> createPackage(
             @Parameter(description = "The package to be created.",
                     schema = @Schema(implementation = Package.class))
@@ -175,7 +175,7 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             tags = {"Packages"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = PACKAGES_URL + "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = PACKAGES_URL + "/{id}")
     public ResponseEntity<?> deletePackage(
             @Parameter(description = "The id of the package to be deleted.")
             @PathVariable("id") String id
@@ -449,7 +449,7 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             }
     )
 
-    @RequestMapping(value = PACKAGES_URL + "/{id}/usage", method = RequestMethod.GET)
+    @GetMapping(value = PACKAGES_URL + "/{id}/usage")
     public ResponseEntity<Map<String, Object>> getPackageUsageInfo(
             @Parameter(description = "The id of the package to check usage for")
             @PathVariable("id") String id

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -135,10 +135,12 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -247,7 +249,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "List all of the service's projects with various filters.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL, method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL)
     public ResponseEntity<CollectionModel<EntityModel<Project>>> getProjectsForUser(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -385,7 +387,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "List all projects associated to the user.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/myprojects", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/myprojects")
     public ResponseEntity<CollectionModel<EntityModel<Project>>> getProjectsFilteredForUser(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -442,7 +444,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get all releases of license clearing.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/licenseClearing", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/licenseClearing")
     public ResponseEntity<HalResource<Project>> licenseClearing(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id,
@@ -509,7 +511,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}")
     public ResponseEntity<EntityModel<Project>> getProject(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id
@@ -524,7 +526,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get a package with project id.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/packages", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/packages")
     public ResponseEntity<List<HalResource<Project>>> getPackagesByProjectId(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id
@@ -577,7 +579,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get linked projects of a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/linkedProjects", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/linkedProjects")
     public ResponseEntity<CollectionModel<EntityModel>> getLinkedProject(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -627,7 +629,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get releases of linked projects of a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/linkedProjects/releases", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/linkedProjects/releases")
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getReleasesOfLinkedProject(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id,
@@ -690,7 +692,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = PROJECTS_URL + "/{id}")
     public ResponseEntity deleteProject(
             @Parameter(description = "Project ID")
             @PathVariable("id") String id,
@@ -721,7 +723,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Create a project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL, method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL)
     public ResponseEntity createProject(
             @Parameter(schema = @Schema(implementation = Project.class))
             @RequestBody Map<String, Object> reqBodyMap
@@ -761,7 +763,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Create a duplicate project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/duplicate/{id}", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/duplicate/{id}")
     public ResponseEntity<EntityModel<Project>> createDuplicateProject(
             @Parameter(description = "Project ID to copy.")
             @PathVariable("id") String id,
@@ -802,7 +804,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass an array of release ids to be linked as request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/releases", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/{id}/releases")
     public ResponseEntity linkReleases(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -836,7 +838,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass an array of project ids to be linked as request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/linkProjects", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/{id}/linkProjects")
     public ResponseEntity linkToProjects(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -936,7 +938,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass an array of release ids or a map of release id to usage to be linked as request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/releases", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/releases")
     public ResponseEntity patchReleases(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -975,7 +977,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             },
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/link/packages", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/link/packages")
     public ResponseEntity<?> linkPackages(
             @Parameter(description = "Project ID.", example = "376576")
             @PathVariable("id") String id,
@@ -1013,7 +1015,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             },
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/unlink/packages", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/unlink/packages")
     public ResponseEntity<?> patchPackages(
             @Parameter(description = "Project ID.", example = "376576")
             @PathVariable("id") String id,
@@ -1045,7 +1047,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get releases of a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/releases", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/releases")
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getProjectReleases(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -1094,7 +1096,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get releases of multiple projects.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/releases", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/releases")
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getProjectsReleases(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -1145,7 +1147,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get all releases with ECC information of a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/releases/ecc", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/releases/ecc")
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getECCsOfReleases(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -1190,7 +1192,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             tags = {"Projects"}
     )
 
-    @RequestMapping(value = PROJECTS_URL + "/{id}/vulnerabilitySummary", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/vulnerabilitySummary")
     public ResponseEntity<CollectionModel<EntityModel<VulnerabilitySummary>>> getAllVulnerabilities(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -1283,7 +1285,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get vulnerabilities of a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/vulnerabilities", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/vulnerabilities")
     public ResponseEntity<CollectionModel<EntityModel<VulnerabilityDTO>>> getVulnerabilitiesOfReleases(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -1358,7 +1360,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Patch vulnerabilities of a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/vulnerabilities", method = RequestMethod.PATCH, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/vulnerabilities", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CollectionModel<EntityModel<VulnerabilityDTO>>> updateVulnerabilitiesOfReleases(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -1417,7 +1419,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass a map of release id to usage to be linked as request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/release/{releaseId}", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/release/{releaseId}")
     public ResponseEntity<EntityModel<ProjectReleaseRelationship>> patchProjectReleaseUsage(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -1502,7 +1504,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get license of releases of a single project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/licenses", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/licenses")
     public ResponseEntity<CollectionModel<EntityModel<License>>> getLicensesOfReleases(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id
@@ -1547,7 +1549,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     `DocxGenerator`.""",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/licenseinfo", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/licenseinfo")
     public void downloadLicenseInfo(
             @Parameter(description = "Project ID.", example = "376576")
             @PathVariable("id") String id,
@@ -1671,7 +1673,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get all attachment information of a project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/attachments", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/attachments")
     public ResponseEntity<CollectionModel<EntityModel<Attachment>>> getProjectAttachments(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id
@@ -1688,7 +1690,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Update and attachment usage for project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/attachment/{attachmentId}", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/attachment/{attachmentId}")
     public ResponseEntity<EntityModel<Attachment>> patchProjectAttachmentInfo(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -1723,7 +1725,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             ),
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{projectId}/attachments/{attachmentId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @GetMapping(value = PROJECTS_URL + "/{projectId}/attachments/{attachmentId}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void downloadAttachmentFromProject(
             @Parameter(description = "Project ID.")
             @PathVariable("projectId") String projectId,
@@ -1744,7 +1746,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             ),
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{projectId}/attachments/clearingReports", method = RequestMethod.GET, produces = "application/zip")
+    @GetMapping(value = PROJECTS_URL + "/{projectId}/attachments/clearingReports", produces = "application/zip")
     public void downloadClearingReports(
             @Parameter(description = "Project ID.")
             @PathVariable("projectId") String projectId,
@@ -1777,7 +1779,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Update a project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}")
     public ResponseEntity<EntityModel<Project>> patchProject(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -1821,7 +1823,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Add attachments to a project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{projectId}/attachments", method = RequestMethod.POST, consumes = {"multipart/mixed", "multipart/form-data"})
+    @PostMapping(value = PROJECTS_URL + "/{projectId}/attachments", consumes = {"multipart/mixed", "multipart/form-data"})
     public ResponseEntity<HalResource> addAttachmentToProject(
             @Parameter(description = "Project ID.")
             @PathVariable("projectId") String projectId,
@@ -1938,7 +1940,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     "values). It's possible to search for projects only by the external id key by leaving the value.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/searchByExternalIds", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/searchByExternalIds")
     public ResponseEntity searchByExternalIds(
             @Parameter(description = "External ID map for filter.",
                     example = "{\"project-ext\": \"515432\", \"project-ext\": \"7657\", \"portal-id\": \"13319-XX3\"}"
@@ -1954,7 +1956,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get all the projects where the project is used.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/usedBy/{id}", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/usedBy/{id}")
     public ResponseEntity<CollectionModel<EntityModel<Project>>> getUsedByProjectDetails(
             @Parameter(description = "Project ID to search.")
             @PathVariable("id") String id
@@ -2016,7 +2018,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     }
             )
     })
-    @RequestMapping(value = PROJECTS_URL + "/{id}/saveAttachmentUsages", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/{id}/saveAttachmentUsages")
     public ResponseEntity<?> saveAttachmentUsages(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -2151,7 +2153,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get all attachmentUsages of the projects.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/attachmentUsage", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/attachmentUsage")
     public ResponseEntity attachmentUsages(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -2414,7 +2416,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Import SBOM in SPDX format.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/import/SBOM", method = RequestMethod.POST, consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = PROJECTS_URL + "/import/SBOM", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> importSBOM(
             @Parameter(description = "Type of SBOM", example = "SPDX")
             @RequestParam(value = "type", required = true) String type,
@@ -2495,7 +2497,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             },
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/import/SBOM", method = RequestMethod.POST, consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = PROJECTS_URL + "/{id}/import/SBOM", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> importSBOMonProject(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable(value = "id", required = true) String id,
@@ -2565,7 +2567,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             },
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/{id}", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/network/{id}")
     public ResponseEntity<?> getProjectWithNetwork(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id
@@ -2585,7 +2587,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             summary = "Create a project with dependencies network.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL+ "/network", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL+ "/network")
     public ResponseEntity createProjectWithNetwork(
             @Parameter(description = "Project with `dependencyNetwork` set.",
                     schema = @Schema(implementation = Project.class))
@@ -2624,7 +2626,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             summary = "Update a project with dependencies network.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/{id}", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/network/{id}")
     public ResponseEntity<?> patchProjectWithNetwork(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id,
@@ -2900,7 +2902,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get project count of a user.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/projectcount", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/projectcount")
     public void getUserProjectCount(HttpServletResponse response) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         try {
@@ -2917,7 +2919,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get the default license info header text.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/licenseInfoHeader", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/licenseInfoHeader")
     public void getLicenseInfoheaderText(HttpServletResponse response) throws TException {
         try {
             response.setContentType("application/json; charset=UTF-8");
@@ -2935,7 +2937,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get license clearing info for a project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/licenseClearingCount", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/licenseClearingCount")
     public void getlicenseClearingCount(
             HttpServletResponse response ,
             @Parameter(description = "Project ID", example = "376521")
@@ -2964,7 +2966,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     "This is more efficient than calling the single project endpoint multiple times.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/licenseClearingCount", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/licenseClearingCount")
     public void getBatchLicenseClearingCount(
             HttpServletResponse response,
             @Parameter(description = "List of project IDs")
@@ -3004,7 +3006,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     "at Administration tab of project detail page.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/clearingDetailsCount", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/clearingDetailsCount")
     public void getlicenseClearingDetailsCount(
             HttpServletResponse response ,
             @Parameter(description = "Project ID", example = "376521")
@@ -3037,7 +3039,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get license obligations data from license database.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/licenseDbObligations", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/licenseDbObligations")
     public ResponseEntity<?> getLicObligations(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -3095,7 +3097,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass an array of orphan obligation titles in request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/orphanObligation", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/orphanObligation")
     public ResponseEntity<?> removeOrphanObligation(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String id,
@@ -3131,7 +3133,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get license obligation data of project tab.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/licenseObligations", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/licenseObligations")
     public ResponseEntity<Object> getLicenseObligations(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -3200,7 +3202,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get obligation data of project tab.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/obligation", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/obligation")
     public ResponseEntity<HalResource> getObligations(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -3285,7 +3287,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass an array of obligation ids in request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/licenseObligation", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/{id}/licenseObligation")
     public ResponseEntity<?> addLicenseObligations(
             @Parameter(description = "License Obligation ID.")
             @PathVariable("id") String id,
@@ -3345,7 +3347,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass a map of obligations in request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/updateLicenseObligation", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/updateLicenseObligation")
     public ResponseEntity<?> patchLicenseObligations(
             @Parameter(description = "Project ID") @PathVariable("id") String id,
             @Parameter(description = "Map of obligation status info")
@@ -3497,7 +3499,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Pass a map of obligations in request body.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/updateObligation", method = RequestMethod.PATCH)
+    @PatchMapping(value = PROJECTS_URL + "/{id}/updateObligation")
     public ResponseEntity<?> patchObligations(
             @Parameter(description = "Project ID") @PathVariable("id") String id,
             @Parameter(description = "Map of obligation status info")
@@ -3587,7 +3589,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get summary and administration page of project tab.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/summaryAdministration", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/summaryAdministration")
     public ResponseEntity<EntityModel<Project>> getAdministration(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id
@@ -3617,7 +3619,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             summary = "Get a list view of dependency network for a project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/{id}/listView", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/network/{id}/listView")
     public ResponseEntity<?> getListViewDependencyNetwork(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String projectId
@@ -3635,7 +3637,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get linked resources (projects, releases) of a project",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/{id}/linkedResources", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/network/{id}/linkedResources")
     public ResponseEntity<ProjectLink> getLinkedResourcesOfProjectForDependencyNetwork(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id,
@@ -3654,7 +3656,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get indirect linked releases of a project in dependency network by release's index path",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/{id}/releases", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/network/{id}/releases")
     public ResponseEntity<CollectionModel<ReleaseLink>> getLinkedReleasesInDependencyNetworkByIndexPath(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String projectId,
@@ -3898,7 +3900,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             summary = "Create a clearing request for a project.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/clearingRequest", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/{id}/clearingRequest")
     public ResponseEntity<?> createClearingRequest(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String id,
@@ -3961,7 +3963,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get linked releases information in project's dependency network.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/{id}/linkedReleases", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/network/{id}/linkedReleases")
     public ResponseEntity<?> getLinkedReleasesInNetwork(
             @Parameter(description = "Project ID.")
             @PathVariable("id") String projectId
@@ -3978,7 +3980,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get linked releases information of linked projects.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/subProjects/releases", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/{id}/subProjects/releases")
     public ResponseEntity<?> getLinkedReleasesOfLinkedProjects(
             @Parameter(description = "Project ID.") @PathVariable("id") String projectId
     ) throws TException {
@@ -3995,7 +3997,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Compare dependency network with default network (relationships between releases).",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/compareDefaultNetwork", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/network/compareDefaultNetwork")
     public ResponseEntity<?> compareDependencyNetworkWithDefaultNetwork(
             @RequestBody List<ReleaseNode> dependencyNetwork
     ) throws SW360Exception {
@@ -4016,7 +4018,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Create a duplicate project with dependency network.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/network/duplicate/{id}", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/network/duplicate/{id}")
     public ResponseEntity<?> createDuplicateProjectWithDependencyNetwork(
             @Parameter(description = "Project ID to copy.")
             @PathVariable("id") String id,
@@ -4123,7 +4125,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = PROJECTS_URL + "/{id}/addLinkedReleasesLicenses", method = RequestMethod.POST)
+    @PostMapping(value = PROJECTS_URL + "/{id}/addLinkedReleasesLicenses")
     public ResponseEntity<HalResource<EntityModel<Map<String, List<String>>>>> addLicenseToLinkedReleases(
             @Parameter(description = "Project ID", example = "376576")
             @PathVariable("id") String projectId
@@ -4168,7 +4170,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Get all the unique groups used by projects.",
             tags = {"Projects"}
     )
-    @RequestMapping(value = PROJECTS_URL + "/groups", method = RequestMethod.GET)
+    @GetMapping(value = PROJECTS_URL + "/groups")
     public Set<String> getAllProjectGroups() {
         Set<String> groups;
         try {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -371,7 +371,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             description = "Get all the resources where the release is used.",
             tags = {"Releases"}
     )
-    @RequestMapping(value = RELEASES_URL + "/usedBy" + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/usedBy" + "/{id}")
     public ResponseEntity<CollectionModel<EntityModel>> getUsedByResourceDetails(@PathVariable("id") String id)
             throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication(); // Project
@@ -879,7 +879,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/checkFossologyProcessStatus", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/{id}/checkFossologyProcessStatus")
     public ResponseEntity<Map<String, Object>> checkFossologyProcessStatus(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String releaseId
@@ -947,7 +947,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/triggerFossologyProcess", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/{id}/triggerFossologyProcess")
     public ResponseEntity<HalResource> triggerFossologyProcess(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String releaseId,
@@ -1037,7 +1037,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/reloadFossologyReport", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/{id}/reloadFossologyReport")
     public ResponseEntity<HalResource> triggerReloadFossologyReport(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String releaseId
@@ -1121,7 +1121,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = RELEASES_URL + "/{id}/releases", method = RequestMethod.POST)
+    @PostMapping(value = RELEASES_URL + "/{id}/releases")
     public ResponseEntity linkReleases(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String id,
@@ -1174,7 +1174,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/link/packages", method = RequestMethod.PATCH)
+    @PatchMapping(value = RELEASES_URL + "/{id}/link/packages")
     public ResponseEntity<?> linkPackages(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String id,
@@ -1215,7 +1215,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/unlink/packages", method = RequestMethod.PATCH)
+    @PatchMapping(value = RELEASES_URL + "/{id}/unlink/packages")
     public ResponseEntity<?> unlinkPackages(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String id,
@@ -1248,7 +1248,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/linkedPackages", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/{id}/linkedPackages")
     public ResponseEntity<CollectionModel<EntityModel<Package>>> getLinkedPackages(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String id,
@@ -1681,7 +1681,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/checkCyclicLink", method = RequestMethod.POST)
+    @PostMapping(value = RELEASES_URL + "/{id}/checkCyclicLink")
     public ResponseEntity<?> checkForCyclicReleaseLink(
             @Parameter(description = "The ID of the checking release.")
             @PathVariable("id") String releaseId,
@@ -1930,7 +1930,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/licenseData/{attachContentId}", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/{id}/licenseData/{attachContentId}")
     public ResponseEntity<List<Map<String,String>>> getReleaseLicenseInfo(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String relId,
@@ -2006,7 +2006,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
 
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/licenseFileList", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/{id}/licenseFileList")
     public ResponseEntity<Map<String, Object>> getReleaseLicenseFileList(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String relId,
@@ -2026,7 +2026,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             description = "Merge source release into target release.",
             tags = {"Releases"}
     )
-    @RequestMapping(value = RELEASES_URL + "/mergereleases", method = RequestMethod.PATCH)
+    @PatchMapping(value = RELEASES_URL + "/mergereleases")
     public ResponseEntity<RequestStatus> mergeReleases(
             @Parameter(description = "The id of the merge target release.")
             @RequestParam(value = "mergeTargetId", required = true) String mergeTargetId,
@@ -2094,7 +2094,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
 
             }
     )
-    @RequestMapping(value = RELEASES_URL + "/{id}/usageInformationForMerge", method = RequestMethod.GET)
+    @GetMapping(value = RELEASES_URL + "/{id}/usageInformationForMerge")
     public ResponseEntity<Map<String, Object>> getUsageInformationForReleaseMerge(
             @Parameter(description = "The ID of the release.")
             @PathVariable("id") String releaseId

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -400,7 +400,7 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                             schema = @Schema(implementation = String.class,
                                     example = "Service name is required"))),
     })
-    @RequestMapping(value = SCHEDULE_URL + "/status", method = RequestMethod.GET)
+    @GetMapping(value = SCHEDULE_URL + "/status")
     public ResponseEntity<Map<String, Object>> checkServiceStatus(
             @Parameter(description = "Name of the service")
             @RequestParam(value = "serviceName", required = true) String serviceName
@@ -432,7 +432,7 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                             schema = @Schema(implementation = Boolean.class,
                                     example = "true")))
     })
-    @RequestMapping(value = SCHEDULE_URL + "/isAnyServiceScheduled", method = RequestMethod.GET)
+    @GetMapping(value = SCHEDULE_URL + "/isAnyServiceScheduled")
     public ResponseEntity<Boolean> isAnyServiceScheduled() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         boolean isAnyServiceScheduled = scheduleService.isAnyServiceScheduled(sw360User) == RequestStatus.SUCCESS;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
@@ -43,8 +43,7 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.NonNull;
@@ -76,7 +75,7 @@ public class SearchController implements RepresentationModelProcessor<Repository
                 "Name for Project, Component and Release, Fullname for License, User and Vendor, Title for Obligation",
             tags = {"Search"}
     )
-    @RequestMapping(value = SEARCH_URL, method = RequestMethod.GET)
+    @GetMapping(value = SEARCH_URL)
     public ResponseEntity<CollectionModel<EntityModel<SearchResult>>> getSearchResult(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -107,7 +107,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
 
     @Operation(summary = "List all of the service's users.",
             description = "List all of the service's users.", tags = {"Users"})
-    @RequestMapping(value = USERS_URL, method = RequestMethod.GET)
+    @GetMapping(value = USERS_URL)
     public ResponseEntity<CollectionModel<EntityModel<User>>> getUsers(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
@@ -170,7 +170,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     // for compatibility with older version of the REST API
     @Operation(summary = "Get a single user.", description = "Get a single user by email.",
             tags = {"Users"})
-    @RequestMapping(value = USERS_URL + "/{email:.+}", method = RequestMethod.GET)
+    @GetMapping(value = USERS_URL + "/{email:.+}")
     public ResponseEntity<EntityModel<User>> getUserByEmail(
             @Parameter(description = "The email of the user to be retrieved.")
             @PathVariable("email") String email
@@ -187,7 +187,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     // getUserByEmail())
     @Operation(summary = "Get a single user.", description = "Get a single user by id.",
             tags = {"Users"})
-    @RequestMapping(value = USERS_URL + "/byid/{id:.+}", method = RequestMethod.GET)
+    @GetMapping(value = USERS_URL + "/byid/{id:.+}")
     public ResponseEntity<EntityModel<User>> getUser(
             @Parameter(description = "The id of the user to be retrieved.")
             @PathVariable("id") String id
@@ -272,7 +272,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             description = "List all of rest api tokens of current user.",
             responses = {@ApiResponse(responseCode = "200", description = "List of tokens.")},
             tags = {"Users"})
-    @RequestMapping(value = USERS_URL + "/tokens", method = RequestMethod.GET)
+    @GetMapping(value = USERS_URL + "/tokens")
     public ResponseEntity<CollectionModel<EntityModel<RestApiToken>>> getUserRestApiTokens() {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         List<RestApiToken> restApiTokens = sw360User.getRestApiTokens();
@@ -294,7 +294,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
                     @ApiResponse(responseCode = "500", description = "Create token failure.")
             },
             tags = {"Users"})
-    @RequestMapping(value = USERS_URL + "/tokens", method = RequestMethod.POST)
+    @PostMapping(value = USERS_URL + "/tokens")
     public ResponseEntity<String> createUserRestApiToken(
             @Parameter(description = "Token request",
                     schema = @Schema(
@@ -333,7 +333,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
                     @ApiResponse(responseCode = "204", description = "Revoke token successfully."),
                     @ApiResponse(responseCode = "404", description = "Token name not found.")},
             tags = {"Users"})
-    @RequestMapping(value = USERS_URL + "/tokens", method = RequestMethod.DELETE)
+    @DeleteMapping(value = USERS_URL + "/tokens")
     public ResponseEntity<String> revokeUserRestApiToken(
             @Parameter(description = "Name of token to be revoked.",
                     example = "MyToken")
@@ -370,7 +370,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
                                 "secondaryGrpList": ["DEPARTMENT1","DEPARTMENT2"]
                             }
                             """))})})
-    @RequestMapping(value = USERS_URL + "/groupList", method = RequestMethod.GET)
+    @GetMapping(value = USERS_URL + "/groupList")
     public ResponseEntity<Map<String, List<String>>> getGroupList() {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         List<String> primaryGrpList = new ArrayList<>();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -84,7 +84,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
             description = "List all of the service's vendors.",
             tags = {"Vendor"}
     )
-    @RequestMapping(value = VENDORS_URL, method = RequestMethod.GET)
+    @GetMapping(value = VENDORS_URL)
     public ResponseEntity<CollectionModel<EntityModel<Vendor>>> getVendors(
             @Parameter(description = "Search text")
             @RequestParam(value = "searchText", required = false) String searchText,
@@ -136,7 +136,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
             description = "Get a single vendor by id.",
             tags = {"Vendor"}
     )
-    @RequestMapping(value = VENDORS_URL + "/{id}", method = RequestMethod.GET)
+    @GetMapping(value = VENDORS_URL + "/{id}")
     public ResponseEntity<EntityModel<Vendor>> getVendor(
             @Parameter(description = "The id of the vendor to get.")
             @PathVariable("id") String id
@@ -153,7 +153,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
             description = "Get the releases by vendor id.",
             tags = {"Vendor"}
     )
-    @RequestMapping(value = VENDORS_URL + "/{id}/releases", method = RequestMethod.GET)
+    @GetMapping(value = VENDORS_URL + "/{id}/releases")
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getReleases(
             @Parameter(description = "The id of the vendor to get.")
             @PathVariable("id") String id
@@ -184,7 +184,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
             description = "Delete vendor by id.",
             tags = {"Vendor"}
     )
-    @RequestMapping(value = VENDORS_URL + "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = VENDORS_URL + "/{id}")
     public ResponseEntity<?> deleteVendor(
             @Parameter(description = "The id of the vendor to be deleted.")
             @PathVariable("id") String id
@@ -207,7 +207,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
             tags = {"Vendor"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = VENDORS_URL, method = RequestMethod.POST)
+    @PostMapping(value = VENDORS_URL)
     public ResponseEntity<?> createVendor(
             @Parameter(description = "The vendor to be created.")
             @RequestBody Vendor vendor
@@ -254,7 +254,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
             )
     })
     @PreAuthorize("hasAuthority('WRITE')")
-    @RequestMapping(value = VENDORS_URL + "/{id}", method = RequestMethod.PATCH)
+    @PatchMapping(value = VENDORS_URL + "/{id}")
     public ResponseEntity<?> updateVendor(
             @Parameter(description = "The id of the vendor")
             @PathVariable("id") String id,
@@ -347,7 +347,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
             },
             tags = {"Vendor"}
     )
-    @RequestMapping(value = VENDORS_URL + "/mergeVendors", method = RequestMethod.PATCH)
+    @PatchMapping(value = VENDORS_URL + "/mergeVendors")
     public ResponseEntity<RequestStatus> mergeVendors(
             @Parameter(description = "The id of the merge target vendor.")
             @RequestParam(value = "mergeTargetId", required = true) String mergeTargetId,


### PR DESCRIPTION
Fixes https://github.com/eclipse-sw360/sw360/issues/3683

This PR modernizes Spring MVC endpoint annotations by migrating legacy `@RequestMapping(..., method = RequestMethod.X)` usages to the composed annotations (`@GetMapping`, `@PostMapping`, `@PatchMapping`, `@DeleteMapping`) across the codebase. The intent is **pure refactor / no functional change**: all existing mapping attributes (path/value, `produces`, `consumes`, etc.) are kept identical.

Issue: `#3683`  
This addresses the issue by making controller mappings consistent with the project’s Spring Boot 3 / Spring 6 baseline and improving readability/maintainability (HTTP method is explicit in the annotation, less boilerplate).

### Suggest Reviewer
@KoukiHama @GMishx @arunazhakesan @ag4ums 

### How To Test?
- Compile to ensure no annotation/import issues:


### Reviewers should know
- This is a **mechanical refactor** only: endpoints, paths, and content negotiation are preserved.
- Any `@RequestMapping` that did more than specify a single HTTP method was **not** changed (only the `method = RequestMethod.X` style was migrated).