### PR TITLE
fix(rest): Add null check for getReleaseIdToUsage() in ProjectController

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1555,7 +1555,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         final List<EntityModel<License>> licenseResources = new ArrayList<>();
         final Set<String> allLicenseIds = new HashSet<>();
 
-        final Set<String> releaseIdToUsage = project.getReleaseIdToUsage().keySet();
+        final Set<String> releaseIdToUsage = CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
         for (final String releaseId : releaseIdToUsage) {
             final Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
             final Set<String> licenseIds = sw360Release.getMainLicenseIds();
@@ -3191,7 +3191,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         List<Release> releases = new ArrayList<>();
         ObligationList obligation = new ObligationList();
         Map<String, ObligationStatusInfo> obligationStatusMap = Maps.newHashMap();
-        List<String> releaseIds = new ArrayList<>(sw360Project.getReleaseIdToUsage().keySet());
+        List<String> releaseIds = new ArrayList<>(CommonUtils.nullToEmptyMap(sw360Project.getReleaseIdToUsage()).keySet());
         for (final String releaseId : releaseIds) {
             Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
             if (sw360Release.getAttachmentsSize() > 0) {
@@ -3263,7 +3263,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Map<String, ObligationStatusInfo> oblData = Maps.newHashMap();
         Map<String, ObligationStatusInfo> filterData = Maps.newHashMap();
 
-        List<String> releaseIds = new ArrayList<>(sw360Project.getReleaseIdToUsage().keySet());
+        List<String> releaseIds = new ArrayList<>(CommonUtils.nullToEmptyMap(sw360Project.getReleaseIdToUsage()).keySet());
         for (final String releaseId : releaseIds) {
             Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
             if (sw360Release.getAttachmentsSize() > 0) {
@@ -3350,7 +3350,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Map<String, ObligationStatusInfo> obligationStatusMapFromReport = Maps.newHashMap();
         final Map<String, String> releaseIdToAcceptedCLI = Maps.newHashMap();
         List<Release> releases = new ArrayList<>();
-        List<String> releaseIds = new ArrayList<>(sw360Project.getReleaseIdToUsage().keySet());
+        List<String> releaseIds = new ArrayList<>(CommonUtils.nullToEmptyMap(sw360Project.getReleaseIdToUsage()).keySet());
         for (final String releaseId : releaseIds) {
             Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
             if (sw360Release.getAttachmentsSize() > 0) {
@@ -3521,7 +3521,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
      * @throws TException If there is an error during the Thrift operation.
      */
     private List<Release> getReleasesWithAttachments(Project project, User user) throws TException {
-        return project.getReleaseIdToUsage().keySet().stream()
+        return CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet().stream()
                 .map(releaseId -> {
                     try {
                         Release release = releaseService.getReleaseForUserById(releaseId, user);


### PR DESCRIPTION
### Summary

Add null-safety for getReleaseIdToUsage() calls in ProjectController.java.

getReleaseIdToUsage() returns null when a project has no linked releases.
Calling .keySet() directly on the returned value causes a NullPointerException at multiple locations in ProjectController.

#### Fix

Wrap the calls with:

CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet()

This safely handles projects without releases and prevents the exception.

Closes #3799 

### Suggest Reviewer
@GMishx 

### How To Test?
1. Create a project without releases:

```
POST /resource/api/projects
Content-Type: application/json
Authorization: Basic admin@sw360.org:12345

{
  "name": "EmptyProject",
  "version": "1.0"
}
```
2. Call:
```
GET /resource/api/projects/{project-id}/licenses
```
Result

#### Before fix
```
400 Bad Request
Cannot invoke "java.util.Map.keySet()" because
Project.getReleaseIdToUsage() is null
```
#### After fix
```
204 No Content
```
### Checklist
Must:
- [x]  Issue referenced in PR
- [x]  Fix tested locally
