### PR TITLE
perf(licenseinfo): remove redundant stream collection in obligation m…

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -703,7 +703,6 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                 .filter(obligation -> !(SW360Constants.OBLIGATION_TOPIC_UNKNOWN.equals(obligation.getTopic())))
                 // sort the obligations by topic in ascending order
                 .sorted(Comparator.comparing(ObligationAtProject::getTopic, String.CASE_INSENSITIVE_ORDER))
-                .collect(Collectors.toList()).stream()
                 // create a Map<licenseId, Set<ObligationAtProject>>
                 .flatMap(obligation -> obligation.getLicenseIDs().stream()
                         .map(id -> new AbstractMap.SimpleEntry<>(obligation, id)))


### PR DESCRIPTION
## Summary

Eliminates the "Collect-then-Stream" anti-pattern in license obligation mapping that was causing unnecessary memory allocation and CPU overhead.

### Changes
- **File**: `backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java`
- **Line**: 706
- **Method**: `mapLicenseObligationsToLicenseInfo()`

Removed redundant `.collect(Collectors.toList()).stream()` from the stream pipeline, allowing the sorted stream to flow directly into the flatMap operation.

### Performance Impact

**Before:**
.sorted(Comparator.comparing(ObligationAtProject::getTopic, String.CASE_INSENSITIVE_ORDER))
.collect(Collectors.toList()).stream()  // Unnecessary intermediate List allocation
.flatMap(obligation -> obligation.getLicenseIDs().stream()

**Dependencies:**
No new dependencies added. 
Closes : https://github.com/eclipse-sw360/sw360/issues/3834
### Suggest Reviewer
@GMishx 

