### PR TITLE
fix(rest): prevent IndexOutOfBoundsException for out-of-range pagination

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -569,6 +569,8 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             getSortedList(sortBy, sortOrder, vulTrackingStatusList);
             Map<String, Object> createPagination = createPaginationMetadata(pageable, vulTrackingStatusList);
             return ResponseEntity.ok(createPagination);
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (SW360Exception e) {
             throw new TException(e.why);
         } catch (Exception ex) {
@@ -580,6 +582,9 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         int pageSize = pageable.getPageSize();
         int pageNumber = pageable.getPageNumber();
         int start = pageNumber * pageSize;
+        if (start > listOfItems.size() || (start == listOfItems.size() && start > 0)) {
+            throw new BadRequestClientException("Requested page number is out of range. Total elements: " + listOfItems.size());
+        }
         int end = Math.min(start + pageSize, listOfItems.size());
         List<Map<String, String>> paginatedList = listOfItems.subList(start, end);
         int totalPages = (int) Math.ceil((double) listOfItems.size() / pageSize);


### PR DESCRIPTION
### Summary

This PR fixes an IndexOutOfBoundsException in the vulnerability tracking
pagination logic of `VulnerabilityController`.

Previously, when a client requested a page number that exceeded the available
dataset, the controller calculated a start index greater than the list size.
This resulted in an invalid `subList()` call and caused the endpoint to return
HTTP 500 Internal Server Error.

### Root Cause

Pagination metadata was created using:

    int start = pageNumber * pageSize;
    int end = Math.min(start + pageSize, listOfItems.size());
    listOfItems.subList(start, end);

If `start >= listOfItems.size()`, the call to `subList()` violated index bounds
requirements and triggered an `IndexOutOfBoundsException`.

Issue: #3919 

### Suggest Reviewer
@GMishx 

### How To Test?
1. Start the SW360 application.
2. Identify a project with 0 or more vulnerabilities.
3. Call the following API in Postman 
GET http://localhost:8080/resource/api/vulnerabilities/trackingStatus/{{projectId}}?page=999&size=10
4. Result: The server should return HTTP 400 Bad Request  instead of a 500 error.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
