### PR TITLE
fix : JWT issuer discovery in resource server

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -57,9 +57,6 @@ public class ResourceServerConfiguration {
     @Autowired
     Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
 
-    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
-    String issuerUri;
-
     @Value("${springdoc.swagger-ui.require-authentication:true}")
     boolean swaggerRequireAuthentication;
 
@@ -70,7 +67,7 @@ public class ResourceServerConfiguration {
                 .addFilterBefore(apiTokenAuthenticationFilter, BasicAuthenticationFilter.class)
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt ->
                         jwt.jwtAuthenticationConverter(sw360JWTAccessTokenConverter)
-                                .jwkSetUri(issuerUri)).authenticationEntryPoint(saep))
+                ).authenticationEntryPoint(saep))
                 .authorizeHttpRequests(auth -> {
                     // Swagger/OpenAPI endpoints - configurable authentication
                     if (!swaggerRequireAuthentication) {

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -50,10 +50,10 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          #issuer-uri: http://localhost:8083/realms/sw360/protocol/openid-connect/certs
+          #issuer-uri: http://localhost:8083/realms/sw360
           #jwk-set-uri: https://localhost:8083/realms/sw360/protocol/openid-connect/certs
-          issuer-uri: http://localhost:8080/authorization/oauth2/jwks
-          jwk-set-uri: http://localhost:8080/authorization/oauth2/jwks
+          issuer-uri: http://localhost:8080/authorization
+          #jwk-set-uri: http://localhost:8080/authorization/oauth2/jwks
 
 #logging:
 #  level:

--- a/rest/resource-server/src/test/resources/application.yml
+++ b/rest/resource-server/src/test/resources/application.yml
@@ -43,8 +43,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8080/authorization/oauth2/jwks
-          jwk-set-uri: http://localhost:8080/authorization/oauth2/jwks
+          issuer-uri: http://localhost:8080/authorization
+          #jwk-set-uri: http://localhost:8080/authorization/oauth2/jwks
 
 #logging:
 #  level:


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: #3739 

### Description : 
- Fix JWT resource server configuration to use issuer discovery instead of treating `issuer-uri` as the JWKS URL.
- Align resource server config examples to point `issuer-uri` at the issuer base.
- Keep JWKS URL commented out unless explicitly required.

### Changes : 
- Removed explicit `.jwkSetUri(issuerUri)` from `ResourceServerConfiguration`.
- Updated `rest/resource-server/src/main/resources/application.yml` and `src/test/resources/application.yml` to use issuer base URL.


### Suggest Reviewer
@GMishx @amritkv 

### How To Test?
- Build: `mvn -Dbase.deploy.dir=.\target -DskipTests -Pfatjar -pl rest/authorization-server,rest/resource-server -am package`
- Manual: start auth + resource servers and verify discovery/JWKS fetch.
- Test run by command : 
   
<img width="1001" height="605" alt="Screenshot 2026-02-21 110629" src="https://github.com/user-attachments/assets/4bf1e5a8-67e1-4c49-bd70-ac05cf24c39f" />


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
