### PR TITLE
docs: update README for CouchDB password setup

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -174,7 +174,7 @@ Here's some extra configurations that can be useful to fix some details.
 
 ### CouchDB
 
-CouchDB in compose runs with one standard admin user in a single node setup, user **sw360** and password **sw360fossy**
+CouchDB in compose runs with one standard admin user in a single node setup, user **sw360** and password **sw360fossie**
 
 To modify the entries and setup, you have two possible options:
 


### PR DESCRIPTION
Fixes #3813

This PR updates README_DOCKER.md to clarify the CouchDB credentials setup needed for docker deployment.

What changed:
- clarified that CouchDB  password