### PR TITLE
fix(sorting): use natural version ordering instead of lexicographic

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1137,7 +1137,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }
             projectLinkOptional.ifPresent(out::add);
         }
-        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion));
+        out.sort(Comparator.comparing(ProjectLink::getName, String.CASE_INSENSITIVE_ORDER).thenComparing(ProjectLink::getVersion, NaturalVersionComparator.NULLS_FIRST_INSTANCE));
         return out;
     }
 
@@ -2765,7 +2765,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }
             projectLinkOptional.ifPresent(out::add);
         }
-        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion));
+        out.sort(Comparator.comparing(ProjectLink::getName, String.CASE_INSENSITIVE_ORDER).thenComparing(ProjectLink::getVersion, NaturalVersionComparator.NULLS_FIRST_INSTANCE));
         return out;
     }
 
@@ -2794,7 +2794,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                     parentNodeId, visitedIds, maxDepth, user, true, WITH_ALL_RELEASES);
             projectLinkOptional.ifPresent(out::add);
         }
-        out.sort(Comparator.comparing(ProjectLink::getName).thenComparing(ProjectLink::getVersion));
+        out.sort(Comparator.comparing(ProjectLink::getName, String.CASE_INSENSITIVE_ORDER).thenComparing(ProjectLink::getVersion, NaturalVersionComparator.NULLS_FIRST_INSTANCE));
         return out;
     }
 

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/NaturalVersionComparator.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/NaturalVersionComparator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Himanshu Gupta, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.datahandler.common;
+
+import java.util.Comparator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class NaturalVersionComparator implements Comparator<String> {
+
+    public static final NaturalVersionComparator INSTANCE = new NaturalVersionComparator();
+
+    public static final Comparator<String> NULLS_FIRST_INSTANCE =
+            Comparator.nullsFirst(INSTANCE);
+
+    private static final Pattern SEGMENT_PATTERN = Pattern.compile("(\\d+)|(\\D+)");
+
+    private NaturalVersionComparator() {
+    }
+
+    @Override
+    public int compare(String v1, String v2) {
+        Matcher m1 = SEGMENT_PATTERN.matcher(v1);
+        Matcher m2 = SEGMENT_PATTERN.matcher(v2);
+
+        while (m1.find() && m2.find()) {
+            String seg1 = m1.group();
+            String seg2 = m2.group();
+
+            int cmp;
+            if (m1.group(1) != null && m2.group(1) != null) {
+                cmp = compareLong(seg1, seg2);
+            } else {
+                cmp = seg1.compareToIgnoreCase(seg2);
+            }
+
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+
+        if (m1.find()) {
+            return 1;
+        }
+        if (m2.find()) {
+            return -1;
+        }
+        return 0;
+    }
+
+    private static int compareLong(String n1, String n2) {
+        String stripped1 = n1.replaceFirst("^0+", "");
+        String stripped2 = n2.replaceFirst("^0+", "");
+
+        if (stripped1.length() != stripped2.length()) {
+            return Integer.compare(stripped1.length(), stripped2.length());
+        }
+        return stripped1.compareTo(stripped2);
+    }
+}

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.NaturalVersionComparator;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.Comment;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
@@ -106,7 +107,7 @@ public class ResourceComparatorGenerator<T> {
         releaseMap.put(Release._Fields.NAME, Comparator.comparing(Release::getName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
         releaseMap.put(Release._Fields.CLEARING_STATE, Comparator.comparing(p -> Optional.ofNullable(p.getClearingState()).map(Object::toString).orElse(null), Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
         releaseMap.put(Release._Fields.CREATED_ON, Comparator.comparing(Release::getCreatedOn, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
-        releaseMap.put(Release._Fields.VERSION, Comparator.comparing(Release::getVersion, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        releaseMap.put(Release._Fields.VERSION, Comparator.comparing(Release::getVersion, NaturalVersionComparator.NULLS_FIRST_INSTANCE));
         return Collections.unmodifiableMap(releaseMap);
     }
 
@@ -121,7 +122,7 @@ public class ResourceComparatorGenerator<T> {
         releaseMapForEcc.put(Release._Fields.NAME,
                 Comparator.comparing(Release::getName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
         releaseMapForEcc.put(Release._Fields.VERSION,
-                Comparator.comparing(Release::getVersion, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+                Comparator.comparing(Release::getVersion, NaturalVersionComparator.NULLS_FIRST_INSTANCE));
         releaseMapForEcc.put(Release._Fields.CREATOR_DEPARTMENT, Comparator.comparing(Release::getCreatorDepartment,
                 Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
         return Collections.unmodifiableMap(releaseMapForEcc);

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/NaturalVersionComparatorTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/NaturalVersionComparatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Himanshu Gupta, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.datahandler.common;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NaturalVersionComparatorTest {
+
+    private final NaturalVersionComparator comparator = NaturalVersionComparator.INSTANCE;
+
+    @Test
+    public void testNumericSegmentsComparedAsNumbers() {
+        assertTrue("15.0 should be > 2.0", comparator.compare("15.0", "2.0") > 0);
+        assertTrue("2.0 should be < 15.0", comparator.compare("2.0", "15.0") < 0);
+    }
+
+    @Test
+    public void testSimpleVersionOrdering() {
+        assertTrue(comparator.compare("1.0", "1.1") < 0);
+        assertTrue(comparator.compare("1.1", "2.0") < 0);
+        assertTrue(comparator.compare("1.9", "1.10") < 0);
+    }
+
+    @Test
+    public void testEqualVersions() {
+        assertEquals(0, comparator.compare("1.0", "1.0"));
+        assertEquals(0, comparator.compare("2.1.3", "2.1.3"));
+    }
+
+    @Test
+    public void testVersionWithSuffixComesAfterBase() {
+        assertTrue("1.1 should be < 1.1 SR1", comparator.compare("1.1", "1.1 SR1") < 0);
+        assertTrue("1.1 SR1 should be < 2.0", comparator.compare("1.1 SR1", "2.0") < 0);
+    }
+
+    @Test
+    public void testSortingFullList() {
+        List<String> versions = Arrays.asList("2.0", "1.1 SR1", "1.0", "1.1");
+        versions.sort(comparator);
+        assertEquals(Arrays.asList("1.0", "1.1", "1.1 SR1", "2.0"), versions);
+    }
+
+    @Test
+    public void testThreePartVersions() {
+        List<String> versions = Arrays.asList("2.1.0", "10.0.0", "2.0.1", "2.0.0");
+        versions.sort(comparator);
+        assertEquals(Arrays.asList("2.0.0", "2.0.1", "2.1.0", "10.0.0"), versions);
+    }
+
+    @Test
+    public void testVersionsWithLeadingZeros() {
+        assertEquals(0, comparator.compare("01.02", "1.2"));
+        assertTrue(comparator.compare("01.02", "1.10") < 0);
+    }
+
+    @Test
+    public void testNullSafeComparator() {
+        assertTrue(NaturalVersionComparator.NULLS_FIRST_INSTANCE.compare(null, "1.0") < 0);
+        assertTrue(NaturalVersionComparator.NULLS_FIRST_INSTANCE.compare("1.0", null) > 0);
+        assertEquals(0, NaturalVersionComparator.NULLS_FIRST_INSTANCE.compare(null, null));
+    }
+
+    @Test
+    public void testIssue206LargeVersionNumbers() {
+        List<String> versions = Arrays.asList("15.0", "2.0", "1.0", "10.0", "3.0");
+        versions.sort(comparator);
+        assertEquals(Arrays.asList("1.0", "2.0", "3.0", "10.0", "15.0"), versions);
+    }
+}


### PR DESCRIPTION
Overview: Solving two sorting issue mentioned in #206, #236. The current version sorting uses `String.CASE_INSENSITIVE_ORDER` (lexicographic ordering) which produces incorrect results:

  1. `15.0` sorts before `2.0` because character `'1'` < `'2'`
  2. `1.1 SR1` sorts before `1.1` due to space/bracket character comparison

  This PR introduces a `NaturalVersionComparator` that splits version strings into numeric and non-numeric segments, comparing numeric parts as integers instead of strings.

  **Before (broken):** `1.0, 1.1, 1.1 SR1, 10.0, 15.0, 2.0, 3.0`
  **After (fixed):** `1.0, 1.1, 1.1 SR1, 2.0, 3.0, 10.0, 15.0`
  
> * Did you add or update any new dependencies that are required for your change? - NO

Issue: #206, #236
Fixes #206
Fixes #236

### Suggest Reviewer
@GMishx @mcjaeger Could you please review or assign someone to this pr? Please let me know if any edge case is missing.

### How To Test?
https://github.com/user-attachments/assets/9415a622-6f9f-4d85-ab99-c20b8c688650

  1. Create a component with releases having versions: `15.0`, `2.0`, `1.0`, `10.0`, `3.0`, `1.1`, `1.1 SR1`
  2. Create a project and link those releases
  3. Call `GET /resource/api/projects/{projectId}/releases?sort=version,asc`
  4. Verify order: `1.0, 1.1, 1.1 SR1, 2.0, 3.0, 10.0, 15.0`
  

> Have you implemented any additional tests? - Yes. Created a test file - libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/NaturalVersionComparatorTest.java 

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
