### PR TITLE
fix(security): Add @PreAuthorize to ScheduleAdminController

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -27,6 +27,7 @@ import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,6 +46,7 @@ import java.util.Map;
 @BasePathAwareController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @RestController
+@PreAuthorize("hasAuthority('ADMIN')")
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
 public class ScheduleAdminController implements RepresentationModelProcessor<RepositoryLinksResource> {


### PR DESCRIPTION
## Description

Added  at class level to secure all admin scheduling endpoints.

## Changes

- Added  annotation to  class
- All scheduling endpoints now require ADMIN authority

## Security Impact

- **Before:** Any authenticated user could access admin scheduling endpoints
- **After:** Only ADMIN users can access scheduling operations like CVE service, SVM sync, attachment deletion, etc.

## Affected Endpoints

- POST /schedule/unscheduleAllServices
- POST /schedule/cveService
- POST /schedule/scheduleSvmSync
- POST /schedule/unscheduleCve
- DELETE /schedule/unscheduleSvmSync
- POST /schedule/deleteAttachment
- And all other scheduling endpoints

This follows the same pattern as other admin controllers in the codebase.

Fixes #3704