### PR TITLE
fix(rest): X-XSS-Protection Header

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -94,7 +94,7 @@ public class ResourceServerConfiguration {
                 })
                 .httpBasic(Customizer.withDefaults())
                 .exceptionHandling(x -> x.authenticationEntryPoint(saep))
-                .headers(headers -> headers.xssProtection(xXssConfig -> xXssConfig.headerValue(XXssProtectionHeaderWriter.HeaderValue.ENABLED_MODE_BLOCK))
+                .headers(headers -> headers.xssProtection(xXssConfig -> xXssConfig.headerValue(XXssProtectionHeaderWriter.HeaderValue.DISABLED))
                         .contentSecurityPolicy(cps -> cps.policyDirectives("script-src 'self'")))
                 .csrf(csrf -> csrf.disable()).build();
     }

--- a/third-party/keycloak-tf/r-sw360-realm.tf
+++ b/third-party/keycloak-tf/r-sw360-realm.tf
@@ -58,7 +58,7 @@ resource "keycloak_realm" "sw360" {
       content_security_policy_report_only = ""
       x_content_type_options              = "nosniff"
       x_robots_tag                        = "none"
-      x_xss_protection                    = "1; mode=block"
+      x_xss_protection                    = "0"
       strict_transport_security           = "max-age=31536000; includeSubDomains"
     }
   }


### PR DESCRIPTION

Description: The web application is currently using the `X-XSS-Protection` header with value `1; mode=block`. The X-XSS-Protection header activates the Cross-Site Scripting (XSS) filter in different browsers,
such as Internet Explorer and Google Chrome, which is usually enabled by default. However, this
mechanism has been deprecated due to the possibility of [creating XSS vulnerabilities](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection). Therefore, the server must send X-XSS-Protection: 0 to explicitly disable it.

Solution: explicitly setting the header as follows: `X-XSS-Protection: 0`. All XSS mitigations should be implemented by the application instead of relying on the browser’s.

Screenshot: 
<img width="849" height="266" alt="image" src="https://github.com/user-attachments/assets/4d5452c8-0d52-4da6-8c64-6eacc774a2b0" />

This confirms the header is now explicitly disabling the browser's XSS filtering mechanism, as recommended. Previously it would have returned X-XSS-Protection: 1; mode=block.

