### PR TITLE
chore(release): changelogs for release 20.0.0-rc-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,157 @@ the first project location:
 
 https://github.com/eclipse-sw360/sw360/releases
 
+## sw360-20.0.0-rc-2
+This is the second release candidate for SW360 in the line of next major release
+version 20.0.0 of SW360. The candidate includes numerous features, corrections,
+and improvements over the previous release
+[20.0.0-rc-1](https://github.com/eclipse-sw360/sw360/releases/tag/sw360-20.0.0-rc-1)
+
+This release serves as a preview of the upcoming major version 20.0.0 for
+testing and should not be used in production environments.
+
+Highlight of the changes includes:
+* **Security Enhancements:** Addressed XXE vulnerabilities in parsers, fixed header injection issues, added XSS protection headers, and reinforced endpoint security.
+* **API & Documentation:** Expanded OpenAPI documentation across multiple core controllers.
+* **Performance & Stability:** Optimize memory usage with static client reuse.
+* **Infrastructure:** Updated container infrastructure for v20 and improve CI checks.
+
+### Credits
+
+The following GitHub users have contributed to the source code since the last
+release (in alphabetical order):
+
+```
+> Abhay349 <pandeyabhay967@gmail.com>
+> ADITYA-CODE-SOURCE <adityavishe67@gmail.com>
+> afsahsyeda <afsah.syeda@siemens-healthineers.com>
+> Alex <alextanzhao22@gmail.com>
+> Ali <aligadallah14@gmail.com>
+> Aman-Cool <aman017102007@gmail.com>
+> Bibhuti Bhusan Dash <bibhuti230185@gmail.com>
+> Dearsh Oberoi <oberoidearsh@gmail.com>
+> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+> Elbialy0 <mahmoudelbialy109@gmail.com>
+> Farooq Fateh Aftab <farooq-fateh.aftab@siemens.com>
+> Gaurav Mishra <mishra.gaurav@siemens.com>
+> harshdeveloper21 <harsh237hk@gmail.com>
+> himanshu07gupta <himanshu29gupta0703@gmail.com>
+> Kareem74x <kareemmostafa74x@gmail.com>
+> Keerthi B L <keerthi.bl@siemens.com>
+> Mahmoud Abdulmawlaa <m.elbaadishy@gmail.com>
+> Matthew Pappas <matteopappas@gmail.com>
+> Nikesh Kumar <kumar.nikesh@siemens.com>
+> Prathmesh <dhoneprathmesh72@gmail.com>
+> Priya Sharma <priyasharma1001a@gmail.com>
+> rudra-superrr <prabhuchopra@gmail.com>
+> saiteja-in <vurukondasaiteja13@gmail.com>
+> Sandip Mandal <sandipsmmandal02@gmail.com>
+> Shivamrut <gshivamrut@gmail.com>
+> VanKhanhAnny <arianne.dangvankhanh@gmail.com>
+```
+
+Please note that also many other persons usually contribute to the project with
+reviews, testing, documentations, conversations or presentations.
+
+### Features
+* `a3b728052` feat(attachments): add test for attachment service
+* `064862f46` feat(agents): add AGENTS.md ref existing doc
+* `857e32f78` feat(vmprocess): add shutdown hook to close thread
+* `3ad882f4a` feat(container): add steps for keycloak image
+* `5ff8538df` feat(container): update container for version 20
+* `fba2f20ff` feat(Project): Handle case sensitive for export spreadsheet
+* `2982f9d65` feat(checkstyle): add Checkstyle configuration
+* `187b7b068` feat(http-support): implement file upload method in NewRequestBodyBuilderImpl
+* `18c916a29` feat(AttachmentUsages): Save existing attachment usages of sub-project at parent project level
+* `e1180015e` feat(Email): Enhancement of e-mail notifications for updation of project
+* `31d4b31f1` feat(licenseInfo): Normalise license text and optimise performance
+
+### Corrections
+* `3597da377` fix(clearingteam): Add clearing team to project api responses
+* `8702d8c43` fix(docker): correct runtime startup configuration Refs: #3945 Signed-off-by: VanKhanhAnny <arianne.dangvankhanh@gmail.com>
+* `8ac24b639` fix(rest): close streams and temp files in attachment bundle download
+* `021dff813` fix(rest): prevent NPE in vulnerability tracking sorting and clean error message
+* `bd3a16194` fix(report): respect withSubProject semantics for licenseInfo
+* `7e8dd3413` fix: XXE vulnerability in SPDX parser
+* `09cecb788` fix(license): include timestamp in backup filename
+* `9a7acdb57` fix(nouveau): add ConflictException retry to putNouveauDesignDocument
+* `ada574770` fix(datahandler): add ConflictException retry to putDesignDocument
+* `342df4f9c` fix(attachmentUsages): fix null owner corruption and infinite recursion in sub-project inheritance
+* `f7786d1c2` fix(attachment): urlencode filename to get
+* `d3ed1ce48` fix(project): ClearingTeam is a string, not user
+* `1acec288d` fix(Docker): add missing runtime dependency
+* `ecbac4f45` fix(release): fix test of attach field in merge
+* `bdac2d5f7` fix(rest): X-XSS-Protection Header
+* `fa0e2d515` fix(clearingrequest): replace per-call THttpClient with shared ThriftClients instance
+* `709dfaeac` fix(rest) : Compilation error fix from different PRs
+* `2b2b0c75c` fix(components): correct clearing state priority in autosetReleaseClearingState
+* `61933e7d2` fix(rest): update clearing request after editing in request tab
+* `5c11a3834` fix(security): Add @PreAuthorize annotation to AttachmentController
+* `bafbd42ac` fix(security): Add @PreAuthorize to ScheduleAdminController
+* `f874c08c2` fix(project): add null checks for both project and actual in updateProject to prevent NPE
+* `b9a63e0fe` fix(vmcomponents): handle NPE and ClassCastException in getVulIdsPerComponentVmId (#3780)
+* `e05569f31` fix(rest): Add null check for getReleaseIdToUsage() ...
+* `ffa9aad1f` fix(rest): return 400 for missing required request parameters instead of 500
+* `96f1a5963` fix(SvmConnector): handle missing keystore
+* `251a50819` fix(backend): close FileInputStream in SvmConnector to prevent resource leak
+* `05b632d05` fix(importCDX):do not alter unknown domain VCS and revert old changes
+* `0c3a7c29d` fix(rest): Unauthorrrized access to backend configurations.
+* `1876d51e3` fix(index): check if vcs exists
+* `61fe5227e` fix(view): check release.eccInformation not null
+* `d8acc1273` Fix/jwt claim validation (#3753)
+* `b33e1be65` Fix CORS filter activation and allowed methods (#3735)
+* `c7534cf0e` fix(rest): Add logic to delete open clearing requests from request tab, when the project has deleted.
+* `34d133488` fix(security): replace newInstance() with newDefaultInstance()
+* `738366d2d` fix(security): fix XXE vulnerability in XML parsing
+* `79ce6f23b` fix: prevent NoSuchElementException when ...
+* `1ed5584d4` fix(licenseinfo): check Optional.isPresent() before get() in DocxGenerator
+* `3b0c53f2a` fix(CR): header injection vulnerability.
+* `de763bb7c` fix: Prevent NullPointerException in Sw360ProjectService
+* `8416467ef` fix(rest): users receive email notification to download project reports for project-only/with-linked-releases
+* `5b8bca91a` fix(RepositoryUrl): update default value VCS_HOST
+* `9720ece9e` fix(config): update VCS_HOSTS to use JSON array format for config consistency
+* `d8e8e7502` fix: Exception Swallowing in UserRepository
+
+### Infrastructure
+* `912b15d27` refactor(licenses): replace String concatenation with StringBuilder
+* `b990ed902` docs(api): add Swagger @ApiResponse status code documentation for additional controllers
+* `842d5ee76` chore(docs/swagger): add @ApiResponses annotations for ...
+* `ba7d5a24d` chore(docs/swagger): add OpenAPI annotations for ImportExportController, LicenseController and UserController
+* `3739ad2f4` chore(core): remove redundant String.format
+* `76caf9ae4` chore(docs/swagger): add OpenAPI annotations for ReleaseController
+* `414a2f62c` chore(docs/swagger): add OpenAPI annotations for ProjectController
+* `aeae97f81` chore(deps): bump org.springframework:spring-webmvc
+* `8979d0ec0` chore(deps): bump actions/cache from 5.0.3 to 5.0.4
+* `b149d3a08` chore(deps): bump github/codeql-action from 4.32.6 to 4.33.0
+* `ebe9dcc80` chore(deps): bump keycloak/keycloak from `a7b0cb7` to `8d44614`
+* `e2ab8ca4d` perf(cloudant): use static client with retries
+* `805205f3e` perf(gson): reuse Gson objects
+* `eec790b27` chore(deps): bump step-security/harden-runner from 2.15.1 to 2.16.0
+* `6904e658b` chore(deps): bump https://github.com/gitleaks/gitleaks
+* `93cb74714` perf(licenseinfo): remove redundant stream collection in obligation mapping
+* `3584fc7f2` chore(deps): bump https://github.com/pre-commit/pre-commit-hooks
+* `847926002` chore(deps): bump https://github.com/compilerla/conventional-pre-commit
+* `58a065cac` chore(deps): bump actions/dependency-review-action from 4.8.3 to 4.9.0
+* `f904ba4f2` chore(deps): bump https://github.com/pylint-dev/pylint
+* `5efa1d134` chore(deps): bump docker/setup-qemu-action from 3.7.0 to 4.0.0
+* `52c9d90b5` chore(deps): bump https://github.com/gitleaks/gitleaks
+* `70ffa370b` chore(deps): bump docker/metadata-action from 5.10.0 to 6.0.0
+* `a08389fc8` chore(workflow): update workflow for containers
+* `e4ec0c915` chore(config): remove unused config
+* `6a35ca228` chore(lint): fix some style linter errors
+* `26a083764` docs: update README for CouchDB password setup
+* `e13be358d` chore(deps): bump docker/login-action from 3.7.0 to 4.0.0
+* `9dd307df6` chore(deps): bump step-security/harden-runner from 2.15.0 to 2.15.1
+* `0a8c4bab5` chore(deps): bump docker/setup-buildx-action from 3.12.0 to 4.0.0
+* `8cd0f096b` chore(deps): bump docker/build-push-action from 6.19.2 to 7.0.0
+* `1fd521312` chore(deps): bump github/codeql-action from 4.32.4 to 4.32.6
+* `4df420199` chore(deps): bump com.fasterxml.jackson.core:jackson-core
+* `b35f52c48` chore(deps): bump actions/upload-artifact from 6.0.0 to 7.0.0
+* `043db8adb` chore(deps): bump step-security/harden-runner from 2.14.2 to 2.15.0
+* `4955cc43e` chore(deps): bump actions/dependency-review-action from 4.8.2 to 4.8.3
+* `205f8d670` chore(deps): bump github/codeql-action from 4.32.3 to 4.32.4
+* `d444ed5bf` ci: cancel stale PR workflow runs using concurrency
+
 ## sw360-20.0.0-rc-1
 This is a first release candidate for SW360 in the line of next major release
 version 20.0.0 of SW360. The candidate includes numerous features, corrections,

--- a/backend/attachments/pom.xml
+++ b/backend/attachments/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-attachments</artifactId>

--- a/backend/changelogs/pom.xml
+++ b/backend/changelogs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-changelogs</artifactId>

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/components/pom.xml
+++ b/backend/components/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-components</artifactId>

--- a/backend/configurations/pom.xml
+++ b/backend/configurations/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-configurations</artifactId>

--- a/backend/cvesearch/pom.xml
+++ b/backend/cvesearch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-cvesearch</artifactId>

--- a/backend/fossology/pom.xml
+++ b/backend/fossology/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-fossology</artifactId>

--- a/backend/health/pom.xml
+++ b/backend/health/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-health</artifactId>

--- a/backend/licenseinfo/pom.xml
+++ b/backend/licenseinfo/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-licenseinfo</artifactId>

--- a/backend/licenses-core/pom.xml
+++ b/backend/licenses-core/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <properties>
         <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>

--- a/backend/licenses/pom.xml
+++ b/backend/licenses/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-licenses</artifactId>

--- a/backend/moderation/pom.xml
+++ b/backend/moderation/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/packages/pom.xml
+++ b/backend/packages/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend</artifactId>

--- a/backend/projects/pom.xml
+++ b/backend/projects/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/schedule/pom.xml
+++ b/backend/schedule/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-schedule</artifactId>

--- a/backend/search/pom.xml
+++ b/backend/search/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-search</artifactId>

--- a/backend/service-core/pom.xml
+++ b/backend/service-core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/spdxdocument/pom.xml
+++ b/backend/spdxdocument/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-spdxdocument</artifactId>

--- a/backend/spdxdocumentcreationinfo/pom.xml
+++ b/backend/spdxdocumentcreationinfo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-spdxdocumentcreationinfo</artifactId>

--- a/backend/spdxpackageinfo/pom.xml
+++ b/backend/spdxpackageinfo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-spdxpackageinfo</artifactId>

--- a/backend/users/pom.xml
+++ b/backend/users/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-users</artifactId>

--- a/backend/utils/pom.xml
+++ b/backend/utils/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-utils</artifactId>

--- a/backend/vendors/pom.xml
+++ b/backend/vendors/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>backend</artifactId>
     <groupId>org.eclipse.sw360</groupId>
-    <version>20.0.0-rc-1</version>
+    <version>20.0.0-rc-2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/backend/vmcomponents/pom.xml
+++ b/backend/vmcomponents/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-vmcomponents</artifactId>

--- a/backend/vulnerabilities-core/pom.xml
+++ b/backend/vulnerabilities-core/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-vulnerabilities-core</artifactId>

--- a/backend/vulnerabilities/pom.xml
+++ b/backend/vulnerabilities/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>backend-vulnerabilities</artifactId>

--- a/backend/wsimport/pom.xml
+++ b/backend/wsimport/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>build-configuration</artifactId>

--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>clients</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>client</artifactId>

--- a/clients/http-support/pom.xml
+++ b/clients/http-support/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>clients</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>http-support</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <name>SW360 Client Utilities</name>

--- a/keycloak/event-listeners/pom.xml
+++ b/keycloak/event-listeners/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>keycloak</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <properties>

--- a/keycloak/pom.xml
+++ b/keycloak/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <build>

--- a/keycloak/user-storage-provider/pom.xml
+++ b/keycloak/user-storage-provider/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>keycloak</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <properties>

--- a/libraries/commonIO/pom.xml
+++ b/libraries/commonIO/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libraries/datahandler/pom.xml
+++ b/libraries/datahandler/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <name>datahandler</name>

--- a/libraries/exporters/pom.xml
+++ b/libraries/exporters/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <name>exporters</name>

--- a/libraries/importers/pom.xml
+++ b/libraries/importers/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<artifactId>libraries</artifactId>
 		<groupId>org.eclipse.sw360</groupId>
-		<version>20.0.0-rc-1</version>
+		<version>20.0.0-rc-2</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/libraries/log4j-osgi-support/pom.xml
+++ b/libraries/log4j-osgi-support/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>19.0.0</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libraries/nouveau-handler/pom.xml
+++ b/libraries/nouveau-handler/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <name>nouveau-handler</name>

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>sw360</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.sw360</groupId>
   <artifactId>sw360</artifactId>
-  <version>20.0.0-rc-1</version>
+  <version>20.0.0-rc-2</version>
   <packaging>pom</packaging>
   <name>Eclipse SW360</name>
   <description>Eclipse SW360 compliance management application</description>

--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>rest</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>authorization-server</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>rest</artifactId>

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>rest</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>resource-server</artifactId>

--- a/rest/rest-common/pom.xml
+++ b/rest/rest-common/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>rest</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
 
     <artifactId>rest-common</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>sw360</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-1</version>
+        <version>20.0.0-rc-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Add release changelogs for version `20.0.0-rc-2` which is the next release candidate before the stable release.