### PR TITLE
fix(rest): avoid NPE in obligation Boolean filter

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -549,10 +549,10 @@ public class RestControllerHelper<T> {
     }
 
     public Set<String> getObligationIdsFromRequestWithValueTrue(Map<String, Boolean> reqBodyMaps) {
-        Map<String, Boolean> obligationIdsRequest = reqBodyMaps.entrySet().stream()
-                .filter(reqBodyMap-> reqBodyMap.getValue().equals(true))
-                .collect(Collectors.toMap(reqBodyMap-> reqBodyMap.getKey(),reqBodyMap -> reqBodyMap.getValue()));
-        return obligationIdsRequest.keySet();
+        return reqBodyMaps.entrySet().stream()
+                .filter(entry -> Boolean.TRUE.equals(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
     }
 
     public boolean checkDuplicateLicense(List<License> licenses, String licenseId) {


### PR DESCRIPTION


Closes: #3881 

### Summary

This PR fixes a possible `NullPointerException` in `RestControllerHelper#getObligationIdsFromRequestWithValueTrue(...)`.

The previous implementation used:
`reqBodyMap.getValue().equals(true)`
which could throw an NPE if the map contained a `null `value.

### Changes made
- Replaced the Boolean check with Boolean.TRUE.equals(...)
- Simplified the stream pipeline to directly collect matching keys into a Set<String>

**Before**
`.filter(reqBodyMap -> reqBodyMap.getValue().equals(true))`

**After**
`.filter(entry -> Boolean.TRUE.equals(entry.getValue()))`

**Result**
- Prevents NPE for `null `Boolean values
- Keeps the intended behavior of returning only keys with value `true`
