### PR TITLE
Fix CSVReader resource leak in UserDatabaseHandler (#3966)

### DIFF
--- a/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -228,9 +228,8 @@ public class UserDatabaseHandler {
     public Map<String, List<String>> readFileCsv(String filePath) {
         Map<String, List<String>> listMap = new HashMap<>();
         List<String> emailCsv = new ArrayList<>();
-        try {
-            File file = new File(filePath);
-            CSVReader reader = new CSVReaderBuilder(new FileReader(file)).withSkipLines(1).build();
+        try (FileReader fileReader = new FileReader(new File(filePath));
+             CSVReader reader = new CSVReaderBuilder(fileReader).withSkipLines(1).build()) {
             List<String[]> rows = reader.readAll();
             String mapTemp = "";
             for (String[] row : rows) {


### PR DESCRIPTION
Fixes unclosed CSVReader and FileReader in readFileCsv(). Wrapped in try-with-resources, matching the pattern already used in readFileExcel() in the same class. Closes #3966