### PR TITLE
fix(datahandler): add ConflictException retry to putDesignDocument #3822

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -617,10 +617,26 @@ public class DatabaseConnectorCloudant {
                 .ddoc(ddoc)
                 .build();
 
-        DocumentResult response =
-            this.instance.getClient()
-                .putDesignDocument(designDocumentOptions).execute()
-                .getResult();
+        DocumentResult response;
+        try {
+            response = this.instance.getClient()
+                    .putDesignDocument(designDocumentOptions).execute()
+                    .getResult();
+        } catch (ConflictException | TooManyRequestsException e) {
+            try {
+                Thread.sleep(Duration.ofMillis(100));
+                existingDoc = getDesignDocument(ddoc);
+                if (existingDoc != null) {
+                    designDocument.setId(existingDoc.getId());
+                    designDocument.setRev(existingDoc.getRev());
+                }
+                response = this.instance.getClient()
+                        .putDesignDocument(designDocumentOptions).execute()
+                        .getResult();
+            } catch (InterruptedException ex) {
+                throw e;
+            }
+        }
         boolean success = response.isOk();
         if (!success) {
             log.error("Unable to put design document {} to {}. Error: {}",


### PR DESCRIPTION
Fixes #3822

## Summary

Multiple WARs starting concurrently in Tomcat can race on CouchDB design document writes, causing `ConflictException` to propagate uncaught through servlet initialization and returning 404 permanently on all affected endpoints.

## Issue

`putDesignDocument` in `DatabaseConnectorCloudant` read the current `_rev` and immediately wrote back the design document without any conflict handling. When two WARs (e.g. `projects.war` and `components.war`) both called `initStandardDesignDocument` at startup for a shared design document:

1. Both read `_rev = X`
2. One wrote successfully → `_rev = X+1`
3. The other wrote with stale `_rev = X` → CouchDB rejected with `ConflictException`
4. No retry → exception propagated up through `initStandardDesignDocument` → repository constructor → `servlet init()` → Tomcat marked the context as failed → 404

## Fix

Added the same `ConflictException | TooManyRequestsException` → sleep 100 ms → re-fetch latest `_rev` → retry pattern that already exists for `putDocument` (lines 119–129) and `postView` (lines 229–239) in the same class. On conflict, the code re-fetches the current design document to get the latest `_rev`, rebuilds the options, and retries the PUT once.

## Suggested Reviewers

@GMishx @rudra-superrr @bibhuti230185 @amritkv @EttingerK

## Testing

Rebuilt and redeployed with all *.war files starting concurrently:

- Zero `ConflictException` in startup logs (previously reproduced consistently on every restart)
- No `threw load() exception` for any servlet context

## Checklist

Must:
- [x] All related issues are referenced in commit messages and in PR
