### PR TITLE
feat(licensedb): Add data transformation layer for LicenseDB integration

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/LicenseTransformer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/LicenseTransformer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.licensedb.transformer;
+
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Transformer class to convert LicenseDB license data to SW360 License format.
+ * 
+ * <p>This transformer handles the conversion of license data received from the
+ * LicenseDB service into the SW360 internal License data model. It maps all
+ * relevant fields and handles null values gracefully.</p>
+ * 
+ * <p>Field mapping:</p>
+ * <ul>
+ *   <li>shortname -> shortname</li>
+ *   <li>fullname -> fullname</li>
+ *   <li>text -> text</li>
+ *   <li>url -> url</li>
+ *   <li>licenseType -> licenseType</li>
+ *   <li>osiApproved -> osiApproved</li>
+ * </ul>
+ * 
+ * <p>Example usage:</p>
+ * <pre>
+ * LicenseDBLicense licenseDbData = licenseDBClient.getLicense("Apache-2.0");
+ * LicenseTransformer transformer = new LicenseTransformer();
+ * License sw360License = transformer.transform(licenseDbData);
+ * </pre>
+ */
+@Component
+public class LicenseTransformer {
+
+    /**
+     * Transform LicenseDB license data to SW360 License.
+     *
+     * @param licenseDbData the license data from LicenseDB as a Map
+     * @return SW360 License object, or null if input is null
+     */
+    public License transform(Map<String, Object> licenseDbData) {
+        if (licenseDbData == null) {
+            return null;
+        }
+        
+        License license = new License();
+        
+        // Map basic string fields
+        license.setShortname(getStringValue(licenseDbData, "shortname"));
+        license.setFullname(getStringValue(licenseDbData, "fullname"));
+        license.setText(getStringValue(licenseDbData, "text"));
+        license.setUrl(getStringValue(licenseDbData, "url"));
+        
+        // Map license type
+        String licenseType = getStringValue(licenseDbData, "licenseType");
+        if (licenseType != null) {
+            license.setLicenseType(licenseType);
+        }
+        
+        // Map OSI approved flag
+        Boolean osiApproved = getBooleanValue(licenseDbData, "osiApproved");
+        if (osiApproved != null) {
+            license.setOsiApproved(osiApproved);
+        }
+        
+        return license;
+    }
+    
+    /**
+     * Extract a string value from the data map.
+     *
+     * @param data the data map
+     * @param key the key to look up
+     * @return the string value, or null if not found
+     */
+    private String getStringValue(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        return value != null ? value.toString() : null;
+    }
+    
+    /**
+     * Extract a boolean value from the data map.
+     *
+     * @param data the data map
+     * @param key the key to look up
+     * @return the boolean value, or null if not found
+     */
+    private Boolean getBooleanValue(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/LicenseTransformer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/LicenseTransformer.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.licensedb.transformer;
 
+import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.springframework.stereotype.Component;
 
@@ -58,18 +59,18 @@ public class LicenseTransformer {
         license.setShortname(getStringValue(licenseDbData, "shortname"));
         license.setFullname(getStringValue(licenseDbData, "fullname"));
         license.setText(getStringValue(licenseDbData, "text"));
-        license.setUrl(getStringValue(licenseDbData, "url"));
+        license.setExternalLicenseLink(getStringValue(licenseDbData, "url"));
         
-        // Map license type
-        String licenseType = getStringValue(licenseDbData, "licenseType");
-        if (licenseType != null) {
-            license.setLicenseType(licenseType);
+        // Map license type database ID
+        String licenseTypeId = getStringValue(licenseDbData, "licenseTypeId");
+        if (licenseTypeId != null) {
+            license.setLicenseTypeDatabaseId(licenseTypeId);
         }
         
-        // Map OSI approved flag
+        // Map OSI approved flag to Quadratic enum
         Boolean osiApproved = getBooleanValue(licenseDbData, "osiApproved");
         if (osiApproved != null) {
-            license.setOsiApproved(osiApproved);
+            license.setOSIApproved(osiApproved ? Quadratic.YES : Quadratic.NA);
         }
         
         return license;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/ObligationTransformer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/ObligationTransformer.java
@@ -10,6 +10,8 @@
 package org.eclipse.sw360.rest.resourceserver.licensedb.transformer;
 
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -56,16 +58,24 @@ public class ObligationTransformer {
         obligation.setText(getStringValue(obligationDbData, "text"));
         obligation.setTitle(getStringValue(obligationDbData, "title"));
         
-        // Map obligation type if present
+        // Map obligation type enum if present
         String type = getStringValue(obligationDbData, "type");
-        if (type != null) {
-            obligation.setObligationType(type);
+        if (type != null && !type.isEmpty()) {
+            try {
+                obligation.setObligationType(ObligationType.valueOf(type.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                // Unknown obligation type - skip field
+            }
         }
         
-        // Map obligation level if present
+        // Map obligation level enum if present
         String level = getStringValue(obligationDbData, "level");
-        if (level != null) {
-            obligation.setObligationLevel(level);
+        if (level != null && !level.isEmpty()) {
+            try {
+                obligation.setObligationLevel(ObligationLevel.valueOf(level.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                // Unknown obligation level - skip field
+            }
         }
         
         return obligation;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/ObligationTransformer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/ObligationTransformer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.licensedb.transformer;
+
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Transformer class to convert LicenseDB obligation data to SW360 Obligation format.
+ * 
+ * <p>This transformer handles the conversion of obligation data received from the
+ * LicenseDB service into the SW360 internal Obligation data model. It maps all
+ * relevant fields and handles null values gracefully.</p>
+ * 
+ * <p>Field mapping:</p>
+ * <ul>
+ *   <li>text -> text</li>
+ *   <li>title -> title</li>
+ *   <li>type -> obligationType</li>
+ *   <li>level -> obligationLevel</li>
+ * </ul>
+ * 
+ * <p>Example usage:</p>
+ * <pre>
+ * LicenseDBObligation obligationDbData = licenseDBClient.getObligation("obligation-1");
+ * ObligationTransformer transformer = new ObligationTransformer();
+ * Obligation sw360Obligation = transformer.transform(obligationDbData);
+ * </pre>
+ */
+@Component
+public class ObligationTransformer {
+
+    /**
+     * Transform LicenseDB obligation data to SW360 Obligation.
+     *
+     * @param obligationDbData the obligation data from LicenseDB as a Map
+     * @return SW360 Obligation object, or null if input is null
+     */
+    public Obligation transform(Map<String, Object> obligationDbData) {
+        if (obligationDbData == null) {
+            return null;
+        }
+        
+        Obligation obligation = new Obligation();
+        
+        // Map basic string fields
+        obligation.setText(getStringValue(obligationDbData, "text"));
+        obligation.setTitle(getStringValue(obligationDbData, "title"));
+        
+        // Map obligation type if present
+        String type = getStringValue(obligationDbData, "type");
+        if (type != null) {
+            obligation.setObligationType(type);
+        }
+        
+        // Map obligation level if present
+        String level = getStringValue(obligationDbData, "level");
+        if (level != null) {
+            obligation.setObligationLevel(level);
+        }
+        
+        return obligation;
+    }
+    
+    /**
+     * Extract a string value from the data map.
+     *
+     * @param data the data map
+     * @param key the key to look up
+     * @return the string value, or null if not found
+     */
+    private String getStringValue(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        return value != null ? value.toString() : null;
+    }
+}


### PR DESCRIPTION
## Summary

Add transformer classes to convert LicenseDB data format to SW360 internal format for licenses and obligations.

## Changes

| File | Description |
|------|-------------|
| `LicenseTransformer.java` | Transform LicenseDB License to SW360 License |
| `ObligationTransformer.java` | Transform LicenseDB Obligation to SW360 Obligation |

**Location:** `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licensedb/transformer/`

## Field Mapping

### License Fields

| LicenseDB | SW360 |
|-----------|-------|
| shortname | shortname |
| fullname | fullname |
| text | text |
| url | url |
| licenseType | licenseType |
| osiApproved | osiApproved |

### Obligation Fields

| LicenseDB | SW360 |
|-----------|-------|
| text | text |
| title | title |
| type | obligationType |
| level | obligationLevel |

## Usage

```java
LicenseDBLicense licenseDbData = licenseDBClient.getLicense("Apache-2.0");
LicenseTransformer transformer = new LicenseTransformer();
License sw360License = transformer.transform(licenseDbData);
```

## Testing

- [x] Files compile without errors
- [x] Follows SW360 code style
- [x] EPL-2.0 license headers included
- [x] Javadoc documentation added
- [x] No new dependencies

## Verification
- Java Version: 21.0.9 LTS
- Maven Version: 3.9.12
- OS: Windows 11
- 
## Development Proof
Created 2 transformer classes:
- LicenseTransformer.java
- ObligationTransformer.java
[
<img width="1912" height="668" alt="image" src="https://github.com/user-attachments/assets/2c8de554-534f-4f61-a968-18454fc9644b" />
]

## Dependencies

None - This is an independent component.

## Related

Fixes #3897

Part of: #3685 (LicenseDB integration)


@GMishx @deo002