### PR TITLE
fix(licenseinfo): check Optional.isPresent() before get() in DocxGenerator

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -107,20 +107,19 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
             switch (getOutputVariant()) {
                 case DISCLOSURE:
                     docxTemplateFile = CommonUtils.loadResource(DocxGenerator.class, DOCX_TEMPLATE_FILE);
-                    xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
-                    if (docxTemplateFile.isPresent()) {
-                        fillDisclosureDocument(
-                                xwpfDocument,
-                                projectLicenseInfoResults,
-                                project,
-                                licenseInfoHeaderText,
-                                false,
-                                externalIds,
-                                excludeReleaseVersion);
-                    } else {
+                    if (!docxTemplateFile.isPresent()) {
                         throw new SW360Exception(
                                 "Could not load the template for xwpf document: " + DOCX_TEMPLATE_FILE);
                     }
+                    xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
+                    fillDisclosureDocument(
+                            xwpfDocument,
+                            projectLicenseInfoResults,
+                            project,
+                            licenseInfoHeaderText,
+                            false,
+                            externalIds,
+                            excludeReleaseVersion);
                     break;
                 case REPORT:
                     if (CommonUtils.isNullEmptyOrWhitespace(fileName)) {
@@ -129,21 +128,20 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
                         docxTemplateFile = CommonUtils.loadResource(DocxGenerator.class,
                                 System.getProperty("file.separator") + fileName + "." + DOCX_OUTPUT_TYPE);
                     }
-                    xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
-                    if (docxTemplateFile.isPresent()) {
-                        fillReportDocument(
-                                xwpfDocument,
-                                projectLicenseInfoResults,
-                                project,
-                                licenseInfoHeaderText,
-                                true,
-                                obligationResults,
-                                user,
-                                obligationsStatus);
-                    } else {
+                    if (!docxTemplateFile.isPresent()) {
                         throw new SW360Exception(
                                 "Could not load the template for xwpf document: " + DOCX_TEMPLATE_REPORT_FILE);
                     }
+                    xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
+                    fillReportDocument(
+                            xwpfDocument,
+                            projectLicenseInfoResults,
+                            project,
+                            licenseInfoHeaderText,
+                            true,
+                            obligationResults,
+                            user,
+                            obligationsStatus);
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown generator variant type: " + getOutputVariant());


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: `Optional.get()` was called before `isPresent()` in both `DISCLOSURE` and 
`REPORT` cases in `DocxGenerator.generateOutputFile()`. If a template file 
is missing this throws a `NoSuchElementException` instead of the intended 
`SW360Exception`. To fix it I moved the `isPresent()` check before `.get()` in both cases.

Closes: #3721

### How To Test?
> How should these changes be tested by the reviewer?

Remove or rename a DOCX template resource file and trigger license info 
DOCX generation. Before this fix a `NoSuchElementException` is thrown. 
After the fix the intended `SW360Exception` with a message 
is thrown instead. The existing `DocxGeneratorTest` passes.
> Have you implemented any additional tests?
- N/A

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
