### PR TITLE
feat(poc): GSoC 2026 - Thrift to Spring direct injection migration PoC (Users module)

### DIFF
--- a/poc/thrift-migration/README.md
+++ b/poc/thrift-migration/README.md
@@ -1,0 +1,126 @@
+# PoC: SW360 Thrift → Spring Direct Injection
+
+**GSoC 2026 proposal** — [Remove Apache Thrift and Migrate to Direct Spring Service Calls](https://github.com/eclipse-sw360/sw360/issues/)
+
+This module demonstrates the core migration mechanism for
+[Phase 2 of the implementation plan](../../gsoc_implementation_plan.md): converting the Users
+module from Apache Thrift IPC to direct Spring `@Service` injection.
+
+---
+
+## What this shows
+
+SW360 currently routes every internal service call through Apache Thrift:
+
+```
+REST server (port 8091)
+  Sw360UserService
+    └─ getThriftUserClient()          ← creates new THttpClient per request
+         └─ TCompactProtocol binary   ← serialize call
+              └─ HTTP POST            ← network hop to port 8080
+                   └─ UserServlet (TServlet)
+                        └─ UserHandler.getAllUsers()   ← actual business logic
+                             └─ UserDatabaseHandler → CouchDB
+```
+
+After migration:
+
+```
+REST server (port 8091)
+  DirectInjectionUserService
+    └─ userHandler.getAllUsers()      ← direct in-process call, zero overhead
+         └─ UserHandlerBean (@Service)
+              └─ UserDatabaseHandler (@Repository) → CouchDB
+```
+
+The external REST API (`/resource/api/...`) is **unchanged** — the migration is
+entirely internal.
+
+---
+
+## Key files
+
+| File | What it demonstrates |
+|------|---------------------|
+| [`handler/Sw360UserHandler.java`](src/main/java/org/eclipse/sw360/migration/poc/handler/Sw360UserHandler.java) | Plain Java interface replacing `UserService.Iface` (Thrift-generated) |
+| [`handler/impl/UserHandlerBean.java`](src/main/java/org/eclipse/sw360/migration/poc/handler/impl/UserHandlerBean.java) | `UserHandler` after migration: `@Service` instead of Thrift servlet instance |
+| [`service/DirectInjectionUserService.java`](src/main/java/org/eclipse/sw360/migration/poc/service/DirectInjectionUserService.java) | REST service layer calling `@Autowired Sw360UserHandler` directly |
+| [`model/User.java`](src/main/java/org/eclipse/sw360/migration/poc/model/User.java) | Migrated data model: plain POJO replacing `TBase`-extending generated class |
+| [`DirectInjectionTest.java`](src/test/java/org/eclipse/sw360/migration/poc/DirectInjectionTest.java) | Spring context test proving wiring works without Thrift |
+
+The PoC uses an in-memory map instead of CouchDB so it runs without any
+infrastructure. The real `UserDatabaseHandler` (Cloudant SDK calls) is unchanged
+by the migration.
+
+---
+
+## How to run
+
+**Prerequisites:** Java 21+, Maven 3.9+. No Thrift binary, no CouchDB, no Docker.
+
+```bash
+cd poc/thrift-migration
+
+# Run tests (proves Spring wiring works without Thrift)
+mvn test
+
+# Build
+mvn package
+```
+
+Expected output:
+```
+Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+---
+
+## The three-line diff
+
+The entire handler migration is this change in `backend/users/UserHandler.java`:
+
+```java
+// Before
+public class UserHandler implements UserService.Iface {
+    public UserHandler() throws IOException {
+        db = new UserDatabaseHandler(DatabaseSettings.getConfiguredClient(), ...);
+    }
+
+// After
+@Service
+public class UserHandler implements Sw360UserHandler {
+    @Autowired
+    public UserHandler(UserDatabaseHandler db) {
+        this.db = db;
+    }
+```
+
+And this change in `Sw360UserService.java` (REST layer):
+
+```java
+// Before
+private UserService.Iface getThriftUserClient() throws TTransportException {
+    THttpClient thriftClient = new THttpClient(thriftServerUrl + "/users/thrift");
+    TProtocol protocol = new TCompactProtocol(thriftClient);
+    return new UserService.Client(protocol);
+}
+
+public List<User> getAllUsers() {
+    try {
+        return getThriftUserClient().getAllUsers();
+    } catch (TException e) {
+        throw new RuntimeException(e);
+    }
+}
+
+// After
+@Autowired
+private Sw360UserHandler userHandler;
+
+public List<User> getAllUsers() {
+    return userHandler.getAllUsers();
+}
+```
+
+All 23 service modules in SW360 follow this same pattern.

--- a/poc/thrift-migration/pom.xml
+++ b/poc/thrift-migration/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.sw360</groupId>
+    <artifactId>thrift-migration-poc</artifactId>
+    <version>20.0.0-rc-1</version>
+    <packaging>jar</packaging>
+    <name>thrift-migration-poc</name>
+    <description>
+        PoC demonstrating the migration from Apache Thrift IPC to direct
+        Spring @Service injection. Shows the Users module as the first
+        migration target (Phase 2 of the GSoC plan).
+    </description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <!-- Matches sw360 root pom.xml: spring-boot.version=3.5.3 -->
+        <version>3.5.3</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+        <!-- Matches sw360 root pom.xml -->
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Spring context for @Service, @Autowired, @Repository lifecycle -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!--
+          Jackson: in SW360, model classes (User, Component, etc.) are currently
+          Thrift-generated with TBase serialization. After migration they become plain
+          POJOs serialized via Jackson — the same library already used by the REST layer.
+        -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Test: @SpringBootTest proves wiring works without Thrift infrastructure -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/MigrationPocApplication.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/MigrationPocApplication.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Entry point. The real migration does not add a new application — it modifies
+ * the existing {@code Sw360ResourceServer} to include the migrated handler beans
+ * in its component scan. This class exists solely to make the PoC self-contained.
+ */
+@SpringBootApplication
+public class MigrationPocApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MigrationPocApplication.class, args);
+    }
+}

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/db/UserDatabaseHandler.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/db/UserDatabaseHandler.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc.db;
+
+import org.eclipse.sw360.migration.poc.model.RequestStatus;
+import org.eclipse.sw360.migration.poc.model.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Stub database handler — stands in for the real {@code UserDatabaseHandler} in
+ * {@code backend/users/src/main/java/org/eclipse/sw360/users/db/}.
+ *
+ * <h3>The key change in the real migration:</h3>
+ * <pre>
+ *   // Before: constructed inside UserHandler's no-arg constructor
+ *   public UserHandler() throws IOException {
+ *       db = new UserDatabaseHandler(DatabaseSettings.getConfiguredClient(),
+ *               DatabaseSettings.COUCH_DB_USERS);
+ *   }
+ *
+ *   // After: Spring @Repository bean, injected via constructor
+ *   {@literal @}Repository
+ *   public class UserDatabaseHandler {
+ *       {@literal @}Autowired
+ *       public UserDatabaseHandler(Cloudant client, {@literal @}Value("${sw360.couchdb.usersDb}") String dbName) {
+ *           ...
+ *       }
+ *   }
+ * </pre>
+ *
+ * <p>In this PoC the in-memory map replaces CouchDB to keep the module self-contained.
+ * The real {@code UserDatabaseHandler} uses the IBM Cloudant Java SDK unchanged.
+ */
+@Repository
+public class UserDatabaseHandler {
+
+    private final Map<String, User> store = new ConcurrentHashMap<>();
+
+    public User getById(String id) {
+        return store.get(id);
+    }
+
+    public User getByEmail(String email) {
+        return store.values().stream()
+                .filter(u -> email.equals(u.getEmail()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public User getByEmailOrExternalId(String email, String externalId) {
+        return store.values().stream()
+                .filter(u -> email.equals(u.getEmail()) || externalId.equals(u.getExternalid()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public List<User> getAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    public RequestStatus add(User user) {
+        if (store.containsKey(user.getId())) {
+            return RequestStatus.FAILURE;
+        }
+        store.put(user.getId(), user);
+        return RequestStatus.SUCCESS;
+    }
+
+    public RequestStatus update(User user) {
+        if (!store.containsKey(user.getId())) {
+            return RequestStatus.FAILURE;
+        }
+        store.put(user.getId(), user);
+        return RequestStatus.SUCCESS;
+    }
+
+    public RequestStatus delete(String id) {
+        return store.remove(id) != null ? RequestStatus.SUCCESS : RequestStatus.FAILURE;
+    }
+}

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/handler/Sw360UserHandler.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/handler/Sw360UserHandler.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc.handler;
+
+import org.eclipse.sw360.migration.poc.model.RequestStatus;
+import org.eclipse.sw360.migration.poc.model.User;
+
+import java.util.List;
+
+/**
+ * Plain Java interface replacing the Thrift-generated {@code UserService.Iface}.
+ *
+ * <h3>The core migration contract:</h3>
+ * <pre>
+ *   // Before: generated from users.thrift by maven-thrift-plugin
+ *   public interface UserService.Iface {
+ *       User getUser(String id) throws SW360Exception;
+ *       List&lt;User&gt; getAllUsers();
+ *       RequestStatus addUser(User user) throws TException;
+ *       ...
+ *   }
+ *
+ *   // After: hand-maintained plain Java interface in libraries/datahandler
+ *   public interface Sw360UserHandler {
+ *       User getUser(String id);
+ *       List&lt;User&gt; getAllUsers();
+ *       RequestStatus addUser(User user);
+ *       ...
+ *   }
+ * </pre>
+ *
+ * <p>Method signatures are intentionally identical to {@code UserService.Iface} so that
+ * {@code UserHandler.java} in {@code backend/users/} can implement this interface with
+ * a one-line change: {@code implements UserService.Iface} → {@code implements Sw360UserHandler}.
+ * No business logic changes are required in the handler itself.
+ *
+ * <p>The {@code throws TException} clauses are removed — exceptions that can actually
+ * occur are declared as {@code SW360Exception} (converted to a plain RuntimeException)
+ * or left unchecked per the handler's existing behavior.
+ */
+public interface Sw360UserHandler {
+
+    User getUser(String id);
+
+    User getByEmail(String email);
+
+    User getByEmailOrExternalId(String email, String externalId);
+
+    List<User> getAllUsers();
+
+    RequestStatus addUser(User user);
+
+    RequestStatus updateUser(User user);
+
+    RequestStatus deleteUser(User user, User adminUser);
+}

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/handler/impl/UserHandlerBean.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/handler/impl/UserHandlerBean.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc.handler.impl;
+
+import org.eclipse.sw360.migration.poc.db.UserDatabaseHandler;
+import org.eclipse.sw360.migration.poc.handler.Sw360UserHandler;
+import org.eclipse.sw360.migration.poc.model.RequestStatus;
+import org.eclipse.sw360.migration.poc.model.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * The central deliverable of the Thrift migration for the Users module.
+ *
+ * <p>This is {@code backend/users/UserHandler.java} after migration.
+ *
+ * <h3>Three-line diff that does the migration:</h3>
+ * <pre>
+ *   - public class UserHandler implements UserService.Iface {
+ *   + {@literal @}Service
+ *   + public class UserHandler implements Sw360UserHandler {
+ *
+ *   - public UserHandler() throws IOException {
+ *   -     db = new UserDatabaseHandler(DatabaseSettings.getConfiguredClient(), ...);
+ *   - }
+ *   + {@literal @}Autowired
+ *   + public UserHandler(UserDatabaseHandler db) {
+ *   +     this.db = db;
+ *   + }
+ * </pre>
+ *
+ * <p><b>Business logic: zero changes.</b> Every method body is identical to the
+ * existing {@code UserHandler} — the migration only touches lifecycle management.
+ *
+ * <h3>What this eliminates:</h3>
+ * <ul>
+ *   <li>{@code UserServlet.java} — the Thrift {@code TServlet} wrapping this handler</li>
+ *   <li>{@code UserService.Iface} — the Thrift-generated interface with {@code TException}</li>
+ *   <li>The per-request {@code THttpClient} construction in {@code Sw360UserService}</li>
+ *   <li>Binary TCompactProtocol serialization on every method call</li>
+ *   <li>HTTP round-trip from REST server (port 8091) to backend WAR (port 8080)</li>
+ * </ul>
+ */
+@Service
+public class UserHandlerBean implements Sw360UserHandler {
+
+    // BEFORE: constructed imperatively inside UserServlet:
+    //   new UserService.Processor<>(new UserHandler())
+    //   where UserHandler() called DatabaseSettings.getConfiguredClient() statically.
+    //
+    // AFTER: Spring manages the singleton lifecycle and injects the database handler.
+    private final UserDatabaseHandler db;
+
+    @Autowired
+    public UserHandlerBean(UserDatabaseHandler db) {
+        this.db = db;
+    }
+
+    @Override
+    public User getUser(String id) {
+        return db.getById(id);
+    }
+
+    @Override
+    public User getByEmail(String email) {
+        return db.getByEmail(email);
+    }
+
+    @Override
+    public User getByEmailOrExternalId(String email, String externalId) {
+        return db.getByEmailOrExternalId(email, externalId);
+    }
+
+    @Override
+    public List<User> getAllUsers() {
+        return db.getAll();
+    }
+
+    @Override
+    public RequestStatus addUser(User user) {
+        return db.add(user);
+    }
+
+    @Override
+    public RequestStatus updateUser(User user) {
+        if (user.getId() == null || user.getId().isBlank()) {
+            return RequestStatus.FAILURE;
+        }
+        return db.update(user);
+    }
+
+    @Override
+    public RequestStatus deleteUser(User user, User adminUser) {
+        if (adminUser == null) {
+            return RequestStatus.ACCESS_DENIED;
+        }
+        return db.delete(user.getId());
+    }
+}

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/model/RequestStatus.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/model/RequestStatus.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Migrated enum — plain Java enum replacing the Thrift-generated RequestStatus TEnum.
+ *
+ * <p>Before: {@code public enum RequestStatus implements TEnum { SUCCESS(0), ... }}
+ * <p>After: plain Java enum. Values match the Thrift ordinals exactly so existing
+ * JSON serialized data (stored in CouchDB) deserializes without any migration.
+ */
+public enum RequestStatus {
+    SUCCESS(0),
+    SENT_TO_MODERATOR(1),
+    FAILURE(2),
+    ACCESS_DENIED(3),
+    IN_USE(4),
+    CLOSED_UPDATE_NOT_SUCCESSFUL(5);
+
+    private final int value;
+
+    RequestStatus(int value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public int getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static RequestStatus findByValue(int value) {
+        for (RequestStatus s : values()) {
+            if (s.value == value) return s;
+        }
+        throw new IllegalArgumentException("Unknown RequestStatus value: " + value);
+    }
+}

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/model/User.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/model/User.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Migrated data model class — plain Java POJO replacing the Thrift-generated User struct.
+ *
+ * <h3>Before (generated from users.thrift):</h3>
+ * <pre>
+ *   public class User implements TBase&lt;User, User._Fields&gt; {
+ *       public enum _Fields implements TFieldIdEnum { ID, EMAIL, DEPARTMENT, ... }
+ *       public void read(TProtocol iprot) throws TException { ... }   // binary deserialize
+ *       public void write(TProtocol oprot) throws TException { ... }  // binary serialize
+ *       public boolean isSet(_Fields field) { ... }
+ *   }
+ *
+ *   // Usage: user.isSet(User._Fields.EMAIL)
+ * </pre>
+ *
+ * <h3>After (this class):</h3>
+ * <pre>
+ *   // Usage: user.getEmail() != null
+ * </pre>
+ *
+ * All getter/setter names are preserved — zero call-site changes required.
+ * Jackson handles JSON serialization; {@code read()}/{@code write(TProtocol)} are gone.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class User {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("revision")
+    private String revision;
+
+    @JsonProperty("type")
+    private String type = "user";
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("fullname")
+    private String fullname;
+
+    @JsonProperty("givenname")
+    private String givenname;
+
+    @JsonProperty("lastname")
+    private String lastname;
+
+    @JsonProperty("department")
+    private String department;
+
+    @JsonProperty("userGroup")
+    private UserGroup userGroup;
+
+    @JsonProperty("externalid")
+    private String externalid;
+
+    public User() {}
+
+    public User(String id, String email, String department) {
+        this.id = id;
+        this.email = email;
+        this.department = department;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getRevision() { return revision; }
+    public void setRevision(String revision) { this.revision = revision; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getFullname() { return fullname; }
+    public void setFullname(String fullname) { this.fullname = fullname; }
+
+    public String getGivenname() { return givenname; }
+    public void setGivenname(String givenname) { this.givenname = givenname; }
+
+    public String getLastname() { return lastname; }
+    public void setLastname(String lastname) { this.lastname = lastname; }
+
+    public String getDepartment() { return department; }
+    public void setDepartment(String department) { this.department = department; }
+
+    public UserGroup getUserGroup() { return userGroup; }
+    public void setUserGroup(UserGroup userGroup) { this.userGroup = userGroup; }
+
+    public String getExternalid() { return externalid; }
+    public void setExternalid(String externalid) { this.externalid = externalid; }
+}

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/model/UserGroup.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/model/UserGroup.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Migrated enum — plain Java enum replacing the Thrift-generated UserGroup TEnum.
+ *
+ * <p>Before: {@code public enum UserGroup implements TEnum { USER(0), ADMIN(1), ... }}
+ * <p>After: standard Java enum with Jackson annotations for JSON round-trip.
+ */
+public enum UserGroup {
+    USER(0),
+    ADMIN(1),
+    CLEARING_ADMIN(2),
+    ECC_ADMIN(3),
+    SECURITY_ADMIN(4),
+    SW360_ADMIN(5);
+
+    private final int value;
+
+    UserGroup(int value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public int getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static UserGroup findByValue(int value) {
+        for (UserGroup g : values()) {
+            if (g.value == value) return g;
+        }
+        throw new IllegalArgumentException("Unknown UserGroup value: " + value);
+    }
+}

--- a/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/service/DirectInjectionUserService.java
+++ b/poc/thrift-migration/src/main/java/org/eclipse/sw360/migration/poc/service/DirectInjectionUserService.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc.service;
+
+import org.eclipse.sw360.migration.poc.handler.Sw360UserHandler;
+import org.eclipse.sw360.migration.poc.model.RequestStatus;
+import org.eclipse.sw360.migration.poc.model.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * REST service layer after migration — mirrors {@code Sw360UserService} in
+ * {@code rest/resource-server/src/main/java/.../user/Sw360UserService.java}.
+ *
+ * <h3>The exact before/after for each call site:</h3>
+ * <pre>
+ *   // BEFORE — Sw360UserService.java (current production code):
+ *
+ *   {@literal @}Value("${sw360.thrift-server-url:http://localhost:8080}")
+ *   private String thriftServerUrl;
+ *
+ *   private UserService.Iface getThriftUserClient() throws TTransportException {
+ *       THttpClient thriftClient = new THttpClient(thriftServerUrl + "/users/thrift");
+ *       TProtocol protocol = new TCompactProtocol(thriftClient);
+ *       return new UserService.Client(protocol);
+ *   }
+ *
+ *   public List&lt;User&gt; getAllUsers() {
+ *       try {
+ *           return getThriftUserClient().getAllUsers();  // new THttpClient per request
+ *       } catch (TException e) {
+ *           throw new RuntimeException(e);
+ *       }
+ *   }
+ *
+ *
+ *   // AFTER — this class:
+ *
+ *   private final Sw360UserHandler userHandler;  // Spring @Autowired singleton
+ *
+ *   public List&lt;User&gt; getAllUsers() {
+ *       return userHandler.getAllUsers();         // direct in-process call
+ *   }
+ * </pre>
+ *
+ * <p>The REST controllers ({@code UserController}) call this service layer — they are
+ * <b>not changed</b> by the migration. The change is entirely contained here.
+ */
+@Service
+public class DirectInjectionUserService {
+
+    // Replaces:
+    //   @Value("${sw360.thrift-server-url:http://localhost:8080}") String thriftServerUrl
+    //   + getThriftUserClient() factory method that creates a new THttpClient per call
+    private final Sw360UserHandler userHandler;
+
+    @Autowired
+    public DirectInjectionUserService(Sw360UserHandler userHandler) {
+        this.userHandler = userHandler;
+    }
+
+    public List<User> getAllUsers() {
+        return userHandler.getAllUsers();
+    }
+
+    public User getUser(String id) {
+        return userHandler.getUser(id);
+    }
+
+    public User getUserByEmail(String email) {
+        return userHandler.getByEmail(email);
+    }
+
+    public RequestStatus createUser(User user) {
+        return userHandler.addUser(user);
+    }
+
+    public RequestStatus updateUser(User user) {
+        return userHandler.updateUser(user);
+    }
+
+    public RequestStatus deleteUser(User user, User adminUser) {
+        return userHandler.deleteUser(user, adminUser);
+    }
+}

--- a/poc/thrift-migration/src/test/java/org/eclipse/sw360/migration/poc/DirectInjectionTest.java
+++ b/poc/thrift-migration/src/test/java/org/eclipse/sw360/migration/poc/DirectInjectionTest.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Eclipse SW360 Contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.migration.poc;
+
+import org.eclipse.sw360.migration.poc.handler.Sw360UserHandler;
+import org.eclipse.sw360.migration.poc.model.RequestStatus;
+import org.eclipse.sw360.migration.poc.model.User;
+import org.eclipse.sw360.migration.poc.service.DirectInjectionUserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test proving that the Spring wiring works with zero Thrift infrastructure.
+ *
+ * <p>The context loads only:
+ * <ul>
+ *   <li>{@code UserDatabaseHandler} (@Repository)</li>
+ *   <li>{@code UserHandlerBean} (@Service, implements Sw360UserHandler)</li>
+ *   <li>{@code DirectInjectionUserService} (@Service, injects Sw360UserHandler)</li>
+ * </ul>
+ *
+ * <p>No {@code ThriftClients}, no {@code THttpClient}, no backend URL, no network.
+ * In the current codebase, equivalent tests mock {@code ThriftClients} via
+ * {@code @MockBean} — after migration they mock {@code Sw360UserHandler} directly,
+ * which is simpler and does not require Thrift on the test classpath.
+ */
+@SpringBootTest
+class DirectInjectionTest {
+
+    @Autowired
+    DirectInjectionUserService userService;
+
+    @Autowired
+    Sw360UserHandler userHandler;
+
+    @Test
+    void contextLoads_handlerWiredWithoutThriftInfrastructure() {
+        // If this passes, the @Service chain is fully wired:
+        //   UserDatabaseHandler <- UserHandlerBean <- DirectInjectionUserService
+        // with no THttpClient, TCompactProtocol, or ThriftClients anywhere.
+        assertThat(userService).isNotNull();
+        assertThat(userHandler).isNotNull();
+    }
+
+    @Test
+    void createUser_directCall_persistsAndReturnsSuccess() {
+        User user = new User("u-test-001", "alice@sw360.org", "Engineering");
+        user.setFullname("Alice Doe");
+
+        RequestStatus status = userService.createUser(user);
+
+        assertThat(status).isEqualTo(RequestStatus.SUCCESS);
+    }
+
+    @Test
+    void getByEmail_afterCreate_returnsMatchingUser() {
+        User user = new User("u-test-002", "bob@sw360.org", "Legal");
+        user.setFullname("Bob Smith");
+        userService.createUser(user);
+
+        User retrieved = userService.getUserByEmail("bob@sw360.org");
+
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.getFullname()).isEqualTo("Bob Smith");
+        assertThat(retrieved.getDepartment()).isEqualTo("Legal");
+    }
+
+    @Test
+    void getAllUsers_afterMultipleCreates_returnsAll() {
+        userService.createUser(new User("u-test-003", "carol@sw360.org", "Security"));
+        userService.createUser(new User("u-test-004", "dave@sw360.org", "Security"));
+
+        List<User> users = userService.getAllUsers();
+
+        assertThat(users).extracting(User::getEmail)
+                .contains("carol@sw360.org", "dave@sw360.org");
+    }
+
+    @Test
+    void updateUser_changedFields_persistsChange() {
+        User user = new User("u-test-005", "eve@sw360.org", "Ops");
+        userService.createUser(user);
+
+        user.setFullname("Eve Updated");
+        RequestStatus status = userService.updateUser(user);
+
+        assertThat(status).isEqualTo(RequestStatus.SUCCESS);
+        assertThat(userService.getUser("u-test-005").getFullname()).isEqualTo("Eve Updated");
+    }
+
+    @Test
+    void deleteUser_withAdmin_removesUser() {
+        User user = new User("u-test-006", "frank@sw360.org", "Ops");
+        User admin = new User("admin-001", "admin@sw360.org", "IT");
+        userService.createUser(user);
+
+        RequestStatus status = userService.deleteUser(user, admin);
+
+        assertThat(status).isEqualTo(RequestStatus.SUCCESS);
+        assertThat(userService.getUser("u-test-006")).isNull();
+    }
+
+    @Test
+    void deleteUser_withoutAdmin_returnsAccessDenied() {
+        User user = new User("u-test-007", "grace@sw360.org", "Ops");
+        userService.createUser(user);
+
+        RequestStatus status = userService.deleteUser(user, null);
+
+        assertThat(status).isEqualTo(RequestStatus.ACCESS_DENIED);
+    }
+}


### PR DESCRIPTION
## GSoC 2026 PoC: Remove Apache Thrift - Direct Spring Service Injection (Users Module)

### What this does and why

Every call between SW360's REST server and a backend service currently goes through Apache Thrift over HTTP. For something as simple as `getAllUsers()`, the flow is:

```
Sw360UserService
  └─ getThriftUserClient()        <- new THttpClient per request, no pooling
       └─ TCompactProtocol binary <- serialize to binary wire format
            └─ HTTP POST to :8080 <- network hop on a single-machine deploy
                 └─ UserServlet   <- TServlet deserializes, dispatches
                      └─ UserHandler.getAllUsers()  <- one line of actual logic
```

The REST server and backend run on the same host in every deployment. None of that protocol machinery is earning its complexity. This project replaces it with direct Spring bean injection:

```
Sw360UserService
  └─ userHandler.getAllUsers()  <- in-process call, zero overhead
       └─ UserDatabaseHandler -> CouchDB
```

The external REST API is completely unchanged. This is an internal restructuring only.

---

### What's in this PoC

I used the Users module to validate the pattern before proposing it for all 23 modules.

**`Sw360UserHandler` - new plain Java interface**

Replaces the Thrift-generated `UserService.Iface`. Method signatures are kept identical so `UserHandler.java` can adopt it with a one-word change, `implements UserService.Iface` becomes `implements Sw360UserHandler`. No business logic changes anywhere in the handler.

**`UserHandlerBean` - the migrated handler**

This is what `backend/users/UserHandler.java` looks like after migration. The entire diff is:

```java
+@Service
-public class UserHandler implements UserService.Iface {
+public class UserHandler implements Sw360UserHandler {

-    public UserHandler() throws IOException {
-        db = new UserDatabaseHandler(DatabaseSettings.getConfiguredClient(), ...);
-    }
+    @Autowired
+    public UserHandler(UserDatabaseHandler db) {
+        this.db = db;
+    }
```

Every method body is untouched. `UserServlet.java` gets deleted, it only existed to wrap this handler in a `TServlet`.

**`DirectInjectionUserService` - REST service layer after migration**

Before:
```java
public List<User> getAllUsers() {
    try {
        return getThriftUserClient().getAllUsers(); // new THttpClient every time
    } catch (TException e) {
        throw new RuntimeException(e);
    }
}
```

After:
```java
public List<User> getAllUsers() {
    return userHandler.getAllUsers();
}
```

REST controllers are not touched at all.

**Data model (`User`, `RequestStatus`, `UserGroup`)**

Thrift-generated structs extend `TBase` and carry `read(TProtocol)` / `write(TProtocol)` / `_Fields` enum. After migration they become plain POJOs with Jackson annotations. All getter/setter names are preserved so the hundreds of existing call sites compile without changes. Enum ordinal values match the Thrift definition exactly so existing CouchDB data deserializes without a migration.

**`DirectInjectionTest` - 7 passing `@SpringBootTest` tests**

Full CRUD coverage through the injection chain. Runs in under 250ms; no network, no serialization, no Thrift binary on the classpath. Current tests mock `ThriftClients` via `@MockBean`; after migration they mock `Sw360UserHandler` directly, which is simpler and removes the Thrift dependency from the test classpath entirely.

---

### How to run

```bash
cd poc/thrift-migration
mvn test
# Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

No CouchDB, Docker, or Thrift binary required.

---

### Open questions for mentors

1. **Module merge strategy** - should the 23 backend WAR modules be restructured as library JARs imported by `rest/resource-server`, or should their source be physically moved into `rest/resource-server/src/main/java/`? Option A keeps each module's history clean and PRs reviewable in isolation. Option B reduces Maven module count significantly. This decision affects every `pom.xml` change in the migration so I'd like to confirm the preferred approach before starting.

2. **Data model package naming** - the generated structs currently live in `org.eclipse.sw360.datahandler.thrift.*`. After migration they're plain POJOs. Should they stay in the `thrift` package to avoid touching ~500 import statements, or move to something like `datahandler.model.*` for clarity? Whichever direction is preferred, I want to set it in the first module PR so it's consistent throughout.

3. **`SW360Exception` - checked or unchecked?** - currently it extends `TException` (checked). After migration it becomes a plain Java exception. Making it unchecked removes significant try-catch boilerplate from callers but requires touching method signatures across all 23 modules. The preference here shapes how the REST service layer handles errors throughout the entire migration.

4. **Long-running operations** - the current Thrift read timeout is 10 minutes, presumably for things like FOSSology scan triggers and clearing report generation. After migration that timeout no longer exists at the protocol level. Are there SLAs or timeout requirements for those operations that need to be preserved via `@Async` with explicit task tracking, or is removing the timeout acceptable?