### PR TITLE
fix: check Optional.isPresent() before calling get() in DocxGenerator (#3721)

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -107,8 +107,8 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
             switch (getOutputVariant()) {
                 case DISCLOSURE:
                     docxTemplateFile = CommonUtils.loadResource(DocxGenerator.class, DOCX_TEMPLATE_FILE);
-                    xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
                     if (docxTemplateFile.isPresent()) {
+                        xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
                         fillDisclosureDocument(
                                 xwpfDocument,
                                 projectLicenseInfoResults,
@@ -129,8 +129,8 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
                         docxTemplateFile = CommonUtils.loadResource(DocxGenerator.class,
                                 System.getProperty("file.separator") + fileName + "." + DOCX_OUTPUT_TYPE);
                     }
-                    xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
                     if (docxTemplateFile.isPresent()) {
+                        xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
                         fillReportDocument(
                                 xwpfDocument,
                                 projectLicenseInfoResults,


### PR DESCRIPTION
## Summary

Fixes #3721 - DocxGenerator crashes with NoSuchElementException when template file is missing

### Bug
In DocxGenerator.generateOutputFile(), the code was calling .get() on the Optional before checking .isPresent(). This caused a raw NoSuchElementException.

### Fix
Reordered the code to check isPresent() first:
- Line 110: Moved inside the if block
- Line 132: Same fix for REPORT case