### PR TITLE
refactor: replace @Autowired field/method injection with constructor …

### DIFF
--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
@@ -71,7 +70,6 @@ public class FossologyHandler implements FossologyService.Iface {
 
     boolean reportStep = false;
 
-    @Autowired
     public FossologyHandler(ThriftClients thriftClients, FossologyRestConfig fossologyRestConfig,
             FossologyRestClient fossologyRestClient, AttachmentConnector attachmentConnector) {
         this.thriftClients = thriftClients;

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyServlet.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyServlet.java
@@ -11,7 +11,6 @@ package org.eclipse.sw360.fossology;
 
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.apache.thrift.protocol.TCompactProtocol;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -25,7 +24,6 @@ import java.net.MalformedURLException;
 @Controller
 public class FossologyServlet extends SpringTServlet {
 
-    @Autowired
     public FossologyServlet(FossologyHandler fossologyHandler) throws MalformedURLException {
         // Create a service processor using the provided handler
         super(new FossologyService.Processor<>(fossologyHandler), new TCompactProtocol.Factory());

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyRestConfig.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyRestConfig.java
@@ -17,7 +17,6 @@ import org.eclipse.sw360.datahandler.thrift.ConfigFor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.net.MalformedURLException;
@@ -52,7 +51,6 @@ public class FossologyRestConfig {
 
     private static final String BASEURL_VERSION_SUFFIX = "/api/v2";
 
-    @Autowired
     public FossologyRestConfig(ConfigContainerRepository repository) throws SW360Exception {
         this.repository = repository;
         // eager loading (or initial insert)

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
@@ -21,7 +21,6 @@ import org.eclipse.sw360.fossology.rest.model.FossologyV2Models.CombinedUploadJo
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -92,7 +91,6 @@ public class FossologyRestClient {
 
     private final String expectedVersionPrefix = "2.";
 
-    @Autowired
     public FossologyRestClient(ObjectMapper objectMapper, FossologyRestConfig restConfig, RestTemplate restTemplate) {
         this.objectMapper = objectMapper;
         this.restConfig = restConfig;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -21,7 +21,6 @@ import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -57,11 +56,14 @@ public class OAuthClientController {
     @Value("${security.oauth2.resource.id}")
     private String resourceId;
 
-    @Autowired
-    private KeyManager keyManager;
+    private final KeyManager keyManager;
 
-    @Autowired
-    private OAuthClientRepository repo;
+    private final OAuthClientRepository repo;
+
+    public OAuthClientController(KeyManager keyManager, OAuthClientRepository repo) {
+        this.keyManager = keyManager;
+        this.repo = repo;
+    }
 
     @GetMapping(path = "")
     public ResponseEntity<List<OAuthClientResource>> getAllClients() {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
@@ -32,8 +31,11 @@ public class Sw360ClientDetailsService implements RegisteredClientRepository {
     @Value("${security.accesstoken.validity}")
     private Integer accessTokenValidity;
 
-    @Autowired
-    private OAuthClientRepository clientRepo;
+    private final OAuthClientRepository clientRepo;
+
+    public Sw360ClientDetailsService(OAuthClientRepository clientRepo) {
+        this.clientRepo = clientRepo;
+    }
 
     @Override
     public RegisteredClient findByClientId(String clientId) {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360OidcUserInfoService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360OidcUserInfoService.java
@@ -6,7 +6,6 @@ package org.eclipse.sw360.rest.authserver.client.service;
 
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.stereotype.Service;
 
@@ -23,8 +22,11 @@ public class Sw360OidcUserInfoService {
 	public static final String USER_GROUP = "userGroup";
 	public static final String DEPARTMENT = "department";
 	public static final String PRIMARY_ROLES = "primaryRoles";
-	@Autowired
-	private Sw360UserDetailsProvider sw360UserDetailsProvider;
+	private final Sw360UserDetailsProvider sw360UserDetailsProvider;
+
+	public Sw360OidcUserInfoService(Sw360UserDetailsProvider sw360UserDetailsProvider) {
+		this.sw360UserDetailsProvider = sw360UserDetailsProvider;
+	}
 
 	public OidcUserInfo loadUser(String username) {
 

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360UserDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360UserDetailsService.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,11 +19,17 @@ public class Sw360UserDetailsService implements UserDetailsService {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    @Autowired
-    private Sw360UserDetailsProvider userProvider;
+    private final Sw360UserDetailsProvider userProvider;
 
-    @Autowired
-    private Sw360GrantedAuthoritiesCalculator authoritiesCalculator;
+    private final Sw360GrantedAuthoritiesCalculator authoritiesCalculator;
+
+    public Sw360UserDetailsService(
+            Sw360UserDetailsProvider userProvider,
+            Sw360GrantedAuthoritiesCalculator authoritiesCalculator
+    ) {
+        this.userProvider = userProvider;
+        this.authoritiesCalculator = authoritiesCalculator;
+    }
 
     /**
      * @param username the username identifying the user whose data is required.

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
@@ -9,16 +9,13 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
-import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360ClientDetailsService;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360OidcUserInfoService;
 import org.eclipse.sw360.rest.authserver.security.authproviders.Sw360UserAuthenticationProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -43,14 +40,21 @@ import java.util.UUID;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Autowired
-    Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+    private final Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+    @SuppressWarnings("unused")
+    private final Sw360ClientDetailsService sw360ClientDetailsService;
+    @SuppressWarnings("unused")
+    private final Sw360OidcUserInfoService sw360OidcUserInfoService;
 
-    @Autowired
-    Sw360ClientDetailsService sw360ClientDetailsService;
-
-    @Autowired
-    private Sw360OidcUserInfoService sw360OidcUserInfoService;
+    public SecurityConfig(
+            Sw360UserAuthenticationProvider sw360UserAuthenticationProvider,
+            Sw360ClientDetailsService sw360ClientDetailsService,
+            Sw360OidcUserInfoService sw360OidcUserInfoService
+    ) {
+        this.sw360UserAuthenticationProvider = sw360UserAuthenticationProvider;
+        this.sw360ClientDetailsService = sw360ClientDetailsService;
+        this.sw360OidcUserInfoService = sw360OidcUserInfoService;
+    }
 
     @Bean
     @Order(1)
@@ -61,6 +65,7 @@ public class SecurityConfig {
 
         httpSecurity
                 .securityMatcher(endpointsMatcher)
+                .authenticationProvider(sw360UserAuthenticationProvider)
                 .with(authorizationServerConfigurer, Customizer.withDefaults())
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login")))
@@ -73,7 +78,9 @@ public class SecurityConfig {
     @Order(2)
     @Bean
     public SecurityFilterChain appSecurity(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity.authorizeHttpRequests(
+        httpSecurity
+                .authenticationProvider(sw360UserAuthenticationProvider)
+                .authorizeHttpRequests(
                 authz -> authz
                 .requestMatchers("/client-management/**").hasAuthority("ADMIN")
                 .anyRequest().authenticated()
@@ -105,16 +112,6 @@ public class SecurityConfig {
     @Bean
     public JwtDecoder jwtDecoder(JWKSource<SecurityContext> jwkSource) {
         return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
-    }
-
-    @Autowired
-    public void authenticationManagerBuilder(AuthenticationManagerBuilder authenticationManagerBuilder) {
-        authenticationManagerBuilder.authenticationProvider(sw360UserAuthenticationProvider);
-    }
-
-    @Bean
-    public ThriftClients thriftClients() {
-        return new ThriftClients();
     }
 
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360TokenCustomizerConfig.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360TokenCustomizerConfig.java
@@ -5,7 +5,6 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.rest.authserver.security;
 
 import org.eclipse.sw360.rest.authserver.client.service.Sw360OidcUserInfoService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
@@ -29,8 +28,11 @@ public class Sw360TokenCustomizerConfig {
 	public static final String AUD = "aud";
 	public static final String SUB = "sub";
 	public static final String SW360_REST_API = "sw360-REST-API";
-	@Autowired
-	private Sw360OidcUserInfoService sw360OidcUserInfoService;
+	private final Sw360OidcUserInfoService sw360OidcUserInfoService;
+
+	public Sw360TokenCustomizerConfig(Sw360OidcUserInfoService sw360OidcUserInfoService) {
+		this.sw360OidcUserInfoService = sw360OidcUserInfoService;
+	}
 
 	@Bean
 	public OAuth2TokenCustomizer<JwtEncodingContext> tokenCustomizer() {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
@@ -16,7 +16,6 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -28,8 +27,11 @@ public class Sw360UserDetailsProvider {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    @Autowired
-    private ThriftClients thriftClients;
+    private final ThriftClients thriftClients;
+
+    public Sw360UserDetailsProvider(ThriftClients thriftClients) {
+        this.thriftClients = thriftClients;
+    }
 
     public User provideUserDetails(String email, String extId) {
         User result = null;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/ThriftClientsConfiguration.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/ThriftClientsConfiguration.java
@@ -1,0 +1,24 @@
+/*
+SPDX-FileCopyrightText: © 2026 Contributors to the SW360 Portal Project
+SPDX-License-Identifier: EPL-2.0
+*/
+package org.eclipse.sw360.rest.authserver.security;
+
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Defines the ThriftClients in its own configuration so
+ * {@link SecurityConfig} can inject the authentication provider without a circular
+ * dependency: the provider needs a {@code ThriftClients} bean that must not be
+ * declared on the same configuration class that injects the provider.
+ */
+@Configuration
+public class ThriftClientsConfiguration {
+
+    @Bean
+    public ThriftClients thriftClients() {
+        return new ThriftClients();
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/authproviders/Sw360UserAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/authproviders/Sw360UserAuthenticationProvider.java
@@ -5,7 +5,6 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.rest.authserver.security.authproviders;
 
 import org.eclipse.sw360.rest.authserver.client.service.Sw360UserDetailsService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -18,11 +17,18 @@ import org.springframework.stereotype.Service;
 @Service
 public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
 
-    @Autowired
-    private Sw360UserDetailsService userDetailsService;
+    private final Sw360UserDetailsService userDetailsService;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    public Sw360UserAuthenticationProvider(Sw360UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    public Sw360UserAuthenticationProvider(Sw360UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
 
     /**
      * @param authentication the authentication request object.

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
@@ -18,7 +18,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -74,8 +73,11 @@ public class Sw360CustomHeaderAuthenticationFilter extends GenericFilterBean {
 
     private boolean active;
 
-    @Autowired
-    private Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+    private final Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+
+    public Sw360CustomHeaderAuthenticationFilter(Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider) {
+        this.sw360CustomHeaderUserDetailsProvider = sw360CustomHeaderUserDetailsProvider;
+    }
 
     @PostConstruct
     public void postSw360CustomHeaderAuthenticationFilterConstruction() {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
@@ -21,7 +21,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.StringTransformer;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -55,14 +54,21 @@ public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationPr
     @Value("${security.customheader.headername.enabled:#{false}}")
     private boolean customHeaderEnabled;
 
-    @Autowired
-    private Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+    private final Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
 
-    @Autowired
-    private RegisteredClientRepository clientDetailsService;
+    private final RegisteredClientRepository clientDetailsService;
 
-    @Autowired
-    private Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator;
+    private final Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator;
+
+    public Sw360CustomHeaderAuthenticationProvider(
+            Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider,
+            RegisteredClientRepository clientDetailsService,
+            Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator
+    ) {
+        this.sw360CustomHeaderUserDetailsProvider = sw360CustomHeaderUserDetailsProvider;
+        this.clientDetailsService = clientDetailsService;
+        this.sw360UserAndClientAuthoritiesCalculator = sw360UserAndClientAuthoritiesCalculator;
+    }
 
     private boolean active;
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
@@ -31,7 +31,6 @@ import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -63,7 +62,7 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
     private final RestControllerHelper restControllerHelper;
 
     @NonNull
-    Sw360FossologyAdminServices sw360FossologyAdminServices;
+    private final Sw360FossologyAdminServices sw360FossologyAdminServices;
 
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/Sw360FossologyAdminServices.java
@@ -27,17 +27,14 @@ import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class Sw360FossologyAdminServices {
 
     @Value("${sw360.thrift-server-url:http://localhost:8080}")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
@@ -34,7 +34,6 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.CollectionModel;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
@@ -38,7 +38,6 @@ import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -72,8 +71,9 @@ public class ChangeLogController implements RepresentationModelProcessor<Reposit
     private static final Logger log = LogManager.getLogger(ChangeLogController.class);
 
     public static final String CHANGE_LOG_URL = "/changelog";
-    @Autowired
-    private Sw360ChangeLogService sw360ChangeLogService;
+
+    @NonNull
+    private final Sw360ChangeLogService sw360ChangeLogService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/Sw360ChangeLogService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/Sw360ChangeLogService.java
@@ -21,14 +21,10 @@ import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogsService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class Sw360ChangeLogService {
     private static final Logger log = LogManager.getLogger(Sw360ChangeLogService.class);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -45,7 +45,6 @@ import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -76,8 +75,8 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
 
     private static final Logger log = LogManager.getLogger(ClearingRequestController.class);
 
-    @Autowired
-    private Sw360ClearingRequestService sw360ClearingRequestService;
+    @NonNull
+    private final Sw360ClearingRequestService sw360ClearingRequestService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/Sw360ClearingRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/Sw360ClearingRequestService.java
@@ -25,6 +25,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -40,10 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class Sw360ClearingRequestService {
     private static final Logger log = LogManager.getLogger(Sw360ClearingRequestService.class);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -39,7 +39,6 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
@@ -28,7 +28,6 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -62,7 +61,7 @@ public class SW360ConfigurationsController implements RepresentationModelProcess
     private final RestControllerHelper restControllerHelper;
 
     @NonNull
-    SW360ConfigurationsService sw360ConfigurationsService;
+    private final SW360ConfigurationsService sw360ConfigurationsService;
 
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsService.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.sw360.rest.resourceserver.configuration;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
@@ -24,7 +23,6 @@ import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.configurations.SW360ConfigsService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -33,7 +31,6 @@ import java.util.Map;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class SW360ConfigurationsService {
     private SW360ConfigsService.Iface getThriftConfigsClient() {
         return new ThriftClients().makeSW360ConfigsClient();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/DatabaseSanitationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/DatabaseSanitationController.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -49,7 +48,7 @@ public class DatabaseSanitationController  implements RepresentationModelProcess
     public static final String DATABASESANITATION_URL = "/databaseSanitation";
 
     @NonNull
-    Sw360DatabaseSanitationService dataSanitationService;
+    private final Sw360DatabaseSanitationService dataSanitationService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/Sw360DatabaseSanitationService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/Sw360DatabaseSanitationService.java
@@ -29,19 +29,15 @@ import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
-@RequiredArgsConstructor
+@Slf4j
 public class Sw360DatabaseSanitationService {
-    private static final Logger log = LogManager.getLogger(Sw360DatabaseSanitationService.class);
 
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
@@ -27,7 +27,6 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/Sw360DepartmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/Sw360DepartmentService.java
@@ -36,15 +36,12 @@ import org.eclipse.sw360.datahandler.thrift.schedule.ScheduleService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
-import lombok.RequiredArgsConstructor;
 
 @Service
-@RequiredArgsConstructor
 public class Sw360DepartmentService {
     private static final Logger log = LogManager.getLogger(Sw360DepartmentService.class);
     @Value("${sw360.thrift-server-url:http://localhost:8080}")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
@@ -25,7 +25,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
@@ -33,7 +33,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
@@ -59,7 +59,6 @@ import org.eclipse.sw360.rest.resourceserver.user.UserCSV;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -75,11 +74,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.Part;
 
-import lombok.RequiredArgsConstructor;
-
 
 @Service
-@RequiredArgsConstructor
 public class Sw360ImportExportService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -45,7 +45,6 @@ import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -10,8 +10,6 @@
 
 package org.eclipse.sw360.rest.resourceserver.license;
 
-import lombok.RequiredArgsConstructor;
-
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
@@ -35,7 +33,6 @@ import org.eclipse.sw360.exporter.LicsExporter;
 import org.eclipse.sw360.exporter.utils.ZipTools;
 import org.eclipse.sw360.importer.LicsImporter;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
@@ -55,7 +52,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 
 @Service
-@RequiredArgsConstructor
 public class Sw360LicenseService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/LicenseInfoController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/LicenseInfoController.java
@@ -15,17 +15,14 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.license.LicenseController;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @BasePathAwareController
 @Slf4j
-@RequiredArgsConstructor
 public class LicenseInfoController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String LICENSE_INFO_URL = "/licenseinfo";
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
@@ -29,14 +29,10 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class Sw360LicenseInfoService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -52,7 +52,6 @@ import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -94,8 +93,8 @@ public class ModerationRequestController implements RepresentationModelProcessor
     private static final String REQUESTING_USER = "requestingUser";
     public static final String MODERATION_REQUEST_URL = "/moderationrequest";
 
-    @Autowired
-    private Sw360ModerationRequestService sw360ModerationRequestService;
+    @NonNull
+    private final Sw360ModerationRequestService sw360ModerationRequestService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.sw360.rest.resourceserver.moderationrequest;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TApplicationException;
@@ -41,7 +40,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -57,7 +55,6 @@ import java.util.Map;
 import java.util.Set;
 
 @Service
-@RequiredArgsConstructor
 public class Sw360ModerationRequestService {
     private static final Logger log = LogManager.getLogger(Sw360ModerationRequestService.class);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
@@ -39,7 +39,6 @@ import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.sw360.rest.resourceserver.obligation;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
@@ -31,7 +30,6 @@ import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.springframework.security.access.AccessDeniedException;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -41,7 +39,6 @@ import java.util.Map;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class Sw360ObligationService {
     public Obligation getObligationById(String obligationId, User user) {
         LicenseService.Iface sw360LicenseClient = null;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
@@ -57,7 +57,6 @@ import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -93,7 +92,7 @@ public class PackageController implements RepresentationModelProcessor<Repositor
     private final Sw360ProjectService projectService;
 
     @NonNull
-    private Sw360ReleaseService releaseService;
+    private final Sw360ReleaseService releaseService;
 
     @NonNull
     private final Sw360UserService userService;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
@@ -30,7 +30,6 @@ import org.eclipse.sw360.datahandler.thrift.packages.PackageService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -71,7 +71,6 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
@@ -137,7 +136,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     private String thriftServerUrl;
 
     @NonNull
-    private RestControllerHelper rch;
+    private final RestControllerHelper rch;
 
     /**
      * This enum is used to indicate the status of the CLI update process.

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -92,7 +92,6 @@ import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -141,10 +140,10 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             .put("message", "Moderation request is created").build();
 
     @NonNull
-    private Sw360ReleaseService releaseService;
+    private final Sw360ReleaseService releaseService;
 
     @NonNull
-    private SW360PackageService packageService;
+    private final SW360PackageService packageService;
 
     @NonNull
     private final Sw360VulnerabilityService vulnerabilityService;
@@ -153,16 +152,16 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     private final Sw360VendorService vendorService;
 
     @NonNull
-    private Sw360AttachmentService attachmentService;
+    private final Sw360AttachmentService attachmentService;
 
     @NonNull
-    private RestControllerHelper restControllerHelper;
+    private final RestControllerHelper restControllerHelper;
 
     @NonNull
-    private Sw360LicenseInfoService sw360LicenseInfoService;
+    private final Sw360LicenseInfoService sw360LicenseInfoService;
 
     @NonNull
-    private SW360SPDXDocumentService sw360SPDXDocumentService;
+    private final SW360SPDXDocumentService sw360SPDXDocumentService;
 
     @NonNull
     private final com.fasterxml.jackson.databind.Module sw360Module;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/SW360SPDXDocumentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/SW360SPDXDocumentService.java
@@ -34,7 +34,6 @@ import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformat
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformationService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.*;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -66,7 +66,6 @@ import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
@@ -113,7 +112,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
     private String thriftServerUrl;
 
     @NonNull
-    private RestControllerHelper rch;
+    private final RestControllerHelper rch;
 
     @NonNull
     private final Sw360ProjectService projectService;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -39,7 +39,6 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -53,7 +53,7 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
     private final RestControllerHelper restControllerHelper;
 
     @NonNull
-    private Sw360ScheduleService scheduleService;
+    private final Sw360ScheduleService scheduleService;
 
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
@@ -20,12 +20,9 @@ import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
-
 import static org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper.throwIfNotAdmin;
 
 @Service
-@RequiredArgsConstructor
 public class Sw360ScheduleService {
     private static final Logger log = LogManager.getLogger(Sw360ScheduleService.class);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
@@ -37,7 +37,6 @@ import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -64,8 +63,8 @@ public class SearchController implements RepresentationModelProcessor<Repository
 
     public static final String SEARCH_URL = "/search";
 
-    @Autowired
-    private Sw360SearchService sw360SearchService;
+    @NonNull
+    private final Sw360SearchService sw360SearchService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/Sw360SearchService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/Sw360SearchService.java
@@ -19,15 +19,11 @@ import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.eclipse.sw360.datahandler.thrift.search.SearchService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Lists;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class Sw360SearchService {
     private static final Logger log = LogManager.getLogger(Sw360SearchService.class);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -15,7 +15,6 @@ import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthentic
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationProvider;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360UserAuthenticationProvider;
 import org.eclipse.sw360.rest.resourceserver.security.jwt.Sw360JWTAccessTokenConverter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,23 +39,30 @@ import java.util.List;
 @EnableMethodSecurity
 public class ResourceServerConfiguration {
 
-    @Autowired
-    SimpleAuthenticationEntryPoint saep;
+    private final Logger log = LogManager.getLogger(this.getClass());
 
-    @Autowired
-    Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;
+    private final SimpleAuthenticationEntryPoint saep;
+    private final Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;
+    private final ApiTokenAuthenticationProvider authProvider;
+    private final Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+    private final String issuerUri;
+    private final boolean swaggerRequireAuthentication;
 
-    @Autowired
-    private ApiTokenAuthenticationProvider authProvider;
-
-    @Autowired
-    Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
-
-    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
-    String issuerUri;
-
-    @Value("${springdoc.swagger-ui.require-authentication:true}")
-    boolean swaggerRequireAuthentication;
+    public ResourceServerConfiguration(
+            SimpleAuthenticationEntryPoint saep,
+            Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter,
+            ApiTokenAuthenticationProvider authProvider,
+            Sw360UserAuthenticationProvider sw360UserAuthenticationProvider,
+            @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}") String issuerUri,
+            @Value("${springdoc.swagger-ui.require-authentication:true}") boolean swaggerRequireAuthentication
+    ) {
+        this.saep = saep;
+        this.sw360JWTAccessTokenConverter = sw360JWTAccessTokenConverter;
+        this.authProvider = authProvider;
+        this.sw360UserAuthenticationProvider = sw360UserAuthenticationProvider;
+        this.issuerUri = issuerUri;
+        this.swaggerRequireAuthentication = swaggerRequireAuthentication;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
@@ -27,7 +27,6 @@ import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.jetbrains.annotations.NotNull;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.InvalidJwtException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationServiceException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsService.java
@@ -7,7 +7,6 @@ package org.eclipse.sw360.rest.resourceserver.security.basic;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
@@ -20,8 +19,7 @@ public class Sw360CustomUserDetailsService implements UserDetailsService {
 
     private static final Logger log = LogManager.getLogger(Sw360CustomUserDetailsService.class);
 
-    @Autowired
-    Sw360UserDetailsProvider sw360UserDetailsProvider;
+    private final Sw360UserDetailsProvider sw360UserDetailsProvider;
 
     @Override
     public UserDetails loadUserByUsername(String userid) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserAuthenticationProvider.java
@@ -6,7 +6,6 @@ package org.eclipse.sw360.rest.resourceserver.security.basic;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -23,11 +22,10 @@ public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
-    private Sw360CustomUserDetailsService userDetailsService;
+    private final Sw360CustomUserDetailsService userDetailsService;
 
-    @Autowired
     public Sw360UserAuthenticationProvider(@Lazy PasswordEncoder passwordEncoder, Sw360CustomUserDetailsService userDetailsService) {
         this.passwordEncoder = passwordEncoder;
         this.userDetailsService = userDetailsService;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
@@ -12,7 +12,6 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
@@ -29,6 +28,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Validate user and extracts the roles from the JWT token and convert into GrantedAuthority
  *
@@ -36,6 +37,7 @@ import java.util.stream.Stream;
  */
 @Profile("!SECURITY_MOCK")
 @Component
+@RequiredArgsConstructor
 public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
 	private static final Logger log = LogManager.getLogger(Sw360JWTAccessTokenConverter.class);
@@ -50,8 +52,7 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 	@Value("${jwt.auth.converter.principle-attribute:email}")
 	private String principleAttribute;
 
-	@Autowired
-	private Sw360UserService userService;
+	private final Sw360UserService userService;
 
 	/**
 	 * Converts the JWT token into an AbstractAuthenticationToken.

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -44,7 +44,6 @@ import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestExceptionHandler;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.sw360.rest.resourceserver.vendor;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
@@ -29,7 +28,6 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorSortColumn;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -42,7 +40,6 @@ import java.util.Map;
 import java.util.Set;
 
 @Service
-@RequiredArgsConstructor
 public class Sw360VendorService {
     public Map<PaginationData, List<Vendor>> getVendors(Pageable pageable) {
         try {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -30,7 +30,6 @@ import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/Sw360VulnerabilityService.java
@@ -44,7 +44,6 @@ import org.eclipse.sw360.rest.resourceserver.core.JacksonCustomizations.Sw360Mod
 import org.eclipse.sw360.rest.resourceserver.core.JacksonCustomizations.Sw360Module.VendorAdvisoryMixin;
 import org.eclipse.sw360.rest.resourceserver.core.JacksonCustomizations.Sw360Module.VulnerabilityMixinForCreateUpdate;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -55,12 +54,10 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class Sw360VulnerabilityService {
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -104,7 +104,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     private final RestControllerHelper restControllerHelper;
 
     @NonNull
-    private Sw360ReleaseService releaseService;
+    private final Sw360ReleaseService releaseService;
 
     @Operation(
             summary = "List all of the service's vulnerabilities.",


### PR DESCRIPTION
Fixes: https://github.com/eclipse-sw360/sw360/issues/3696
## Summary
- Refactor Spring wiring to use constructor injection consistently (replace `@Autowired` field/method injection with single-constructor injection and `private final` dependencies).
- Keep behavior the same; this is a non-functional refactor to improve consistency, immutability, and testability across REST/backend modules.

## Issue
- Fixes/Refs: #3696 (`Refactor: replace field injection (@Autowired on fields) with constructor injection across the repo`)

## Dependencies
- No new or updated dependencies.

## Suggest Reviewer
- @GMishx  @heliocastro  @arunazhakesan  @KoukiHama 

## Checklist
- [x] All related issues are referenced in commit messages and in PR