### PR TITLE
Chore/docs/swagger api: add ApiResponses to ImportExportController, LicenseController and UserController

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/ImportExportController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -83,6 +84,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "CSV component template stream.")
+    })
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadComponentTemplate")
     public void downloadComponentTemplate(HttpServletResponse response) throws SW360Exception {
         try {
@@ -103,6 +107,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "CSV attachment sample stream.")
+    })
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadAttachmentSample")
     public void downloadAttachmentSample(HttpServletResponse response) throws SW360Exception {
         try {
@@ -123,6 +130,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "CSV attachment info stream.")
+    })
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadAttachmentInfo")
     public void downloadAttachmentInfo(HttpServletResponse response) throws TTransportException, SW360Exception {
         try {
@@ -143,6 +153,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "CSV release sample stream.")
+    })
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadReleaseSample")
     public void downloadReleaseSample(HttpServletResponse response) throws SW360Exception {
         try {
@@ -163,6 +176,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "CSV release link stream.")
+    })
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadReleaseLink")
     public void downloadReleaseLink(HttpServletResponse response) throws SW360Exception {
         try {
@@ -203,6 +219,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Import summary.")
+    })
     @PostMapping(
             value = IMPORTEXPORT_URL + "/uploadComponent",
             consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
@@ -228,6 +247,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Import summary.")
+    })
     @PostMapping(
             value = IMPORTEXPORT_URL + "/uploadRelease",
             consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
@@ -253,6 +275,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Import summary.")
+    })
     @PostMapping(
             value = IMPORTEXPORT_URL + "/componentAttachment",
             consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
@@ -278,6 +303,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Users CSV export stream.")
+    })
     @GetMapping(value = IMPORTEXPORT_URL + "/downloadUsers", produces = {MediaType.TEXT_PLAIN_VALUE})
     public void downloadUsers(HttpServletResponse response) throws SW360Exception {
         try {
@@ -329,6 +357,9 @@ public class ImportExportController implements RepresentationModelProcessor<Repo
             }
     )
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Import summary.")
+    })
     @PostMapping(
             value = IMPORTEXPORT_URL + "/usersCsv",
             consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -108,6 +108,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "List all of the service's licenses. Supports quick filtering.",
             tags = {"Licenses"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Paginated list of licenses.")
+    })
     @GetMapping(value = LICENSES_URL)
     public ResponseEntity<CollectionModel<License>> getLicenses(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -148,6 +151,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "List all obligations of a license.",
             tags = {"Licenses"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of obligations for the license.")
+    })
     @GetMapping(value = LICENSES_URL + "/{id}/obligations")
     public ResponseEntity<CollectionModel<EntityModel<Obligation>>> getObligationsByLicenseId(
             @PathVariable("id") String id
@@ -169,6 +175,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "List all of the service's licenseTypes.",
             tags = {"Licenses"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of license types.")
+    })
     @GetMapping(value = LICENSE_TYPES_URL)
     public ResponseEntity<CollectionModel<EntityModel<LicenseType>>> getLicenseTypes(
             @Parameter(description = "The search license type text.")
@@ -196,6 +205,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "Get a specific license.",
             tags = {"Licenses"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "License with embedded obligations.")
+    })
     @GetMapping(value = LICENSES_URL + "/{id:.+}")
     public ResponseEntity<EntityModel<License>> getLicense(
             @Parameter(description = "The id of the license.")
@@ -214,6 +226,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "License deleted successfully.")
+    })
     @DeleteMapping(value = LICENSES_URL + "/{id:.+}")
     public ResponseEntity deleteLicense(
             @Parameter(description = "The id of the license.")
@@ -230,6 +245,11 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "License created successfully."),
+            @ApiResponse(responseCode = "409", description = "License with same shortname already exists.",
+                content = @Content(mediaType = "application/json"))
+    })
     @PostMapping(value = LICENSES_URL)
     public ResponseEntity<EntityModel<License>> createLicense(
             @Parameter(description = "The license to be created.")
@@ -461,6 +481,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "All licenses deleted successfully.")
+    })
     @DeleteMapping(value = LICENSES_URL + "/deleteAll")
     public ResponseEntity deleteAllLicense() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -474,6 +497,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "SPDX license imported successfully.")
+    })
     @PostMapping(value = LICENSES_URL + "/import/SPDX")
     public ResponseEntity<RequestSummary> importSPDX() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -492,6 +518,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             }
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "License archive (ZIP) stream.")
+    })
     @GetMapping(value = LICENSES_URL + "/downloadLicenses", produces = "application/zip")
     public void downloadLicenseArchive(
             HttpServletRequest request,
@@ -508,6 +537,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             description = "Upload license archive.",
             tags = {"Licenses"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "License archive uploaded successfully.")
+    })
     @PostMapping(value = LICENSES_URL + "/upload", consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> uploadLicenses(
             @Parameter(description = "The license archive file to be uploaded.")
@@ -533,6 +565,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OSADL information imported successfully.")
+    })
     @PostMapping(value = LICENSES_URL + "/import/OSADL")
     public ResponseEntity<RequestSummary> importOsadlInfo() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -41,6 +41,7 @@ import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.core.RestExceptionHandler;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
@@ -109,6 +110,11 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
 
     @Operation(summary = "List all of the service's users.",
             description = "List all of the service's users.", tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Paginated list of users."),
+            @ApiResponse(responseCode = "204", description = "No users found.",
+                content = @Content)
+    })
     @GetMapping(value = USERS_URL)
     public ResponseEntity<CollectionModel<EntityModel<User>>> getUsers(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -172,6 +178,9 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     // for compatibility with older version of the REST API
     @Operation(summary = "Get a single user.", description = "Get a single user by email.",
             tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User with given email.")
+    })
     @GetMapping(value = USERS_URL + "/{email:.+}")
     public ResponseEntity<EntityModel<User>> getUserByEmail(
             @Parameter(description = "The email of the user to be retrieved.")
@@ -189,6 +198,9 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     // getUserByEmail())
     @Operation(summary = "Get a single user.", description = "Get a single user by id.",
             tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User with given ID.")
+    })
     @GetMapping(value = USERS_URL + "/byid/{id:.+}")
     public ResponseEntity<EntityModel<User>> getUser(
             @Parameter(description = "The id of the user to be retrieved.")
@@ -202,6 +214,9 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     @Operation(summary = "Create a new user.", description = "Create a user (not in Liferay).",
             tags = {"Users"})
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "User created successfully.")
+    })
     @PostMapping(value = USERS_URL)
     public ResponseEntity<EntityModel<User>> createUser(
             @Parameter(description = "The user to be created.")
@@ -227,6 +242,9 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
 
     @Operation(summary = "Get current user's profile.", description = "Get current user's profile.",
             tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Current user profile.")
+    })
     @GetMapping(value = USERS_URL + "/profile")
     public ResponseEntity<HalResource<User>> getUserProfile() {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -236,6 +254,9 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
 
     @Operation(summary = "Update user's profile.", description = "Update user's profile.",
             tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Profile updated successfully.")
+    })
     @PatchMapping(value = USERS_URL + "/profile")
     public ResponseEntity<HalResource<User>> updateUserProfile(
             @Parameter(description = "Updated user profile", schema = @Schema(example = """
@@ -399,6 +420,9 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
 
     @Operation(summary = "Update an existing user.", description = "Update an existing user",
             tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User updated successfully.")
+    })
     @PatchMapping(value = USERS_URL + "/{id}")
     @PreAuthorize("hasAuthority('ADMIN')")
     public ResponseEntity<EntityModel<User>> patchUser(
@@ -424,6 +448,11 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
 
     @Operation(summary = "Get existing departments.", description = "Get existing departments from all users",
             tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of departments."),
+            @ApiResponse(responseCode = "400", description = "Invalid type parameter (must be primary or secondary)",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestExceptionHandler.ErrorMessage.class)))
+    })
     @GetMapping(value = USERS_URL + "/departments")
     public ResponseEntity<?> getExistingDepartments(
             @Parameter(description = "Type of department (primary, secondary)")


### PR DESCRIPTION
### Summary
Fix and update OpenAPI docs for 30 endpoints in ImportExportController, LicenseController, and UserController.
This includes:

-Added comprehensive @ApiResponses annotations to all 30 endpoints (11 + 11 + 8)
-Documented common HTTP status codes (200, 201, 202, 204, 400,403
-Added proper error response schemas with RestExceptionHandler.ErrorMessage

Issue: #2565

### Suggest Reviewer
@GMishx , @amritkv 

### How To Test?
Check OpenAPI docs at  http://localhost:8080/resource/swagger-ui/index.html

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR