### PR TITLE
refactor(component): decouple export summary assembly from repositories

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
@@ -9,15 +9,10 @@
  */
 package org.eclipse.sw360.components.summary;
 
-import org.eclipse.sw360.datahandler.db.ReleaseRepository;
-import org.eclipse.sw360.datahandler.db.VendorRepository;
-import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.copyField;
 
@@ -28,38 +23,13 @@ import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.copyField;
  */
 public class ComponentSummary extends DocumentSummary<Component> {
 
-    private final ReleaseRepository releaseRepository;
-    private final VendorRepository vendorRepository;
-
-    public ComponentSummary() {
-        // Create summary without database connection
-        this(null, null);
-    }
-
-    public ComponentSummary(ReleaseRepository releaseRepository, VendorRepository vendorRepository) {
-        this.releaseRepository = releaseRepository;
-        this.vendorRepository = vendorRepository;
-    }
-
     @Override
     protected Component summary(SummaryType type, Component document) {
-
         Component copy = new Component();
         if (type == SummaryType.EXPORT_SUMMARY) {
-            List<Release> releases = releaseRepository.getReleasesFromComponentId(document.getId());
-            return makeExportSummary(document, releases);
+            throw new IllegalStateException("Export summaries must be built with preloaded releases.");
         } else if (type == SummaryType.DETAILED_EXPORT_SUMMARY) {
-            List<Release> releases = releaseRepository.getReleasesFromComponentId(document.getId());
-
-            final Map<String, Vendor> vendorsById = ThriftUtils.getIdMap(vendorRepository.getAll());
-
-            for (Release release : releases) {
-                if (!release.isSetVendor() && release.isSetVendorId()) {
-                    release.setVendor(vendorsById.get(release.getVendorId()));
-                }
-            }
-
-            return makeDetailedExportSummary(document, releases);
+            throw new IllegalStateException("Detailed export summaries must be built with preloaded releases.");
         } else if (type == SummaryType.HOME) {
             copyField(document, copy, Component._Fields.ID);
             copyField(document, copy, Component._Fields.DESCRIPTION);
@@ -80,19 +50,12 @@ public class ComponentSummary extends DocumentSummary<Component> {
         return copy;
     }
 
-    private Component makeDetailedExportSummary(Component document, List<Release> releases) {
-
+    public Component makeDetailedExportSummary(Component document, List<Release> releases) {
         document.setReleases(releases);
-
         return document;
     }
 
-    private Component makeExportSummary(Component document, List<Release> releases) {
-
-        if (releaseRepository == null) {
-            throw new IllegalStateException("Cannot make export summary without database connection!");
-        }
-
+    public Component makeExportSummary(Component document, List<Release> releases) {
         Component copy = new Component();
 
         copyField(document, copy, Component._Fields.ID);
@@ -110,8 +73,6 @@ public class ComponentSummary extends DocumentSummary<Component> {
         copyField(document, copy, Component._Fields.HOMEPAGE);
         copyField(document, copy, Component._Fields.EXTERNAL_IDS);
 
-
-
         for (Release release : releases) {
             Release exportRelease = new Release();
             copyField(release, exportRelease, Release._Fields.NAME);
@@ -121,8 +82,5 @@ public class ComponentSummary extends DocumentSummary<Component> {
         }
 
         return copy;
-
     }
-
-
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -16,9 +16,12 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.SummaryAwareRepository;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 
 import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
 import com.ibm.cloud.cloudant.v1.model.PostViewOptions;
@@ -163,9 +166,20 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
             "}";
 
     private static final String COMPONENT_BY_ALL_IDX = "ComponentByAllIdx";
+    private final ReleaseRepository releaseRepository;
+    private final VendorRepository vendorRepository;
+    private final ComponentSummary componentSummary;
 
     public ComponentRepository(DatabaseConnectorCloudant db, ReleaseRepository releaseRepository, VendorRepository vendorRepository) {
-        super(Component.class, db, new ComponentSummary(releaseRepository, vendorRepository));
+        this(db, releaseRepository, vendorRepository, new ComponentSummary());
+    }
+
+    private ComponentRepository(DatabaseConnectorCloudant db, ReleaseRepository releaseRepository,
+            VendorRepository vendorRepository, ComponentSummary componentSummary) {
+        super(Component.class, db, componentSummary);
+        this.releaseRepository = releaseRepository;
+        this.vendorRepository = vendorRepository;
+        this.componentSummary = componentSummary;
         Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
         views.put("all", createMapReduce(ALL, null));
         views.put("byCreatedOn", createMapReduce(BY_CREATED_ON, null));
@@ -228,12 +242,12 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
 
     public List<Component> getSummaryForExport() {
         final List<Component> componentList = getAll();
-        return makeSummaryFromFullDocs(SummaryType.EXPORT_SUMMARY, componentList);
+        return buildExportSummaries(componentList);
     }
 
     public List<Component> getDetailedSummaryForExport() {
         final List<Component> componentList = getAll();
-        return makeSummaryFromFullDocs(SummaryType.DETAILED_EXPORT_SUMMARY, componentList);
+        return buildDetailedExportSummaries(componentList);
     }
 
     public List<Component> getComponentSummary(User user) {
@@ -263,7 +277,45 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
             componentIds = queryForIdsAsValueByPrefix("bynamelowercase", name);
         }
         final List<Component> componentList = new ArrayList<Component>(getFullDocsById(componentIds));
-        return makeSummaryFromFullDocs(SummaryType.EXPORT_SUMMARY, componentList);
+        return buildExportSummaries(componentList);
+    }
+
+    private List<Component> buildExportSummaries(Collection<Component> components) {
+        List<Component> exportSummaries = new ArrayList<>(components.size());
+        for (Component component : components) {
+            List<Release> releases = releaseRepository.getReleasesFromComponentId(component.getId());
+            exportSummaries.add(componentSummary.makeExportSummary(component, releases));
+        }
+        return exportSummaries;
+    }
+
+    private List<Component> buildDetailedExportSummaries(Collection<Component> components) {
+        List<Component> exportSummaries = new ArrayList<>(components.size());
+        for (Component component : components) {
+            List<Release> releases = releaseRepository.getReleasesFromComponentId(component.getId());
+            enrichVendors(releases);
+            exportSummaries.add(componentSummary.makeDetailedExportSummary(component, releases));
+        }
+        return exportSummaries;
+    }
+
+    private void enrichVendors(Collection<Release> releases) {
+        Set<String> vendorIds = new HashSet<>();
+        for (Release release : releases) {
+            if (release != null && release.isSetVendorId() && !CommonUtils.isNullEmptyOrWhitespace(release.getVendorId())) {
+                vendorIds.add(release.getVendorId());
+            }
+        }
+        if (vendorIds.isEmpty()) {
+            return;
+        }
+
+        Map<String, Vendor> vendorsById = ThriftUtils.getIdMap(vendorRepository.get(vendorIds));
+        for (Release release : releases) {
+            if (release != null && !release.isSetVendor() && release.isSetVendorId()) {
+                release.setVendor(vendorsById.get(release.getVendorId()));
+            }
+        }
     }
 
     public Set<Component> getUsingComponents(String releaseId) {

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.entitlement.ComponentModerator;
 import org.eclipse.sw360.datahandler.entitlement.ProjectModerator;
 import org.eclipse.sw360.datahandler.entitlement.ReleaseModerator;
 import org.eclipse.sw360.datahandler.thrift.*;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -322,6 +323,67 @@ public class ComponentDatabaseHandlerTest {
         List<Component> summaryForExport = handler.getSummaryForExport();
         // C4 should NOT be in the results
         assertTrue(containsInAnyOrder("C1", "C2", "C3").matches(getComponentIds(summaryForExport)));
+
+        Component component = getComponent(summaryForExport, "C1");
+        assertNotNull(component);
+        assertThat(getReleaseVersions(component.getReleases()), containsInAnyOrder("releaseA", "releaseB"));
+        for (Release release : component.getReleases()) {
+            assertTrue(release.isSetName());
+            assertTrue(release.isSetVersion());
+            assertEquals("", release.getComponentId());
+            assertFalse(release.isSetVendor());
+            assertFalse(release.isSetAttachments());
+        }
+    }
+
+    @Test
+    public void testGetDetailedSummaryForExport() throws Exception {
+        DatabaseConnectorCloudant databaseConnector = new DatabaseConnectorCloudant(
+                DatabaseSettingsTest.getConfiguredClient(), dbName);
+
+        Release release = handler.getRelease("R1A", user1);
+        release.setReleaseIdToRelationship(ImmutableMap.of("R1B", ReleaseRelationship.CONTAINED));
+        release.setAttachments(new HashSet<>(Collections.singletonList(
+                new Attachment().setAttachmentContentId("ATT-1").setFilename("release-attachment.tar.gz")
+        )));
+        databaseConnector.update(release);
+
+        Component component = handler.getComponent("C1", user1);
+        component.setAttachments(new HashSet<>(Collections.singletonList(
+                new Attachment().setAttachmentContentId("COMP-1").setFilename("component-attachment.txt")
+        )));
+        databaseConnector.update(component);
+
+        List<Component> detailedSummaryForExport = handler.getComponentDetailedSummaryForExport();
+
+        Component detailedComponent = getComponent(detailedSummaryForExport, "C1");
+        assertNotNull(detailedComponent);
+        assertThat(getReleaseIds(detailedComponent.getReleases()), containsInAnyOrder("R1A", "R1B"));
+        assertThat(detailedComponent.getAttachments(), hasSize(1));
+
+        Release detailedRelease = getRelease(detailedComponent.getReleases(), "R1A");
+        assertNotNull(detailedRelease);
+        assertNotNull(detailedRelease.getVendor());
+        assertEquals("Microsoft Corporation", detailedRelease.getVendor().getFullname());
+        assertThat(detailedRelease.getAttachments(), hasSize(1));
+        assertThat(detailedRelease.getReleaseIdToRelationship(), hasEntry("R1B", ReleaseRelationship.CONTAINED));
+    }
+
+    @Test
+    public void testSearchComponentByNameForExport() throws Exception {
+        List<Component> searchResults = handler.searchComponentByNameForExport("component1", true);
+
+        assertTrue(containsInAnyOrder("C1").matches(getComponentIds(searchResults)));
+
+        Component component = getComponent(searchResults, "C1");
+        assertNotNull(component);
+        assertThat(getReleaseVersions(component.getReleases()), containsInAnyOrder("releaseA", "releaseB"));
+        for (Release release : component.getReleases()) {
+            assertTrue(release.isSetName());
+            assertTrue(release.isSetVersion());
+            assertEquals("", release.getComponentId());
+            assertFalse(release.isSetVendor());
+        }
     }
 
     @Test
@@ -1096,6 +1158,23 @@ public class ComponentDatabaseHandlerTest {
                 return true;
         }
         return false;
+    }
+
+    private static Release getRelease(Collection<Release> releases, @NotNull String id) {
+        for (Release release : releases) {
+            if (id.equals(release.getId())) {
+                return release;
+            }
+        }
+        return null;
+    }
+
+    private static Collection<String> getReleaseVersions(Collection<Release> releases) {
+        List<String> versions = new ArrayList<>();
+        for (Release release : releases) {
+            versions.add(release.getVersion());
+        }
+        return versions;
     }
 
 


### PR DESCRIPTION
Fixes #3947 

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> This PR refactors the component export summary path so that `ComponentSummary` no longer performs direct repository-backed data fetching for export-related summaries.
> * The change keeps the current export behavior but moves release and vendor loading responsibilities to the caller side, which makes the export summary path easier to reason about and reduces coupling in the component backend.

No new dependencies were added

### Suggest Reviewer
> @GMishx @bibhuti230185 @amritkv @rudra-superrr

### How To Test?
> 1. Ensure the local CouchDB test instance is available and the backend test environment is configured.
> 2. Run:
   `mvn --% -pl backend/components -Dbase.deploy.dir=D:/sw360/.deploy -Denforcer.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=ComponentDatabaseHandlerTest test`
> 3. Verify that the test suite passes.
> 4. Confirm that export-related component summary behavior remains unchanged, including:
>>* export summary generation
>>* detailed export summary generation
>>* export-related component search behavior

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR