### PR TITLE
feat: add batch summary endpoint for release lookups

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -86,6 +86,24 @@ include::{snippets}/should_document_get_recent_releases/http-response.adoc[]
 include::{snippets}/should_document_get_recent_releases/links.adoc[]
 
 
+[[resources-release-batch-summary]]
+==== Fetching release summaries in batch
+
+A `POST` request will return lightweight release summary data for a list of release IDs.
+
+===== Request structure
+include::{snippets}/should_document_get_release_batch_summary/request-fields.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_release_batch_summary/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_release_batch_summary/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_release_batch_summary/http-response.adoc[]
+
+
 [[resources-releases-list-with-fields]]
 ==== Listing releases with fields
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -109,6 +109,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 
 @BasePathAwareController
@@ -118,6 +119,7 @@ import com.google.common.collect.ImmutableMap;
 @SecurityRequirement(name = "basic")
 public class ReleaseController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String RELEASES_URL = "/releases";
+    private static final int MAX_BATCH_SUMMARY_IDS = 200;
     private static final String SPDX_DOCUMENT = "spdxDocument";
     private static final String DOCUMENT_CREATION_INFORMATION = "documentCreationInformation";
     private static final String PACKAGE_INFORMATION = "packageInformation";
@@ -308,6 +310,75 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             restControllerHelper.addEmbeddedReleaseLinks(halRelease, linkedReleaseRelations);
         }
         return new ResponseEntity<>(halRelease, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Get release summaries in a single batch.",
+            description = "Returns lightweight release summary data for a list of release IDs.",
+            tags = {"Releases"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", description = "Batch release summary.",
+                            content = {
+                                    @Content(mediaType = "application/json",
+                                            schema = @Schema(
+                                                    example = """
+                                                        {
+                                                          "items": [
+                                                            {
+                                                              "id": "releaseId1",
+                                                              "name": "Release A",
+                                                              "version": "1.0.0",
+                                                              "clearingState": "APPROVED"
+                                                            }
+                                                          ],
+                                                          "missingIds": ["releaseId2"]
+                                                        }
+                                                        """
+                                            ))
+                            }
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Invalid request body.")
+            }
+    )
+    @PostMapping(value = RELEASES_URL + "/batch-summary", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> getReleaseBatchSummary(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(name = "Batch summary request", value = """
+                                            {
+                                              "ids": ["releaseId1", "releaseId2", "releaseId3"]
+                                            }
+                                            """)
+                            }
+                    )
+            )
+            @RequestBody Map<String, Object> reqBodyMap
+    ) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        LinkedHashSet<String> releaseIds = normalizeReleaseBatchSummaryIds(extractReleaseBatchSummaryIds(reqBodyMap));
+        List<Release> releases = releaseService.getAccessibleReleasesByIds(releaseIds, sw360User);
+        Map<String, Release> releasesById = releases.stream()
+                .collect(Collectors.toMap(Release::getId, release -> release, (existing, ignored) -> existing));
+
+        List<Map<String, Object>> items = new ArrayList<>();
+        List<String> missingIds = new ArrayList<>();
+        for (String releaseId : releaseIds) {
+            Release release = releasesById.get(releaseId);
+            if (release == null) {
+                missingIds.add(releaseId);
+                continue;
+            }
+            items.add(createReleaseBatchSummaryItem(release));
+        }
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("items", items);
+        response.put("missingIds", missingIds);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @Operation(
@@ -1785,6 +1856,50 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(ReleaseController.class).slash("api" + RELEASES_URL).withRel("releases"));
         return resource;
+    }
+
+    private List<String> extractReleaseBatchSummaryIds(Map<String, Object> reqBodyMap) {
+        if (reqBodyMap == null || !reqBodyMap.containsKey("ids")) {
+            throw new BadRequestClientException("The request body must contain an 'ids' array.");
+        }
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            mapper.registerModule(sw360Module);
+            return mapper.convertValue(reqBodyMap.get("ids"), new TypeReference<List<String>>() {});
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestClientException("The 'ids' field must be an array of release IDs.");
+        }
+    }
+
+    private LinkedHashSet<String> normalizeReleaseBatchSummaryIds(List<String> releaseIds) {
+        if (releaseIds == null) {
+            throw new BadRequestClientException("The 'ids' field must be an array of release IDs.");
+        }
+
+        LinkedHashSet<String> normalizedIds = new LinkedHashSet<>();
+        for (String releaseId : releaseIds) {
+            if (StringUtils.isBlank(releaseId)) {
+                throw new BadRequestClientException("The 'ids' field must not contain blank values.");
+            }
+            normalizedIds.add(releaseId);
+        }
+
+        if (normalizedIds.size() > MAX_BATCH_SUMMARY_IDS) {
+            throw new BadRequestClientException("A maximum of " + MAX_BATCH_SUMMARY_IDS + " unique release IDs is allowed.");
+        }
+
+        return normalizedIds;
+    }
+
+    private Map<String, Object> createReleaseBatchSummaryItem(Release release) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("id", release.getId());
+        item.put("name", release.getName());
+        item.put("version", release.getVersion());
+        item.put("clearingState", release.getClearingState() == null ? null : release.getClearingState().name());
+        return item;
     }
 
     private HalResource<Release> createHalReleaseResource(Release release, boolean verbose) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -182,6 +182,15 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return limitedSet;
     }
 
+    public List<Release> getAccessibleReleasesByIds(Set<String> releaseIds, User sw360User) throws TException {
+        if (CommonUtils.isNullOrEmptyCollection(releaseIds)) {
+            return Collections.emptyList();
+        }
+
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.getAccessibleReleasesById(releaseIds, sw360User);
+    }
+
     public List<ReleaseLink> getLinkedReleaseRelations(Release release, User user) throws TException {
         List<ReleaseLink> linkedReleaseRelations = getLinkedReleaseRelationsWithAccessibility(release, user);
         linkedReleaseRelations = linkedReleaseRelations.stream().filter(Objects::nonNull).sorted(Comparator.comparing(

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -70,6 +70,7 @@ import java.util.Set;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -336,6 +337,37 @@ public class ReleaseTest extends TestIntegrationBase {
                         String.class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         TestHelper.checkResponse(response.getBody(), "releases", 2, Collections.singletonList(extraField));
+    }
+
+    @Test
+    public void should_get_release_batch_summary() throws IOException, TException {
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        List<String> requestedIds = Arrays.asList(TestHelper.releaseId2, TestHelper.release1Id, TestHelper.releaseId2, "missing-release");
+        LinkedHashSet<String> deduplicatedIds = new LinkedHashSet<>(Arrays.asList(TestHelper.releaseId2, TestHelper.release1Id, "missing-release"));
+        Release releaseTwo = getDummyReleaseListForTest().get(1);
+
+        given(this.releaseServiceMock.getAccessibleReleasesByIds(eq(deduplicatedIds), any()))
+                .willReturn(Arrays.asList(release, releaseTwo));
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("ids", requestedIds);
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/releases/batch-summary",
+                        HttpMethod.POST,
+                        new HttpEntity<>(body, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
+        assertEquals(2, responseBody.get("items").size());
+        assertEquals(TestHelper.releaseId2, responseBody.get("items").get(0).get("id").textValue());
+        assertEquals(TestHelper.release1Id, responseBody.get("items").get(1).get("id").textValue());
+        assertEquals("missing-release", responseBody.get("missingIds").get(0).textValue());
+
+        then(releaseServiceMock).should().getAccessibleReleasesByIds(eq(deduplicatedIds), any());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -860,6 +861,37 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:releases.[]version").description("The version of the release"),
                                 subsectionWithPath("_embedded.sw360:releases").description("An array of <<resources-releases, Releases resources>>"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_release_batch_summary() throws Exception {
+        LinkedHashSet<String> requestedIds = new LinkedHashSet<>(Arrays.asList(release3.getId(), release.getId(), "missing-release"));
+        given(this.releaseServiceMock.getAccessibleReleasesByIds(eq(requestedIds), any()))
+                .willReturn(Arrays.asList(release, release3));
+
+        mockMvc.perform(post("/api/releases/batch-summary")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "ids": ["987456", "3765276512", "987456", "missing-release"]
+                        }
+                        """)
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        requestFields(
+                                fieldWithPath("ids").description("Array of release IDs. Duplicate IDs are deduplicated while preserving first-seen order.")
+                        ),
+                        responseFields(
+                                fieldWithPath("items").description("Ordered release summaries for all accessible requested releases."),
+                                fieldWithPath("items[].id").description("The release ID."),
+                                fieldWithPath("items[].name").description("The release name."),
+                                fieldWithPath("items[].version").description("The release version."),
+                                fieldWithPath("items[].clearingState").description("The release clearing state, possible values are " + Arrays.asList(ClearingState.values())).optional(),
+                                fieldWithPath("missingIds").description("Requested release IDs that were missing or inaccessible."),
+                                fieldWithPath("missingIds[]").description("A requested release ID that was not returned.").optional()
                         )));
     }
 


### PR DESCRIPTION
Closes: eclipse-sw360/sw360-frontend#1743  

### Summary:

This PR adds a dedicated batch release summary API to avoid repeated GET /releases/{id} calls from frontend screens that already have a list of release IDs and only need lightweight display data. The new endpoint allows the frontend to fetch release summaries in a single request instead of calling the single-release detail API in a loop.

### Changes Made: 
- created new endpoint `POST /api/releases/batch-summary` .
- payload : 
``` 
{
  "ids": ["releaseId1", "releaseId2", "releaseId3"]
}
``` 
- response : 
```
{
  "items": [
    {
      "id": "releaseId1",
      "name": "Release A",
      "version": "1.0.0",
      "clearingState": "APPROVED"
    },
    {
      "id": "releaseId2",
      "name": "Release B",
      "version": "2.1.4",
      "clearingState": "IN_PROGRESS"
    }
  ],
  "missingIds": ["releaseId3"]
}
 
```

### Suggest Reviewer
@GMishx 

### Files Changed : 
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java`
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java`
- `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java`
- `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java`
- `rest/resource-server/src/docs/asciidoc/releases.adoc`

### How To Test?
- mvn -pl rest/resource-server -am "-Dtest=ReleaseTest,ReleaseSpecTest" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dmaven.repo.local=.m2\repository" "-Dbase.deploy.dir=.codex-build" test
- mvn -pl rest/resource-server -am "-Dmaven.repo.local=.m2\repository" "-Dbase.deploy.dir=.codex-build" -DskipTests package

### Checklist
Must:
 - [x] Added new batch summary endpoint
 - [x] Kept existing single-release endpoint unchanged
 - [x] Added integration test coverage
 - [x] Added REST Docs coverage
 - [x] Updated API documentation
 - [x] Verified build and tests
- [x] All related issues are referenced in commit messages and in PR
