### PR TITLE
fix(project): fix NPE and attachment client leak in saveAttachmentUsages

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -521,24 +521,23 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     private void saveAttachmentUsages(Project project) {
-        AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
         String projectId = project.getId();
         List<String> projectPaths = new ArrayList<>();
-
-        buildProjectPaths(project, null, projectPaths, new HashSet<>());
-        projectPaths.remove(project.getId());
         try {
+            buildProjectPaths(project, null, projectPaths, new HashSet<>());
+            projectPaths.remove(projectId);
             if (!projectPaths.isEmpty()) {
-                List<AttachmentUsage> newAttachmentUsages = parseAttachmentUsages(projectPaths,projectId);
+                AttachmentService.Iface attachmentClient = thriftClients.makeAttachmentClient();
+                List<AttachmentUsage> newAttachmentUsages = parseAttachmentUsages(projectPaths, projectId, attachmentClient);
                 attachmentClient.makeAttachmentUsages(newAttachmentUsages);
             }
-        } catch (TException e) {
+        } catch (TException | RuntimeException e) {
             log.error("Saving attachment usages for project " + projectId + " failed", e);
         }
     }
 
     void buildProjectPaths(Project project, String parentPath, List<String> results, Set<String> visited) {
-        if (project == null || visited.contains(project.getId())) {
+        if (project == null || project.getId() == null || visited.contains(project.getId())) {
             return;
         }
         visited.add(project.getId());
@@ -553,31 +552,29 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
     }
 
-    private List<AttachmentUsage> parseAttachmentUsages(List<String> projectPaths, String projectId) {
+    private List<AttachmentUsage> parseAttachmentUsages(List<String> projectPaths, String projectId,
+            AttachmentService.Iface attachmentClient) throws TException {
         List<AttachmentUsage> result = new ArrayList<>();
-        try {
-            for(String projectPath: projectPaths) {
-                String[] pathArray = projectPath.split(":");
-                String subProjectId = pathArray[pathArray.length-1];
-                List<AttachmentUsage> subProjectAttachmentUsages = thriftClients.makeAttachmentClient().getUsedAttachments(Source.projectId(subProjectId), null);
+        for (String projectPath : projectPaths) {
+            String[] pathArray = projectPath.split(":");
+            String subProjectId = pathArray[pathArray.length - 1];
+            List<AttachmentUsage> subProjectAttachmentUsages =
+                    attachmentClient.getUsedAttachments(Source.projectId(subProjectId), null);
 
-                for(AttachmentUsage usage: subProjectAttachmentUsages) {
-                    if (!usage.getOwner().isSetReleaseId()) {
-                        continue;
-                    }
-                    String releaseId = usage.getOwner().getReleaseId();
-                    String attachmentContentId = usage.getAttachmentContentId();
-                    AttachmentUsage newUsage = new AttachmentUsage(Source.releaseId(releaseId), attachmentContentId, Source.projectId(projectId));
-                    final UsageData usageData;
-                    LicenseInfoUsage licenseInfoUsage = new LicenseInfoUsage(Collections.emptySet());
-                    licenseInfoUsage.setProjectPath(projectPath);
-                    usageData = UsageData.licenseInfo(licenseInfoUsage);
-                    newUsage.setUsageData(usageData);
-                    result.add(newUsage);
+            for (AttachmentUsage usage : subProjectAttachmentUsages) {
+                if (!usage.getOwner().isSetReleaseId()) {
+                    log.warn("Skipping attachment usage with non-release owner for sub-project {}", subProjectId);
+                    continue;
                 }
+                String releaseId = usage.getOwner().getReleaseId();
+                String attachmentContentId = usage.getAttachmentContentId();
+                AttachmentUsage newUsage = new AttachmentUsage(
+                        Source.releaseId(releaseId), attachmentContentId, Source.projectId(projectId));
+                LicenseInfoUsage licenseInfoUsage = new LicenseInfoUsage(Collections.emptySet());
+                licenseInfoUsage.setProjectPath(projectPath);
+                newUsage.setUsageData(UsageData.licenseInfo(licenseInfoUsage));
+                result.add(newUsage);
             }
-        } catch (TException e) {
-            log.error("Saving attachment usages for project " + projectId + " failed", e);
         }
         return result;
     }


### PR DESCRIPTION
Was going through the project attachment usage flow and noticed a few things that felt off, so fixed them together since they're all in the same method chain.

- No specific issue tracked yet, but this silently breaks license-info generation for projects with sub-project hierarchies when a Thrift/Cloudant error occurs mid-loop, and the NPE in `buildProjectPaths` can surface when project objects come in partially constructed (e.g. from a moderation approval path). 
- No new dependencies.

Issue: - NA

### Suggest Reviewer
@GMishx 

### How To Test?

1. Create a project with at least 2–3 linked sub-projects, each having releases with source attachments
2. Trigger a license-info generation — attachment usages should propagate correctly from sub-projects to the parent
3. To hit the old leak path: add a breakpoint or log in `makeAttachmentClient()` and count how many times it gets called; should now be once total, not once per sub-project
4. For the NPE: pass a project object with a null id into `buildProjectPaths`, old code throws, new code returns cleanly
5. For the `RuntimeException` catch: simulate a Cloudant connection failure during `saveAttachmentUsages`, old code would let it bubble as a 500, new code logs it and continues

No new automated tests added; the affected methods are `private` and the setup for integration testing this path is fairly heavy. 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR