### PR TITLE
fix(rest): resolve Authorization header lookup via servlet getHeader

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilter.java
@@ -28,9 +28,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Profile("!SECURITY_MOCK")
 public class ApiTokenAuthenticationFilter implements Filter {
@@ -58,11 +55,11 @@ public class ApiTokenAuthenticationFilter implements Filter {
         if (context.getAuthentication() != null && context.getAuthentication().isAuthenticated()) {
             log.trace("Already authenticated");
         } else {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
             try {
-                Map<String, String> headers = Collections.list(((HttpServletRequest) request).getHeaderNames()).stream()
-                        .collect(Collectors.toMap(h -> h, ((HttpServletRequest) request)::getHeader));
-                if (!headers.isEmpty() && headers.containsKey(AUTHENTICATION_TOKEN_PARAMETER)) {
-                    String authorization = headers.get(AUTHENTICATION_TOKEN_PARAMETER);
+                String authorization = httpRequest.getHeader(AUTHENTICATION_TOKEN_PARAMETER);
+                if (authorization != null && !authorization.isBlank()) {
                     String[] token = authorization.trim().split("\\s+");
                     if (token.length == 2 && token[0].equalsIgnoreCase("token")) {
                         Authentication auth = authenticationManager.authenticate(new ApiTokenAuthentication(token[1]));
@@ -71,19 +68,20 @@ public class ApiTokenAuthenticationFilter implements Filter {
                         Authentication auth = authenticationManager.authenticate(new ApiTokenAuthentication(token[1]).setType(AuthType.JWKS));
                         SecurityContextHolder.getContext().setAuthentication(auth);
                     }
-                } else if (Sw360ResourceServer.IS_JWKS_VALIDATION_ENABLED && !headers.isEmpty()
-                        && headers.containsKey(OIDC_AUTHENTICATION_TOKEN_PARAMETER)) {
-                    String authorization = headers.get(OIDC_AUTHENTICATION_TOKEN_PARAMETER);
-                    String[] token = authorization.trim().split("\\s+");
-                    if (token.length == 2 && token[0].equalsIgnoreCase("Bearer")) {
-                        Authentication auth = authenticationManager.authenticate(new ApiTokenAuthentication(token[1]).setType(AuthType.JWKS));
-                        SecurityContextHolder.getContext().setAuthentication(auth);
+                } else if (Sw360ResourceServer.IS_JWKS_VALIDATION_ENABLED) {
+                    String oidcAuthorization = httpRequest.getHeader(OIDC_AUTHENTICATION_TOKEN_PARAMETER);
+                    if (oidcAuthorization != null && !oidcAuthorization.isBlank()) {
+                        String[] token = oidcAuthorization.trim().split("\\s+");
+                        if (token.length == 2 && token[0].equalsIgnoreCase("Bearer")) {
+                            Authentication auth = authenticationManager.authenticate(new ApiTokenAuthentication(token[1]).setType(AuthType.JWKS));
+                            SecurityContextHolder.getContext().setAuthentication(auth);
+                        }
                     }
                 }
             } catch (AuthenticationException e) {
                 log.error("Authentication failed: {}", e.getMessage());
                 SecurityContextHolder.clearContext();
-                authenticationEntryPoint.commence((HttpServletRequest) request, (HttpServletResponse) response, e);
+                authenticationEntryPoint.commence(httpRequest, httpResponse, e);
             }
         }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary

`ApiTokenAuthenticationFilter` built a map of headers using whatever casing `getHeaderNames()` returns, then used `containsKey("authorization")` / `containsKey("oidcauthorization")`. `Map` keys are case-sensitive, so on stacks that expose header names with different casing (e.g. `Authorization`), the filter could skip token / OIDC handling even though `getHeader("Authorization")` would return the value.

The filter now uses `HttpServletRequest.getHeader(...)` for the standard `Authorization` header and for the OIDC custom header. The Servlet API defines header lookup as case-insensitive, so behavior is portable. Null/blank checks preserve the previous “header absent or empty” branching. `HttpServletResponse` is cast once in the unauthenticated branch and reused in `AuthenticationEntryPoint.commence(...)`.

**Dependencies:** None.

### How To Test?

- Run the `rest/resource-server` test suite (`mvn -pl rest/resource-server test -Dbase.deploy.dir=/tmp/sw360-deploy`).
- Optional manual check: call a protected API with `Authorization: token …` or `Authorization: Bearer …` (and, if JWKS is enabled, the OIDC custom header) and confirm responses match the previous deployment.
- **Additional tests:** Not added; change is a straight swap to the servlet API for header reads; existing integration tests should cover the filter in context.