### PR TITLE
fix(release-service): ensure proper lock handling in Fossology process

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -986,9 +986,10 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
                 log.info("Release : " + releaseId + " .Fossology Process exited, removing lock.");
                 if (service != null)
                     service.shutdownNow();
-                if (lockObj.isLocked())
+                if (lockObj.isHeldByCurrentThread()) {
                     lockObj.unlock();
-                mapOfLocks.remove(releaseId);
+                    mapOfLocks.remove(releaseId);
+                }
             }
         });
 


### PR DESCRIPTION
## Refined lock handling for FOSSology process

### Summary

This PR fixes a bug in the FOSSology process lock handling in `Sw360ReleaseService` that could cause `IllegalMonitorStateException` and incorrect lock removal when multiple requests target the same release.

### Problem

When two FOSSology processes were triggered for the same release in quick succession:

1. **`IllegalMonitorStateException`** – The second request failed to acquire the lock (`tryLock()` returned `false`), but the `finally` block still called `lockObj.unlock()`. `isLocked()` returns true if any thread holds the lock, so the second thread tried to unlock a lock it did not own, causing `IllegalMonitorStateException`.

2. **Incorrect lock removal** – `mapOfLocks.remove(releaseId)` ran even when the current thread never acquired the lock, so the lock could be removed while another thread was still using it.

### Solution

- Replaced `isLocked()` with `isHeldByCurrentThread()` so unlock and removal only run when the current thread holds the lock.
- Moved `mapOfLocks.remove(releaseId)` inside the `if` block so it runs only when the current thread actually held the lock.

### Changes

- **File:** `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java`
- **Method:** `executeFossologyProcess` (async runnable `finally` block)

### Dependencies

No new dependencies were added or updated.
Issue: 

### Suggest Reviewer
@GMishx 
