### PR TITLE
fix(fossology): rollback clearingState when upload preparation fails

### DIFF
--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -262,14 +262,22 @@ public class FossologyHandler implements FossologyService.Iface {
                     furthestStep.setStepStatus(ExternalToolProcessStatus.NEW);
                     fossologyProcess.setProcessStatus(ExternalToolProcessStatus.NEW);
                     furthestStep.setResult("Upload preparation failed: " + e.getMessage());
-                    updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
+                    try {
+                        updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
+                    } catch (Exception rollbackEx) {
+                        log.error("Failed to roll back clearing state after upload failure: {}", rollbackEx.getMessage());
+                    }
                     throw e;
                 } catch (RuntimeException e) {
                     log.error("Upload preparation failed for release, rolling back clearing state: {}", e.getMessage());
                     furthestStep.setStepStatus(ExternalToolProcessStatus.NEW);
                     fossologyProcess.setProcessStatus(ExternalToolProcessStatus.NEW);
                     furthestStep.setResult("Upload preparation failed: " + e.getMessage());
-                    updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
+                    try {
+                        updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
+                    } catch (Exception rollbackEx) {
+                        log.error("Failed to roll back clearing state after upload failure: {}", rollbackEx.getMessage());
+                    }
                     throw e;
                 }
                 break;


### PR DESCRIPTION
When triggering a FOSSology upload, the handler marks the release as `SENT_TO_CLEARING_TOOL` in CouchDB before it actually tries to fetch the attachment and upload it. If anything goes wrong during that prep work (missing attachment content, transient DB error, etc.), the exception just bubbles up and the clearing state never gets reset; leaving the release permanently stuck with no way to re-trigger from the UI.

This fix wraps the risky part in a try-catch so that on any failure, we reset the step back to `NEW` and write `NEW_CLEARING` back to the document before re-throwing, the same cleanup that already happens on a normal upload failure response.

Issue: NA

### Suggest Reviewer
@GMishx 

### How To Test?

1. Create a release with a source attachment, then delete the attachment content document directly from CouchDB (simulating a stale reference or failed upload).
2. Trigger FOSSology from the release page.
3. **Before fix:** the release gets stuck at `SENT_TO_CLEARING_TOOL` even though nothing was sent. Re-triggering is blocked.
4. **After fix:** the release returns to `NEW_CLEARING` and you can retry once the attachment issue is resolved.

No new tests added; the existing FOSSology handler tests cover the upload step; manual reproduction is straightforward with a CouchDB document edit.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR