### PR TITLE
fix: null handling in CLIParser and CombinedCLIParser

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
@@ -66,6 +66,10 @@ public class CLIParser extends AbstractCLIParser {
         super(attachmentConnector, attachmentContentProvider);
     }
 
+    /**
+     * Checks if this parser is applicable to the given attachment by verifying
+     * the file extension is XML and the root element is ComponentLicenseInformation.
+     */
     @Override
     public <T> boolean isApplicableTo(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
@@ -76,18 +80,30 @@ public class CLIParser extends AbstractCLIParser {
         return hasThisXMLRootElement(content, CLI_ROOT_ELEMENT_NAMESPACE, CLI_ROOT_ELEMENT_NAME, user, context);
     }
 
+    /**
+     * Parses license information from a CLI attachment, optionally including file hashes.
+     *
+     * @param includeFilesHash if true, includes source file hashes in copyright info
+     */
     @Override
     public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context,
             boolean includeFilesHash) throws TException {
         return getLicenseInfosDelegated(attachment, user, context, includeFilesHash);
     }
 
+    /**
+     * Parses license information from a CLI attachment without file hashes.
+     */
     @Override
     public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context)
             throws TException {
         return getLicenseInfosDelegated(attachment, user, context, false);
     }
 
+    /**
+     * Parses obligation information from a CLI attachment.
+     * Returns a failure status result if the XML cannot be parsed.
+     */
     @Override
     public <T> ObligationParsingResult getObligations(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
@@ -167,8 +183,10 @@ public class CLIParser extends AbstractCLIParser {
                 String textContent = childNodes.item(i).getTextContent();
                 assessmentSummaryMap.put(nodeName, textContent);
             }
+        } else if (assessmentSummaryList.getLength() == 0) {
+            log.warn("AssessmentSummary element not found in CLI file");
         } else {
-            log.error("AssessmentSummary not found in CLI!");
+            log.warn("Multiple AssessmentSummary elements found in CLI file (count: " + assessmentSummaryList.getLength() + "), expected exactly 1. Skipping.");
         }
         return assessmentSummaryMap;
     }
@@ -200,6 +218,10 @@ public class CLIParser extends AbstractCLIParser {
         String content = findNamedSubelement(node, LICENSE_CONTENT_ELEMENT_NAME)
                 .map(AbstractCLIParser::normalizeEscapedXhtml).orElse(null);
         Map<String, Set<String>> copyrightWithFileHash = new HashMap<String, Set<String>>();
+        if (content == null) {
+            log.warn("Copyright node is missing Content element, skipping entry");
+            return copyrightWithFileHash;
+        }
         copyrightWithFileHash.put(content, filesHash);
         return copyrightWithFileHash;
     }

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
@@ -72,6 +72,10 @@ public class CombinedCLIParser extends AbstractCLIParser{
         return releaseExternalIdCorrelationKey;
     }
 
+    /**
+     * Checks if this parser is applicable to the given attachment by verifying
+     * the file extension is XML and the root element is CombinedCLI.
+     */
     @Override
     public <T> boolean isApplicableTo(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
@@ -82,6 +86,10 @@ public class CombinedCLIParser extends AbstractCLIParser{
         return hasThisXMLRootElement(content, COMBINED_CLI_ROOT_ELEMENT_NAMESPACE, COMBINED_CLI_ROOT_ELEMENT_NAME, user, context);
     }
 
+    /**
+     * Parses license information from a CombinedCLI attachment.
+     * Groups results by external component ID and correlates them with known releases.
+     */
     @Override
     public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
@@ -159,10 +167,16 @@ public class CombinedCLIParser extends AbstractCLIParser{
             String contentText = findNamedSubelement(nodes.item(i), contentElementName)
                     .map(AbstractCLIParser::normalizeEscapedXhtml)
                     .orElse(null);
+            if (externalId == null) {
+                log.warn("Copyright node is missing srcComponent attribute, skipping entry");
+                continue;
+            }
             if (!result.containsKey(externalId)){
                 result.put(externalId, Sets.newHashSet());
             }
-            result.get(externalId).add(contentText);
+            if (contentText != null) {
+                result.get(externalId).add(contentText);
+            }
         }
         return result;
     }


### PR DESCRIPTION
## Summary
Fixed latent null-pointer vulnerabilities in the CLI XML parser layer 
and improved diagnostic logging.

## Changes

### CLIParser.java
- Guard against null `Content` element in copyright parsing — previously 
  a null key could be silently inserted into the HashMap
- Split `AssessmentSummary` missing/multiple element cases into separate 
  branches with `warn` instead of `error` log level
- Add Javadoc to public parser methods

### CombinedCLIParser.java
- Skip copyright entries where `srcComponent` (externalId) is null to 
  prevent NPE on map lookup
- Skip null `contentText` values to avoid polluting result Sets
- Add Javadoc to public parser methods

## Testing
Verified changes do not affect happy-path parsing behavior. Guards only 
activate on malformed XML input.

Closes #4000 
