### PR TITLE
Improve null safety in ComponentDatabaseHandler

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1311,7 +1311,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
             Set<String> updatedAttachmentId = updatedAttachments.stream().map(Attachment::getAttachmentContentId).collect(Collectors.toSet());
 
             // check if attachments are updated
-            if (!originalAttachmentId.equals(updatedAttachmentId)) {
+            if (!Objects.equals(originalAttachmentId, updatedAttachmentId)) {
                 // fetch all the projects associated with this release and collect the Clearing request Ids
                 final Set<Project> usingProjects = projectRepository.searchByReleaseId(release.getId());
                 final Set<String> crIds = CommonUtils.nullToEmptySet(usingProjects).stream()

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/BulkDeleteUtilTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/BulkDeleteUtilTest.java
@@ -1465,7 +1465,7 @@ public class BulkDeleteUtilTest {
             timeLogLastTime = System.nanoTime();
             return true;
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("IOException occurred", e);
             return false;
         }
     }
@@ -1478,7 +1478,7 @@ public class BulkDeleteUtilTest {
             timeLogLastTime = 0;
             return true;
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("IOException occurred", e);
             return false;
         }
     }
@@ -1496,7 +1496,7 @@ public class BulkDeleteUtilTest {
             }
             return true;
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("IOException occurred", e);
             return false;
         }
     }
@@ -1508,3 +1508,4 @@ public class BulkDeleteUtilTest {
         }
     }
 }
+


### PR DESCRIPTION
This PR improves null safety by replacing direct equals comparison with Objects.equals.

Change:
Objects.equals(originalAttachmentId, updatedAttachmentId)

This prevents potential NullPointerException if values are null.

No functional changes.