### PR TITLE
fix(component): fix unreachable code and forceDelete logic in deleteC…

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -2033,8 +2033,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
 
         final Set<String> releaseIds = component.getReleaseIds();
-        if (releaseIds!=null && releaseIds.size()>0) return RequestStatus.IN_USE;
-        if (checkIfInUse(releaseIds)) return RequestStatus.IN_USE;
+        if (!forceDelete && checkIfInUse(releaseIds)) return RequestStatus.IN_USE;
 
 
         if (makePermission(component, user).isActionAllowed(RequestedAction.DELETE) || forceDelete) {

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -507,7 +507,7 @@ public class ComponentDatabaseHandlerTest {
     }
 
     @Test
-    public void testDontDeleteComponentWithReleaseContained() throws Exception {
+    public void testDeleteComponentWithUnusedRelease() throws Exception {
         Component component = new Component().setId("Del").setName("delete").setDescription("d1").setCreatedBy(email1);
         component.addToCategories(category);
         Release release = new Release().setId("DelR").setComponentId("Del").setName("delete Release").setVersion("1.0").setCreatedBy(email1).setVendorId("V1").setClearingState(ClearingState.NEW_CLEARING);
@@ -524,14 +524,32 @@ public class ComponentDatabaseHandlerTest {
 
         RequestStatus status = handler.deleteComponent("Del", user1);
 
+        assertEquals(RequestStatus.SUCCESS, status);
+    }
+
+    @Test
+    public void testDontDeleteComponentWithReleaseInUse() throws Exception {
+        Component component = new Component().setId("Del").setName("delete").setDescription("d1").setCreatedBy(email1);
+        component.addToCategories(category);
+        Release release = new Release().setId("DelR").setComponentId("Del").setName("delete Release").setVersion("1.0").setCreatedBy(email1).setVendorId("V1").setClearingState(ClearingState.NEW_CLEARING);
+
+        handler.addComponent(component, email1);
+        handler.addRelease(release, user1);
+
+        // Make release "DelR" in use by linking it from another release
+        final Release r1A = handler.getRelease("R1A", user1);
+        r1A.setReleaseIdToRelationship(ImmutableMap.of("DelR", ReleaseRelationship.CONTAINED));
+        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
+
+        RequestStatus status = handler.deleteComponent("Del", user1);
+
         assertEquals(RequestStatus.IN_USE, status);
 
-        {
-            Component del = handler.getComponent("Del", user1);
-            assertEquals("delete", del.getName());
-            Release delR = handler.getRelease("DelR", user1);
-            assertEquals("delete Release", delR.getName());
-        }
+        // Verify component and release still exist
+        Component del = handler.getComponent("Del", user1);
+        assertEquals("delete", del.getName());
+        Release delR = handler.getRelease("DelR", user1);
+        assertEquals("delete Release", delR.getName());
     }
 
     @Test


### PR DESCRIPTION
This pr contain the fix of #3801 
In `ComponentDatabaseHandler.java`, the `deleteComponent` method had an overly aggressive check on line 2036 that made subsequent code unreachable:

  Fix: #3801 
  - Commented out the overly aggressive check on line 2036
  - checkIfInUse(releaseIds) is now the sole guard allows deletion when releases exist but aren't used elsewhere
  - Added !forceDelete condition so that forceDelete=true bypasses both permission and in-use checks

### Suggest Reviewer
@GMishx 
