### PR TITLE
fix: add @PreAuthorize to AttachmentCleanUpController for security

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
@@ -28,11 +28,15 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+
 
 
 @RestController
 @BasePathAwareController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@PreAuthorize("hasAuthority('ADMIN')")
+
 public class AttachmentCleanUpController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String ATTACHMENT_CLEANUP_URL = "/attachmentCleanUp";
 


### PR DESCRIPTION

## Fixes #3761

## Problem
AttachmentCleanUpController exposes a destructive `DELETE /api/attachmentCleanUp/deleteAll` 
endpoint without any authorization check. Any authenticated user, regardless of role, 
could call this endpoint and delete all unused attachments.

## Solution
Added `@PreAuthorize("hasAuthority('ADMIN')")` annotation to the controller class, 
following the same security pattern used in `FossologyAdminController`.

## Changes Made
- Added `@PreAuthorize("hasAuthority('ADMIN')")` annotation to `AttachmentCleanUpController`
- Added corresponding import for `PreAuthorize`

## Testing
- Verified annotation follows same pattern as `FossologyAdminController`
- Endpoint now requires ADMIN authority to access

## Security Impact
This fix prevents unauthorized users from triggering bulk deletion of attachments.

