### PR TITLE
Fix NullPointerException in vulnerability tracking sorting (#3924)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ output
 /third-party/keycloak-tf/terraform.tfstate*
 /third-party/keycloak-tf/.terraform.lock.hcl
 /third-party/keycloak-tf/.terraform/**
+.claude/

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1211,7 +1211,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 return actualProjectReleaseRelationship;
             }
         }
-        throw new ResourceNotFoundException("Requested Re<<<<<< HEAD\n" + "=======lease Not Found");
+        throw new ResourceNotFoundException("Requested Release Not Found");
     }
 
     @PreDestroy

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -599,9 +599,19 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         Collections.sort(vulTrackingStatusList, new Comparator<Map<String, String>>() {
             public int compare(Map<String, String> m1, Map<String, String> m2) {
                 if ("asc".equalsIgnoreCase(sortOrder)) {
-                    return (m1.get(sortBy)).compareTo(m2.get(sortBy));
+                    String v1 = m1.get(sortBy);
+                    String v2 = m2.get(sortBy);
+                    if (v1 == null && v2 == null) return 0;
+                    if (v1 == null) return 1;
+                    if (v2 == null) return -1;
+                    return v1.compareTo(v2);
                 } else {
-                    return (m2.get(sortBy)).compareTo(m1.get(sortBy));
+                    String v1 = m1.get(sortBy);
+                    String v2 = m2.get(sortBy);
+                    if (v1 == null && v2 == null) return 0;
+                    if (v1 == null) return 1;
+                    if (v2 == null) return -1;
+                    return v2.compareTo(v1);
                 }
             }
         });

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
@@ -10,11 +10,13 @@
 
 package org.eclipse.sw360.rest.resourceserver.integration;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.VerificationState;
 import org.eclipse.sw360.datahandler.thrift.VerificationStateInfo;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -511,6 +513,53 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertTrue("Response should contain vulnerability tracking status", responseBody.contains("vulnerabilityTrackingStatus"));
         assertTrue("Response should contain pagination info", responseBody.contains("page"));
         assertTrue("Response should contain totalElements", responseBody.contains("totalElements"));
+    }
+
+    @Test
+    public void should_not_crash_when_sortBy_key_is_invalid() throws IOException, TException {
+        // Regression test for SW360-3924: an invalid sortBy parameter must not
+        // cause a NullPointerException inside getSortedList.
+        Release releaseObj = new Release();
+        releaseObj.setId("rel-sort-test");
+        releaseObj.setName("SortTestRelease");
+
+        ReleaseClearingStatusData statusData = new ReleaseClearingStatusData();
+        statusData.setComponentType(ComponentType.OSS);
+        statusData.setProjectNames("TestProject");
+        statusData.setRelease(releaseObj);
+
+        Release releaseObj2 = new Release();
+        releaseObj2.setId("rel-sort-test-2");
+        releaseObj2.setName("SortTestRelease2");
+
+        ReleaseClearingStatusData statusData2 = new ReleaseClearingStatusData();
+        statusData2.setComponentType(ComponentType.OSS);
+        statusData2.setProjectNames("TestProject2");
+        statusData2.setRelease(releaseObj2);
+
+        List<ReleaseClearingStatusData> clearingStatusList = new ArrayList<>();
+        clearingStatusList.add(statusData);
+        clearingStatusList.add(statusData2);
+
+        given(this.vulnerabilityServiceMock.getReleasesClearingStatusWithAccessibility(any(), eq("projectSort")))
+                .willReturn(clearingStatusList);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/vulnerabilities/trackingStatus/projectSort?page=0&page_entries=5&sortBy=fakeField&sortOrder=asc",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        JsonNode root = new ObjectMapper().readTree(response.getBody());
+        JsonNode trackingStatus = root.get("vulnerabilityTrackingStatus");
+        assertNotNull("Response must contain vulnerabilityTrackingStatus", trackingStatus);
+        assertTrue("vulnerabilityTrackingStatus must be an array", trackingStatus.isArray());
+        assertEquals("List must contain the single release", 1, trackingStatus.size());
     }
 
     // ========== EXCEPTION COVERAGE TESTS ==========


### PR DESCRIPTION
## Summary

Fixes two issues reported in #3924:

1. **NullPointerException in sorting**: `getSortedList()` comparator crashes when `sortBy` key doesn't exist in the map. Added null-safety checks — nulls are pushed to end of list.

2. **Corrupted error message**: Unresolved merge conflict markers in `Sw360ProjectService.java` produced garbled error text. Fixed to `"Requested Release Not Found"`.

Closes #3924

## Changes

- `VulnerabilityController.java`: Null-safe comparator in `getSortedList()`
- `Sw360ProjectService.java`: Fixed merge conflict marker in error message
- `VulnerabilityTest.java`: Regression test with 2 items and invalid `sortBy` parameter