### PR TITLE
fix(rest): prevent NullPointerException in vulnerability tracking sorting

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1211,7 +1211,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 return actualProjectReleaseRelationship;
             }
         }
-        throw new ResourceNotFoundException("Requested Re<<<<<< HEAD\n" + "=======lease Not Found");
+        throw new ResourceNotFoundException("Requested Release Not Found");
     }
 
     @PreDestroy

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -598,10 +598,14 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     private void getSortedList(String sortBy, String sortOrder, List<Map<String, String>> vulTrackingStatusList) {
         Collections.sort(vulTrackingStatusList, new Comparator<Map<String, String>>() {
             public int compare(Map<String, String> m1, Map<String, String> m2) {
+                String val1 = m1.get(sortBy);
+                String val2 = m2.get(sortBy);
+                if (val1 == null) val1 = "";
+                if (val2 == null) val2 = "";
                 if ("asc".equalsIgnoreCase(sortOrder)) {
-                    return (m1.get(sortBy)).compareTo(m2.get(sortBy));
+                    return val1.compareTo(val2);
                 } else {
-                    return (m2.get(sortBy)).compareTo(m1.get(sortBy));
+                    return val2.compareTo(val1);
                 }
             }
         });


### PR DESCRIPTION
### Summary

1. Sorting Fix: Fix NullPointerException in `getSortedList`  when an invalid sortBy parameter is provided.

2. Corrupted String Fix: Repair a corrupted error message string in `Sw360ProjectService.java`  caused by an accidental merge conflict commit.

Fixes: #3924 

### Suggest Reviewer
@GMishx 

### How To Test?

Issue 1 — Sorting crash

1.Ensure a project has at least two linked releases and vulnerability tracking rows exist.

2.Send request:
GET /resource/api/vulnerabilities/trackingStatus/{projectId}?sortBy=fakeField
Example:
GET http://localhost:8080/resource/api/vulnerabilities/trackingStatus/753d0cc056d9d0da55fe7343a0000da8?sortBy=fakeField

3.Observe the response.
Issue 2 — Corrupted error message

1.Trigger a “Release Not Found” scenario in updateProjectReleaseRelationship.
2.Observe the error message returned by the API.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
