### PR TITLE
Fix path traversal in addAttachment by sanitizing filename (#3938)

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -274,7 +274,7 @@ public class Sw360AttachmentService {
     }
 
     public Attachment addAttachment(MultipartFile file, User sw360User) throws IOException, TException {
-        String fileName = file.getOriginalFilename();
+        String fileName = CommonUtils.sanitizeFilename(file.getOriginalFilename());
         String contentType = file.getContentType();
         final AttachmentContent attachmentContent = makeAttachmentContent(fileName, contentType);
         final AttachmentConnector attachmentConnector = getConnector();


### PR DESCRIPTION
## Summary

Fixes path traversal vulnerability in `addAttachment()` by sanitizing the filename using `CommonUtils.sanitizeFilename()`, consistent with the existing pattern used in `uploadAttachment()` (line 238), `renameFile()` (line 423), and `downloadAttachmentBundleWithContext()` (line 217).

Closes #3938

## Changes

`Sw360AttachmentService.java`: Added `CommonUtils.sanitizeFilename()` call on `file.getOriginalFilename()` in `addAttachment()` before passing to `makeAttachmentContent()`.

Without this, a filename like `../../../etc/passwd` would be passed unsanitized to the attachment content.