### PR TITLE
fix(obligation): stop persisting tab chars in obligation text (#3214)

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -56,12 +56,19 @@ public class ThriftValidate {
         assertNotNull(oblig.getTitle());
         assertNotNull(oblig.getObligationLevel());
 
+        oblig.setText(normalizeObligationText(oblig.getText()));
+
         if (oblig.whitelist == null) {
             oblig.setWhitelist(Collections.emptySet());
         }
 
         // Check type
         oblig.setType(TYPE_OBLIGATION);
+    }
+
+    private static String normalizeObligationText(String text) {
+        // Store printable indentation only to avoid persisting tab control characters in DB text fields.
+        return text.replace('\t', ' ');
     }
 
     public static void prepareLicenseType(LicenseType licenseType) throws SW360Exception {

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftValidateTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftValidateTest.java
@@ -10,13 +10,18 @@
 package org.eclipse.sw360.datahandler.thrift;
 
 import org.junit.Test;
-import static org.eclipse.sw360.datahandler.common.SW360Constants.TYPE_USER;
-import static org.junit.Assert.assertEquals;
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
+import static org.eclipse.sw360.datahandler.common.SW360Constants.TYPE_OBLIGATION;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.TYPE_USER;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareTodo;
 import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareUser;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ThriftValidateTest {
     final String DUMMY_EMAIL_ADDRESS = "dummy.name@dummy.domain.tld";
@@ -39,5 +44,20 @@ public class ThriftValidateTest {
         assertNull(user.getId());
         assertEquals(TYPE_USER, user.getType());
         assertFalse(user.isSetCommentMadeDuringModerationRequest());
+    }
+
+    @Test
+    public void testPrepareTodoNormalizesTabCharacters() throws Exception {
+        Obligation obligation = new Obligation();
+        obligation.setTitle("Test Obligation");
+        obligation.setText("Line1\n\tIndented\tsegment");
+        obligation.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
+
+        prepareTodo(obligation);
+
+        assertEquals(TYPE_OBLIGATION, obligation.getType());
+        assertFalse(obligation.getText().contains("\t"));
+        assertEquals("Line1\n Indented segment", obligation.getText());
+        assertTrue(obligation.getWhitelist().isEmpty());
     }
 }


### PR DESCRIPTION
Fixes: #3214

This PR focuses on the remaining reproducible part of the issue: tab characters (`\t`) getting persisted in obligation text.

What changed
- Added obligation text normalization in `ThriftValidate.prepareTodo(...)`.
- Tabs are converted to regular spaces before persistence.
- Added unit test coverage in `ThriftValidateTest` to prevent regressions.

Why this approach
- `prepareTodo(...)` is used by obligation add/update flows, so this keeps behavior consistent across write paths.
- It is a minimal, targeted fix and avoids touching unrelated obligation rendering logic.

Validation
- Ran locally:
  - `mvn -pl :datahandler -Dtest=ThriftValidateTest -Dbase.deploy.dir=. test`
  - `mvn -pl :datahandler -DskipTests -Dbase.deploy.dir=. compile`
- Result: both commands passed.

Notes
- The HTML entity part (`&#34;`) appears already handled by current XSS sanitization on main.
- This PR addresses the tab-character persistence part of #3214.