### PR TITLE
chore(release): change log for version 20.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,101 @@ the first project location:
 
 https://github.com/eclipse-sw360/sw360/releases
 
+## sw360-20.0.0
+We are proud to announce the release of SW360 version 20.0.0. This major release
+brings significant architectural changes, security enhancements, and performance
+improvements over the 19.2.x series. The most notable update in this version is
+the removal of the Liferay UI; the SW360 backend is now fully decoupled, and
+users must set up the new Next.js-based frontend from the
+[eclipse-sw360/sw360-frontend](https://github.com/eclipse-sw360/sw360-frontend)
+repository.
+
+Highlight of the changes in this version includes:
+* **Frontend Decoupling:** Complete removal of the legacy Liferay UI,
+  introducing a standalone backend with expanded endpoints to support the new
+  Next.js frontend.
+* **Security Improvements:** Addressed multiple vulnerabilities including XXE
+  and path traversal, added XSS protection headers, and reinforced endpoint
+  security.
+* **API & Documentation:** Introduced extensive OpenAPI documentation and
+  implemented robust pagination under the hood.
+* **User & Identity Management:** Enhanced Keycloak user synchronization with
+  CouchDB, and added batch processing.
+* **Performance & Stability:** Implemented database-side pagination, optimized
+  memory usage, and improved indexing and search speeds.
+
+### Credits
+
+The following GitHub users have contributed to the source code since the last
+release (in alphabetical order):
+
+```
+> Aashish Jha <aashishjha1107@gmail.com>
+> Abhay349 <pandeyabhay967@gmail.com>
+> Achal Jhawar <35405812+achaljhawar@users.noreply.github.com>
+> Aditya Vishe <adityavishe67@gmail.com>
+> afsahsyeda <afsah.syeda@siemens-healthineers.com>
+> airajena <airajena0@gmail.com>
+> Akshit Joshi <akshit.joshi@siemens-healthineers.com>
+> Alex <alextanzhao22@gmail.com>
+> Ali <aligadallah14@gmail.com>
+> Aman-Cool <aman017102007@gmail.com>
+> amritkv <er.akverma8@gmail.com>
+> Bibhuti Bhusan Dash <bibhuti230185@gmail.com>
+> Dearsh Oberoi <oberoidearsh@gmail.com>
+> drockparashar <pranshu007parashar@gmail.com>
+> Elbialy0 <mahmoudelbialy109@gmail.com>
+> Farooq Fateh Aftab <farooq-fateh.aftab@siemens.com>
+> Gaurav Mishra <mishra.gaurav@siemens.com>
+> harshdeveloper21 <harsh237hk@gmail.com>
+> harshitg927 <121371860+harshitg927@users.noreply.github.com>
+> Helio Chissini de Castro <dev@heliocastro.info>
+> himanshu07gupta <himanshu29gupta0703@gmail.com>
+> Himanshu A Garode <himanshu2006garode@gmail.com>
+> Hritik Raj <hritik23154049@akgec.ac.in>
+> Kareem74x <kareemmostafa74x@gmail.com>
+> Kaushlendra Pratap <kaushlendra-pratap.singh@siemens.com>
+> Keerthi B L <keerthi.bl@siemens.com>
+> Mahmoud Abdulmawlaa <m.elbaadishy@gmail.com>
+> Matthew Pappas <matteopappas@gmail.com>
+> Md Ali <mdali620563@gmail.com>
+> Mohamed Hanafy <mohamed.hanfy.dev@outlook.com>
+> naitikk31 <DARJINAITIK7@GMAIL.COM>
+> Nikesh Kumar <kumar.nikesh@siemens.com>
+> pranayh24 <pranayheda24@gmail.com>
+> Prathmesh <dhoneprathmesh72@gmail.com>
+> Priya Sharma <priyasharma1001a@gmail.com>
+> Rajnish Kumar <22it3036@rgipt.ac.in>
+> RITANKAR SAHA <ritankar.saha786@gmail.com>
+> rohit <brohit11544@gmail.com>
+> Rudra Chopra <prabhuchopra@gmail.com>
+> saiteja-in <vurukondasaiteja13@gmail.com>
+> Sameed Ahmad <sameed.ahmad@siemens-healthineers.com>
+> Sandip Mandal <sandipsmmandal02@gmail.com>
+> Sathwik Hejamady Bhat <sathwikhbhat@gmail.com>
+> sathwik-y <sathwik.yellapragada@gmail.com>
+> Shivamrut <gshivamrut@gmail.com>
+> Suhas2109 <suhas.n@siemens-healthineers.com>
+> suvrat1629 <suvrat1629@gmail.com>
+> Taanvi Khevaria <149520227+taanvi2205@users.noreply.github.com>
+> tanwar-div <tanwarkheritalwana@gmail.com>
+> VanKhanhAnny <arianne.dangvankhanh@gmail.com>
+```
+
+Please note that also many other persons usually contribute to the project with
+reviews, testing, documentations, conversations or presentations.
+
+### Features
+* `7d37bb9b8` feat(version): update /version endpoint
+
+### Corrections
+* `ba842fcaa` fix(UI): The Linked Packages is not appearing in the project
+  details page, even though packages are linked to the project.
+* `29af0f8fb` fix(Release): merge release issue fixed.
+
+### Infrastructure
+* `924ca4397` chore(lang): remove old README_LANG.md
+
 ## sw360-20.0.0-rc-2
 This is the second release candidate for SW360 in the line of next major release
 version 20.0.0 of SW360. The candidate includes numerous features, corrections,
@@ -16,7 +111,8 @@ This release serves as a preview of the upcoming major version 20.0.0 for
 testing and should not be used in production environments.
 
 Highlight of the changes includes:
-* **Security Enhancements:** Addressed XXE vulnerabilities in parsers, fixed header injection issues, added XSS protection headers, and reinforced endpoint security.
+* **Security Enhancements:** Addressed XXE vulnerabilities in parsers, fixed
+  header injection issues, added XSS protection headers, and reinforced endpoint security.
 * **API & Documentation:** Expanded OpenAPI documentation across multiple core controllers.
 * **Performance & Stability:** Optimize memory usage with static client reuse.
 * **Infrastructure:** Updated container infrastructure for v20 and improve CI checks.

--- a/backend/attachments/pom.xml
+++ b/backend/attachments/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-attachments</artifactId>

--- a/backend/changelogs/pom.xml
+++ b/backend/changelogs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-changelogs</artifactId>

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/components/pom.xml
+++ b/backend/components/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-components</artifactId>

--- a/backend/configurations/pom.xml
+++ b/backend/configurations/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-configurations</artifactId>

--- a/backend/cvesearch/pom.xml
+++ b/backend/cvesearch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-cvesearch</artifactId>

--- a/backend/fossology/pom.xml
+++ b/backend/fossology/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-fossology</artifactId>

--- a/backend/health/pom.xml
+++ b/backend/health/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-health</artifactId>

--- a/backend/licenseinfo/pom.xml
+++ b/backend/licenseinfo/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-licenseinfo</artifactId>

--- a/backend/licenses-core/pom.xml
+++ b/backend/licenses-core/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <properties>
         <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>

--- a/backend/licenses/pom.xml
+++ b/backend/licenses/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-licenses</artifactId>

--- a/backend/moderation/pom.xml
+++ b/backend/moderation/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/packages/pom.xml
+++ b/backend/packages/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend</artifactId>

--- a/backend/projects/pom.xml
+++ b/backend/projects/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/schedule/pom.xml
+++ b/backend/schedule/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-schedule</artifactId>

--- a/backend/search/pom.xml
+++ b/backend/search/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-search</artifactId>

--- a/backend/service-core/pom.xml
+++ b/backend/service-core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/spdxdocument/pom.xml
+++ b/backend/spdxdocument/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-spdxdocument</artifactId>

--- a/backend/spdxdocumentcreationinfo/pom.xml
+++ b/backend/spdxdocumentcreationinfo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-spdxdocumentcreationinfo</artifactId>

--- a/backend/spdxpackageinfo/pom.xml
+++ b/backend/spdxpackageinfo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-spdxpackageinfo</artifactId>

--- a/backend/users/pom.xml
+++ b/backend/users/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>backend</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-users</artifactId>

--- a/backend/utils/pom.xml
+++ b/backend/utils/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-utils</artifactId>

--- a/backend/vendors/pom.xml
+++ b/backend/vendors/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>backend</artifactId>
     <groupId>org.eclipse.sw360</groupId>
-    <version>20.0.0-rc-2</version>
+    <version>20.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/backend/vmcomponents/pom.xml
+++ b/backend/vmcomponents/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-vmcomponents</artifactId>

--- a/backend/vulnerabilities-core/pom.xml
+++ b/backend/vulnerabilities-core/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-vulnerabilities-core</artifactId>

--- a/backend/vulnerabilities/pom.xml
+++ b/backend/vulnerabilities/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>backend-vulnerabilities</artifactId>

--- a/backend/wsimport/pom.xml
+++ b/backend/wsimport/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>backend</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/build-configuration/pom.xml
+++ b/build-configuration/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>build-configuration</artifactId>

--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>clients</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>client</artifactId>

--- a/clients/http-support/pom.xml
+++ b/clients/http-support/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>clients</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>http-support</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <name>SW360 Client Utilities</name>

--- a/keycloak/event-listeners/pom.xml
+++ b/keycloak/event-listeners/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>keycloak</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <properties>

--- a/keycloak/pom.xml
+++ b/keycloak/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <build>

--- a/keycloak/user-storage-provider/pom.xml
+++ b/keycloak/user-storage-provider/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>keycloak</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <properties>

--- a/libraries/commonIO/pom.xml
+++ b/libraries/commonIO/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libraries/datahandler/pom.xml
+++ b/libraries/datahandler/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <name>datahandler</name>

--- a/libraries/exporters/pom.xml
+++ b/libraries/exporters/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <name>exporters</name>

--- a/libraries/importers/pom.xml
+++ b/libraries/importers/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<artifactId>libraries</artifactId>
 		<groupId>org.eclipse.sw360</groupId>
-		<version>20.0.0-rc-2</version>
+		<version>20.0.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/libraries/log4j-osgi-support/pom.xml
+++ b/libraries/log4j-osgi-support/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libraries/nouveau-handler/pom.xml
+++ b/libraries/nouveau-handler/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <name>nouveau-handler</name>

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>sw360</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.sw360</groupId>
   <artifactId>sw360</artifactId>
-  <version>20.0.0-rc-2</version>
+  <version>20.0.0</version>
   <packaging>pom</packaging>
   <name>Eclipse SW360</name>
   <description>Eclipse SW360 compliance management application</description>

--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>rest</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>authorization-server</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.sw360</groupId>
         <artifactId>sw360</artifactId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>rest</artifactId>

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>rest</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>resource-server</artifactId>

--- a/rest/rest-common/pom.xml
+++ b/rest/rest-common/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>rest</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
 
     <artifactId>rest-common</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>sw360</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.0.0-rc-2</version>
+        <version>20.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Changelog in preparation for Release 20.0.0 of backend.

This PR is in preparation for the release 20.0.0
This PR also serves as an intimation of merge freeze and a request for testing for finding new bugs.

If until 27/03/2026, there are no comments on this PR, will proceed with the release.

Thank you everyone involved for their hard work and make this release possible!