### PR TITLE
fix(rest): filter license obligations by project release main licenses when no CLI attachment exists.

### DIFF
--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -629,7 +629,11 @@ public class LicenseDatabaseHandler {
         // only a new license gets its id from the shortname. Id of an existing license isn't supposed to be changed anyway
         if (!license.isSetId()) license.setId(inputLicense.getShortname());
         license.unsetShortname();
-        license.setLicenseTypeDatabaseId(inputLicense.getLicenseTypeDatabaseId());
+        if (CommonUtils.isNotNullEmptyOrWhitespace(inputLicense.getLicenseTypeDatabaseId())) {
+            license.setLicenseTypeDatabaseId(inputLicense.getLicenseTypeDatabaseId());
+        } else {
+            license.unsetLicenseTypeDatabaseId();
+        }
         license.unsetLicenseType();
         license.setOSIApproved(Optional.ofNullable(inputLicense.getOSIApproved())
                 .orElse(Quadratic.NA));
@@ -649,7 +653,8 @@ public class LicenseDatabaseHandler {
 
     public License setLicenseForChangelogs(License license) throws SW360Exception {
         License licenseForChangelogs = license.deepCopy();
-        if (licenseForChangelogs.isSetLicenseTypeDatabaseId()) {
+        if (licenseForChangelogs.isSetLicenseTypeDatabaseId()
+                && !licenseForChangelogs.getLicenseTypeDatabaseId().isEmpty()) {
             LicenseType licenseTypeForChangelogs = getLicenseTypeById(licenseForChangelogs.getLicenseTypeDatabaseId());
             licenseForChangelogs.setLicenseType(licenseTypeForChangelogs);
             licenseForChangelogs.unsetLicenseTypeDatabaseId();

--- a/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -409,8 +409,21 @@ public class LicenseHandler implements LicenseService.Iface {
     public Map<PaginationData, List<Obligation>> searchObligationTextPaginated(
             String searchText, ObligationLevel obligationLevel, PaginationData pageData
     ) {
-        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) || obligationLevel != null) {
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             return obligationSearchHandler.searchWithPagination(searchText, obligationLevel, pageData);
+        }
+        if (obligationLevel != null) {
+            Map<PaginationData, List<Obligation>> result = handler.getObligationsPaginated(pageData);
+            if (result == null || result.isEmpty()) {
+                return result;
+            }
+            Map.Entry<PaginationData, List<Obligation>> entry = result.entrySet().iterator().next();
+            List<Obligation> filtered = entry.getValue().stream()
+                    .filter(o -> obligationLevel.equals(o.getObligationLevel()))
+                    .collect(java.util.stream.Collectors.toList());
+            PaginationData pd = entry.getKey();
+            pd.setTotalRowCount(filtered.size());
+            return java.util.Collections.singletonMap(pd, filtered);
         }
         return handler.getObligationsPaginated(pageData);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3291,10 +3291,28 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             return new ResponseEntity<String>("No release linked to the project", HttpStatus.NO_CONTENT);
         }
         Map<String, AttachmentUsage> licenseInfoAttachmentUsage = projectService.getLicenseInfoAttachmentUsage(id);
-        if(licenseInfoAttachmentUsage.size() == 0) {
-            return new ResponseEntity<String>("No approved CLI or licenseInfo attachment usage present for the project", HttpStatus.NO_CONTENT);
+        Map<String, Set<Release>> licensesFromAttachmentUsage;
+        if (licenseInfoAttachmentUsage.isEmpty()) {
+            // Fallback: build license->releases map from release mainLicenseIds
+            licensesFromAttachmentUsage = new HashMap<>();
+            for (String releaseId : sw360Project.getReleaseIdToUsage().keySet()) {
+                try {
+                    Release release = releaseService.getReleaseForUserById(releaseId, sw360User);
+                    if (release != null && !CommonUtils.isNullOrEmptyCollection(release.getMainLicenseIds())) {
+                        for (String licenseId : release.getMainLicenseIds()) {
+                            licensesFromAttachmentUsage.computeIfAbsent(licenseId, k -> new HashSet<>()).add(release);
+                        }
+                    }
+                } catch (TException e) {
+                    log.warn("Error fetching release {} for licenseDbObligations fallback: {}", releaseId, e.getMessage());
+                }
+            }
+        } else {
+            licensesFromAttachmentUsage = projectService.getLicensesFromAttachmentUsage(licenseInfoAttachmentUsage, sw360User);
         }
-        Map<String, Set<Release>> licensesFromAttachmentUsage = projectService.getLicensesFromAttachmentUsage(licenseInfoAttachmentUsage, sw360User);
+        if (licensesFromAttachmentUsage.isEmpty()) {
+            return new ResponseEntity<String>("No license obligations found for the project releases", HttpStatus.NO_CONTENT);
+        }
         Map<String, ObligationStatusInfo> licenseObligation = projectService.getLicenseObligationData(licensesFromAttachmentUsage, sw360User);
 
         Map<String, Object> responseBody = createPaginationMetadata(pageable, licenseObligation);
@@ -3559,8 +3577,25 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         final Project sw360Project = projectService.getProjectForUserById(id, sw360User);
         Map<String, AttachmentUsage> licenseInfoAttachmentUsage = projectService.getLicenseInfoAttachmentUsage(id);
-        Map<String, Set<Release>> licensesFromAttachmentUsage = projectService.getLicensesFromAttachmentUsage(
-                licenseInfoAttachmentUsage, sw360User);
+        Map<String, Set<Release>> licensesFromAttachmentUsage;
+        if (licenseInfoAttachmentUsage.isEmpty()) {
+            licensesFromAttachmentUsage = new HashMap<>();
+            for (String releaseId : CommonUtils.nullToEmptyMap(sw360Project.getReleaseIdToUsage()).keySet()) {
+                try {
+                    Release release = releaseService.getReleaseForUserById(releaseId, sw360User);
+                    if (release != null && !CommonUtils.isNullOrEmptyCollection(release.getMainLicenseIds())) {
+                        for (String licenseId : release.getMainLicenseIds()) {
+                            licensesFromAttachmentUsage.computeIfAbsent(licenseId, k -> new HashSet<>()).add(release);
+                        }
+                    }
+                } catch (TException e) {
+                    log.warn("Error fetching release {} for addLicenseObligations fallback: {}", releaseId, e.getMessage());
+                }
+            }
+        } else {
+            licensesFromAttachmentUsage = projectService.getLicensesFromAttachmentUsage(
+                    licenseInfoAttachmentUsage, sw360User);
+        }
         Map<String, ObligationStatusInfo> licenseObligation = projectService.getLicenseObligationData(licensesFromAttachmentUsage, sw360User);
         Map<String, ObligationStatusInfo> selectedLicenseObligation = new HashMap<String, ObligationStatusInfo>();
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: Close #4016

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. create license obligation using admin -> obligation (for ex: licObj 1, licObj 2, licObj 3)
2. create license (for ex: MIT) and add created license obligation (for ex: licObj 1, licObj 2, licObj 3)
4. create release (for ex: release1) and add the license(MIT) in main license field.
3. navigate to project tab and link the release (release1), which has a license added
4. navigate to obligation tab
5. click on "Add obligation from license database" button
6. new window will open and there we see the lists of license obligation(licObj 1, licObj 2, licObj 3)
7. select one or many license obligation and "Add"

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
