### PR TITLE
fix(users): :Update differing externalId in getByEmailOrExternalId

### DIFF
--- a/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
@@ -127,9 +127,9 @@ public class UserHandler implements UserService.Iface {
                 && externalId != null
                 && !externalId.isEmpty()) {
             String currentExternalId = user.getExternalid();
-            if (currentExternalId == null
-                    || currentExternalId.isEmpty()
-                    || !currentExternalId.equals(externalId)) {
+            if (!externalId.equals(email)
+                    && (CommonUtils.isNullEmptyOrWhitespace(currentExternalId)
+                    || !currentExternalId.equals(externalId))) {
                 log.info("Updating differing externalId for user: {} | was: {} | now: {}",
                         email, currentExternalId, externalId);
                 user.setExternalid(externalId);

--- a/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
@@ -123,6 +123,20 @@ public class UserHandler implements UserService.Iface {
         if (user != null && user.isDeactivated()) {
             return null;
         }
+        if (user != null
+                && externalId != null
+                && !externalId.isEmpty()) {
+            String currentExternalId = user.getExternalid();
+            if (currentExternalId == null
+                    || currentExternalId.isEmpty()
+                    || !currentExternalId.equals(externalId)) {
+                log.info("Updating differing externalId for user: {} | was: {} | now: {}",
+                        email, currentExternalId, externalId);
+                user.setExternalid(externalId);
+                db.updateUser(user);
+            }
+        }
+
         return user;
     }
 

--- a/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.sw360.users;
 
-
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotEmpty;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertUser;
@@ -26,6 +25,7 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;


### PR DESCRIPTION
When a user is found by email but has a missing or incorrect externalId, the externalId is now automatically updated in the database.

This prevents login failures when a user changes their email address, which previously resulted in the account being unreachable by both email and externalId lookups.

Fixes #358 