### PR TITLE
fix(rest): Unauthorrrized access to backend configurations.

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -74,6 +74,9 @@ public class SW360ConfigKeys {
     public static final String VCS_HOSTS = "vcs.hosts";
     public static final String NON_PKG_MANAGED_COMPS_PROP = "non.pkg.managed.comps.prop";
 
+    // This property is used to configure the SVM notification URL
+    public static final String SVM_NOTIFICATION_URL = "svm.notification.url";
+
     // Properties purely used by UI
     // This property is used in Project Administration
     public static final String UI_CLEARING_TEAMS = "ui.clearing.teams";
@@ -118,6 +121,23 @@ public class SW360ConfigKeys {
     public static final String UI_SOFTWARE_PLATFORMS = "ui.software.platforms";
     // This property is used to create State of Projects
     public static final String UI_STATE = "ui.state";
+
+    // Configuration keys that should only be visible to ADMIN and SW360_ADMIN users
+    public static final Set<String> ADMIN_ONLY_CONFIG_KEYS = Set.of(
+            RELEASE_FRIENDLY_URL,
+            IS_STORE_ATTACHMENT_TO_FILE_SYSTEM_ENABLED,
+            REST_API_TOKEN_LENGTH,
+            INHERIT_ATTACHMENT_USAGES,
+            SKIP_DOMAINS_FOR_VALID_SOURCE_CODE,
+            ATTACHMENT_STORE_FILE_SYSTEM_LOCATION,
+            IS_FORCE_UPDATE_ENABLED,
+            AUTO_SET_ECC_STATUS,
+            IS_ADMIN_PRIVATE_ACCESS_ENABLED,
+            DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD,
+            COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY,
+            SVM_NOTIFICATION_URL,
+            VCS_HOSTS
+    );
 
     // List of all known config keys
     public static final Set<String> ALL_KNOWN_CONFIG_KEYS = Set.of(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsController.java
@@ -98,15 +98,16 @@ public class SW360ConfigurationsController implements RepresentationModelProcess
             )
             @RequestParam(required = false, name = "changeable") Boolean changeable)
             throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        Map<String, String> configs;
         if (changeable == null) {
-            return ResponseEntity.ok(sw360ConfigurationsService.getSW360Configs());
+            configs = sw360ConfigurationsService.getSW360Configs();
+        } else if (changeable) {
+            configs = sw360ConfigurationsService.getSW360ConfigFromDb();
+        } else {
+            configs = sw360ConfigurationsService.getSW360ConfigFromProperties();
         }
-
-        if (changeable) {
-            return ResponseEntity.ok(sw360ConfigurationsService.getSW360ConfigFromDb());
-        }
-
-        return ResponseEntity.ok(sw360ConfigurationsService.getSW360ConfigFromProperties());
+        return ResponseEntity.ok(sw360ConfigurationsService.filterAdminOnlyKeys(configs, sw360User));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")
@@ -190,15 +191,16 @@ public class SW360ConfigurationsController implements RepresentationModelProcess
             @PathVariable(name = "configFor") ConfigFor configFor,
             @RequestParam(required = false, name = "changeable") Boolean changeable
     ) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        Map<String, String> configs;
         if (changeable == null) {
-            return ResponseEntity.ok(sw360ConfigurationsService.getConfigForContainer(configFor));
+            configs = sw360ConfigurationsService.getConfigForContainer(configFor);
+        } else if (changeable) {
+            configs = sw360ConfigurationsService.getSW360ConfigFromDb(configFor);
+        } else {
+            configs = sw360ConfigurationsService.getSW360ConfigFromProperties();
         }
-
-        if (changeable) {
-            return ResponseEntity.ok(sw360ConfigurationsService.getSW360ConfigFromDb(configFor));
-        }
-
-        return ResponseEntity.ok(sw360ConfigurationsService.getSW360ConfigFromProperties());
+        return ResponseEntity.ok(sw360ConfigurationsService.filterAdminOnlyKeys(configs, sw360User));
     }
 
     @PreAuthorize("hasAuthority('ADMIN')")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsService.java
@@ -14,7 +14,9 @@ package org.eclipse.sw360.rest.resourceserver.configuration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.ConfigFor;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
@@ -85,5 +87,23 @@ public class SW360ConfigurationsService {
         } catch (SW360Exception sw360Exception) {
             throw new InvalidPropertiesFormatException(sw360Exception.getWhy());
         }
+    }
+
+    /**
+     * Filters out admin-only configuration keys from the given config map
+     * if the user is not an ADMIN or SW360_ADMIN.
+     *
+     * @param configs The configuration map to filter.
+     * @param user    The current user requesting the configurations.
+     * @return A filtered map without admin-only keys for non-admin users,
+     *         or the original map if the user is an admin.
+     */
+    public Map<String, String> filterAdminOnlyKeys(Map<String, String> configs, User user) {
+        if (PermissionUtils.isAdmin(user)) {
+            return configs;
+        }
+        Map<String, String> filtered = new HashMap<>(configs);
+        SW360ConfigKeys.ADMIN_ONLY_CONFIG_KEYS.forEach(filtered::remove);
+        return filtered;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
@@ -86,6 +86,10 @@ public class ConfigurationsTest extends TestIntegrationBase {
         given(this.sw360ConfigurationsService.updateSW360Configs(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.sw360ConfigurationsService.updateSW360ConfigForContainer(any(), any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.sw360ConfigurationsService.getConfigForContainer(any())).willReturn(testConfigsFromDb);
+        // filterAdminOnlyKeys returns configs as-is for ADMIN users (test user is ADMIN)
+        given(this.sw360ConfigurationsService.filterAdminOnlyKeys(eq(allTestConfigs), any())).willReturn(allTestConfigs);
+        given(this.sw360ConfigurationsService.filterAdminOnlyKeys(eq(testConfigsFromDb), any())).willReturn(testConfigsFromDb);
+        given(this.sw360ConfigurationsService.filterAdminOnlyKeys(eq(testConfigsFromProperties), any())).willReturn(testConfigsFromProperties);
     }
 
     // ========== GET CONFIGURATIONS TESTS ==========


### PR DESCRIPTION
Description: Any regular user in the SW360 web application is able to read the backend configuration values through
the REST API.

Problem: The GET /api/configurations/container/SW360_CONFIGURATION endpoint exposes all configuration keys—including sensitive admin-only settings like attachment.store.file.system.location, rest.apitoken.generator.length, force.update.enabled, and admin.private.project.access.enabled—to any authenticated user with READ authority, with no role-based filtering.

Solution: Define an ADMIN_ONLY_CONFIG_KEYS set in SW360ConfigKeys, then filter those keys out in SW360ConfigurationsService for non-admin users before returning the configuration map from the controller's GET endpoints.

Testing: Verify that when a regular user (USER role) calls GET /api/configurations/container/SW360_CONFIGURATION, the response does not contain attachment.store.file.system.location, rest.apitoken.generator.length, force.update.enabled, or admin.private.project.access.enabled. When an ADMIN or SW360_ADMIN user calls the same endpoint, all keys including the admin-only ones should be present in the response.

