### PR TITLE
fix(security): Fix XXE vulnerability in XML parsing by disabling external entities and DOCTYPE

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -139,7 +139,7 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
     }
 
     protected Document getDocument(InputStream attachmentStream) throws ParserConfigurationException, SAXException, IOException {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newDefaultInstance();
 
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: 
Updated the XML parser to follow secure parsing practices and prevent XXE attacks. Disabled DOCTYPE declarations, external entities, DTDs, XInclude, and entity expansion to eliminate risks like reading local files, SSRF, or DoS.

Modified `getDocument(InputStream attachmentStream)` method in `AbstractCLIParser.java` 

No functional changes expected for valid XML inputs, purely a security improvement.

### Suggest Reviewer
@GMishx 

### How To Test?
I ran local tests to the affected modules by running `mvn test -pl backend/licenseinfo` 

<img width="871" height="239" alt="image" src="https://github.com/user-attachments/assets/52436a84-69e8-47c9-915c-5817a846cf97" />

Note: No new tests added.
