### PR TITLE
fix(CDXImporter): Do not remove valid URL string after .git

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/common/utils/RepositoryURL.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/utils/RepositoryURL.java
@@ -38,7 +38,8 @@ public class RepositoryURL {
 
         List<String> extractedParams = new ArrayList<>();
         for (int i = 3; i < urlParts.length && extractedParams.size() < paramCount; i++) {
-            String part = urlParts[i].replaceAll("\\.git.*|#.*", "");
+            String part = urlParts[i];
+            if(i == urlParts.length-1) part = part.replaceAll("\\.git.*|#.*", "");
 
             if (part.equals("+") || part.equals("-") || CommonUtils.isNullEmptyOrWhitespace(part)) {
                 break;


### PR DESCRIPTION
**Description**

- The current importer sanitizes a VCS URL by removing any content after .git or #, assuming it represents query parameters or unnecessary information.
- This logic should be applied only to the final segment of the URL.