### PR TITLE
fix(security): add @PreAuthorize ADMIN check to AttachmentCleanUpCont…

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.rest.resourceserver.admin.attachment;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.apache.thrift.TException;
@@ -24,6 +25,7 @@ import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 
 import lombok.NonNull;
@@ -34,6 +36,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @BasePathAwareController
 @RequiredArgsConstructor
+@SecurityRequirement(name = "tokenAuth")
+@SecurityRequirement(name = "basic")
+@PreAuthorize("hasAuthority('ADMIN')")
 public class AttachmentCleanUpController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String ATTACHMENT_CLEANUP_URL = "/attachmentCleanUp";
 


### PR DESCRIPTION
Fixes #3761
## Summary

`AttachmentCleanUpController` exposed `DELETE /api/attachmentCleanUp/deleteAll` 
a destructive bulk-delete operation, without any authorization check. Any 
authenticated user, regardless of role, could call this endpoint and permanently 
delete all unused attachments from the database.

`FossologyAdminController`, a sibling controller in the same `admin` package, 
correctly gates all its endpoints with `@PreAuthorize("hasAuthority('ADMIN')")`. 
`AttachmentCleanUpController` was missing this guard entirely.

This PR adds the three missing annotations at the class level to match the 
established pattern:

- `@PreAuthorize("hasAuthority('ADMIN')")` - enforces ADMIN role at runtime; 
  Spring Security returns `403 Forbidden` for non-admin callers before the method 
  body executes
- `@SecurityRequirement(name = "tokenAuth")` - documents token auth in Swagger UI
- `@SecurityRequirement(name = "basic")` - documents basic auth in Swagger UI

Issue: Fixes #3761

### Suggest Reviewer
@GMishx @amritkv @rudra-superrr 