### PR TITLE
fix(rest): align PATCH and DELETE success status codes

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -221,7 +221,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     ) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         licenseService.deleteLicenseById(id, sw360User);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
@@ -183,7 +183,7 @@ public class PackageController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus requestStatus = packageService.deletePackage(id, sw360User);
         if(requestStatus == RequestStatus.SUCCESS) {
-            return new ResponseEntity<>(HttpStatus.OK);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         } else if(requestStatus == RequestStatus.IN_USE) {
             return new ResponseEntity<>(HttpStatus.CONFLICT);
         } else if (requestStatus == RequestStatus.ACCESS_DENIED) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -228,10 +228,10 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             tags = {"Vulnerabilities"},
             responses = {
                     @ApiResponse(
-                            responseCode = "201",
+                            responseCode = "200",
                             content = @Content(mediaType = "application/hal+json",
                                     schema = @Schema(implementation = VulnerabilityApiDTO.class)),
-                            description = "Redirection to the created vulnerability."
+                            description = "Updated vulnerability."
                     )
             }
     )
@@ -260,10 +260,8 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         vulnerabilityService.updateFromVulnerabilityDTO(vulnerabilityByExtId, vulnerability, vulnerabilityApiDTO);
         vulnerabilityService.createUpdateDeleteVulnerability(vulnerabilityByExtId, user, VulnerabilityOperation.UPDATE);
 
-        URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(externalId)
-                .toUri();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        return ResponseEntity.created(location).body(mapper.convertValue(vulnerabilityAsMap, Map.class));
+        return ResponseEntity.ok(mapper.convertValue(vulnerabilityAsMap, Map.class));
     }
 
     @PreAuthorize("hasAuthority('WRITE')")


### PR DESCRIPTION
## Summary
- align REST success status codes for update/delete endpoints to improve API semantics consistency
- return `200 OK` for `PATCH /resource/api/vulnerabilities/{externalId}` instead of `201 Created`
- return `204 No Content` for successful `DELETE /resource/api/packages/{id}` and `DELETE /resource/api/licenses/{id}`

## Test plan
- [x] reproduce pre-fix behavior in browser Network tab: PATCH vulnerability returned `201`, DELETE package/license returned `200`
- [x] verify backend changes are limited to three controllers and preserve non-success paths (`409`, access denied, etc.)


Closes #3774