### PR TITLE
fix(report): fix the file traversal path vulnerability.

### DIFF
--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -86,12 +86,19 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
         final SXSSFWorkbook workbook = new SXSSFWorkbook();
         String token = UUID.randomUUID().toString();
         String filePath = TMP_EXPORTEDFILES + user.getEmail() + SLASH + "file" + SLASH;
-        File file;
+        String relativePath;
         try {
             File dir = new File(filePath);
-            dir.mkdirs();
-            file = new File(dir.getPath() + SLASH + SW360Utils.getCreatedOn() + "_" + token);
-            file.createNewFile();
+            if (!dir.mkdirs() && !dir.exists()) {
+                log.error("Failed to create export directory: {}", dir.getAbsolutePath());
+                throw new IOException("Failed to create export directory: " + dir.getAbsolutePath());
+            }
+            File file = new File(dir.getPath() + SLASH + SW360Utils.getCreatedOn() + "_" + token);
+            if (!file.createNewFile()) {
+                log.error("Failed to create export file: {}", file.getAbsolutePath());
+                throw new IOException("Failed to create export file: " + file.getAbsolutePath());
+            }
+            relativePath = user.getEmail() + SLASH + "file" + SLASH + file.getName();
             SXSSFSheet sheet = workbook.createSheet("Data");
 
             /** Adding styles to cells */
@@ -118,21 +125,29 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
         } finally {
             workbook.close();
         }
-        return file.getPath();
+        return relativePath;
     }
 
-    public InputStream downloadExcelSheet(String token) {
-        InputStream stream = null;
+    public InputStream downloadExcelSheet(String token) throws FileNotFoundException {
         try {
-            File file = new File(token);
+            File file = new File(TMP_EXPORTEDFILES + token);
+            String canonicalPath = file.getCanonicalPath();
+            String allowedDir = new File(TMP_EXPORTEDFILES).getCanonicalPath();
+            if (!canonicalPath.startsWith(allowedDir + File.separator)) {
+                log.error("Path traversal attempt detected. Token: {}", token);
+                throw new FileNotFoundException("Invalid file token: " + token);
+            }
             if (file.exists()) {
-                stream = new FileInputStream(new File(token));
+                return new FileInputStream(file);
+            } else {
+                throw new FileNotFoundException("Report file not found for token: " + token);
             }
         } catch (FileNotFoundException e) {
-            log.error("Error getting file", e);
+            throw e;
+        } catch (IOException e) {
+            log.error("Error resolving canonical path for token: {}", token, e);
+            throw new FileNotFoundException("Unable to validate file path for token: " + token);
         }
-
-        return stream;
     }
 
     /**

--- a/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ExcelExporterDownloadTest.java
+++ b/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ExcelExporterDownloadTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.exporter;
+
+import org.eclipse.sw360.exporter.helper.ExporterHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link ExcelExporter#downloadExcelSheet(String)} to verify
+ * path traversal protection.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExcelExporterDownloadTest {
+
+    @Mock
+    private ExporterHelper<?> helper;
+
+    private ExcelExporter<?, ?> exporter;
+    private File validTempFile;
+
+    @Before
+    public void setUp() throws IOException {
+        exporter = new ExcelExporter<>(helper);
+        File dir = new File("/tmp/testuser@example.com/file/");
+        dir.mkdirs();
+        validTempFile = new File(dir, "2026-04-01_test-report");
+        try (FileWriter writer = new FileWriter(validTempFile)) {
+            writer.write("report content");
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (validTempFile != null && validTempFile.exists()) {
+            validTempFile.delete();
+        }
+    }
+
+    @Test
+    public void shouldAllowValidFileUnderTmp() throws IOException {
+        InputStream stream = exporter.downloadExcelSheet("testuser@example.com/file/" + validTempFile.getName());
+        assertNotNull("Valid relative token should return file stream", stream);
+        stream.close();
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void shouldBlockPathTraversalWithDotDot() throws FileNotFoundException {
+        exporter.downloadExcelSheet("../etc/passwd");
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void shouldBlockDeepPathTraversal() throws FileNotFoundException {
+        exporter.downloadExcelSheet("user/../../../etc/shadow");
+    }
+}


### PR DESCRIPTION

Issue: The report download endpoint GET /api/reports/download accepted a token parameter that was used directly as a file path without any validation. An unauthenticated attacker could supply an arbitrary path to read any file readable by the application process on the server.

How To Test:
-> Generate a report.
-> Test legitimate download  (http://localhost:8080/resource/api/reports/download?module=projects \
  &token=<user-email>/file/<timestamp>_<uuid>&user=<user-email>)                 # Expected: 200 OK, Excel file returned
-> Test path traversal attack (http://localhost:8080/resource/api/reports/download?module=projects \
  &token=../etc/passwd&user=<user-email>            Expected: 500 error, no file content returned

