### PR TITLE
fix#3857 (http-support): implement native file request body support

### DIFF
--- a/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
+++ b/clients/http-support/src/main/java/org/eclipse/sw360/http/NewRequestBodyBuilderImpl.java
@@ -4,7 +4,7 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.http;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.file.Path;
@@ -63,7 +63,7 @@ class NewRequestBodyBuilderImpl implements RequestBodyBuilder {
             initBody(BodyPublishers.ofFile(path));
             Path fileNamePath = path.getFileName();
             fileName = (fileNamePath != null) ? fileNamePath.toString() : null;
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/clients/http-support/src/test/java/org/eclipse/sw360/http/NewRequestBodyBuilderImplTest.java
+++ b/clients/http-support/src/test/java/org/eclipse/sw360/http/NewRequestBodyBuilderImplTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2020.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.http.utils.HttpConstants;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test class for {@code NewRequestBodyBuilderImpl} file body behavior.
+ */
+public class NewRequestBodyBuilderImplTest {
+
+    @Test
+    public void testFileBodyWithExistingFile() throws IOException {
+        NewRequestBodyBuilderImpl bodyBuilder = new NewRequestBodyBuilderImpl(mock(ObjectMapper.class));
+        Path tempFile = Files.createTempFile("new-request-body", ".txt");
+        try {
+            Files.writeString(tempFile, "file-body-content");
+
+            bodyBuilder.file(tempFile, HttpConstants.CONTENT_OCTET_STREAM);
+
+            assertThat(bodyBuilder.getBody()).isNotNull();
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    public void testFileBodyWithMissingFile() {
+        NewRequestBodyBuilderImpl bodyBuilder = new NewRequestBodyBuilderImpl(mock(ObjectMapper.class));
+        Path missingFile = Path.of("target", "does-not-exist", "missing-upload.bin");
+
+        try {
+            bodyBuilder.file(missingFile, HttpConstants.CONTENT_OCTET_STREAM);
+            fail("No exception thrown!");
+        } catch (IllegalStateException ex) {
+            assertThat(ex.getCause()).isInstanceOf(IOException.class);
+        }
+    }
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Implemented native file body support in `NewRequestBodyBuilderImpl.file(Path, String)`.

- Closes #3857
- How this solves it:
  - `file(...)` was previously unimplemented (`TODO`), so native client file upload body could not be created.
  - This PR now uses `BodyPublishers.ofFile(path)` to create the request body.
  - `IOException` is wrapped in `IllegalStateException` for consistent builder error handling.
- Dependencies:
  - No new dependencies added or updated.


### Suggest Reviewer
@GMishx 

### How To Test?
Run:
```bash
mvn -pl clients/http-support "-Dbase.deploy.dir=." "-DskipTests=false" "-Dmaven.test.skip=false" "-Dtest=NewRequestBodyBuilderImplTest,RequestBodyBuilderImplTest" test