### PR TITLE
refactor(wsimport): improve duplicate releaseId logging in ThriftUplo…

### DIFF
--- a/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftUploader.java
+++ b/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftUploader.java
@@ -104,11 +104,13 @@ public class ThriftUploader {
                     .collect(Collectors.toMap(
                             ReleaseRelation::getReleaseId,
                             ReleaseRelation::getProjectReleaseRelationship,
-                            (projectReleaseRelationship1, projectReleaseRelationship2) -> {
-                                LOGGER.info("--- Duplicate key found!");
-                                LOGGER.info("--- 1: " + projectReleaseRelationship1.getReleaseRelation());
-                                LOGGER.info("--- 2: " + projectReleaseRelationship2.getReleaseRelation());
-                                return projectReleaseRelationship1;
+                            (existing, duplicate) -> {
+                                LOGGER.warn(
+                                        "Duplicate releaseId detected. Keeping existing relation {} and ignoring {}",
+                                        existing.getReleaseRelation(),
+                                        duplicate.getReleaseRelation()
+                                );
+                                return existing;
                             }
                     ));
         sw360Project.setReleaseIdToUsage(releaseIdToUsage);


### PR DESCRIPTION
- This PR improves the logging for duplicate releaseId handling in the Whitesource import functionality.
- Replace multi-line INFO logging with single WARN level parameterized message
- Use more descriptive parameter names (`existing`, `duplicate`)