### PR TITLE
feat(Project): Handle case sensitive for export spreadsheet

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -135,33 +135,22 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         SW360ReportBean reportBean = createReportBeanObject(withLinkedReleases, excludeReleaseVersion, generatorClassName, variant,
                 template, externalIds, withSubProject, bomType, selectedRelRelationship);
         String baseUrl = getBaseUrl(request);
-        switch (module) {
-            case SW360Constants.PROJECTS:
-                getProjectReports(response, sw360User, module, projectId, baseUrl, reportBean);
-                break;
-            case SW360Constants.COMPONENTS:
-                getComponentsReports(response, sw360User, module, baseUrl, reportBean);
-                break;
-            case SW360Constants.LICENSES:
-                getLicensesReports(response, sw360User, module, reportBean);
-                break;
-            case LICENSE_INFO:
-                getLicensesInfoReports(response, sw360User, module, projectId, reportBean);
-                break;
-            case LICENSES_RESOURCE_BUNDLE:
-                getLicenseResourceBundleReports(projectId, response, sw360User, module, reportBean);
-                break;
-            case SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO:
-                getProjectReleaseWithEccSpreadSheet(response, sw360User, module, projectId, reportBean);
-                break;
-            case EXPORT_CREATE_PROJ_CLEARING_REPORT:
-                exportProjectCreateClearingRequest(response, sw360User, module, projectId, reportBean);
-                break;
-            case SW360Constants.SBOM:
-                exportSBOM(response, sw360User, module, projectId, reportBean);
-                break;
-            default:
-                break;
+        if (SW360Constants.PROJECTS.equalsIgnoreCase(module)) {
+            getProjectReports(response, sw360User, module, projectId, baseUrl, reportBean);
+        } else if (SW360Constants.COMPONENTS.equalsIgnoreCase(module)) {
+            getComponentsReports(response, sw360User, module, baseUrl, reportBean);
+        } else if (SW360Constants.LICENSES.equalsIgnoreCase(module)) {
+            getLicensesReports(response, sw360User, module, reportBean);
+        } else if (LICENSE_INFO.equals(module)) {
+            getLicensesInfoReports(response, sw360User, module, projectId, reportBean);
+        } else if (LICENSES_RESOURCE_BUNDLE.equals(module)) {
+            getLicenseResourceBundleReports(projectId, response, sw360User, module, reportBean);
+        } else if (SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO.equals(module)) {
+            getProjectReleaseWithEccSpreadSheet(response, sw360User, module, projectId, reportBean);
+        } else if (EXPORT_CREATE_PROJ_CLEARING_REPORT.equals(module)) {
+            exportProjectCreateClearingRequest(response, sw360User, module, projectId, reportBean);
+        } else if (SW360Constants.SBOM.equalsIgnoreCase(module)) {
+            exportSBOM(response, sw360User, module, projectId, reportBean);
         }
     }
 
@@ -285,35 +274,26 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             String fileName = sw360ReportService.getDocumentName(user, null, module);
             response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
 
-            switch (module) {
-                case SW360Constants.PROJECTS:
-                    buff = sw360ReportService.getProjectBuffer(user, reportBean.isWithLinkedReleases(), projectId);
-                    fileName = sw360ReportService.getDocumentName(user, projectId, module);
-                    break;
-                case SW360Constants.COMPONENTS:
-                    buff = sw360ReportService.getComponentBuffer(user, reportBean.isWithLinkedReleases());
-                    break;
-                case SW360Constants.LICENSES:
-                    buff = sw360ReportService.getLicenseBuffer();
-                    fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
-                    break;
-                case LICENSES_RESOURCE_BUNDLE:
-                    buff = buffer;
-                    response.setContentType(ZIP_CONTENT_TYPE);
-                    fileName = sw360ReportService.getSourceCodeBundleName(projectId, user);
-                    break;
-                case LICENSE_INFO:
-                case EXPORT_CREATE_PROJ_CLEARING_REPORT:
-                    buff = sw360ReportService.getLicenseInfoBuffer(user, projectId, reportBean);
-                    fileName = sw360ReportService.getGenericLicInfoFileName(user, projectId, reportBean.getGeneratorClassName(),
-                            reportBean.getVariant());
-                    break;
-                case SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO:
-                    buff = sw360ReportService.getProjectReleaseSpreadSheetWithEcc(user, projectId);
-                    fileName = sw360ReportService.getDocumentName(user, projectId, module);
-                    break;
-                default:
-                    break;
+            if (SW360Constants.PROJECTS.equalsIgnoreCase(module)) {
+                buff = sw360ReportService.getProjectBuffer(user, reportBean.isWithLinkedReleases(), projectId);
+                fileName = sw360ReportService.getDocumentName(user, projectId, module);
+                response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
+            } else if (SW360Constants.COMPONENTS.equalsIgnoreCase(module)) {
+                buff = sw360ReportService.getComponentBuffer(user, reportBean.isWithLinkedReleases());
+            } else if (SW360Constants.LICENSES.equalsIgnoreCase(module)) {
+                buff = sw360ReportService.getLicenseBuffer();
+                fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
+            } else if (LICENSES_RESOURCE_BUNDLE.equals(module)) {
+                buff = buffer;
+                response.setContentType(ZIP_CONTENT_TYPE);
+                fileName = sw360ReportService.getSourceCodeBundleName(projectId, user);
+            } else if (LICENSE_INFO.equals(module) || EXPORT_CREATE_PROJ_CLEARING_REPORT.equals(module)) {
+                buff = sw360ReportService.getLicenseInfoBuffer(user, projectId, reportBean);
+                fileName = sw360ReportService.getGenericLicInfoFileName(user, projectId, reportBean.getGeneratorClassName(),
+                        reportBean.getVariant());
+            } else if (SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO.equals(module)) {
+                buff = sw360ReportService.getProjectReleaseSpreadSheetWithEcc(user, projectId);
+                fileName = sw360ReportService.getDocumentName(user, projectId, module);
             }
             if (null == buff) {
                 throw new TException("No data available for the user " + user.getEmail());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -127,29 +127,22 @@ public class SW360ReportService {
 
     public String getDocumentName(User user, String projectId, String module) throws TException {
         String documentName = String.format("projects-%s.xlsx", SW360Utils.getCreatedOn());
-        switch (module) {
-        case SW360Constants.PROJECTS:
+        if (SW360Constants.PROJECTS.equalsIgnoreCase(module)) {
             if (projectId != null && !projectId.equalsIgnoreCase("null")) {
                 Project project = projectclient.getProjectById(projectId, user);
                 documentName = String.format("project-%s-%s-%s.xlsx", project.getName(), project.getVersion(),
                         SW360Utils.getCreatedOn());
             }
-            break;
-        case SW360Constants.COMPONENTS:
+        } else if (SW360Constants.COMPONENTS.equalsIgnoreCase(module)) {
             documentName = String.format("components-%s.xlsx", SW360Utils.getCreatedOn());
-            break;
-        case SW360Constants.LICENSES:
+        } else if (SW360Constants.LICENSES.equalsIgnoreCase(module)) {
             documentName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
-            break;
-        case SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO:
+        } else if (SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO.equals(module)) {
             if (projectId != null && !projectId.equalsIgnoreCase("null")) {
                 Project project = projectclient.getProjectById(projectId, user);
                 documentName = String.format("releases-%s-%s-%s.xlsx", project.getName(), project.getVersion(),
                         SW360Utils.getCreatedOn());
             }
-            break;
-        default:
-            break;
         }
         return documentName;
     }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (https://github.com/eclipse-sw360/sw360/issues/3789)
> * Did you add or update any new dependencies that are required for your change?

Fixes: https://github.com/eclipse-sw360/sw360/issues/3789

### Suggest Reviewer
> @GMishx 

### How To Test?
>1. Start the SW360 backend and REST resource-server locally (or in Docker).
>2. Obtain a valid Bearer token or use Basic Auth credentials.
>3. Call the report endpoint with mixed-case module values and verify the correct report is returned:
#### Should return a project spreadsheet (was broken before — returned nothing)
curl -s -o project_report.xlsx -w "%{http_code}" \
  "http://localhost:8080/api/reports?module=Projects&projectId=<id>&withLinkedReleases=true" \
  -H "Authorization: Bearer <token>"

#### Upper-case variant
curl -s -o project_report.xlsx -w "%{http_code}" \
  "http://localhost:8080/api/reports?module=PROJECTS&projectId=<id>&withLinkedReleases=true" \
  -H "Authorization: Bearer <token>"

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
