### PR TITLE
fix(docker): correct runtime startup configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,6 @@ services:
       - "11311:11311"
     stdin_open: true
     tty: true
-    networks:
-      - sw360-network
     volumes:
       - etc:/etc/sw360
     healthcheck:

--- a/scripts/docker-config/docker-entrypoint.sh
+++ b/scripts/docker-config/docker-entrypoint.sh
@@ -4,13 +4,15 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Source secrets if available. This allows overriding the default ENV values.
+# Export sourced secrets so envsubst can see them when generating configs.
+set -o allexport
 if [ -f "/run/secrets/COUCHDB_SECRETS" ]; then
   source /run/secrets/COUCHDB_SECRETS
 fi
 if [ -f "/run/secrets/SW360_SECRETS" ]; then
   source /run/secrets/SW360_SECRETS
 fi
+set +o allexport
 
 mkdir -p /etc/sw360/authorization /etc/sw360/rest
 


### PR DESCRIPTION
Fixes #3945

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> This PR fixes two Docker runtime startup problems:
> * remove the invalid explicit `sw360-network` reference from `docker-compose.yml`
> * export secret values sourced by `docker-entrypoint.sh` before generating runtime configuration with `envsubst`

No new dependencies were added.

### Suggest Reviewer
> @GMishx

### How To Test?
> 1. Check out `main` at commit `064862f4`.
> 2. Run `docker compose up -d`.
> 3. Observe the compose validation failure caused by the undefined `sw360-network`.
> 4. Apply this branch and run `docker compose up -d` again.
> 5. Verify the stack starts successfully.
> 6. Verify secret-backed values from `/run/secrets/COUCHDB_SECRETS` and `/run/secrets/SW360_SECRETS` are written into the generated files under `/etc/sw360/`.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR