### PR TITLE
fix: Prevent NullPointerException in VulnerabilityController.getSortedList

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -598,7 +598,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     private void getSortedList(String sortBy, String sortOrder, List<Map<String, String>> vulTrackingStatusList) {
         Collections.sort(vulTrackingStatusList, new Comparator<Map<String, String>>() {
             public int compare(Map<String, String> m1, Map<String, String> m2) {
-                if (sortOrder.equalsIgnoreCase("asc")) {
+                if ("asc".equalsIgnoreCase(sortOrder)) {
                     return (m1.get(sortBy)).compareTo(m2.get(sortBy));
                 } else {
                     return (m2.get(sortBy)).compareTo(m1.get(sortBy));


### PR DESCRIPTION
## Description

Fixed potential NullPointerException in VulnerabilityController.getSortedList method by changing:
- `sortOrder.equalsIgnoreCase("asc")` → `"asc".equalsIgnoreCase(sortOrder)`

This prevents NPE when sortOrder parameter is null.

Fixes #3699