### PR TITLE
Replace String concatenation with StringBuilder in OSADLObligationConnector (#3955)

### DIFF
--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/OSADLObligationConnector.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/OSADLObligationConnector.java
@@ -277,17 +277,17 @@ public class OSADLObligationConnector extends ObligationConnector {
 			}
 		}
 
-		String type = "";
+		StringBuilder typeBuilder = new StringBuilder();
 		String value = "";
 		String[] words = text.split(" ");
 		for (int i = 0; i < words.length; i++) {
 			if (words[i].equals(words[i].toUpperCase())) {
-				type = type + ' ' + words[i];
+				typeBuilder.append(' ').append(words[i]);
 			} else {
 				break;
 			}
 		}
-		type = type.trim();
+		String type = typeBuilder.toString().trim();
 		if (type.isEmpty()) {
 			type = words[0];
 		}


### PR DESCRIPTION
## Summary

Replaces String concatenation in a loop with StringBuilder in `OSADLObligationConnector.parseSentenceElement()`.

Closes #3955

## Changes

In the `parseSentenceElement` method, the loop that builds the `type` string used `type = type + ' ' + words[i]`, creating a new String object on every iteration. Replaced with `StringBuilder.append()` for better performance.

Behavior is identical — same output string in all cases.