### PR TITLE
fix(Rest) : Backend API for All Obligation Tab

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3389,7 +3389,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @PathVariable("id") String id,
             @Parameter(description = "If true, returns the license obligation data in release view. "
                     + "Otherwise, returns it in project view.")
-            @RequestParam(value = "view", defaultValue = "false") boolean releaseView
+            @RequestParam(value = "view", defaultValue = "false") boolean releaseView,
+            @Parameter(description = "If true, includes obligations from all sub-projects with status "
+                    + "FULFILLED_AND_PARENT_MUST_ALSO_FULFILL. Default is false.")
+            @RequestParam(value = "includeSubprojectObligations", defaultValue = "false") boolean includeSubprojectObligations
     ) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
@@ -3398,6 +3401,30 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         List<Release> releases = new ArrayList<>();
         ObligationList obligation = new ObligationList();
         Map<String, ObligationStatusInfo> obligationStatusMap = Maps.newHashMap();
+
+        // Handle includeSubprojects flag for "All Obligations" tab
+        if (includeSubprojectObligations) {
+            // Get obligations from current project and all sub-projects with FULFILLED_AND_PARENT_MUST_ALSO_FULFILL status
+            obligationStatusMap = getInheritedObligationsFromProjectHierarchy(sw360Project, sw360User);
+
+            // Enrich obligation status info with release data
+            for (Map.Entry<String, ObligationStatusInfo> entry : obligationStatusMap.entrySet()) {
+                ObligationStatusInfo statusInfo = entry.getValue();
+                if (statusInfo.getReleaseIdToAcceptedCLI() != null && !statusInfo.getReleaseIdToAcceptedCLI().isEmpty()) {
+                    Set<Release> limitedSet = releaseService.getReleasesForUserByIds(
+                            statusInfo.getReleaseIdToAcceptedCLI().keySet());
+                    statusInfo.setReleases(limitedSet);
+                }
+                statusInfo.setId(entry.getKey());
+            }
+
+            // Return paginated response
+            Map<String, Object> responseBody = createPaginationMetadata(pageable, obligationStatusMap);
+            HalResource<Map<String, Object>> halObligation = new HalResource<>(responseBody);
+            return new ResponseEntity<>(halObligation, HttpStatus.OK);
+        }
+
+        // Default behavior - existing functionality for current project only
         List<String> releaseIds = new ArrayList<>(CommonUtils.nullToEmptyMap(sw360Project.getReleaseIdToUsage()).keySet());
         for (final String releaseId : releaseIds) {
             Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
@@ -3435,9 +3462,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 if(statusInfo.getStatus() == null){
                     statusInfo.setStatus(ObligationStatus.OPEN);
                 }
-                Set<Release> limitedSet = releaseService
-                        .getReleasesForUserByIds(statusInfo.getReleaseIdToAcceptedCLI().keySet());
-                statusInfo.setReleases(limitedSet);
+                if(statusInfo.getReleaseIdToAcceptedCLI()!=null){
+                    Set<Release> limitedSet = releaseService
+                            .getReleasesForUserByIds(statusInfo.getReleaseIdToAcceptedCLI().keySet());
+                    statusInfo.setReleases(limitedSet);
+                }
             }
 
             Map<String, Object> responseBody = createPaginationMetadata(pageable, obligationStatusMap);
@@ -3533,6 +3562,77 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     return obligationLevel == null || obligationLevel == targetLevel;
                 })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Fetches obligations from the entire project hierarchy (current project + all sub-projects)
+     * and filters by FULFILLED_AND_PARENT_MUST_ALSO_FULFILL status.
+     *
+     * @param rootProject The root project
+     * @param sw360User   The authenticated user
+     * @return Map of obligation ID to ObligationStatusInfo with filtered status
+     * @throws TException If there's an error fetching project or obligation data
+     */
+    private Map<String, ObligationStatusInfo> getInheritedObligationsFromProjectHierarchy(
+            Project rootProject, User sw360User) throws TException {
+
+        Map<String, ObligationStatusInfo> aggregatedObligations = Maps.newHashMap();
+
+        // Collect all projects in hierarchy (root + all sub-projects recursively)
+        List<Project> allProjects = new ArrayList<>();
+        allProjects.add(rootProject);
+
+        // Get all linked sub-projects recursively
+        try {
+            Collection<ProjectLink> linkedProjectLinks = SW360Utils.getLinkedProjectsAsFlatList(
+                    rootProject, true, new ThriftClients(), log, sw360User);
+
+            // Fetch full project objects for each linked project
+            for (ProjectLink projectLink : linkedProjectLinks) {
+                try {
+                    Project subProject = projectService.getProjectForUserById(projectLink.getId(), sw360User);
+                    allProjects.add(subProject);
+                } catch (Exception e) {
+                    log.warn("Could not fetch sub-project with ID: " + projectLink.getId(), e);
+                    // Continue processing other projects
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error traversing project hierarchy for project: " + rootProject.getId(), e);
+        }
+
+        // Collect obligations from all projects
+        for (Project project : allProjects) {
+            if (CommonUtils.isNotNullEmptyOrWhitespace(project.getLinkedObligationId())) {
+                try {
+                    ObligationList obligationList = projectService.getObligationData(
+                            project.getLinkedObligationId(), sw360User);
+
+                    Map<String, ObligationStatusInfo> projectObligations =
+                            CommonUtils.nullToEmptyMap(obligationList.getLinkedObligationStatus());
+
+                    // Add project name/info to help identify source project
+                    for (Map.Entry<String, ObligationStatusInfo> entry : projectObligations.entrySet()) {
+                        ObligationStatusInfo statusInfo = entry.getValue();
+                        // Only add obligations with FULFILLED_AND_PARENT_MUST_ALSO_FULFILL status
+                        if (statusInfo.getStatus() == ObligationStatus.FULFILLED_AND_PARENT_MUST_ALSO_FULFILL) {
+                            // Approach 3: Keep both with different keys
+                            // Create a unique key combining project ID and obligation ID
+                            String obligationId = entry.getKey();
+                            String uniqueKey = project.getId() + ":" + obligationId;
+
+                            // Store with the unique key to preserve obligations from all projects
+                            aggregatedObligations.put(uniqueKey, statusInfo);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Could not fetch obligations for project: " + project.getId(), e);
+                    // Continue processing other projects
+                }
+            }
+        }
+
+        return aggregatedObligations;
     }
     @PreAuthorize("hasAuthority('WRITE')")
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -800,7 +800,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             obligationStatusMap = licenseObligation.getObligationStatusMap();
             for (Map.Entry<String, ObligationStatusInfo> entry : obligationStatusMap.entrySet()) {
                 ObligationStatusInfo details = entry.getValue();
-                if (details.getReleaseIdToAcceptedCLI() == null) {
+                if (details.getReleaseIdToAcceptedCLI() == null && details.getReleases()!=null) {
                     Set<Release> releaseData = details.getReleases();
                     for (Release rel : releaseData) {
                         String releaseId = rel.getId();


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)

Closes #3996 

> * Did you add or update any new dependencies that are required for your change?
No

Issue: #3996 

### Suggest Reviewer
@GMishx 

### How To Test?
> Sample URL : 

http://localhost:8080/resource/api/projects/<projectId>/licenseObligations?page=0&page_entries=20&sort=name&includeSubprojectObligations=true

Based on param : includeSubprojectObligations - filter will apply for new AllObligation tab

Sample Response : 
```json
{
  "obligations": {
    "680c93e0cb3b3f7712503c355b000d56:marking modifications": {
      "text": "Note for Apache-2.0, ECL-2.0, ImageMagick:  \nIf you modify this component and do not intend to contribute the modifications/the modified work back to open source community, you must conspicuously mark or designate the modifications as “Not a Contribution”.\n\nIf you modify this component and intend to contribute the modifications/the modified work back to open source community, you must contact your 3rd Party Software Manager. There is a process for contributions.\n\nNote for CDDL-1.0:  \nIf you modify this component and intend to contribute the modifications/the modified work back to open source community, you must contact your 3rd Party Software Manager. There is a process for contributions.\n\nNote for Permission Notice Intel Corporation:\nIn addition, Intel grants this permission provided that you prominently mark as \"not part of the original\" any modifications made to this software or documentation, and that the name of Intel Corporation not be used in advertising or publicity pertaining to distribution of the software or the documentation without specific, written prior permission.\n\nNote for CISST-1.0:\nModified versions of the Software must be clearly identified and marked as such, and must not be misrepresented as being the original Software.\n\nNote for Matplotlib License Agreement:\nWhen you modifiy versions of Matplotlib and distribute the modified versions you must include in any such work a brief summary of the changes made to matplotlib .",
      "status": "FULFILLED_AND_PARENT_MUST_ALSO_FULFILL",
      "modifiedBy": "admin@sw360.org",
      "modifiedOn": "2026-03-26",
      "releases": [
        {
          "id": "b930e704760d45d3800cea1ee59b4a1b",
          "type": "release",
          "name": "testComp10",
          "version": "1.0"
        }
      ],
      "licenseIds": [
        "Apache-2.0",
        "Apache-2.0 WITH LLVM-exception"
      ],
      "releaseIdToAcceptedCLI": {
        "b930e704760d45d3800cea1ee59b4a1b": "f203d656fffb4208819bae1c2cd3976b"
      },
      "id": "680c93e0cb3b3f7712503c355b000d56:marking modifications"
    },
    "680c93e0cb3b3f7712503c355b000d56:Patentleft effect": {
      "text": "You must contact your Patent Strategy Manager to check the patentleft effect",
      "status": "FULFILLED_AND_PARENT_MUST_ALSO_FULFILL",
      "modifiedBy": "admin@sw360.org",
      "modifiedOn": "2026-03-26",
      "releases": [
        {
          "id": "b930e704760d45d3800cea1ee59b4a1b",
          "type": "release",
          "name": "testComp10",
          "version": "1.0"
        }
      ],
      "licenseIds": [
        "Artistic-2.0",
        "APSL-2.0",
        "LGPL-2.1-only",
        "MPL-2.0"
      ],
      "releaseIdToAcceptedCLI": {
        "b930e704760d45d3800cea1ee59b4a1b": "f203d656fffb4208819bae1c2cd3976b"
      },
      "id": "680c93e0cb3b3f7712503c355b000d56:Patentleft effect"
    }
  },
  "page": {
    "totalElements": 2,
    "number": 0,
    "size": 2,
    "totalPages": 1
  }
}
```