### PR TITLE
fix(components): correct clearing state priority in autosetReleaseCle…

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -250,12 +250,12 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 releaseAfter.setClearingState(ClearingState.NEW_CLEARING);
             }
 
-            if (newSecondBestCR.isPresent() &&  (newSecondBestCR.get().getCheckStatus() == CheckStatus.ACCEPTED)) {
-                releaseAfter.setClearingState(ClearingState.INTERNAL_USE_SCAN_AVAILABLE);
-            }
-
             if (isrCountAfter > 0) {
                 releaseAfter.setClearingState(ClearingState.SCAN_AVAILABLE);
+            }
+
+            if (newSecondBestCR.isPresent() &&  (newSecondBestCR.get().getCheckStatus() == CheckStatus.ACCEPTED)) {
+                releaseAfter.setClearingState(ClearingState.INTERNAL_USE_SCAN_AVAILABLE);
             }
         }
     }


### PR DESCRIPTION
`INTERNAL_USE_SCAN_AVAILABLE` (enum=6) outranks `SCAN_AVAILABLE` (enum=5), but in the no-clearing-report else branch the ISR check ran last and overwrote an accepted internal-use scan result with the lower state. Swap the two checks so `INTERNAL_USE_SCAN_AVAILABLE` wins as intended.

**Issue:** NA

**### Suggest Reviewer**
@GMishx @keerthi-bl 

**### How To Test?**
1. Create a release, attach an `INITIAL_SCAN_REPORT` (e.g. via FOSSology integration)
2. Attach an `INTERNAL_USE_SCAN` and set its check status to `ACCEPTED`
3. Confirm no clearing report exists on the release
4. Verify clearing state is now `INTERNAL_USE_SCAN_AVAILABLE`, not `SCAN_AVAILABLE`
5. Check the parent project's clearing summary reflects `internalUseScanAvailable++`

No new dependencies added.

**### Checklist**
- [x] All related issues are referenced in commit messages and in PR
- [ ] Unit test covering accepted internal scan + ISR + no clearing report combination (follow-up recommended)