### PR TITLE
docs: correct install-thrift.sh path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you can't install thrift 0.20 runtime, you will need the following requiremen
 Then run the current build script:
 
 ```bash
-./scripts/install-thrift.sh
+./third-party/thrift/install-thrift.sh
 ```
 
 #### Local Building


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Issue: 
When building the project locally I didn't find the "install-thrift.sh" script file in "./scripts" directory as mentioned in the README.

I noticed that the script file is now in "./third-party/thrift" directory, so I modified the README with the new path.

### Suggest Reviewer
@GMishx @amritkv 

### How To Test?
This is a documentation-only change.
Reviewers can verify the update by reading the Development section in README.
No additional tests were required.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
