### PR TITLE
Chore/docs/swagger api: add OpenAPI/Swagger response documentation for ComponentController 

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
@@ -145,6 +146,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "List all of the service's components.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Paginated list of components.")
+    })
     @GetMapping(value = COMPONENTS_URL)
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getComponents(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -255,6 +259,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all the resources where the component is used.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Projects and components using this component.")
+    })
     @GetMapping(value = COMPONENTS_URL + "/usedBy" + "/{id}")
     public ResponseEntity<CollectionModel<EntityModel>> getUsedByResourceDetails(
             @Parameter(description = "The id of the component.")
@@ -288,6 +295,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get a single component by its id.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Single component with embedded resources."),
+            @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to access this component",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class)))
+    })
     @GetMapping(value = COMPONENTS_URL + "/{id}")
     public ResponseEntity<EntityModel<Component>> getComponent(
             @Parameter(description = "The id of the component to be retrieved.")
@@ -305,6 +317,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Return 5 of the service's most recently created components.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Up to 5 recent components.")
+    })
     @GetMapping(value = COMPONENTS_URL + "/recentComponents")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getRecentComponent() throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
@@ -325,6 +340,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "List all of the service's mysubscriptions components.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of subscribed components."),
+            @ApiResponse(responseCode = "204", description = "No subscriptions; no response body.",
+                content = @Content)
+    })
     @GetMapping(value = COMPONENTS_URL + "/mySubscriptions")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getMySubscriptions() throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
@@ -346,6 +366,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Subscribes or unsubscribes the user to a specified component based on their current subscription status.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Subscription toggled successfully.")
+    })
     @PostMapping(value = COMPONENTS_URL + "/{id}/subscriptions")
     public ResponseEntity<String> toggleComponentSubscription(
             @Parameter(description = "The ID of the component.")
@@ -371,6 +394,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get components by external ID.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Components matching external IDs.")
+    })
     @GetMapping(value = COMPONENTS_URL + "/searchByExternalIds")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> searchByExternalIds(
             @Parameter(
@@ -473,6 +499,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Delete existing components by ids.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "207", description = "Multi-status - per-component delete result")
+    })
     @DeleteMapping(value = COMPONENTS_URL + "/{ids}")
     public ResponseEntity<List<MultiStatus>> deleteComponents(
             @Parameter(description = "The ids of the components to be deleted.")
@@ -506,6 +535,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Create a new component.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Component created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input or missing required fields",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class)))
+    })
     @PostMapping(value = COMPONENTS_URL)
     public ResponseEntity<EntityModel<Component>> createComponent(
             @Parameter(description = "The component to be created.")
@@ -549,6 +583,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all attachment information of a component.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Component attachments successfully retrieved.")
+    })
     @GetMapping(value = COMPONENTS_URL + "/{id}/attachments")
     public ResponseEntity<CollectionModel<EntityModel<Attachment>>> getComponentAttachments(
             @Parameter(description = "The id of the component.")
@@ -566,6 +603,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all releases of a component.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Component releases successfully retrieved.")
+    })
     @GetMapping(value = COMPONENTS_URL + "/{id}/releases")
     public ResponseEntity<CollectionModel<ReleaseLink>> getReleaseLinksByComponentId(
             @Parameter(description = "The id of the component.")
@@ -634,7 +674,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                             }
                     ),
                     @ApiResponse(
-                            responseCode = "500", description = "Failed to upload attachment."
+                            responseCode = "500", description = "Failed to upload attachment.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
                     )
             },
             tags = {"Components"}
@@ -681,6 +725,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             },
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Attachment file stream")
+    })
     @GetMapping(value = COMPONENTS_URL + "/{componentId}/attachments/{attachmentId}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public void downloadAttachmentFromComponent(
             @Parameter(description = "The id of the component.")
@@ -703,6 +750,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             },
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Attachment bundle (ZIP) stream")
+    })
     @GetMapping(value = COMPONENTS_URL + "/{componentId}/attachments/download", produces="application/zip")
     public void downloadAttachmentBundleFromComponent(
             @Parameter(description = "The id of the component.")
@@ -725,7 +775,13 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             responses = {
                     @ApiResponse(responseCode = "200", description = "Attachments deleted successfully"),
                     @ApiResponse(responseCode = "202", description = "Deletion sent for moderation"),
-                    @ApiResponse(responseCode = "500", description = "Attachment in use, can't delete")
+                    @ApiResponse(
+                            responseCode = "500", description = "Attachment in use, can't delete",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
+                    )
             },
             tags = {"Components"}
     )
@@ -769,6 +825,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get vulnerabilities of a single component.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Component vulnerabilities successfully retrieved.")
+    })
     @GetMapping(value = COMPONENTS_URL + "/{id}/vulnerabilities")
     public ResponseEntity<CollectionModel<VulnerabilityDTO>> getVulnerabilitiesOfComponent(
             @Parameter(description = "The id of the component.")
@@ -843,6 +902,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Get all components associated to the user.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Paginated list of user's components."),
+            @ApiResponse(responseCode = "204", description = "No components; no response body.",
+                content = @Content)
+    })
     @GetMapping(value = COMPONENTS_URL + "/mycomponents")
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getMyComponents(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -876,6 +940,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Update the vulnerability of a component.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Vulnerability state updated successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid vulnerability data or missing required fields",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class)))
+    })
     @PatchMapping(value = COMPONENTS_URL + "/{id}/vulnerabilities")
     public ResponseEntity<CollectionModel<EntityModel<VulnerabilityDTO>>> patchReleaseVulnerabilityRelation(
             @Parameter(description = "The id of the component.")
@@ -1026,7 +1095,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                             }
                     ),
                     @ApiResponse(
-                            responseCode = "500", description = "Failed to upload attachment."
+                            responseCode = "500", description = "Failed to upload attachment.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
                     )
             },
             tags = {"Components"}
@@ -1080,7 +1153,11 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
                             }
                     ),
                     @ApiResponse(
-                            responseCode = "500", description = "Failed to upload attachment."
+                            responseCode = "500", description = "Failed to upload attachment.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class))
+                            }
                     )
             },
             tags = {"Components"}
@@ -1132,6 +1209,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             description = "Merge source component into target component.",
             tags = {"Components"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Components merged successfully.")
+    })
     @PatchMapping(value = COMPONENTS_URL + "/mergecomponents")
     public ResponseEntity<RequestStatus> mergeComponents(
             @Parameter(description = "The id of the merge target component.")


### PR DESCRIPTION
### Summary
Fix and update OpenAPI docs for all 43 endpoints in ComponentController (17)
This includes:

-Added @ApiResponses with status codes and response body schemas for all 17 endpoints
-Documented HTTP status codes (200, 201, 202, 204, 207,400,403,)
-Error responses use ErrorMessage with application/json for 400,403, 500
-204 NO_CONTENT with Void schema
-ComponentController: added missing status codes and schemas for PATCH/DELETE/POST
-Added import: ApiResponses in ComponentController

Issue:  #2565

### Suggest Reviewer
@GMishx , @amritkv 

### How To Test?
Check OpenAPI docs at  http://localhost:8080/resource/swagger-ui/index.html

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
