### PR TITLE
fix(rest): close streams and temp files in attachment bundle download

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -200,28 +200,44 @@ public class Sw360AttachmentService {
             return;
         }
         List<File> files = new ArrayList<>();
-        for (Attachment attachment : attachments) {
-            AttachmentContent attachmentContent = getAttachmentContent(attachment.getAttachmentContentId());
-            InputStream inputStream = getStreamToAttachments(Collections.singleton(attachmentContent), user, context);
-            String fileType = getFileType(attachmentContent.getFilename());
-            File sourceFile = saveAsTempFile(inputStream, attachment.getAttachmentContentId(), fileType);
-            File file = renameFile(sourceFile, attachment.getFilename());
-            files.add(file);
-            FileUtils.delete(sourceFile);
+        File sourceFile = null;
+        try {
+            for (Attachment attachment : attachments) {
+                AttachmentContent attachmentContent = getAttachmentContent(attachment.getAttachmentContentId());
+                try (InputStream inputStream = getStreamToAttachments(Collections.singleton(attachmentContent), user, context)) {
+                    String fileType = getFileType(attachmentContent.getFilename());
+                    sourceFile = saveAsTempFile(inputStream, attachment.getAttachmentContentId(), fileType);
+                    File file = renameFile(sourceFile, attachment.getFilename());
+                    files.add(file);
+                } finally {
+                    if (sourceFile != null) {
+                        FileUtils.delete(sourceFile);
+                    }
+                }
+            }
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.addHeader("Content-Disposition", "attachment; filename=\"AttachmentBundle.zip\"");
+            try (ZipOutputStream zipOutputStream = new ZipOutputStream(response.getOutputStream())) {
+                for (File file : files) {
+                    // Sanitize filename for ZIP entry to prevent path traversal
+                    String sanitizedName = CommonUtils.sanitizeFilename(file.getName());
+                    zipOutputStream.putNextEntry(new ZipEntry(sanitizedName));
+                    try (FileInputStream fileInputStream = new FileInputStream(file)) {
+                        IOUtils.copy(fileInputStream, zipOutputStream);
+                    } finally {
+                        zipOutputStream.closeEntry();
+                        FileUtils.deleteQuietly(file);
+                    }
+                }
+            }
+        } finally {
+            for (File file : files) {
+                if (file.exists()) {
+                    FileUtils.deleteQuietly(file);
+                }
+            }
         }
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.addHeader("Content-Disposition", "attachment; filename=\"AttachmentBundle.zip\"");
-        ZipOutputStream zipOutputStream = new ZipOutputStream(response.getOutputStream());
-        for (File file : files) {
-            // Sanitize filename for ZIP entry to prevent path traversal
-            String sanitizedName = CommonUtils.sanitizeFilename(file.getName());
-            zipOutputStream.putNextEntry(new ZipEntry(sanitizedName));
-            FileInputStream fileInputStream = new FileInputStream(file);
-            IOUtils.copy(fileInputStream, zipOutputStream);
-            fileInputStream.close();
-            zipOutputStream.closeEntry();
-        }
-        zipOutputStream.close();
+
     }
 
     public <T> InputStream getStreamToAttachments(Set<AttachmentContent> attachments, User sw360User, T context) throws IOException, TException {


### PR DESCRIPTION
## Summary

This PR fixes resource leaks in `downloadAttachmentBundleWithContext` in `Sw360AttachmentService`.


The method had several resource leaks that could cause file descriptor exhaustion and temp file accumulation on the server:

- **InputStream leak** – Streams returned by `getStreamToAttachments()` were never closed in the loop
- **ZipOutputStream leak** – Could remain open if an exception occurred during ZIP creation
- **FileInputStream leak** – Could remain open if `IOUtils.copy` threw
- **Temp file leak** – Temp files were not deleted when exceptions occurred before or during ZIP writing
- **ZIP entry corruption** – `closeEntry()` was not guaranteed to run on exception, leaving the ZIP in an invalid state

**Changes:**
- Wrap `InputStream`, `ZipOutputStream`, and `FileInputStream` in try-with-resources
- Delete `sourceFile` in a `finally` block when `renameFile` throws
- Add an outer try-finally to delete temp files on any exception path
- Move `closeEntry()` into a `finally` block to avoid corrupted ZIP on exception

### Did you add or update any new dependencies that are required for your change?

No new dependencies were added or updated.

---



Closes: https://github.com/eclipse-sw360/sw360/issues/3928

### Suggest Reviewer
@GMishx 

