### PR TITLE
Fix duplicate id handling in ThriftUploader (#3931)

### DIFF
--- a/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftUploader.java
+++ b/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftUploader.java
@@ -96,21 +96,17 @@ public class ThriftUploader {
         Set<ReleaseRelation> releases = createReleases(wsProject, sw360User, tokenCredentials);
         sw360Project.setProjectResponsible(sw360User.getEmail());
 
-        /*
-         * TODO: Improve duplicate handling
-         */
-        Map<String, ProjectReleaseRelationship> releaseIdToUsage =
-                releases.stream()
+        Map<String, ProjectReleaseRelationship> releaseIdToUsage;
+        try {
+            releaseIdToUsage = releases.stream()
                     .collect(Collectors.toMap(
                             ReleaseRelation::getReleaseId,
-                            ReleaseRelation::getProjectReleaseRelationship,
-                            (projectReleaseRelationship1, projectReleaseRelationship2) -> {
-                                LOGGER.info("--- Duplicate key found!");
-                                LOGGER.info("--- 1: " + projectReleaseRelationship1.getReleaseRelation());
-                                LOGGER.info("--- 2: " + projectReleaseRelationship2.getReleaseRelation());
-                                return projectReleaseRelationship1;
-                            }
-                    ));
+                            ReleaseRelation::getProjectReleaseRelationship));
+        } catch (IllegalStateException e) {
+            LOGGER.warn("Duplicate release relation found in upload data for project: "
+                    + wsProject.getProjectName(), e);
+            return new ProjectImportResult(ProjectImportError.DUPLICATE_RELEASE_RELATION);
+        }
         sw360Project.setReleaseIdToUsage(releaseIdToUsage);
         String projectId = thriftExchange.addProject(sw360Project, sw360User);
 

--- a/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/helper/ProjectImportError.java
+++ b/backend/wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/helper/ProjectImportError.java
@@ -17,6 +17,7 @@ package org.eclipse.sw360.wsimport.thrift.helper;
 public enum ProjectImportError {
     PROJECT_NOT_FOUND("Unable to get project from server"),
     PROJECT_ALREADY_EXISTS("Project already in database"),
+    DUPLICATE_RELEASE_RELATION("Upload data contains duplicate release relations"),
     OTHER("Other error");
 
     private final String text;


### PR DESCRIPTION
## Summary

Fixes duplicate release relation handling in `ThriftUploader.createProject()`.

Closes #3931

## Changes

Previously, duplicate `releaseId` values in upload data were silently dropped (first-wins via a merge function), hiding data corruption. Now:

- Removed the silent merge function from `Collectors.toMap()`
- Added `IllegalStateException` catch to detect duplicates
- Returns `ProjectImportResult(DUPLICATE_RELEASE_RELATION)` to fail the import with a clear error
- Added `DUPLICATE_RELEASE_RELATION` enum value to `ProjectImportError`
- Logs at WARN level with project name and details