### PR TITLE
fix(security):Add @PreAuthorize annotation to AttachmentController #3712

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
@@ -43,6 +43,7 @@ import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -126,6 +127,7 @@ public class AttachmentController implements RepresentationModelProcessor<Reposi
             description = "Create an attachment.",
             tags = {"Attachments"}
     )
+    @PreAuthorize("hasAuthority('WRITE')")
     @PostMapping(
             value = ATTACHMENTS_URL,
             consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE}


### PR DESCRIPTION
### Summary
Adds missing `@PreAuthorize("hasAuthority('WRITE')")` annotation to file upload endpoint in AttachmentController.

## Changes Made
- Added `@PreAuthorize("hasAuthority('WRITE')")` to `AttachmentController.createAttachment()`
- Added missing import for `PreAuthorize` in AttachmentController

## Security Impact
**Before:** Any authenticated user (including READ-only users) could upload attachments  
**After:** Only users with WRITE authority can upload attachments

Fixes #3712

### Suggest Reviewer
@GMishx , @amritkv

### Checklist
Must:

- [x] All related issues are referenced in commit messages and in PR
