### PR TITLE
fix(LicenseInfo): harden XML parsers against XXE in SPDXParser and AbstractCLIParser

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -114,6 +114,8 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
 
     protected <T> boolean hasThisXMLRootElement(AttachmentContent content, String rootElementNamespace, String rootElementName, User user, T context) throws TException {
         XMLInputFactory xmlif = XMLInputFactory.newFactory();
+        xmlif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        xmlif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         XMLStreamReader xmlStreamReader = null;
         InputStream attachmentStream = null;
         try {

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
@@ -93,8 +93,14 @@ public class SPDXParser extends LicenseInfoParser {
 
     protected <T> Optional<Document> openAsSpdx(AttachmentContent attachmentContent, User user, T context) throws SW360Exception {
         try (InputStream attachmentStream = attachmentConnector.getAttachmentStream(attachmentContent, user, context)) {
-            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newDefaultInstance();
             dbFactory.setNamespaceAware(true);
+            dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbFactory.setXIncludeAware(false);
+            dbFactory.setExpandEntityReferences(false);
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
             Document doc = dBuilder.parse(attachmentStream);
             doc.getDocumentElement().normalize();

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -19,12 +19,14 @@ import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -41,7 +43,9 @@ import org.w3c.dom.Document;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static org.eclipse.sw360.licenseinfo.TestHelper.*;
@@ -138,8 +142,14 @@ public class SPDXParserTest {
                 .setFilename(exampleFile);
 
         InputStream input = makeAttachmentContentStream(exampleFile);
-        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newDefaultInstance();
         dbFactory.setNamespaceAware(true);
+        dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbFactory.setXIncludeAware(false);
+        dbFactory.setExpandEntityReferences(false);
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
         Document spdxDocument = dBuilder.parse(input);
         spdxDocument.getDocumentElement().normalize();
@@ -175,6 +185,58 @@ public class SPDXParserTest {
             assertLicenseInfoParsingResult(result);
             assertIsResultOfExample(result.getLicenseInfo(), exampleFile, expectedLicenses, numberOfCoyprights,
                     exampleCopyright, exampleConcludedLicenseIds);
+        }
+    }
+
+    @Test
+    public void testXXEAttackIsBlocked() throws Exception {
+        String xxePayload = "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE foo [\n" +
+                "  <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n" +
+                "]>\n" +
+                "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n" +
+                "         xmlns:spdx=\"http://spdx.org/rdf/terms#\">\n" +
+                "  <spdx:SpdxDocument>\n" +
+                "    <spdx:name>&xxe;</spdx:name>\n" +
+                "  </spdx:SpdxDocument>\n" +
+                "</rdf:RDF>";
+
+        AttachmentContent attachmentContent = new AttachmentContent()
+                .setId("xxe-test")
+                .setFilename("malicious.rdf");
+
+        // Register content in the store (so AttachmentContentProvider can resolve it),
+        // then override the mock to return our XXE payload instead of a file resource.
+        attachmentContentStore.put(attachmentContent);
+        InputStream xxeStream = new ByteArrayInputStream(xxePayload.getBytes(StandardCharsets.UTF_8));
+        Mockito.when(connector.getAttachmentStream(Mockito.eq(attachmentContent), Mockito.any(), Mockito.any()))
+                .thenReturn(xxeStream);
+
+        // With disallow-doctype-decl=true, the parser rejects DOCTYPE declarations.
+        // openAsSpdx catches SAXException and throws SW360Exception, but
+        // getLicenseInfo wraps it and returns FAILURE status.
+        Attachment attachment = new Attachment()
+                .setAttachmentContentId("xxe-test")
+                .setFilename("malicious.rdf")
+                .setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_XML);
+
+        // The parser should reject the XXE payload. With disallow-doctype-decl=true,
+        // openAsSpdx throws SW360Exception (wrapping SAXException) when it encounters DOCTYPE.
+        try {
+            LicenseInfoParsingResult result = parser.getLicenseInfos(attachment, dummyUser,
+                            new Project()
+                                    .setVisbility(Visibility.ME_AND_MODERATORS)
+                                    .setCreatedBy(dummyUser.getEmail())
+                                    .setAttachments(Collections.singleton(new Attachment().setAttachmentContentId("xxe-test"))))
+                    .stream()
+                    .findFirst()
+                    .orElse(null);
+
+            // If no exception, result must not be SUCCESS
+            assertTrue("XXE payload should not be parsed successfully",
+                    result == null || result.getStatus() != LicenseInfoRequestStatus.SUCCESS);
+        } catch (SW360Exception e) {
+            // Expected — parser rejects DOCTYPE declaration and throws SW360Exception
         }
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Commit `738366d2` hardened `AbstractCLIParser.getDocument()` against XXE attacks, but two other
> XML parsing locations in the same module were missed. This PR applies the same OWASP-recommended
> security features to close the remaining XXE attack surface in the licenseinfo module.
>
> * No new dependencies added.

Issue: #3890 
### Changes

#### 1. `SPDXParser.openAsSpdx()` — `DocumentBuilderFactory` hardening

**File:** `backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java`

**Before (vulnerable):**
```java
DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
dbFactory.setNamespaceAware(true);
DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
```

**After (hardened):**
```java
DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newDefaultInstance();
dbFactory.setNamespaceAware(true);
dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
dbFactory.setXIncludeAware(false);
dbFactory.setExpandEntityReferences(false);
DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
```

- Changed `newInstance()` to `newDefaultInstance()` (matches `getDocument()` pattern)
- Added all 6 OWASP-recommended security features (identical to `AbstractCLIParser.getDocument()`)
- Kept `setNamespaceAware(true)` — required for SPDX RDF parsing (`rdf:`, `spdx:` namespace prefixes)
- `disallow-doctype-decl` is the strongest defense: rejects all DOCTYPE declarations at parse time

#### 2. `AbstractCLIParser.hasThisXMLRootElement()` — `XMLInputFactory` hardening

**File:** `backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java`

**Before (vulnerable):**
```java
XMLInputFactory xmlif = XMLInputFactory.newFactory();
```

**After (hardened):**
```java
XMLInputFactory xmlif = XMLInputFactory.newFactory();
xmlif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
xmlif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
```

- `XMLInputFactory` (StAX) uses a different API than `DocumentBuilderFactory` (DOM)
- `IS_SUPPORTING_EXTERNAL_ENTITIES = false` — disables external entity resolution
- `SUPPORT_DTD = false` — disables DTD processing entirely (strongest protection for StAX)
- These are the OWASP-recommended hardening properties for `XMLInputFactory`

#### 3. `SPDXParserTest` — test consistency + XXE regression test

**File:** `backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java`

- Updated `testAddSPDXContentToCLI` to use the same hardened `DocumentBuilderFactory` configuration as production code (ensures tests validate behavior with the secured parser, not a different config)
- Added `testXXEAttackIsBlocked()` — a regression test that:
  1. Constructs a malicious RDF payload with a `<!DOCTYPE>` XXE entity pointing to `file:///etc/passwd`
  2. Feeds it through the `SPDXParser.getLicenseInfos()` public API
  3. Asserts the parser rejects the payload (either throws `SW360Exception` or returns non-SUCCESS status)

### Suggest Reviewer

> @AliAhmed, @nickvonkaenel — as the authors of the prior XXE fix (commit `738366d2`) and licenseinfo module maintainers.

