### PR TITLE
fix(backend): enable update release's clearing state

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1159,6 +1159,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         removeLeadingTrailingWhitespace(release);
         String name = release.getName();
         String version = release.getVersion();
+        ClearingState cs = release.isSetClearingState() ? release.getClearingState() : null;
         if (name == null || name.isEmpty() || version == null || version.isEmpty()) {
             return RequestStatus.NAMINGERROR;
         }
@@ -1206,6 +1207,8 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 release.setAttachments(
                         getAllAttachmentsToKeep(toSource(actual), actual.getAttachments(), release.getAttachments()));
                 autosetReleaseClearingState(release, actual);
+
+                if(cs != null) release.setClearingState(cs);
 
                 List<ChangeLogs> referenceDocLogList = new LinkedList<>();
                 Set<Attachment> attachmentsAfter = release.getAttachments();

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -24,6 +24,9 @@ import org.eclipse.sw360.datahandler.entitlement.ComponentModerator;
 import org.eclipse.sw360.datahandler.entitlement.ProjectModerator;
 import org.eclipse.sw360.datahandler.entitlement.ReleaseModerator;
 import org.eclipse.sw360.datahandler.thrift.*;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -891,6 +894,27 @@ public class ComponentDatabaseHandlerTest {
         // Check releases
         assertEquals(1, actual.getSubscribersSize());
         assertTrue(actual.getSubscribers().contains(email1));
+    }
+
+    @Test
+    public void testUpdateReleaseClearingState() throws Exception {
+        Release expected = releases.get(1);
+
+        // To trigger autosetReleaseClearingState
+        Attachment clearingReport = new Attachment("clearing-report.pdf", "doc-9999");
+        clearingReport.setAttachmentType(AttachmentType.CLEARING_REPORT);
+        clearingReport.setCheckStatus(CheckStatus.ACCEPTED);
+        clearingReport.setSha1("1234567890abcdef1234567890abcdef12345678");
+        expected.addToAttachments(clearingReport);
+
+        handler.updateRelease(expected, user2, ThriftUtils.IMMUTABLE_OF_RELEASE);
+
+        expected.setClearingState(ClearingState.UNDER_CLEARING);
+
+        RequestStatus status = handler.updateRelease(expected, user2, ThriftUtils.IMMUTABLE_OF_RELEASE);
+        Release actual = handler.getRelease("R1B", user1);
+
+        assertEquals(ClearingState.UNDER_CLEARING, actual.getClearingState());
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary of changes:
This PR fixes an issue where the Clearing State of a Release was not properly updated or saved in the backend. Previously, the clearing state was being automatically overwritten by the state of attachments or Fossology reports. I modified the backend-components module to ensure that the clearing state is correctly updated and persisted when a user explicitly specifies it.

Issue: 
Fixes #119 

### Suggest Reviewer

### Test
I created test cases for this feature.

To simulate the scenario where the clearing state is automatically updated, I mocked attachments as if they were already stored in the database.

### Checklist
Must:
- [x ] All related issues are referenced in commit messages and in PR
