### PR TITLE
fix(Rest) : Acknowledgement missing from ReadmeOSS for license with same name.

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -805,12 +805,12 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
                 String licenseName = entry.getKey();
                 Set<String> acknowledgementSet = entry.getValue();
                 if (!acknowledgementSet.isEmpty()) {
-                    // Print license name as heading
-                    XWPFRun licenseRun = document.createParagraph().createRun();
-                    addFormattedText(licenseRun, licenseName + ":", FONT_SIZE, true);
-                    // Print each acknowledgement under the license name
+                    // Print license name before each acknowledgement text
                     for (String acknowledgement : acknowledgementSet) {
+                        XWPFRun licenseRun = document.createParagraph().createRun();
+                        addFormattedText(licenseRun, licenseName, FONT_SIZE, true);
                         setText(document.createParagraph().createRun(), nullToEmptyString(acknowledgement));
+                        addNewLines(document, 1);
                     }
                 }
             }

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -257,12 +257,9 @@ public abstract class OutputGenerator<T> {
                 Map<String, Set<String>> licenseAckMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
                 for (LicenseNameWithText lnt : licenseInfo.getLicenseNamesWithTexts()) {
                     String licenseName = lnt.getLicenseName();
-                    Set<String> acknowledgementsSet = new HashSet<>();
-                    if(lnt.getAcknowledgements()!=null && !lnt.getAcknowledgements().isEmpty()){
-                        acknowledgementsSet.add(lnt.getAcknowledgements());
-                    }
-                    if (!acknowledgementsSet.isEmpty()) {
-                        licenseAckMap.put(licenseName, new TreeSet<>(acknowledgementsSet));
+                    String ack = lnt.getAcknowledgements();
+                    if (licenseName != null && ack != null && !ack.trim().isEmpty()) {
+                        licenseAckMap.computeIfAbsent(licenseName, k -> new TreeSet<>()).add(ack.trim());
                     }
                 }
                 if (!licenseAckMap.isEmpty()) {

--- a/backend/licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -42,18 +42,23 @@ Details
 
 ## Acknowledgments
 ##
-#set($acks = [])
+#set($licenseAckMap = [])
 #if(${acknowledgements.get($releaseName)})
-#set($acks = $acknowledgements.get($releaseName))
-#if($acks.size() > 0)
+#set($licenseAckMap = $acknowledgements.get($releaseName))
+#if($licenseAckMap.size() > 0)
 Acknowledgements for $releaseName
 ----------------
+#foreach($licenseName in $licenseAckMap.keySet())
+#set($acks = $licenseAckMap.get($licenseName))
 #foreach($ack in ${acks})
-$ack
+$licenseName
+    $ack
+
 #end## foreach($ack in ${acks})
+#end## foreach($licenseName in $licenseAckMap.keySet())
 
 
-#end## if($acks.size() > 0)
+#end## if($licenseAckMap.size() > 0)
 #end## if(${acknowledgements.get($releaseName)})
 ##
 ##

--- a/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -136,9 +136,9 @@
                         #set($licenseAckMap = $acknowledgements.get($releaseName))
     <pre class="acknowledgements">
 #foreach($licenseName in $licenseAckMap.keySet())
-    <strong>$esc.xml($licenseName)</strong><br/>
     #set($acks = $licenseAckMap.get($licenseName))
 #foreach($ack in ${acks})
+     <strong>$esc.xml($licenseName)</strong><br/>
      #set($containsLink = $ack.matches($anchorRegEx))
      #set($containsScript = $ack.matches($scriptRegEx))
      #set($ackAsHtml = $esc.xml($ack))
@@ -146,6 +146,7 @@
      #set($ackAsHtml = $ack)
      #end
      $ackAsHtml<br/>
+  <br/>
      #end
      #end
          </pre>


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Closes #4009 


### Suggest Reviewer
> @GMishx 

### How To Test?
> How should these changes be tested by the reviewer?
Login to sw360 application and directed to Projects tab
Open any project having licenseinfo data
Download readmeoss file and can find the difference in the generated file.



### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
