### PR TITLE
fix(importCDX):do not alter unknown domain VCS and revert old changes

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/common/utils/RepositoryURL.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/utils/RepositoryURL.java
@@ -45,8 +45,7 @@ public class RepositoryURL {
 
         List<String> extractedParams = new ArrayList<>();
         for (int i = 3; i < urlParts.length && extractedParams.size() < paramCount; i++) {
-            String part = urlParts[i];
-            if(i == urlParts.length-1) part = part.replaceAll("\\.git.*|#.*", "");
+            String part = urlParts[i].replaceAll("\\.git.*|#.*", "");
 
             if (part.equals("+") || part.equals("-") || CommonUtils.isNullEmptyOrWhitespace(part)) {
                 break;
@@ -85,7 +84,7 @@ public class RepositoryURL {
                 return sanitizeVCSByHost(vcs, host);
             }
         }
-        return vcs.replaceAll("\\.git.*|#.*", "");
+        return vcs;
     }
 
     public static String getComponentNameFromVCS(String vcsUrl, boolean isGetVendorandName) {


### PR DESCRIPTION
**Description**

- Revert to the older code where everything after .git or # is removed in the VCS of identified domains.
- For VCS of unidentified domains, do not alter the vcs by removing the URL after .git or #.
