### PR TITLE
fix(nouveau): add ConflictException retry to putNouveauDesignDocument

### DIFF
--- a/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
+++ b/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
@@ -18,8 +18,10 @@ import com.ibm.cloud.cloudant.v1.model.PutDesignDocumentOptions;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.ResponseConverter;
 import com.ibm.cloud.sdk.core.http.ServiceCall;
+import com.ibm.cloud.sdk.core.service.exception.ConflictException;
 import com.ibm.cloud.sdk.core.service.exception.NotFoundException;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
+import com.ibm.cloud.sdk.core.service.exception.TooManyRequestsException;
 import com.ibm.cloud.sdk.core.util.ResponseConverterUtils;
 import com.ibm.cloud.sdk.core.util.Validator;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
@@ -148,9 +150,28 @@ public class LuceneAwareCouchDbConnector {
                             .ddoc(ddoc)
                             .build();
 
-            DocumentResult response =
-                    this.putDesignDocument(designDocumentOptions)
+            DocumentResult response;
+            try {
+                response = this.putDesignDocument(designDocumentOptions)
+                        .execute().getResult();
+            } catch (ConflictException | TooManyRequestsException e) {
+                try {
+                    Thread.sleep(100);
+                    try {
+                        existingDoc = this.getNouveauDesignDocument(this.ddoc).execute().getResult();
+                    } catch (NotFoundException ignored) {
+                        existingDoc = null;
+                    }
+                    if (existingDoc != null) {
+                        designDocument.setId(existingDoc.getId());
+                        designDocument.setRev(existingDoc.getRev());
+                    }
+                    response = this.putDesignDocument(designDocumentOptions)
                             .execute().getResult();
+                } catch (InterruptedException ex) {
+                    throw e;
+                }
+            }
             boolean success = response.isOk();
             if (!success) {
                 throw new RuntimeException(


### PR DESCRIPTION
Fixes #3824

## Summary

`putNouveauDesignDocument` in `LuceneAwareCouchDbConnector` has the same missing `ConflictException` retry as #3822/#3823. All 13 search handlers share `DDOC_NAME = "lucene"` on the same `COUCH_DB_DATABASE`, so any two WARs starting concurrently (e.g. `projects.war`, `components.war`, `vendors.war`) race on writing the same `_design/lucene` document, causing servlet initialization to fail and endpoints to return 404 permanently.

## Fix

On `ConflictException | TooManyRequestsException`, the code now sleeps 100 ms, re-fetches the latest `_rev`, updates `designDocument` in-place, and retries the PUT once — reusing the existing `designDocumentOptions` without rebuilding it, since `PutDesignDocumentOptions` holds a direct reference to `designDocument`. This is consistent with the pattern in `DatabaseConnectorCloudant` fixed in #3823.

## Suggested Reviewers

@GMishx @rudra-superrr @bibhuti230185 @amritkv @EttingerK

## Checklist

Must:
- [x] All related issues are referenced in commit messages and in PR
