### PR TITLE
Add Swagger @ApiResponse for Vendor, Vulnerability, Department, Obligation, ModerationRequest, Package and ClearingRequest controllers

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -96,6 +96,11 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "Get a clearing request by id.",
             tags = {"ClearingRequest"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Clearing request successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No clearing request found.",
+                content = @Content)
+    })
     @GetMapping(value = CLEARING_REQUEST_URL + "/{id}")
     public ResponseEntity<EntityModel<ClearingRequest>> getClearingRequestById(
             @Parameter(description = "id of the clearing request")
@@ -114,6 +119,11 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "Get the ClearingRequest based on the project id.",
             tags = {"ClearingRequest"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Clearing request for project successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No clearing request found for this project.",
+                content = @Content)
+    })
     @GetMapping(value = CLEARING_REQUEST_URL + "/project/{id}")
     public ResponseEntity<EntityModel<ClearingRequest>> getClearingRequestByProjectId(
             @Parameter(description = "id of the project")
@@ -165,6 +175,11 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "List all clearing requests visible to user",
             tags = {"ClearingRequest"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Clearing requests successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No clearing requests found.",
+                content = @Content)
+    })
     @GetMapping(value = CLEARING_REQUESTS_URL)
     public ResponseEntity<CollectionModel<?>> getClearingRequests(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -295,6 +310,9 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             tags = {"ClearingRequest"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Comment added successfully.")
+    })
     @PostMapping(value = CLEARING_REQUEST_URL + "/{id}/comments")
     public ResponseEntity<?> addComment(
             @Parameter(description = "ID of the clearing request")
@@ -348,6 +366,9 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             description = "Update a clearing request by id.",
             tags = {"ClearingRequest"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Clearing request updated successfully.")
+    })
     @PatchMapping(value = CLEARING_REQUEST_URL + "/{id}")
     public ResponseEntity<HalResource<ClearingRequest>> patchClearingRequest(
             @Parameter(description = "id of the clearing request")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
@@ -43,6 +43,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -73,6 +76,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Manually active the service.",
             tags = {"Departments"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Department import triggered.")
+    })
     @PostMapping(value = DEPARTMENT_URL + "/manuallyactive")
     public ResponseEntity<RequestSummary> importDepartmentManually() throws SW360Exception {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -93,6 +99,11 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Schedule import.",
             tags = {"Departments"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Department import scheduled."),
+            @ApiResponse(responseCode = "409", description = "Import already scheduled.",
+                content = @Content(mediaType = "application/json"))
+    })
     @PostMapping(value = DEPARTMENT_URL + "/scheduleImport")
     public ResponseEntity<Map<String, String>> scheduleImportDepartment() throws SW360Exception {
         try {
@@ -122,6 +133,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
     @Operation(summary = "Unschedule Department Import",
             description = "Cancels the scheduled import task for the department.",
             tags = {"Departments"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Department import unscheduled.")
+    })
     @PostMapping(value = DEPARTMENT_URL + "/unscheduleImport")
     public ResponseEntity<Map<String, String>> unScheduleImportDepartment() throws SW360Exception {
 
@@ -145,6 +159,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Updates the department folder path configuration.",
             tags = {"Departments"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Path updated.")
+    })
     @PostMapping(value = DEPARTMENT_URL + "/writePathFolder")
     public ResponseEntity<String> updatePath(
             @Parameter(description = "The path of the folder")
@@ -164,6 +181,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Get information about importing the department (import path folder, interval, last run time, next run time, and whether the scheduler is started or not)",
             tags = {"Departments"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Import information retrieved.")
+    })
     @GetMapping(value = DEPARTMENT_URL + "/importInformation")
     public ResponseEntity<Map<String, Object>> getImportInformation() throws TException {
         final User user = restControllerHelper.getSw360UserFromAuthentication();
@@ -175,6 +195,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Get log file list",
             tags = {"Departments"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Log file list retrieved.")
+    })
     @GetMapping(value = DEPARTMENT_URL + "/logFiles")
     public ResponseEntity<Set<String>> getLogFileList() throws TException {
         return new ResponseEntity<>(departmentService.getLogFileList(), HttpStatus.OK);
@@ -185,6 +208,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             description = "Get log file content by date",
             tags = {"Departments"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Log file content retrieved.")
+    })
     @GetMapping(value = DEPARTMENT_URL + "/logFileContent")
     public ResponseEntity<List<String>> getLogFileContentByDate(
             @RequestParam(value = "date") String date
@@ -194,6 +220,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
 
     @Operation(summary = "Fetch a list of members' emails from each department.",
             description = "Fetch a list of members' emails from each department.", tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Member emails retrieved.")
+    })
     @GetMapping(value = DEPARTMENT_URL + "/members")
     public ResponseEntity<Map<String, List<String>>> getMembersEmailsOfSecondaryDepartments(
             @Parameter(description = "departmentName") @RequestParam(value = "departmentName", required = false) String departmentName
@@ -206,6 +235,9 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
 
     @Operation(summary = "Update members of a secondary department.",
             description = "Update members of a secondary department.", tags = {"Users"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Members updated.")
+    })
     @PatchMapping(value = DEPARTMENT_URL + "/members")
     public ResponseEntity<Map<String, List<String>>> updateMembersOfSecondaryDepartment(
             @Parameter(description = "Department name") @RequestParam(value = "departmentName", required = false) String departmentName,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -114,6 +114,11 @@ public class ModerationRequestController implements RepresentationModelProcessor
             description = "List all of the service's moderation requests.",
             tags = {"Moderation Requests"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Moderation requests successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No moderation requests found.",
+                content = @Content)
+    })
     @GetMapping(value = MODERATION_REQUEST_URL)
     public ResponseEntity<CollectionModel<ModerationRequest>> getModerationRequests(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -140,6 +145,11 @@ public class ModerationRequestController implements RepresentationModelProcessor
             description = "Get a single moderation request by id.",
             tags = {"Moderation Requests"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Moderation request successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No moderation request found.",
+                content = @Content)
+    })
     @GetMapping(value = MODERATION_REQUEST_URL + "/{id}")
     public ResponseEntity<HalResource<Map<String, Object>>> getModerationRequestById(
             @Parameter(description = "The id of the moderation request to be retrieved.")
@@ -177,6 +187,11 @@ public class ModerationRequestController implements RepresentationModelProcessor
             description = "List all the ModerationRequest visible to the user based on the state and  respond with MR where user is a moderator",
             tags = {"Moderation Requests"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Moderation requests by state successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No moderation requests found for this state.",
+                content = @Content)
+    })
     @GetMapping(value = MODERATION_REQUEST_URL + "/byState")
     public ResponseEntity<CollectionModel<ModerationRequest>> getModerationRequestsByState(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -342,6 +357,11 @@ public class ModerationRequestController implements RepresentationModelProcessor
                     "\"timestamp\", \"documentName\" and \"moderationState\".",
             tags = {"Moderation Requests"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User submissions successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No submissions found.",
+                content = @Content)
+    })
     @GetMapping(value = MODERATION_REQUEST_URL + "/mySubmissions")
     public ResponseEntity<CollectionModel<ModerationRequest>> getSubmissions(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -635,6 +655,11 @@ public class ModerationRequestController implements RepresentationModelProcessor
             tags = {"Moderation Requests"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Moderation request deleted."),
+            @ApiResponse(responseCode = "409", description = "Cannot delete - moderation request in use.",
+                content = @Content(mediaType = "application/json"))
+    })
     @DeleteMapping(value = MODERATION_REQUEST_URL + "/delete")
     public ResponseEntity<?> deleteModerationRequest(
             @Parameter(description = "List of moderation request IDs to delete")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
@@ -11,8 +11,10 @@ package org.eclipse.sw360.rest.resourceserver.obligation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.NonNull;
@@ -78,6 +80,11 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "List all of the service's obligations.",
             tags = {"Obligations"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Obligations successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No obligations found.",
+                content = @Content)
+    })
     @GetMapping(value = OBLIGATION_URL)
     public ResponseEntity<CollectionModel<EntityModel<Obligation>>> getObligations(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
@@ -137,6 +144,9 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "Get an obligation by id.",
             tags = {"Obligations"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Obligation successfully retrieved.")
+    })
     @GetMapping(value = OBLIGATION_URL + "/{id}")
     public ResponseEntity<EntityModel<Obligation>> getObligation(
             @Parameter(description = "The id of the obligation to be retrieved.")
@@ -159,6 +169,9 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             tags = {"Obligations"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Obligation created successfully.")
+    })
     @PostMapping(value = OBLIGATION_URL)
     public ResponseEntity<HalResource<Obligation>> createObligation(
             @Parameter(description = "The obligation to be created.")
@@ -181,6 +194,9 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             tags = {"Obligations"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "207", description = "Multi-status - per-obligation delete result.")
+    })
     @DeleteMapping(value = OBLIGATION_URL + "/{ids}")
     public ResponseEntity<List<MultiStatus>> deleteObligations(
             @Parameter(description = "The ids of the obligations to be deleted.")
@@ -284,6 +300,9 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "Get all Obligation Nodes from the server to render Obligations.",
             tags = {"Obligations"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Obligation nodes successfully retrieved.")
+    })
     @GetMapping(value = OBLIGATION_URL + "/nodes")
     public ResponseEntity<CollectionModel<ObligationNode>> getObligationNodes() {
         List<ObligationNode> obligationNodes = obligationService.getObligationNodes();
@@ -295,6 +314,9 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             description = "Get all Obligation Elements from the server to render Obligation suggestions.",
             tags = {"Obligations"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Obligation elements successfully retrieved.")
+    })
     @GetMapping(value = OBLIGATION_URL + "/elements")
     public ResponseEntity<CollectionModel<ObligationElement>> getObligationElements() {
         List<ObligationElement> obligationNodes = obligationService.getObligationElements();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.thrift.TException;
@@ -109,6 +110,9 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             tags = {"Packages"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Package created successfully.")
+    })
     @PostMapping(value = PACKAGES_URL)
     public ResponseEntity<EntityModel<Package>> createPackage(
             @Parameter(description = "The package to be created.",
@@ -175,6 +179,11 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             tags = {"Packages"}
     )
     @PreAuthorize("hasAuthority('WRITE')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Package deleted successfully."),
+            @ApiResponse(responseCode = "409", description = "Package is in use and cannot be deleted.",
+                content = @Content(mediaType = "application/json"))
+    })
     @DeleteMapping(value = PACKAGES_URL + "/{id}")
     public ResponseEntity<?> deletePackage(
             @Parameter(description = "The id of the package to be deleted.")
@@ -200,6 +209,9 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             description = "Get a package by id.",
             tags = {"Packages"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Package successfully retrieved.")
+    })
     @GetMapping(value = PACKAGES_URL + "/{id}")
     public ResponseEntity<EntityModel<Package>> getPackage(
             @Parameter(description = "The id of the package to be retrieved.")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -86,6 +86,11 @@ public class VendorController implements RepresentationModelProcessor<Repository
             description = "List all of the service's vendors.",
             tags = {"Vendor"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Vendors successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No vendors found.",
+                content = @Content)
+    })
     @GetMapping(value = VENDORS_URL)
     public ResponseEntity<CollectionModel<EntityModel<Vendor>>> getVendors(
             @Parameter(description = "Search text")
@@ -138,6 +143,9 @@ public class VendorController implements RepresentationModelProcessor<Repository
             description = "Get a single vendor by id.",
             tags = {"Vendor"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Vendor successfully retrieved.")
+    })
     @GetMapping(value = VENDORS_URL + "/{id}")
     public ResponseEntity<EntityModel<Vendor>> getVendor(
             @Parameter(description = "The id of the vendor to get.")
@@ -155,6 +163,11 @@ public class VendorController implements RepresentationModelProcessor<Repository
             description = "Get the releases by vendor id.",
             tags = {"Vendor"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Releases for vendor successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No releases found for this vendor.",
+                content = @Content)
+    })
     @GetMapping(value = VENDORS_URL + "/{id}/releases")
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getReleases(
             @Parameter(description = "The id of the vendor to get.")
@@ -187,6 +200,9 @@ public class VendorController implements RepresentationModelProcessor<Repository
             tags = {"Vendor"}
     )
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Vendor deleted successfully.")
+    })
     @DeleteMapping(value = VENDORS_URL + "/{id}")
     public ResponseEntity<?> deleteVendor(
             @Parameter(description = "The id of the vendor to be deleted.")
@@ -213,6 +229,9 @@ public class VendorController implements RepresentationModelProcessor<Repository
             tags = {"Vendor"}
     )
     @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Vendor created successfully.")
+    })
     @PostMapping(value = VENDORS_URL)
     public ResponseEntity<?> createVendor(
             @Parameter(description = "The vendor to be created.")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -110,6 +111,11 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             description = "List all of the service's vulnerabilities.",
             tags = {"Vulnerabilities"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Vulnerabilities successfully retrieved."),
+            @ApiResponse(responseCode = "204", description = "No vulnerabilities found.",
+                content = @Content)
+    })
     @GetMapping(value = VULNERABILITIES_URL)
     public ResponseEntity<CollectionModel<EntityModel<VulnerabilityApiDTO>>> getVulnerabilities(
             @Parameter(description = "Filter for External Id or Title")
@@ -160,6 +166,9 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             description = "Get a vulnerability by the external ID.",
             tags = {"Vulnerabilities"}
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Vulnerability successfully retrieved.")
+    })
     @GetMapping(VULNERABILITIES_URL + "/{id}")
     public ResponseEntity<HalResource<VulnerabilityApiDTO>> getVulnerability(
             @Parameter(description = "The external ID of the vulnerability to be retrieved.")


### PR DESCRIPTION
### Summary
Added OpenAPI status code annotations (@ApiResponses) to 7 REST controllers:
-VendorController (8 endpoints)
-VulnerabilityController (8 endpoints)
-DepartmentController (9 endpoints)
-ObligationController (7 endpoints)
-ModerationRequestController (7 endpoints)
-PackageController (6 endpoints)
-ClearingRequestController (6 endpoints)
Standardized status codes (200, 201, 204, 400, 401, 403, 404, 409, 500, 207) with error response schemas

Issue: #2565

### Suggest Reviewer
@GMishx , @amritkv 

### How To Test?
Check OpenAPI docs at  http://localhost:8080/resource/swagger-ui/index.html

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR