### PR TITLE
fix(CR): header injection vulnerability.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     container_name: sw360
     depends_on:
       - couchdb
+    environment:
+      - SW360_BASE_URL=${SW360_BASE_URL:-http://localhost:8080}
     ports:
       - "8080:8080"
       - "11311:11311"

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -1587,9 +1587,21 @@ public class RestControllerHelper<T> {
         halClearingRequest.addEmbeddedResource("requestClosedOn", humanReadableDate);
     }
 
+    @org.springframework.beans.factory.annotation.Value("${sw360.base-url:http://localhost:8080}")
+    private String configuredBaseUrl;
+
+    /**
+     * Returns the configured base URL for generating hyperlinks in emails.
+     * <p>
+     * This method uses a hardcoded configuration value instead of deriving
+     * the URL from the HTTP request to prevent HTTP header injection
+     * attacks via X-Forwarded-Host or similar headers.
+     *
+     * @param request the HTTP request (ignored, kept for API compatibility)
+     * @return the configured base URL
+     */
     public String getBaseUrl(HttpServletRequest request) {
-        String requestURL = request.getRequestURL().toString();
-        return requestURL.substring(0, requestURL.indexOf(request.getRequestURI()));
+        return configuredBaseUrl;
     }
 
     public VulnerabilitySummary convertToEmbeddedVulnerabilitySumm(VulnerabilitySummary sw360Vul) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -395,10 +395,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     }
 
     private String getBaseUrl(HttpServletRequest request) {
-        StringBuffer url = request.getRequestURL();
-        String uri = request.getRequestURI();
-        String ctx = request.getContextPath();
-        return url.substring(0, url.length() - uri.length() + ctx.length()) + "/";
+        return restControllerHelper.getBaseUrl(request) + "/";
     }
 
     private void exportSBOM(

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -69,6 +69,7 @@ jwt:
 
 sw360:
   thrift-server-url: ${SW360_THRIFT_SERVER_URL:http://localhost:8080}
+  base-url: ${SW360_BASE_URL:http://localhost:8080}
   test-user-id: admin@sw360.org
   test-user-password: 12345
   couchdb-url: ${SW360_COUCHDB_URL:http://localhost:5984}

--- a/rest/resource-server/src/test/resources/application.yml
+++ b/rest/resource-server/src/test/resources/application.yml
@@ -64,6 +64,7 @@ jwt:
 
 sw360:
   thrift-server-url: ${SW360_THRIFT_SERVER_URL:http://localhost:8080}
+  base-url: ${SW360_BASE_URL:http://localhost:8080}
   test-user-id: admin@sw360.org
   test-user-password: 12345
   couchdb-url: ${SW360_COUCHDB_URL:http://localhost:5984}

--- a/scripts/docker-config/etc_sw360/rest/application.yml
+++ b/scripts/docker-config/etc_sw360/rest/application.yml
@@ -54,6 +54,7 @@ security:
 
 sw360:
   thrift-server-url: ${SW360_THRIFT_SERVER_URL:http://localhost:8080}
+  base-url: ${SW360_BASE_URL:http://localhost:8080}
   test-user-id: admin@sw360.org
   test-user-password: sw360-password
   couchdb-url: ${SW360_COUCHDB_URL:http://couchdb:5984}


### PR DESCRIPTION
Description: HTTP header injection vulnerabilities arise when user-supplied data is copied into a response header
without validation. The attacker can inject characters into the HTTP header or might inject arbitrary
code into the HTML body. The SW360 web application sends e-mail messages with an hyperlink that points to the URL of the associated project to users when a clearing request is created or updated. It was identified that malicious users are able to inject arbitrary URLs into the generated hyperlink by sending a manually crafted `X-Forwarded-Host` header in the HTTP request that is sent to create or update clearing requests.

Solution: The domain used to create hyperlinks should be hardcoded on the application code or set in configuration values.

NOTE: add the SW360_BASE_URL value in the env file or the application.yml file.

Testing steps:
Go to the project page and create or update a CR.
Add a random value to the X-Forwarded-Host header.
Check your email — the CR link will not include the X-Forwarded-Host value, since it is now hardcoded in the application code.

