### PR TITLE
fix(license): include timestamp in backup filename

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -235,13 +235,12 @@ public class Sw360LicenseService {
         }
     }
 
-    public void getDownloadLicenseArchive(User sw360User ,HttpServletRequest request,HttpServletResponse response) throws TException,IOException{
+    public void getDownloadLicenseArchive(User sw360User ,HttpServletRequest request,HttpServletResponse response) throws TException, IOException {
         if (!PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             throw new BadRequestClientException("Unable to download archive license. User is not admin");
         }
         try {
             LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
-            String fileConstant="LicensesBackup.lics";
             Map<String, InputStream> fileNameToStreams = (new LicsExporter(sw360LicenseClient)).getFilenameToCSVStreams();
             final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             try (ZipOutputStream zipOutputStream = new ZipOutputStream(byteArrayOutputStream)) {
@@ -253,9 +252,9 @@ public class Sw360LicenseService {
                 zipOutputStream.finish();
             }
             final ByteArrayInputStream zipFile = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
-            String filename = String.format(fileConstant, SW360Utils.getCreatedOn());
+            String filename = "LicensesBackup_" + SW360Utils.getCreatedOn() + ".lics";
             response.setContentType(CONTENT_TYPE);
-            response.setHeader("Content-Disposition", String.format("license; filename=\"%s\"", filename));
+            response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
             copyDataStreamToResponse(response, zipFile);
         } catch (SW360Exception exp) {
             if (exp.getErrorCode() == 404) {


### PR DESCRIPTION


Closes: #3885 

## Summary

This PR fixes the generated filename for license archive downloads and updates the download response header.

## Changes made

- Fixed the backup filename so the timestamp is actually included
- Updated `Content-Disposition` to use `attachment; filename="..."`

## Problem

Previously, the backup filename was built using:


```
String fileConstant = "LicensesBackup.lics";
String filename = String.format(fileConstant, SW360Utils.getCreatedOn());
```

Since `fileConstant `did not contain a `%s` placeholder, the timestamp argument was ignored. As a result, the downloaded filename was always constant.

In addition, the response header used:
`response.setHeader("Content-Disposition", String.format("license; filename=\"%s\"", filename));`
which is not the standard disposition type for downloadable files.

## Fix

Changed the filename generation so the timestamp is included correctly

Changed the response header to: attachment
