### PR TITLE
fix(docker): install gettext-base in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,12 @@ COPY --from=binaries /sw360_tomcat_webapps/*.jar ${CATALINA_HOME}/webapps/
 # Shared streamlined jar libs
 COPY --from=binaries /sw360_tomcat_webapps/libs/*.jar ${CATALINA_HOME}/lib/
 
+# Install gettext for envsubst
+RUN apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends \
+    gettext-base \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app/sw360
 
 # Copy the configuration files


### PR DESCRIPTION
Refs: #3916

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> This PR fixes the Docker runtime image by installing `gettext-base`, which provides `envsubst` required by `scripts/docker-config/docker-entrypoint.sh`.
> * This PR belongs to issue #3916 and solves it by adding the missing runtime dependency used to render configuration templates before Tomcat startup.
> * It adds one OS package in the Docker runtime image: `gettext-base`.

Issue: #3916 

Closes #3916 

### Suggest Reviewer
> @GMishx 

### How To Test?
> 1. Build the Docker image from this branch.
> 2. Start the container.
> 3. Verify the container no longer fails due to missing `/usr/bin/envsubst`.
> 4. Confirm configuration templates are rendered and startup proceeds to Tomcat.

> Local validation performed:
> * Reviewed that `docker-entrypoint.sh` requires `/usr/bin/envsubst`
> * Verified the base Tomcat runtime image does not provide `envsubst`
> * Added `gettext-base` in the runtime stage so `envsubst` is available

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] If code is AI-generated, mention the tool and model used (e.g., GitHub Copilot, GPT-4)

AI assistance:
- GitHub Copilot
