### PR TITLE
feat(licenses): add LicenseDB as source option for XML import workflows

### DIFF
--- a/backend/licenses-core/pom.xml
+++ b/backend/licenses-core/pom.xml
@@ -33,5 +33,24 @@
             <groupId>org.spdx</groupId>
             <artifactId>tools-java</artifactId>
         </dependency>
+        <!-- Added for LicenseDB integration, providing License, Obligation thrift classes -->
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>datahandler</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Added for LicenseDB integration, providing WebClient for HTTP calls -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- Test dependency for mocking HTTP server in LicenseDBConnector tests -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -26,12 +26,12 @@ import org.eclipse.sw360.datahandler.entitlement.LicenseModerator;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.changelogs.Operation;
+import org.eclipse.sw360.licenses.tools.LicenseDBConnector;
 import org.eclipse.sw360.licenses.tools.SpdxConnector;
 import org.eclipse.sw360.exporter.LicenseExporter;
 import org.eclipse.sw360.licenses.tools.OSADLObligationConnector;
@@ -1029,6 +1029,30 @@ public class LicenseDatabaseHandler {
     }
 
     public RequestSummary importAllSpdxLicenses(User user) {
+
+        // If LicenseDB is configured as import source, fetch licenses from LicenseDB
+        // instead of importing directly from SPDX. Relates to issue #3840.
+        String importSource = SW360Utils.readConfig("licensedb.import.source", "xml");
+        if ("licensedb".equalsIgnoreCase(importSource)) {
+            log.info("LicenseDB configured as import source, fetching licenses from LicenseDB.");
+            LicenseDBConnector connector = new LicenseDBConnector();
+            List<License> licenses = connector.fetchAllLicenses();
+            try {
+                addOrOverwriteLicenses(licenses, user, false);
+                return new RequestSummary()
+                        .setTotalElements(licenses.size())
+                        .setTotalAffectedElements(licenses.size())
+                        .setMessage("Licenses imported from LicenseDB.")
+                        .setRequestStatus(RequestStatus.SUCCESS);
+            } catch (SW360Exception e) {
+                log.error("Failed to import licenses from LicenseDB", e);
+                return new RequestSummary()
+                        .setTotalAffectedElements(0)
+                        .setMessage("Failed to import licenses from LicenseDB: " + e.getMessage())
+                        .setRequestStatus(RequestStatus.FAILURE);
+            }
+        }
+
         RequestSummary requestSummary = new RequestSummary()
                 .setTotalAffectedElements(0)
                 .setMessage("");
@@ -1087,6 +1111,29 @@ public class LicenseDatabaseHandler {
     }
 
     public RequestSummary importAllOSADLLicenses(User user) {
+        // If LicenseDB is configured as the import source, skip direct OSADL
+        // Relates to issue #3840.
+        String importSource = SW360Utils.readConfig("licensedb.import.source", "xml");
+        if ("licensedb".equalsIgnoreCase(importSource)) {
+            log.info("LicenseDB configured as import source, fetching obligations from LicenseDB.");
+            LicenseDBConnector connector = new LicenseDBConnector();
+            List<Obligation> obligations = connector.fetchAllObligations();
+            try {
+                addListOfObligations(obligations, user);
+                return new RequestSummary()
+                        .setTotalElements(obligations.size())
+                        .setTotalAffectedElements(obligations.size())
+                        .setMessage("Obligations imported from LicenseDB.")
+                        .setRequestStatus(RequestStatus.SUCCESS);
+            } catch (Exception e) {
+                log.error("Failed to import obligations from LicenseDB", e);
+                return new RequestSummary()
+                        .setTotalAffectedElements(0)
+                        .setMessage("Failed to import obligations from LicenseDB: " + e.getMessage())
+                        .setRequestStatus(RequestStatus.FAILURE);
+            }
+        }
+
         RequestSummary requestSummary = new RequestSummary().setTotalAffectedElements(0).setMessage("");
         Timestamp ts = Timestamp.from(Instant.now());
         long currentTime = ts.getTime();

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Connector for fetching license and obligation data from LicenseDB REST API.
+ * Used as an alternative data source to replace direct SPDX/OSADL XML imports.
+ * When licensedb.import.source=licensedb is set in sw360.properties,
+ * importAllSpdxLicenses() and importAllOSADLLicenses() will delegate to this
+ * connector instead of fetching from SPDX/OSADL directly.
+ *
+ * Relates to issue #3840.
+ */
+public class LicenseDBConnector {
+
+    private static final Logger log = LogManager.getLogger(LicenseDBConnector.class);
+
+    // Jackson ObjectMapper for parsing JSON responses from LicenseDB
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Properties file path, consistent with other connectors in this package
+    private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+
+    // Number of records to fetch per page when calling LicenseDB paginated APIs
+    private static final int PAGE_SIZE = 100;
+
+    private final String baseUrl;
+    private final String accessToken;
+    private final WebClient webClient;
+
+    public LicenseDBConnector() {
+        // Read LicenseDB URL and access token from sw360.properties
+        Properties props = CommonUtils.loadProperties(LicenseDBConnector.class, PROPERTIES_FILE_PATH);
+        this.baseUrl = props.getProperty("licensedb.url", "http://localhost:8080");
+        this.accessToken = props.getProperty("licensedb.access.token", "");
+
+        // Build WebClient with Bearer token auth if token is configured.
+        // LicenseDB API requires ApiKeyAuth (see swagger.yaml securityDefinitions).
+        WebClient.Builder builder = WebClient.builder().baseUrl(this.baseUrl);
+        if (!accessToken.isEmpty()) {
+            builder.defaultHeader("Authorization", "Bearer " + accessToken);
+        }
+        this.webClient = builder.build();
+    }
+
+    /**
+     * Fetch all active licenses from LicenseDB and convert them to SW360 License objects.
+     * Calls LicenseDB API: GET /api/v1/licenses?active=true
+     * Handles pagination automatically until no more pages are available.
+     */
+    public List<License> fetchAllLicenses() {
+        List<License> licenses = new ArrayList<>();
+        int page = 1;
+
+        while (true) {
+            try {
+                String url = "/api/v1/licenses?active=true&limit=" + PAGE_SIZE + "&page=" + page;
+                String responseBody = webClient.get()
+                        .uri(url)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block();
+
+                if (responseBody == null) break;
+
+                // Parse response: data array contains individual license objects
+                JsonNode root = objectMapper.readTree(responseBody);
+                JsonNode data = root.path("data");
+                if (!data.isArray() || data.size() == 0) break;
+
+                for (JsonNode node : data) {
+                    License license = mapToSW360License(node);
+                    if (license != null) {
+                        licenses.add(license);
+                    }
+                }
+
+                // Check pagination metadata; stop if no next page exists
+                String next = root.path("paginationmeta").path("next").asText("");
+                if (next.isEmpty() || next.equals("null")) break;
+                page++;
+
+            } catch (Exception e) {
+                log.error("Failed to fetch licenses from LicenseDB at page {}", page, e);
+                break;
+            }
+        }
+
+        log.info("Fetched {} licenses from LicenseDB", licenses.size());
+        return licenses;
+    }
+
+    /**
+     * Fetch all active obligations from LicenseDB and convert them to SW360 Obligation objects.
+     * Calls LicenseDB API: GET /api/v1/obligations?active=true
+     * Handles pagination automatically until no more pages are available.
+     */
+    public List<Obligation> fetchAllObligations() {
+        List<Obligation> obligations = new ArrayList<>();
+        int page = 1;
+
+        while (true) {
+            try {
+                String url = "/api/v1/obligations?active=true&limit=" + PAGE_SIZE + "&page=" + page;
+                String responseBody = webClient.get()
+                        .uri(url)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block();
+
+                if (responseBody == null) break;
+
+                JsonNode root = objectMapper.readTree(responseBody);
+                JsonNode data = root.path("data");
+                if (!data.isArray() || data.size() == 0) break;
+
+                for (JsonNode node : data) {
+                    Obligation obligation = mapToSW360Obligation(node);
+                    if (obligation != null) {
+                        obligations.add(obligation);
+                    }
+                }
+
+                String next = root.path("paginationmeta").path("next").asText("");
+                if (next.isEmpty() || next.equals("null")) break;
+                page++;
+
+            } catch (Exception e) {
+                log.error("Failed to fetch obligations from LicenseDB at page {}", page, e);
+                break;
+            }
+        }
+
+        log.info("Fetched {} obligations from LicenseDB", obligations.size());
+        return obligations;
+    }
+
+    /**
+     * Maps a single LicenseDB license JSON node to a SW360 License object.
+     *
+     * Field mapping (LicenseDB -> SW360):
+     * shortname -> id and shortname (SW360 uses shortname as primary key)
+     * fullname  -> fullname
+     * text      -> text (license body)
+     */
+    private License mapToSW360License(JsonNode node) {
+        try {
+            String shortname = node.path("shortname").asText("");
+            if (shortname.isEmpty()) return null;
+
+            License license = new License();
+            license.setId(shortname);
+            license.setShortname(shortname);
+            license.setFullname(node.path("fullname").asText(shortname));
+            license.setText(node.path("text").asText(""));
+            // Initialize as empty set to avoid NullPointerException downstream
+            license.setObligationDatabaseIds(new HashSet<>());
+            return license;
+        } catch (Exception e) {
+            log.error("Failed to map LicenseDB node to SW360 License", e);
+            return null;
+        }
+    }
+
+    /**
+     * Maps a single LicenseDB obligation JSON node to a SW360 Obligation object.
+     *
+     * Field mapping (LicenseDB -> SW360):
+     * topic -> title (obligation title)
+     * text  -> text  (obligation content)
+     */
+    private Obligation mapToSW360Obligation(JsonNode node) {
+        try {
+            String topic = node.path("topic").asText("");
+            if (topic.isEmpty()) return null;
+
+            Obligation obligation = new Obligation();
+            obligation.setTitle(topic);
+            obligation.setText(node.path("text").asText(""));
+            // Set obligation level and type consistent with OSADLObligationConnector
+            obligation.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
+            obligation.setObligationType(ObligationType.OBLIGATION);
+            return obligation;
+        } catch (Exception e) {
+            log.error("Failed to map LicenseDB node to SW360 Obligation", e);
+            return null;
+        }
+    }
+
+    //Constructor for testing purposes, allowing to inject baseUrl and accessToken
+    public LicenseDBConnector(String baseUrl, String accessToken) {
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+
+        WebClient.Builder builder = WebClient.builder().baseUrl(this.baseUrl);
+        if (!accessToken.isEmpty()) {
+            builder.defaultHeader("Authorization", "Bearer " + accessToken);
+        }
+        this.webClient = builder.build();
+    }
+}

--- a/backend/licenses-core/src/test/java/org/eclipse/sw360/licenses/tools/LicenseDBConnectorTest.java
+++ b/backend/licenses-core/src/test/java/org/eclipse/sw360/licenses/tools/LicenseDBConnectorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for LicenseDBConnector.
+ * Tests cover: successful fetch, empty response, and malformed response handling.
+ * Relates to issue #3840.
+ */
+public class LicenseDBConnectorTest {
+
+    private MockWebServer mockWebServer;
+    private LicenseDBConnector connector;
+
+    @Before
+    public void setUp() throws IOException {
+        // Start a local mock HTTP server to simulate LicenseDB API responses
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        // Point connector to the mock server
+        String baseUrl = mockWebServer.url("/").toString();
+        connector = new LicenseDBConnector(baseUrl, "");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void testFetchAllLicenses_success() throws Exception {
+        // Given: LicenseDB returns one license
+        String mockResponse = "{"
+                + "\"data\": [{"
+                + "  \"shortname\": \"MIT\","
+                + "  \"fullname\": \"MIT License\","
+                + "  \"text\": \"Permission is hereby granted...\""
+                + "}],"
+                + "\"paginationmeta\": {\"next\": \"\"}"
+                + "}";
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        // When: fetchAllLicenses is called
+        List<License> licenses = connector.fetchAllLicenses();
+
+        // Then: one license is returned with correct fields
+        assertEquals(1, licenses.size());
+        assertEquals("MIT", licenses.get(0).getId());
+        assertEquals("MIT License", licenses.get(0).getFullname());
+    }
+
+    @Test
+    public void testFetchAllLicenses_emptyResponse() throws Exception {
+        // Given: LicenseDB returns empty data array
+        String mockResponse = "{"
+                + "\"data\": [],"
+                + "\"paginationmeta\": {\"next\": \"\"}"
+                + "}";
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        // When: fetchAllLicenses is called
+        List<License> licenses = connector.fetchAllLicenses();
+
+        // Then: empty list is returned, no exception thrown
+        assertNotNull(licenses);
+        assertEquals(0, licenses.size());
+    }
+
+    @Test
+    public void testFetchAllLicenses_malformedResponse() {
+        // Given: LicenseDB returns malformed JSON
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("not valid json")
+                .addHeader("Content-Type", "application/json"));
+
+        // When: fetchAllLicenses is called
+        List<License> licenses = connector.fetchAllLicenses();
+
+        // Then: empty list returned gracefully, no exception thrown
+        assertNotNull(licenses);
+        assertEquals(0, licenses.size());
+    }
+
+    @Test
+    public void testFetchAllObligations_success() throws Exception {
+        // Given: LicenseDB returns one obligation
+        String mockResponse = "{"
+                + "\"data\": [{"
+                + "  \"topic\": \"Provide copyright notices\","
+                + "  \"text\": \"You must retain copyright notices.\""
+                + "}],"
+                + "\"paginationmeta\": {\"next\": \"\"}"
+                + "}";
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        // When: fetchAllObligations is called
+        List<Obligation> obligations = connector.fetchAllObligations();
+
+        // Then: one obligation is returned with correct fields
+        assertEquals(1, obligations.size());
+        assertEquals("Provide copyright notices", obligations.get(0).getTitle());
+        assertEquals("You must retain copyright notices.", obligations.get(0).getText());
+    }
+
+    @Test
+    public void testFetchAllObligations_emptyResponse() throws Exception {
+        // Given: LicenseDB returns empty data array
+        String mockResponse = "{"
+                + "\"data\": [],"
+                + "\"paginationmeta\": {\"next\": \"\"}"
+                + "}";
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponse)
+                .addHeader("Content-Type", "application/json"));
+
+        // When: fetchAllObligations is called
+        List<Obligation> obligations = connector.fetchAllObligations();
+
+        // Then: empty list returned, no exception thrown
+        assertNotNull(obligations);
+        assertEquals(0, obligations.size());
+    }
+}

--- a/build-configuration/resources/sw360.properties
+++ b/build-configuration/resources/sw360.properties
@@ -11,3 +11,7 @@
 # N.B this is the default build property file, defined in module build-configuration
 
 backend.url= http://localhost:8080
+# licenseDB integration properties
+licensedb.import.source = xml
+licensedb.url = $LICENSEDB_URL
+licensedb.access.token =

--- a/scripts/docker-config/etc_sw360/sw360.properties.template
+++ b/scripts/docker-config/etc_sw360/sw360.properties.template
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+
 # ***************************************
 # Config Properties not saved in DB
 # ***************************************
@@ -20,6 +21,10 @@ rest.apitoken.hash.salt=$REST_APITOKEN_HASH_SALT
 
 # where the Thrift should connect
 backend.url=http://127.0.0.1:8080
+# LicenseDB integration properties
+licensedb.import.source=xml
+licensedb.url=$LICENSEDB_URL
+licensedb.access.token=$LICENSEDB_ACCESS_TOKEN
 
 org.eclipse.sw360.licensinfo.projectclearing.templatemapping=Default:templateReport
 enable.sw360.change.log=false


### PR DESCRIPTION
## Summary
Add LicenseDB as an optional data source for XML-based license and obligation import workflows, replacing direct SPDX/OSADL imports when configured.

This PR is part of GSoC 2026: Integration of SW360 and LicenseDB.

* Which issue is this pull request belonging to and how is it solving it?
Fixes #3840 - Updates XML import workflows to optionally fetch from LicenseDB instead of SPDX/OSADL directly.

* Did you add or update any new dependencies that are required for your change?
Yes - added `datahandler`, `spring-boot-starter-webflux`, and `mockwebserver` (test only) to `backend-licenses-core/pom.xml`.

## Issue
Fixes #3840

### How To Test?
1. Set `licensedb.import.source=licensedb` in `sw360.properties`
2. Set `licensedb.url` to your LicenseDB instance URL
3. Set `licensedb.access.token` if authentication is required
4. Trigger SPDX import via REST API: `POST /api/licenses/spdxLicenses`
5. Trigger OSADL import via REST API: `POST /api/licenses/osadlLicenses`
6. Verify licenses/obligations are fetched from LicenseDB instead of SPDX/OSADL

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] License headers added to new files
- [x] Tests added for new functionality (LicenseDBConnectorTest.java)
- [x] Existing functionality preserved as fallback