### PR TITLE
fix(rest): fix NPEs and missing security annotation in ProjectController

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -481,7 +481,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Project sw360Project = projectService.getProjectForUserById(id, sw360User);
 
         //check the below condition when releaseRelation is not null
-        if (releaseRelation != null) {
+        if (releaseRelation != null && sw360Project.getReleaseIdToUsage() != null) {
             Map<String, ProjectReleaseRelationship> filteredReleaseIdToUsage = sw360Project.getReleaseIdToUsage().entrySet().stream()
                     .filter(entry -> entry.getValue().getReleaseRelation() == releaseRelation)
                     .collect(Collectors.toMap(
@@ -500,13 +500,15 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 .collect(Collectors.toSet());
 
         // Filter the releaseIdToUsage map
-        Map<String, ProjectReleaseRelationship> filteredReleaseIdData = sw360Project.getReleaseIdToUsage().entrySet().stream()
-                .filter(entry -> validReleaseIds.contains(entry.getKey()))
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue
-                ));
-        sw360Project.setReleaseIdToUsage(filteredReleaseIdData);
+        if (sw360Project.getReleaseIdToUsage() != null) {
+            Map<String, ProjectReleaseRelationship> filteredReleaseIdData = sw360Project.getReleaseIdToUsage().entrySet().stream()
+                    .filter(entry -> validReleaseIds.contains(entry.getKey()))
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            Map.Entry::getValue
+                    ));
+            sw360Project.setReleaseIdToUsage(filteredReleaseIdData);
+        }
 
         Map<String, ProjectReleaseRelationship> releaseIdToUsageMap = sw360Project.getReleaseIdToUsage();
         List<EntityModel<Release>> releaseList = releases.stream().map(sw360Release -> wrapTException(() -> {
@@ -736,6 +738,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     )
             }
     )
+    @PreAuthorize("hasAuthority('WRITE')")
     @DeleteMapping(value = PROJECTS_URL + "/{id}")
     public ResponseEntity deleteProject(
             @Parameter(description = "Project ID")
@@ -961,7 +964,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Project sourceProj = projectService.getProjectForUserById(id, sw360User);
         Map<String, String> responseMap = new HashMap<>();
-        HttpStatus status = null;
+        if (projectIdsInRequestBody == null || projectIdsInRequestBody.isEmpty()) {
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        }
+        HttpStatus status = HttpStatus.OK;
         Set<String> alreadyLinkedIds = new HashSet<>();
         Set<String> idsSentToModerator = new HashSet<>();
         Set<String> idsWithCyclicPath = new HashSet<>();


### PR DESCRIPTION
### Summary
**1. Stopping an unexpected crash:** I fixed an issue where the "License Clearing" page would crash if you opened it for a project that didn't have any releases yet. I've added a simple safety check to make sure the app handles these empty projects gracefully.
**2. Plugging a security gap:** I noticed that the "Delete Project" function wasn't properly checking for user permissions like other parts of the app do. I've now added a security check to ensure only users with the right authority can actually delete projects.
**3. Fixing a server response error:** When trying to link projects but using an empty list, the server would get confused and throw an error because it didn't know what status code to return. I've updated the logic to always return a clear response, even when there's nothing to link.

Issue:  #4033 

### Suggest Reviewer
@GMishx 

### How To Test?

**1. For the License Clearing fix:** Just try to fetch the license clearing info for any project that doesn't have any releases yet. It used to crash with a 400 error, but now it should correctly return a clean 200 OK with an empty list.
**2. For the Missing Security Annotation fix:** Try deleting a project using a user account that only has Read permissions. The request should now be immediately blocked with a 403 Forbidden, ensuring better security.
**3. For the Project Linking fix:** Try to 'link' projects but send an empty list [] in the request body. Previously, this triggered a 400 error about missing status codes, but now it handles it and returns 204 No Content.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
