### PR TITLE
fix #3855: (http-support): correct native request builder URI/body/header sem…

### DIFF
--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBuilderImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBuilderImpl.java
@@ -5,9 +5,9 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.http;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +44,6 @@ class NewRequestBuilderImpl implements RequestBuilder {
     /**
      * The body of the request.
      */
-
     private BodyPublisher body;
 
     /**
@@ -67,11 +66,7 @@ class NewRequestBuilderImpl implements RequestBuilder {
 
     @Override
     public RequestBuilder uri(String uri) {
-        try {
-            requestBuilder.uri(new URI(uri));
-        } catch (URISyntaxException e) {
-            // nothing to do
-        }
+        requestBuilder.uri(URI.create(uri));
         return this;
     }
 
@@ -110,8 +105,8 @@ class NewRequestBuilderImpl implements RequestBuilder {
      * @return the request constructed by this builder
      */
     public HttpRequest build() {
-        BodyPublisher requestBody = getBody();
-        return requestBuilder.method(httpMethod, requestBody).header("Content-Type", "application/json").build();
+        BodyPublisher requestBody = (getBody() != null) ? getBody() : BodyPublishers.noBody();
+        return requestBuilder.method(httpMethod, requestBody).build();
     }
 
     /**

--- a/clients/http-support/src/test/java/org/eclipse/sw360/http/NewRequestBuilderImplTest.java
+++ b/clients/http-support/src/test/java/org/eclipse/sw360/http/NewRequestBuilderImplTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.http.HttpRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit test class for {@code NewRequestBuilderImpl}. This class focuses on
+ * request-building semantics for the native HttpClient variant.
+ */
+public class NewRequestBuilderImplTest {
+    /**
+     * The builder to be tested.
+     */
+    private NewRequestBuilderImpl requestBuilder;
+
+    @Before
+    public void setUp() {
+        ObjectMapper mapper = mock(ObjectMapper.class);
+        requestBuilder = new NewRequestBuilderImpl(mapper);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidUriRejected() {
+        requestBuilder.uri("://invalid-uri");
+    }
+
+    @Test
+    public void testBuildGetWithoutBody() {
+        requestBuilder.uri("http://example.org/releases");
+        HttpRequest request = requestBuilder.build();
+
+        assertThat(request.method()).isEqualTo("GET");
+        assertThat(request.headers().firstValue("Content-Type")).isEmpty();
+    }
+
+    @Test
+    public void testBuildPostWithoutBody() {
+        requestBuilder.uri("http://example.org/releases");
+        requestBuilder.method(RequestBuilder.Method.POST);
+        HttpRequest request = requestBuilder.build();
+
+        assertThat(request.method()).isEqualTo("POST");
+        assertThat(request.headers().firstValue("Content-Type")).isEmpty();
+    }
+
+    @Test
+    public void testDoesNotOverrideExplicitContentType() {
+        requestBuilder.uri("http://example.org/releases");
+        requestBuilder.header("Content-Type", "text/plain");
+        requestBuilder.body(body -> body.string("payload", "text/plain"));
+        HttpRequest request = requestBuilder.build();
+
+        assertThat(request.headers().firstValue("Content-Type")).hasValue("text/plain");
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes request-construction semantics in the native HTTP client path (`newHttpClientAlt`) by updating `NewRequestBuilderImpl`.

### What was wrong

`NewRequestBuilderImpl` had three behavior issues:
1. Invalid URIs were silently ignored.
2. Requests without an explicit body could be built through a null-body path.
3. `Content-Type: application/json` was forced for all requests in `build()`.

These behaviors are inconsistent with expected HTTP request semantics and can produce incorrect requests.

## Changes

### Code changes
- Updated `uri(String uri)` to use `URI.create(uri)` directly, so invalid URIs fail fast with `IllegalArgumentException`.
- Updated `build()` to use `BodyPublishers.noBody()` when no body is provided.
- Removed unconditional `Content-Type: application/json` injection from `build()`.

### Tests added
Added new unit test class:
- `NewRequestBuilderImplTest`

Covered scenarios:
- invalid URI is rejected,
- GET without body builds successfully and does not set forced content type,
- POST without body builds successfully and does not set forced content type,
- explicitly set `Content-Type` is preserved and not overridden.

## Verification

Executed:
```bash
mvn -pl clients/http-support "-Dbase.deploy.dir=." "-DskipTests=false" "-Dmaven.test.skip=false" "-Dtest=NewRequestBuilderImplTest" test
