### PR TITLE
fix(users): close CSVReader and FileReader in readFileCsv

### DIFF
--- a/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -230,29 +230,30 @@ public class UserDatabaseHandler {
         List<String> emailCsv = new ArrayList<>();
         try {
             File file = new File(filePath);
-            CSVReader reader = new CSVReaderBuilder(new FileReader(file)).withSkipLines(1).build();
-            List<String[]> rows = reader.readAll();
-            String mapTemp = "";
-            for (String[] row : rows) {
-                if (row.length > 1) {
-                    if (!Objects.equals(row[0], "")) {
-                        if (!mapTemp.isEmpty()) {
-                            if (listMap.containsKey(mapTemp)) {
-                                departmentDuplicate.add(mapTemp);
+            try (CSVReader reader = new CSVReaderBuilder(new FileReader(file)).withSkipLines(1).build()) {
+                List<String[]> rows = reader.readAll();
+                String mapTemp = "";
+                for (String[] row : rows) {
+                    if (row.length > 1) {
+                        if (!Objects.equals(row[0], "")) {
+                            if (!mapTemp.isEmpty()) {
+                                if (listMap.containsKey(mapTemp)) {
+                                    departmentDuplicate.add(mapTemp);
+                                }
+                                listMap.put(mapTemp, emailCsv);
+                                emailCsv = new ArrayList<>();
                             }
-                            listMap.put(mapTemp, emailCsv);
-                            emailCsv = new ArrayList<>();
+                            mapTemp = row[0];
                         }
-                        mapTemp = row[0];
+                        String email = row[1];
+                        emailCsv.add(email);
                     }
-                    String email = row[1];
-                    emailCsv.add(email);
                 }
+                if (listMap.containsKey(mapTemp)) {
+                    departmentDuplicate.add(mapTemp);
+                }
+                listMap.put(mapTemp, emailCsv);
             }
-            if (listMap.containsKey(mapTemp)) {
-                departmentDuplicate.add(mapTemp);
-            }
-            listMap.put(mapTemp, emailCsv);
         } catch (IOException | CsvException e) {
             log.error("Can't read file csv: {}", e.getMessage());
         }

--- a/backend/users/src/test/java/org/eclipse/sw360/users/db/UserDatabaseHandlerTest.java
+++ b/backend/users/src/test/java/org/eclipse/sw360/users/db/UserDatabaseHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Siemens AG, 2024. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.users.db;
+
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link UserDatabaseHandler} that do not require live user data.
+ */
+public class UserDatabaseHandlerTest {
+
+    private static final String DB_NAME = DatabaseSettingsTest.COUCH_DB_USERS;
+
+    private UserDatabaseHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), DB_NAME);
+        handler = new UserDatabaseHandler(DatabaseSettingsTest.getConfiguredClient(), DB_NAME);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), DB_NAME);
+    }
+
+    @Test
+    public void testReadFileCsv_parsesGroupsAndEmails() {
+        String path = getClass().getClassLoader()
+                .getResource("test-department-users.csv").getPath();
+
+        Map<String, List<String>> result = handler.readFileCsv(path);
+
+        assertEquals("Expected two department entries", 2, result.size());
+        assertTrue("Engineering entry should exist", result.containsKey("Engineering"));
+        assertEquals("Engineering should have two members",
+                List.of("alice@example.org", "bob@example.org"),
+                result.get("Engineering"));
+        assertTrue("Legal entry should exist", result.containsKey("Legal"));
+        assertEquals("Legal should have one member",
+                List.of("carol@example.org"),
+                result.get("Legal"));
+    }
+
+    @Test
+    public void testReadFileCsv_nonExistentFile_returnsEmptyMap() {
+        Map<String, List<String>> result = handler.readFileCsv("/nonexistent/path/file.csv");
+        assertTrue("Should return empty map for missing file", result.isEmpty());
+    }
+}

--- a/backend/users/src/test/resources/test-department-users.csv
+++ b/backend/users/src/test/resources/test-department-users.csv
@@ -1,0 +1,4 @@
+Department,Email
+Engineering,alice@example.org
+,bob@example.org
+Legal,carol@example.org


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? Closes #3966 
> * Did you add or update any new dependencies that are required for your change? NO

- Wrapped `CSVReader` (and its underlying `FileReader`) in a try-with-resources block in `UserDatabaseHandler.readFileCsv`
- Closing `CSVReader` via try-with-resources automatically closes the wrapped `FileReader`, releasing the file descriptor on all exit paths
- Added an integration test `UserDatabaseHandlerTest` with two test cases and a CSV fixture to verify correct parsing behaviour

### Suggest Reviewer
> @ag4ums @arunazhakesan @KoukiHama @GMishx 

### How To Test?
> How should these changes be tested by the reviewer?

1. Check out this branch.
2. Build and run tests for the `backend/users` module (requires a running CouchDB):
mvn -pl backend/users test
3. Confirm `UserDatabaseHandlerTest` passes — it validates that a CSV with two departments is parsed into the correct map, and that a non-existent file path returns an empty map.

> Have you implemented any additional tests?

Yes. Added `UserDatabaseHandlerTest` (new file) with:
- `testReadFileCsvParsesGroupsAndEmails` — verifies correct parsing of departments and emails from a CSV fixture
- `testReadFileCsvNonExistentFileReturnsEmptyMap` — verifies a missing file is handled gracefully
Also added `backend/users/src/test/resources/test-department-users.csv` as the test fixture.

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
