### PR TITLE
Feat/3983 clixml parser test coverage

### DIFF
--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
@@ -177,4 +177,80 @@ public class CLIParserTest {
         assertThat(res.getLicenseInfo(), notNullValue());
         assertThat(res.getLicenseInfo().getFilenames(), contains("a.xml"));
     }
+
+    @Test
+    public void testIsApplicableToFailsOnNonXmlExtension() throws Exception {
+        // A file whose name does not end in .xml must be rejected without reading content.
+        AttachmentContent txtContent = new AttachmentContent().setId("B1").setFilename("report.txt").setContentType("text/plain");
+        Attachment txtAttachment = new Attachment("B1", "report.txt").setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_XML);
+        CLIParser txtParser = new CLIParser(connector, a -> txtContent);
+        assertFalse(txtParser.isApplicableTo(txtAttachment, new User(), new Project()));
+    }
+
+    @Test
+    public void testGetCLIWithNoLicenseElements_returnsSuccessWithEmptyLicenseSet() throws Exception {
+        // A valid CLI XML that contains no <License> elements must parse successfully
+        // and return an empty licence set rather than throwing.
+        String noLicensesXml =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<ComponentLicenseInformation component=\"empty-comp\" creator=\"test\" date=\"01/01/2024\">\n" +
+                "<Copyright>\n" +
+                "<Content><![CDATA[Copyright 2024 Example Corp.]]></Content>\n" +
+                "<Files><![CDATA[src/main.c]]></Files>\n" +
+                "</Copyright>\n" +
+                "</ComponentLicenseInformation>";
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(noLicensesXml)).setCharset(StandardCharsets.UTF_8).get()
+        );
+        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project())
+                .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result list"));
+        assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
+        assertThat(res.getLicenseInfo().getLicenseNamesWithTexts(), is(empty()));
+        assertThat(res.getLicenseInfo().getCopyrights(), containsInAnyOrder("Copyright 2024 Example Corp."));
+    }
+
+    @Test
+    public void testGetCLIWithSpecialCharactersInCDATA_preservesTextVerbatim() throws Exception {
+        // CDATA sections must pass through <, >, and & literally without XML-escaping them.
+        String specialCharsXml =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<ComponentLicenseInformation component=\"special\" creator=\"test\" date=\"01/01/2024\">\n" +
+                "<License type=\"global\" name=\"Custom\" spdxidentifier=\"n/a\">\n" +
+                "<Content><![CDATA[Use <this> library & tools freely.]]></Content>\n" +
+                "<Files><![CDATA[lib/]]></Files>\n" +
+                "</License>\n" +
+                "</ComponentLicenseInformation>";
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(specialCharsXml)).setCharset(StandardCharsets.UTF_8).get()
+        );
+        LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project())
+                .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result list"));
+        assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
+        assertThat(res.getLicenseInfo().getLicenseNamesWithTexts().size(), is(1));
+        String licenseText = res.getLicenseInfo().getLicenseNamesWithTexts().iterator().next().getLicenseText();
+        assertThat(licenseText, containsString("<this>"));
+        assertThat(licenseText, containsString("&"));
+    }
+
+    @Test
+    public void testGetObligationsWithNoObligationElements_returnsSuccessWithEmptyList() throws Exception {
+        // A valid CLI XML with no <Obligation> elements must return SUCCESS and an empty list.
+        String noObligationsXml =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<ComponentLicenseInformation component=\"no-oblig\" creator=\"test\" date=\"01/01/2024\">\n" +
+                "<License type=\"global\" name=\"MIT\" spdxidentifier=\"MIT\">\n" +
+                "<Content><![CDATA[MIT License text.]]></Content>\n" +
+                "<Files><![CDATA[src/]]></Files>\n" +
+                "</License>\n" +
+                "</ComponentLicenseInformation>";
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(noObligationsXml)).setCharset(StandardCharsets.UTF_8).get()
+        );
+        ObligationParsingResult oblRes = parser.getObligations(cliAttachment, new User(), new Project());
+        assertThat(oblRes.getStatus(), is(ObligationInfoRequestStatus.SUCCESS));
+        assertThat(oblRes.getObligationsAtProjectSize(), is(0));
+    }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

- Added 4 new edge-case test methods to the existing `CLIParserTest` class:
  1. `testIsApplicableToFailsOnNonXmlExtension` — verifies that a `.txt` attachment is rejected without reading content
  2. `testGetCLIWithNoLicenseElements_returnsSuccessWithEmptyLicenseSet` — verifies that a valid CLI XML with no `<License>` elements returns `SUCCESS` with an empty licence set rather than throwing
  3. `testGetCLIWithSpecialCharactersInCDATA_preservesTextVerbatim` — verifies that `<`, `>`, and `&` inside CDATA sections are preserved literally in the parsed licence text
  4. `testGetObligationsWithNoObligationElements_returnsSuccessWithEmptyList` — verifies that a CLI XML with no `<Obligation>` elements returns `SUCCESS` with an empty obligation list

> * Which issue is this pull request belonging to and how is it solving it? Closes #3983 
> * Did you add or update any new dependencies that are required for your change? No The tests use only the existing Mockito and JUnit infrastructure already present in the `backend/licenseinfo` module.

### Suggest Reviewer
@ag4ums @arunazhakesan @KoukiHama @GMishx

### How To Test?
> How should these changes be tested by the reviewer?

1. Check out this branch.
2. Build and run the `backend/licenseinfo` tests:
mvn -pl backend/licenseinfo test
3. Confirm all 4 new test methods pass alongside the existing tests.

> Have you implemented any additional tests?
Yes, the entire PR consists of test additions. Four new test methods cover: non-XML file extension rejection, no-licence elements graceful handling, CDATA special character preservation, and no-obligation elements graceful handling.

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
