### PR TITLE
fix(report) #3836: respect withSubProject for licenseInfo reports 

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -235,7 +235,6 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     private void getLicensesInfoReports(
             HttpServletResponse response, User sw360User, String module, String projectId, SW360ReportBean reportBean
     ) throws SW360Exception {
-        // TODO: use `withSubProject` while generating LicenseInfo report.
         try {
             downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
         } catch (Exception e) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -236,7 +236,8 @@ public class SW360ReportService {
                 : null;
 
         List<ProjectLink> mappedProjectLinks = projectService.createLinkedProjects(sw360Project,
-                projectService.filterAndSortAttachments(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES), true, true, sw360User);
+                projectService.filterAndSortAttachments(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES), true,
+                reportBean.isWithSubProject(), sw360User);
 
         List<AttachmentUsage> attchmntUsg = attachmentService.getAttachemntUsages(id);
 


### PR DESCRIPTION
### What changed
- Respect `withSubProject` in `licenseInfo` report service path.
- Keep `exportCreateProjectClearingReport` behavior unchanged by forcing `withSubProject=true`.

### How To Test?
You can test it with the project with the sub-project
and also link the release, and then for the compare the result with true and false in `withSubProject`
<img width="896" height="893" alt="image" src="https://github.com/user-attachments/assets/a2daf590-b620-4b71-978c-756d8bfe5d79" />


Closes #3903