### PR TITLE
fix issue #3883: Remove redundant String.format usage

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -307,9 +307,9 @@ public class CycloneDxBOMImporter {
                         requestSummary.setMessage(convertCollectionToJSONString(messageMap));
                     }
                 } else {
-                    requestSummary.setMessage(String.format(String.format(
+                    requestSummary.setMessage(String.format(
                             "SBOM import aborted with error: Multiple vcs information found in components, vcs found: %s and total components: %s",
-                            vcsCount, componentsCount)));
+                            vcsCount, componentsCount));
                     return requestSummary;
                 }
             }


### PR DESCRIPTION


Closes: #3883 

## Summary

This PR removes a redundant nested `String.format(...)` call in `CycloneDxBOMImporter`.

## Changes made

- Replaced `String.format(String.format(...))` with a single `String.format(...)`
- No functional behavior changed

## Why this change

The previous implementation worked, but it included unnecessary nesting that reduced readability. Since the inner `String.format(...)` already produces the final string, the outer call was redundant.

