### PR TITLE
fix(rest): add early validation and permission check for SBOM update #3810

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2548,6 +2548,16 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "doNotReplacePackageAndRelease", required = false) boolean doNotReplacePackageAndRelease
     ) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        
+        Project project = projectService.getProjectForUserById(id, sw360User);
+        if (!restControllerHelper.isWriteActionAllowed(project, sw360User)) {
+            throw new BadCredentialsException("You do not have sufficient permissions to update this project.");
+        }
+
+        if (!attachmentService.isValidSbomFile(file, "CycloneDX")) {
+            throw new BadRequestClientException("Invalid SBOM file. Only CycloneDX(.xml/.json) files are supported.");
+        }
+
         Attachment attachment = null;
         final RequestSummary requestSummary;
         String projectId = null;
@@ -2580,7 +2590,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     "Project name or version present in SBOM metadata tag is not same as the current SW360 project!");
         }
 
-        Project project = projectService.getProjectForUserById(projectId, sw360User);
+        project = projectService.getProjectForUserById(projectId, sw360User);
         HalResource<Project> halResource = createHalProject(project, sw360User);
         return new ResponseEntity<HalResource<Project>>(halResource, HttpStatus.OK);
     }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary of Changes

This PR implements a "Fail-Fast" validation mechanism for the project SBOM update endpoint (`POST /api/projects/{id}/import/SBOM`). It ensures that permission and file integrity checks occur before any resource-intensive operations.

Which issue is this pull request belonging to and how is it solving it? This PR addresses Issue https://github.com/eclipse-sw360/sw360/issues/3810

- Authorization Guard: It adds an explicit check using restControllerHelper.isWriteActionAllowed at the start of the method to prevent unauthorized users from triggering file processing.
- Validation Alignment: It integrates the isValidSbomFile check to ensure the update endpoint follows the same strict validation logic as the project creation endpoint.
- Resource Protection: By validating the request early, the fix prevents malformed or unauthorized files from reaching the database and parsing layers.

Did you add or update any new dependencies that are required for your change? No new dependencies were added.

Issue: Closes https://github.com/eclipse-sw360/sw360/issues/3810

Suggest Reviewer
@Suhas2109 @akshitjoshii @amritkv @GMishx

How To Test?

Build Verification: Run mvn install -pl rest -am -DskipTests to confirm the module compiles with the new logic.

Permission Test: Attempt to call the endpoint with a user who does not have WRITE access to the project; the server should now return a 403 Forbidden (BadCredentialsException) before any file is uploaded.

Validation Test: Attempt to upload a non-SBOM file; the server should return a 400 Bad Request (BadRequestClientException) immediately.

Checklist
Must:

- [x] All related issues are referenced in commit messages and in PR