### PR TITLE
fix: Prevent NullPointerException in Sw360ProjectService

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -735,15 +735,15 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         ThriftClients thriftClients = new ThriftClients();
         ComponentService.Iface componentClient = thriftClients.makeComponentClient();
 
-        if (oblLevel.equalsIgnoreCase("Project")) {
+        if ("Project".equalsIgnoreCase(oblLevel)) {
             updatedObligationStatusMap = SW360Utils.getProjectComponentOrganisationLicenseObligationToDisplay(
                     obligationStatusMap, obligations, ObligationLevel.PROJECT_OBLIGATION, true);
             return updatedObligationStatusMap;
-        } else if (oblLevel.equalsIgnoreCase("Organization")) {
+        } else if ("Organization".equalsIgnoreCase(oblLevel)) {
             updatedObligationStatusMap = SW360Utils.getProjectComponentOrganisationLicenseObligationToDisplay(
                     obligationStatusMap, obligations, ObligationLevel.ORGANISATION_OBLIGATION, true);
             return updatedObligationStatusMap;
-        } else if (oblLevel.equalsIgnoreCase("Component")) {
+        } else if ("Component".equalsIgnoreCase(oblLevel)) {
             updatedObligationStatusMap = SW360Utils.getProjectComponentOrganisationLicenseObligationToDisplay(
                     obligationStatusMap, obligations, ObligationLevel.COMPONENT_OBLIGATION, true);
             return updatedObligationStatusMap;


### PR DESCRIPTION
## Description

Fixed potential NullPointerException in Sw360ProjectService.setObligationsFromAdminSection method.

## Changes

Changed from:


To:


## Why This Fix Works

This is a standard Java idiom to avoid NullPointerException - by putting the constant string first ("Project".equalsIgnoreCase(oblLevel)), if oblLevel is null, it simply returns false instead of throwing an NPE.

## Testing

- No functional changes, only null-safety improvement
- The logic remains the same

Fixes #3706