### PR TITLE
fix(license): improve exception handling in uploadLicense stream cleanup

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -271,34 +271,44 @@ public class Sw360LicenseService {
     }
 
     public void uploadLicense(User sw360User, MultipartFile file, boolean overwriteIfExternalIdMatches, boolean overwriteIfIdMatchesEvenWithoutExternalIdMatch) throws IOException, TException {
-        final HashMap<String, InputStream> inputMap = new HashMap<>();
-
+        if (file == null || file.isEmpty()) {
+            throw new BadRequestClientException("License file is missing or empty");
+        }
         if (!PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             throw new BadRequestClientException("Unable to upload license file. User is not admin");
         }
+
+        final HashMap<String, InputStream> inputMap = new HashMap<>();
+        Exception primaryException = null;
+
         try (InputStream inputStream = file.getInputStream()) {
             ZipTools.extractZipToInputStreamMap(inputStream, inputMap);
             LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
             final LicsImporter licsImporter = new LicsImporter(sw360LicenseClient, overwriteIfExternalIdMatches, overwriteIfIdMatchesEvenWithoutExternalIdMatch);
             licsImporter.importLics(sw360User, inputMap);
+        } catch (Exception e) {
+            primaryException = e;
+            throw e;
         } finally {
-            IOException closeFailure = null;
-            for (InputStream in : inputMap.values()) {
-                try {
+            closeInputMapStreams(inputMap, primaryException);
+        }
+    }
+
+    private void closeInputMapStreams(Map<String, InputStream> inputMap, Exception primaryException) {
+        for (InputStream in : inputMap.values()) {
+            try {
+                if (in != null) {
                     in.close();
-                } catch (IOException e) {
-                    if (closeFailure == null) {
-                        closeFailure = e;
-                    } else {
-                        closeFailure.addSuppressed(e);
-                    }
+                }
+            } catch (IOException e) {
+                if (primaryException != null) {
+                    primaryException.addSuppressed(e);
+                } else {
+                    throw new RuntimeException("Failed to close input stream", e);
                 }
             }
-            if (closeFailure != null) {
-                throw closeFailure;
-            }
         }
-	}
+    }
 
     public RequestSummary importOsadlInformation(User sw360User) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();


### PR DESCRIPTION
## Summary

This PR fixes a critical exception handling flaw in the `uploadLicense()` method where the original exception could be lost during stream cleanup failures.

**Problem:** 

The finally block would throw a new IOException during cleanup, replacing and hiding the actual import failure exception, making debugging extremely difficult.

**Solution:**

- Added null/empty file validation
- Refactored exception handling to preserve primary exceptions
- Extracted cleanup logic to separate method
- Close failures are now added as suppressed exceptions

**Changed from:**

```java
finally { if (closeFailure != null) throw closeFailure; }
```

**To:**

```java
catch (Exception e) { primaryException = e; throw e; }
finally { closeInputMapStreams(inputMap, primaryException); }
```

**Dependencies**
No new dependencies added.

Issue: https://github.com/eclipse-sw360/sw360/issues/3895


### Suggest Reviewer
@GMishx 


