### PR TITLE
fix(release): fix test of attach field in merge

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -1555,19 +1555,22 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return requestStatus;
     }
 
-    private void validateReleaseMergeSelection(ReleaseMergeSelector releaseSelection) throws SW360Exception {
+    private void validateReleaseMergeSelection(ReleaseMergeSelector releaseSelection) throws BadRequestClientException {
         if (releaseSelection == null) {
             throw new BadRequestClientException("Body for merge cannot be null");
         }
-        Set<Release._Fields> requiredFields = ImmutableSet.<Release._Fields>builder().add(Release._Fields.NAME)
-                .add(Release._Fields.CREATED_ON).add(Release._Fields.CREATED_BY).add(Release._Fields.VERSION)
-                .add(Release._Fields.ATTACHMENTS).build();
+        Set<Release._Fields> requiredFields = ImmutableSet.<Release._Fields>builder()
+                .add(Release._Fields.NAME).add(Release._Fields.CREATED_ON)
+                .add(Release._Fields.CREATED_BY).add(Release._Fields.VERSION).build();
 
         for (Release._Fields field : requiredFields) {
             if (!releaseSelection.isSet(field)
                     || isNullEmptyOrWhitespace((String) releaseSelection.getFieldValue(field))) {
                 throw new BadRequestClientException("Merge body is missing field " + field.getFieldName());
             }
+        }
+        if (!releaseSelection.isSetAttachments()) {
+            throw new BadRequestClientException("Merge body is missing field attachments");
         }
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Fix the test of required `attachments` field as a separate case for merge release endpoint.

Fixes #3860

### Suggest Reviewer
@amritkv @nikkuma7

### How To Test?
Try to merge two Releases.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
