### PR TITLE
fix(user): prevent permanent import lockout on unchecked exceptions

### DIFF
--- a/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -35,6 +35,7 @@ import java.io.*;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
@@ -59,7 +60,7 @@ public class UserDatabaseHandler {
     private static final String SUCCESS = "SUCCESS";
     private static final String FAIL = "FAIL";
     private static final String TITLE = "IMPORT";
-    private static boolean IMPORT_DEPARTMENT_STATUS = false;
+    private static final AtomicBoolean IMPORT_DEPARTMENT_STATUS = new AtomicBoolean(false);
     private List<String> departmentDuplicate;
     private List<String> emailDoNotExist;
     DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH);
@@ -169,10 +170,9 @@ public class UserDatabaseHandler {
         DepartmentConfigDTO configDTO = readFileDepartmentConfig.readFileJson();
         String pathFolderLog = configDTO.getPathFolderLog();
         Map<String, List<String>> mapArrayList = new HashMap<>();
-        if (IMPORT_DEPARTMENT_STATUS) {
+        if (!IMPORT_DEPARTMENT_STATUS.compareAndSet(false, true)) {
             return requestSummary.setRequestStatus(RequestStatus.PROCESSING);
         }
-        IMPORT_DEPARTMENT_STATUS = true;
         Calendar calendar = Calendar.getInstance(Locale.getDefault());
         String lastRunningTime = dateFormat.format(calendar.getTime());
         readFileDepartmentConfig.writeLastRunningTimeConfig(lastRunningTime);
@@ -207,19 +207,24 @@ public class UserDatabaseHandler {
                     listFileFail.add(fileName);
                 }
             }
-            IMPORT_DEPARTMENT_STATUS = false;
             requestSummary.setTotalAffectedElements(listFileSuccess.size());
             requestSummary.setTotalElements(listFileSuccess.size() + listFileFail.size());
             requestSummary.setRequestStatus(RequestStatus.SUCCESS);
         } catch (IOException e) {
-            IMPORT_DEPARTMENT_STATUS = false;
             String msg = "Failed to import department";
             requestSummary.setMessage(msg);
             requestSummary.setRequestStatus(RequestStatus.FAILURE);
             FileUtil.writeLogToFile(TITLE, "FILE ERROR: " + e.getMessage(), "", pathFolderLog);
+        } catch (Exception e) {
+            String msg = "Unexpected error during department import";
+            requestSummary.setMessage(msg);
+            requestSummary.setRequestStatus(RequestStatus.FAILURE);
+            FileUtil.writeLogToFile(TITLE, "UNEXPECTED ERROR: " + e.getMessage(), "", pathFolderLog);
+        } finally {
+            FileUtil.writeLogToFile(TITLE, "[ FILE SUCCESS: " + listFileSuccess.size() + " - " + "FILE FAIL: " + listFileFail.size() + " - " + "TOTAL FILE: " + (listFileSuccess.size() + listFileFail.size()) + " ]", "Complete The File Import", pathFolderLog);
+            FileUtil.writeLogToFile(TITLE, "END IMPORT DEPARTMENT", "", pathFolderLog);
+            IMPORT_DEPARTMENT_STATUS.set(false);
         }
-        FileUtil.writeLogToFile(TITLE, "[ FILE SUCCESS: " + listFileSuccess.size() + " - " + "FILE FAIL: " + listFileFail.size() + " - " + "TOTAL FILE: " + (listFileSuccess.size() + listFileFail.size()) + " ]", "Complete The File Import", pathFolderLog);
-        FileUtil.writeLogToFile(TITLE, "END IMPORT DEPARTMENT", "", pathFolderLog);
 
         return requestSummary;
     }


### PR DESCRIPTION
### Summary

Fixes the IMPORT_DEPARTMENT_STATUS flag in UserDatabaseHandler.importFileToDB() which can get permanently stuck at true after an unchecked exception, disabling department import until server restart.
-This PR fixes issue #3778 by moving the flag reset to a finally block and replacing the plain static boolean with AtomicBoolean.compareAndSet() for thread-safe guarding.
-No new dependencies added. AtomicBoolean is part of java.util.concurrent.atomic (standard JDK).

Fixes: #3778 

### Suggest Reviewer
@GMishx

### How To Test?
1. Verify the flag resets correctly on success — trigger a department import with valid files and confirm it completes and can be re-triggered
2. Verify the flag resets on failure — trigger an import with a malformed Excel file (blank second column) and confirm the next import attempt works instead of returning PROCESSING forever
3. Verify concurrent guard — trigger a manual import while a scheduled import is running and confirm the second call returns PROCESSING (not both running simultaneously)
