### PR TITLE
feat(http-support): implement file upload method in NewRequestBodyBui…

### DIFF
--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
@@ -4,6 +4,7 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.http;
 
+import java.io.FileNotFoundException;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.file.Path;
@@ -35,6 +36,12 @@ class NewRequestBodyBuilderImpl implements RequestBodyBuilder {
     private BodyPublisher body;
 
     /**
+     * Stores the name of a file to be uploaded. This field is only defined if
+     * a body of type file has been set.
+     */
+    private String fileName;
+
+    /**
      * Creates a new {@code RequestBodyBuilderImpl} object and initializes it
      * with the JSON object mapper.
      *
@@ -52,7 +59,13 @@ class NewRequestBodyBuilderImpl implements RequestBodyBuilder {
 
     @Override
     public void file(Path path, String mediaType) {
-        //TODO: implementation pending.
+        try {
+            initBody(BodyPublishers.ofFile(path));
+            Path fileNamePath = path.getFileName();
+            fileName = (fileNamePath != null) ? fileNamePath.toString() : null;
+        } catch (FileNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @Override
@@ -78,6 +91,16 @@ class NewRequestBodyBuilderImpl implements RequestBodyBuilder {
             throw new IllegalStateException("A RequestBodyBuilder was requested, but no body was defined.");
         }
         return body;
+    }
+
+    /**
+     * Returns the file name for a file upload request. A file name is only
+     * defined if the {@code file()} method was called.
+     *
+     * @return a file name for an upload request
+     */
+    public String getFileName() {
+        return fileName;
     }
 
     /**


### PR DESCRIPTION
- Implemented file upload functionality in `NewRequestBodyBuilderImpl`.
- Resolved the TODO at line 55 in the file method.
- Added a `fileName` field and `getFileName()` method to store the uploaded file name and match `RequestBodyBuilderImpl` behavior.