### PR TITLE
Fix IndexOutOfBoundsException in VulnerabilityController pagination (#3919)

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -579,10 +579,15 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     public Map<String, Object> createPaginationMetadata(Pageable pageable, List<Map<String, String>> listOfItems) {
         int pageSize = pageable.getPageSize();
         int pageNumber = pageable.getPageNumber();
+        int totalPages = (int) Math.ceil((double) listOfItems.size() / pageSize);
         int start = pageNumber * pageSize;
         int end = Math.min(start + pageSize, listOfItems.size());
-        List<Map<String, String>> paginatedList = listOfItems.subList(start, end);
-        int totalPages = (int) Math.ceil((double) listOfItems.size() / pageSize);
+        List<Map<String, String>> paginatedList;
+        if (start < 0 || start >= listOfItems.size()) {
+            paginatedList = Collections.emptyList();
+        } else {
+            paginatedList = listOfItems.subList(start, end);
+        }
         Map<String, Integer> pagination =  Map.of(
             "size", pageSize,
             "totalElements", listOfItems.size(),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
@@ -10,11 +10,13 @@
 
 package org.eclipse.sw360.rest.resourceserver.integration;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.VerificationState;
 import org.eclipse.sw360.datahandler.thrift.VerificationStateInfo;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -511,6 +513,50 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertTrue("Response should contain vulnerability tracking status", responseBody.contains("vulnerabilityTrackingStatus"));
         assertTrue("Response should contain pagination info", responseBody.contains("page"));
         assertTrue("Response should contain totalElements", responseBody.contains("totalElements"));
+    }
+
+    @Test
+    public void should_return_empty_list_when_page_exceeds_total_pages() throws IOException, TException {
+        // Regression test for SW360-3919: requesting an out-of-range page must not
+        // throw IndexOutOfBoundsException. The fix in createPaginationMetadata returns
+        // an empty list when the computed start offset exceeds the list size.
+        Release releaseObj = new Release();
+        releaseObj.setId("rel-page-test");
+        releaseObj.setName("PaginationTestRelease");
+
+        ReleaseClearingStatusData statusData = new ReleaseClearingStatusData();
+        statusData.setComponentType(ComponentType.OSS);
+        statusData.setProjectNames("TestProject");
+        statusData.setRelease(releaseObj);
+
+        List<ReleaseClearingStatusData> clearingStatusList = new ArrayList<>();
+        clearingStatusList.add(statusData);
+
+        given(this.vulnerabilityServiceMock.getReleasesClearingStatusWithAccessibility(any(), eq("projectPagination")))
+                .willReturn(clearingStatusList);
+
+        HttpHeaders headers = getHeaders(port);
+        // Request page 999 with 5 entries per page -- far beyond the single-item list
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/vulnerabilities/trackingStatus/projectPagination?page=999&page_entries=5&sortBy=name&sortOrder=asc",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        JsonNode root = new ObjectMapper().readTree(response.getBody());
+        JsonNode trackingStatus = root.get("vulnerabilityTrackingStatus");
+        assertNotNull("Response must contain vulnerabilityTrackingStatus", trackingStatus);
+        assertTrue("vulnerabilityTrackingStatus must be an array", trackingStatus.isArray());
+        assertEquals("Out-of-range page must return empty list", 0, trackingStatus.size());
+
+        JsonNode page = root.get("page");
+        assertNotNull("Response must contain page metadata", page);
+        assertEquals("totalElements must reflect actual data size", 1, page.get("totalElements").asInt());
+        assertEquals("page number must echo the requested page", 999, page.get("number").asInt());
     }
 
     // ========== EXCEPTION COVERAGE TESTS ==========


### PR DESCRIPTION
## Summary

Fixes `IndexOutOfBoundsException` when requesting an out-of-range page in the vulnerability tracking status endpoint.

Closes #3919

## Changes

- Added bounds check in `createPaginationMetadata`: if `start >= listOfItems.size()`, return `Collections.emptyList()` instead of calling `subList()` which throws
- Returns HTTP 200 with empty data and correct pagination metadata (totalElements, totalPages) instead of HTTP 500

## Test

Added regression test `should_return_empty_list_when_page_exceeds_total_pages` that:
- Requests page=999 with 1 item in the list
- Asserts HTTP 200 (not 500)
- Asserts empty `vulnerabilityTrackingStatus` array
- Asserts correct pagination metadata (totalElements=1, number=999)