### PR TITLE
fix(component): close FileInputStream in uploadAttachment

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -3407,9 +3407,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         String fileName = file.getName();
         String contentType = "application/zip";
         final AttachmentContent attachmentContent = makeAttachmentContent(fileName, contentType);
-        FileInputStream inputStream = new FileInputStream(file);
-        Attachment attachment = new AttachmentFrontendUtils().uploadAttachmentContent(attachmentContent, inputStream, null);
-
+        Attachment attachment;
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            attachment = new AttachmentFrontendUtils().uploadAttachmentContent(attachmentContent, inputStream, null);
+        }
         attachment.setSha1(attachmentConnector.getSha1FromAttachmentContentId(attachmentContent.getId()));
         attachment.setAttachmentType(AttachmentType.SOURCE);
         attachment.setCheckStatus(CheckStatus.NOTCHECKED);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? closes #3965 
> * Did you add or update any new dependencies that are required for your change? NO

- Wrapped the `FileInputStream` in `uploadAttachment` inside a try-with-resources block in `ComponentDatabaseHandler`
- The stream is now guaranteed to be closed on all exit paths, including when `uploadAttachmentContent` throws an exception
Closes #3965 
`ComponentDatabaseHandler.uploadAttachment` created a `FileInputStream` but never closed it. If `uploadAttachmentContent` threw an exception the file descriptor would leak. The fix wraps the stream in a try-with-resources block, matching the pattern already used in `downloadFile()` in the same class.


### Suggest Reviewer
> @GMishx @KoukiHama @arunazhakesan @ag4ums 

### How To Test?
> How should these changes be tested by the reviewer?

1. Check out this branch.
2. Build the `backend/common` module:
mvn -pl backend/common compile
3. Confirm it compiles cleanly with no errors.
4. Optionally trigger the automatic source upload scheduler for a release that has a VCS URL configured and verify attachments upload correctly.

> Have you implemented any additional tests?

No unit test was added. The fix is a purely structural resource-management change, the method's observable contract (return value, exception behaviour) is unchanged. Adding a unit test would require mocking the CouchDB connector and the attachment service; the signal-to-noise ratio does not justify it for a one-line structural fix.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
