### PR TITLE
fix: Prevent NullPointerException in ModerationRequestController

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -200,7 +200,7 @@ public class ModerationRequestController implements RepresentationModelProcessor
                     "Invalid ModerationRequest state '%s', possible values are: %s", state, stateOptions));
         }
 
-        boolean stateOpen = stateOptions.get(0).equalsIgnoreCase(state);
+        boolean stateOpen = "open".equalsIgnoreCase(state);
         Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData =
                 sw360ModerationRequestService.getRequestsByState(sw360User, pageable, stateOpen, allDetails);
         return getModerationResponseEntity(pageable, request, allDetails, modRequestsWithPageData);


### PR DESCRIPTION
## Description

Fixed potential NullPointerException in ModerationRequestController.getModerationRequestsByState method.

## Changes

Changed from:


To:


## Why This Fix Works

This is a standard Java idiom to avoid NullPointerException - by putting the constant string first ("open".equalsIgnoreCase(state)), if state is null, it simply returns false instead of throwing an NPE.

## Testing

- No functional changes, only null-safety improvement
- The logic remains the same since stateOptions.get(0) is always "open"

Fixes #3705