### PR TITLE
fix: prevent NoSuchElementException when spdxPackageInfoIds is empty in ReleaseController

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -295,11 +295,13 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                 sw360SPDXDocumentService.sortSectionForDocumentCreation(documentCreationInformation);
                 restControllerHelper.addEmbeddedDocumentCreationInformation(halRelease, documentCreationInformation);
             }
-            String spdxPackageInfoId = spdxDocument.getSpdxPackageInfoIds().stream().findFirst().get();
-            if(CommonUtils.isNotNullEmptyOrWhitespace(spdxPackageInfoId)) {
-                PackageInformation packageInformation = releaseService.getPackageInformationById(spdxPackageInfoId, sw360User);
-                sw360SPDXDocumentService.sortSectionForPackageInformation(packageInformation);
-                restControllerHelper.addEmbeddedPackageInformation(halRelease, packageInformation);
+            if (!CommonUtils.isNullOrEmptyCollection(spdxDocument.getSpdxPackageInfoIds())) {
+                String spdxPackageInfoId = spdxDocument.getSpdxPackageInfoIds().stream().findFirst().get();
+                if (CommonUtils.isNotNullEmptyOrWhitespace(spdxPackageInfoId)) {
+                    PackageInformation packageInformation = releaseService.getPackageInformationById(spdxPackageInfoId, sw360User);
+                    sw360SPDXDocumentService.sortSectionForPackageInformation(packageInformation);
+                    restControllerHelper.addEmbeddedPackageInformation(halRelease, packageInformation);
+                }
             }
         }
         if (linkedReleaseRelations != null) {


### PR DESCRIPTION
### Summary 

Added a null/empty collection guard before calling findFirst().get() on spdxDocument.getSpdxPackageInfoIds() in 
ReleaseController.java. Previously, if spdxPackageInfoIds was null or an empty set, calling .get() on the empty Optional
returned by findFirst() would throw a NoSuchElementException, causing the GET /api/releases/{id} endpoint to return a 500 error.
The fix wraps the unsafe call with a CommonUtils.isNullOrEmptyCollection() check — the same pattern already used correctly in SW360SPDXDocumentService.java(line 126).
spdxPackageInfoIds is declared as optional with no default value in spdxdocument.thrift(field 6), so it can legally be 
null or empty. This PR adds the missing guard to prevent the crash.

Fixes #3732

### Suggest Reviewer
@GMishx  , @heliocastro 

### How To Test?
1. Enable SPDX document support (SPDX_DOCUMENT_ENABLED=true)
2. Create a release linked to an SPDX document that has no package info IDs (spdxPackageInfoIds is empty/null)
3. Call GET /api/releases/{id} for that release
4. Before fix: endpoint throws NoSuchElementException → 500 error
5. After fix: endpoint returns the release successfully without the package info section (since the set is empty)