### PR TITLE
perf(license): optimize getLicenseTypeUsageCount to use database view

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -380,10 +380,7 @@ public class Sw360LicenseService {
         try {
             LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
 
-            List<License> allLicenses = sw360LicenseClient.getLicenseSummary();
-            return (int) allLicenses.stream()
-                    .filter(license -> license.getLicenseType() != null && license.getLicenseType().getId().equals(licenseTypeId))
-                    .count();
+            return sw360LicenseClient.checkLicenseTypeInUse(licenseTypeId);
         } catch (SW360Exception sw360Exp) {
             if (sw360Exp.getErrorCode() == 404) {
                 throw new ResourceNotFoundException("License type not found with ID: " + licenseTypeId);


### PR DESCRIPTION
# Summary of Changes

This PR optimizes the `getLicenseTypeUsageCount` method in the `Sw360LicenseService` class to improve performance and reduce resource consumption.

Replace inefficient implementation that fetched all licenses from the database and filtered in application code with a direct call to `checkLicenseTypeInUse()`, which uses an indexed CouchDB view. This change:

- Eliminates fetching all licenses when only a count is needed
- Uses the existing `bylicensetypeid` database view for efficient lookup
- Reduces memory usage and network overhead
- Improves query performance, especially with large datasets
- Removes code duplication (same logic already exists in backend)


## Changes Made

**Modified File:**
`rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java`

**What Changed:**
- Replaced `getLicenseSummary()` call and stream filtering logic
- Now uses existing `checkLicenseTypeInUse()` Thrift service method
- Reduced method implementation from ~13 lines to 3 lines
- Maintained all existing error handling and access control

**Before:**
```java
List<License> allLicenses = sw360LicenseClient.getLicenseSummary();
return (int) allLicenses.stream()
    .filter(license -> license.getLicenseType() != null &&
        license.getLicenseType().getId().equals(licenseTypeId))
    .count();
```

**After:**
```java
return sw360LicenseClient.checkLicenseTypeInUse(licenseTypeId);
```

---

## Dependencies

No new dependencies added or updated. This change leverages existing infrastructure:

- Existing `checkLicenseTypeInUse()` method in `LicenseService.Iface`
- Existing `bylicensetypeid` CouchDB view in `LicenseRepository`
- Existing backend implementation in `LicenseDatabaseHandler`

---


## Performance Impact

With 10,000 licenses in database:

| | Before | After |
|---|---|---|
| **Data fetched** | All 10,000 license objects loaded into memory | Indexed database query returns count directly |
| **Query time** | Full scan O(n) | Indexed lookup O(log n) |
| **Memory usage** | Large object collection in heap | Minimal |
| **Network transfer** | All records | Count only |

---

## Behavioral Note

> **Important:** This change improves data integrity by querying the actual `licenseTypeDatabaseId` field in the database rather than checking populated license type objects.

This means:

- The new implementation may count licenses with **orphaned references** (where `licenseTypeDatabaseId` exists but the referenced license type was deleted)
- The previous implementation would skip such licenses due to null check on the populated object
- This is **intentional and correct** behavior for the use case of preventing license type deletion when references still exist in the database

This ensures better referential integrity and prevents scenarios where a license type could be deleted while licenses still reference it.

---

## Additional Notes

This optimization aligns the REST service implementation with the existing backend logic used by `deleteLicenseType()`, ensuring consistency across the codebase.

Issue: https://github.com/eclipse-sw360/sw360/issues/3905

### Suggest Reviewer
@GMishx 

