### PR TITLE
feat(licensedb): Add exception handling classes for error management

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBAuthenticationException.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBAuthenticationException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.licensedb.exception;
+
+/**
+ * Exception thrown when OAuth2 authentication with LicenseDB fails.
+ * 
+ * <p>This exception is thrown when the SW360 application cannot authenticate
+ * with the LicenseDB service using OAuth2 Machine-to-Machine credentials.
+ * This could be due to:</p>
+ * <ul>
+ *   <li>Invalid client credentials</li>
+ *   <li>Expired access token</li>
+ *   <li>Missing or invalid OAuth2 configuration</li>
+ *   <li>Insufficient permissions</li>
+ * </ul>
+ * 
+ * <p>Example usage:</p>
+ * <pre>
+ * try {
+ *     accessToken = oauth2Service.getAccessToken();
+ * } catch (LicenseDBAuthenticationException e) {
+ *     log.error("OAuth2 authentication failed: {}", e.getMessage());
+ *     // Handle authentication error
+ * }
+ * </pre>
+ */
+public class LicenseDBAuthenticationException extends LicenseDBException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private static final String ERROR_CODE = "AUTHENTICATION_ERROR";
+    
+    /**
+     * Constructs a new LicenseDBAuthenticationException with the specified message.
+     *
+     * @param message the error message describing the authentication failure
+     */
+    public LicenseDBAuthenticationException(String message) {
+        super(message, ERROR_CODE);
+    }
+    
+    /**
+     * Constructs a new LicenseDBAuthenticationException with the specified message and cause.
+     *
+     * @param message the error message describing the authentication failure
+     * @param cause the underlying cause of the authentication failure
+     */
+    public LicenseDBAuthenticationException(String message, Throwable cause) {
+        super(message, ERROR_CODE, cause);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBConnectionException.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBConnectionException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.licensedb.exception;
+
+/**
+ * Exception thrown when connection to LicenseDB server fails.
+ * 
+ * <p>This exception is thrown when the SW360 application cannot establish
+ * a connection to the LicenseDB service. This could be due to:</p>
+ * <ul>
+ *   <li>Network connectivity issues</li>
+ *   <li>LicenseDB server being unavailable</li>
+ *   <li>Connection timeout</li>
+ *   <li>DNS resolution failures</li>
+ * </ul>
+ * 
+ * <p>Example usage:</p>
+ * <pre>
+ * try {
+ *     licenses = licenseDBClient.getAllLicenses();
+ * } catch (LicenseDBConnectionException e) {
+ *     log.error("Failed to connect to LicenseDB: {}", e.getMessage());
+ *     // Handle connection error
+ * }
+ * </pre>
+ */
+public class LicenseDBConnectionException extends LicenseDBException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private static final String ERROR_CODE = "CONNECTION_ERROR";
+    
+    /**
+     * Constructs a new LicenseDBConnectionException with the specified message.
+     *
+     * @param message the error message describing the connection failure
+     */
+    public LicenseDBConnectionException(String message) {
+        super(message, ERROR_CODE);
+    }
+    
+    /**
+     * Constructs a new LicenseDBConnectionException with the specified message and cause.
+     *
+     * @param message the error message describing the connection failure
+     * @param cause the underlying cause of the connection failure
+     */
+    public LicenseDBConnectionException(String message, Throwable cause) {
+        super(message, ERROR_CODE, cause);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBDataException.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBDataException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.licensedb.exception;
+
+/**
+ * Exception thrown when LicenseDB data validation fails.
+ * 
+ * <p>This exception is thrown when the data received from LicenseDB
+ * does not match the expected format or fails validation. This could be due to:</p>
+ * <ul>
+ *   <li>Missing required fields in license data</li>
+ *   <li>Invalid data types</li>
+ *   <li>Data format conversion errors</li>
+ *   <li>Schema validation failures</li>
+ * </ul>
+ * 
+ * <p>Example usage:</p>
+ * <pre>
+ * try {
+ *     License license = transformer.transform(licenseDbData);
+ * } catch (LicenseDBDataException e) {
+ *     log.error("Invalid license data: {}", e.getMessage());
+ *     // Handle data validation error
+ * }
+ * </pre>
+ */
+public class LicenseDBDataException extends LicenseDBException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private static final String ERROR_CODE = "DATA_ERROR";
+    
+    /**
+     * Constructs a new LicenseDBDataException with the specified message.
+     *
+     * @param message the error message describing the data validation failure
+     */
+    public LicenseDBDataException(String message) {
+        super(message, ERROR_CODE);
+    }
+    
+    /**
+     * Constructs a new LicenseDBDataException with the specified message and cause.
+     *
+     * @param message the error message describing the data validation failure
+     * @param cause the underlying cause of the data validation failure
+     */
+    public LicenseDBDataException(String message, Throwable cause) {
+        super(message, ERROR_CODE, cause);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBException.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/LicenseDBException.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.licensedb.exception;
+
+/**
+ * Base exception for all LicenseDB-related errors.
+ * 
+ * <p>This exception serves as the parent class for all LicenseDB-specific
+ * exceptions in the SW360 application. It provides a common structure for
+ * error handling when interacting with the LicenseDB service.</p>
+ * 
+ * <p>Subclasses include:</p>
+ * <ul>
+ *   <li>{@link LicenseDBConnectionException} - Connection errors</li>
+ *   <li>{@link LicenseDBAuthenticationException} - OAuth2 authentication errors</li>
+ *   <li>{@link LicenseDBDataException} - Data validation errors</li>
+ * </ul>
+ */
+public class LicenseDBException extends RuntimeException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private final String errorCode;
+    
+    /**
+     * Constructs a new LicenseDBException with the specified message.
+     *
+     * @param message the error message
+     */
+    public LicenseDBException(String message) {
+        super(message);
+        this.errorCode = "UNKNOWN_ERROR";
+    }
+    
+    /**
+     * Constructs a new LicenseDBException with the specified message and error code.
+     *
+     * @param message the error message
+     * @param errorCode the error code identifying the type of error
+     */
+    public LicenseDBException(String message, String errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+    
+    /**
+     * Constructs a new LicenseDBException with the specified message and cause.
+     *
+     * @param message the error message
+     * @param cause the cause of the exception
+     */
+    public LicenseDBException(String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = "UNKNOWN_ERROR";
+    }
+    
+    /**
+     * Constructs a new LicenseDBException with the specified message, error code, and cause.
+     *
+     * @param message the error message
+     * @param errorCode the error code identifying the type of error
+     * @param cause the cause of the exception
+     */
+    public LicenseDBException(String message, String errorCode, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+    
+    /**
+     * Returns the error code associated with this exception.
+     *
+     * @return the error code
+     */
+    public String getErrorCode() {
+        return errorCode;
+    }
+}


### PR DESCRIPTION
## Summary
Add custom exception classes for LicenseDB integration to handle various error scenarios when communicating with the external LicenseDB service.

## Changes

Added 4 new exception classes in a new `exception` package:

| Class | Purpose |
|-------|---------|
| `LicenseDBException` | Base exception for all LicenseDB errors |
| `LicenseDBConnectionException` | Thrown when LicenseDB server is unreachable |
| `LicenseDBAuthenticationException` | Thrown when OAuth2 authentication fails |
| `LicenseDBDataException` | Thrown when data validation fails |

## File Structure

```
rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/exception/
├── LicenseDBException.java
├── LicenseDBConnectionException.java
├── LicenseDBAuthenticationException.java
└── LicenseDBDataException.java
```

## Example Usage

```java
try {
    licenses = licenseDBClient.getAllLicenses();
} catch (LicenseDBConnectionException e) {
    log.error("Cannot connect to LicenseDB: {}", e.getMessage());
    return error("LicenseDB service unavailable");
} catch (LicenseDBAuthenticationException e) {
    log.error("OAuth2 auth failed: {}", e.getMessage());
    return error("LicenseDB authentication failed");
} catch (LicenseDBDataException e) {
    log.error("Invalid data from LicenseDB: {}", e.getMessage());
    return error("LicenseDB data validation failed");
}
```

## Verification
- Java Version: 21.0.9 LTS
- Maven Version: 3.9.12
- OS: Windows 11

## Development Proof
Created 4 exception classes:
- LicenseDBAuthenticationException.java
- LicenseDBConnectionException.java
- LicenseDBDataException.java
- LicenseDBException.java
[
<img width="1918" height="700" alt="image" src="https://github.com/user-attachments/assets/16bd1564-9362-405b-9032-cc027b1b659a" />
]


## Testing

- [x] Files compile without errors
- [x] Follow SW360 code style
- [x] EPL-2.0 license headers included
- [x] No dependencies on other components

## Documentation

Each exception class includes Javadoc documentation explaining:
- When to use the exception
- Common causes
- Example usage

## Dependencies

None - This is an independent component that does not require other components.

## Related

- Fixes #3893
- Parent issue: #3685
- Related PR: #3686 (LicenseDB configuration)

@GMishx @deo002
