### PR TITLE
Fixed typo in Sw360AuthorizationServerConfiguration

### DIFF
--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
@@ -36,7 +36,7 @@ public class Sw360AuthorizationServerConfiguration {
 
 	@Order(1)
 	@Bean
-	public SecurityFilterChain appSecurtiy(HttpSecurity httpSecurity) throws Exception {
+	public SecurityFilterChain appSecurity(HttpSecurity httpSecurity) throws Exception {
 		SimpleAuthenticationEntryPoint saep = new SimpleAuthenticationEntryPoint();
 		httpSecurity.authorizeHttpRequests(
 				authz -> authz


### PR DESCRIPTION


### Summary

Corrects a method name typo in `Sw360AuthorizationServerConfiguration` (`appSecurtiy` → `appSecurity`) so it matches the intended meaning and aligns with `SecurityConfig.appSecurity` in the authorization-server module. Behavior is unchanged; only the `@Bean` method name (and thus the default Spring bean name) is updated.


### Issue

- **Problem:** Test security config used a misspelled method name `appSecurtiy` instead of `appSecurity`.
- **Impact:** None on runtime behavior; readability and consistency only.

