### PR TITLE
fix(project): assert correct variable in updateProject to prevent NPE

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -460,6 +460,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         Project actual = repository.get(project.getId());
 
         assertNotNull(project);
+        assertNotNull(actual);
 
         DatabaseHandlerUtil.saveAttachmentInFileSystem(attachmentConnector, actual.getAttachments(),
                 project.getAttachments(), user.getEmail(), project.getId());


### PR DESCRIPTION
assertNotNull was checking the input `project` parameter instead of `actual` (the DB result). If the project no longer exists in the database, this caused an unhandled NullPointerException on actual.getAttachments() instead of a clean error.

**Fix:** Changed `assertNotNull(project)` to `assertNotNull(actual)` so the DB result is properly validated.

Issue: Fix #3802 

### Suggest Reviewer
@GMishx 
