### PR TITLE
fix(rest): sanitize filename in addAttachment to prevent path traversal

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -275,8 +275,9 @@ public class Sw360AttachmentService {
 
     public Attachment addAttachment(MultipartFile file, User sw360User) throws IOException, TException {
         String fileName = file.getOriginalFilename();
+        String sanitizedFileName = CommonUtils.sanitizeFilename(fileName);
         String contentType = file.getContentType();
-        final AttachmentContent attachmentContent = makeAttachmentContent(fileName, contentType);
+        final AttachmentContent attachmentContent = makeAttachmentContent(sanitizedFileName, contentType);
         final AttachmentConnector attachmentConnector = getConnector();
         Attachment attachment = new AttachmentFrontendUtils().uploadAttachmentContent(attachmentContent, file.getInputStream(), sw360User);
         attachment.setSha1(attachmentConnector.getSha1FromAttachmentContentId(attachmentContent.getId()));


### PR DESCRIPTION
## Summary
Sanitizes the filename in `addAttachment` to prevent path traversal when uploading attachments.

## Changes
- **Sw360AttachmentService.addAttachment:** Apply `CommonUtils.sanitizeFilename()` to `file.getOriginalFilename()` before passing it to `makeAttachmentContent`.
- Aligns `addAttachment` with `uploadAttachment`, which already sanitizes filenames.
## Dependencies
None.

Closes: https://github.com/eclipse-sw360/sw360/issues/3938

### Suggest Reviewer
@GMishx @deo002 

