### PR TITLE
fix(rest): avoid NPE on JWKS API-token auth when user or OIDC client is missing

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.thrift.users.ClientMetadata;
 import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserAccess;
@@ -41,6 +42,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -135,13 +137,20 @@ public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
     }
 
     private User getUserFromClientId(String clientId) {
+        User user;
         try {
-            return userService.getUserFromClientId(clientId);
+            user = userService.getUserFromClientId(clientId);
         } catch (RuntimeException e) {
             log.debug("Could not find any user for the entered clientId " + clientId);
             throw new AuthenticationServiceException(
                     "Your entered OIDC token is not associated with any user for authorization.");
         }
+        if (user == null) {
+            log.debug("Could not find any user for the entered clientId " + clientId);
+            throw new AuthenticationServiceException(
+                    "Your entered OIDC token is not associated with any user for authorization.");
+        }
+        return user;
     }
 
     private Optional<RestApiToken> getApiTokenFromUser(String tokenHash, User sw360User) {
@@ -182,8 +191,19 @@ public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
     }
 
     private PreAuthenticatedAuthenticationToken authenticatedOidcUser(User user, String credentials) {
-        Set<GrantedAuthority> grantedAuthorities = getGrantedAuthoritiesFromUserAccess(
-                user.getOidcClientInfos().get(credentials).getAccess());
+        Map<String, ClientMetadata> oidcInfos = user.getOidcClientInfos();
+        ClientMetadata clientMetadata = oidcInfos == null ? null : oidcInfos.get(credentials);
+        if (clientMetadata == null) {
+            log.debug("No OIDC client metadata for clientId {} and user {}", credentials, user.getEmail());
+            throw new AuthenticationServiceException(
+                    "Your entered OIDC token is not associated with any user for authorization.");
+        }
+        UserAccess access = clientMetadata.getAccess();
+        if (access == null) {
+            throw new AuthenticationServiceException(
+                    "Your entered OIDC token is not associated with any user for authorization.");
+        }
+        Set<GrantedAuthority> grantedAuthorities = getGrantedAuthoritiesFromUserAccess(access);
         PreAuthenticatedAuthenticationToken preAuthenticatedAuthenticationToken = new PreAuthenticatedAuthenticationToken(
                 user.getEmail(), credentials, grantedAuthorities);
         preAuthenticatedAuthenticationToken.setAuthenticated(true);


### PR DESCRIPTION

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary

Hardens JWKS-based API token authentication in `ApiTokenAuthenticationProvider` so missing SW360 users or missing OIDC client metadata no longer causes a **NullPointerException** (HTTP 500). Failures are turned into **`AuthenticationServiceException`**, which Spring Security treats as an **`AuthenticationException`**, so the existing **`ApiTokenAuthenticationFilter`** path runs: context is cleared and **`AuthenticationEntryPoint`** responds with a proper auth error instead of an internal error.

**New dependencies:** None.


### Problem (flow)

1. A client calls the REST API with a **Bearer** token on the **`Authorization`** header (or **`oidcauthorization`** when JWKS is enabled), using **`AuthType.JWKS`**.
2. **`ApiTokenAuthenticationFilter`** calls **`AuthenticationManager.authenticate(...)`**, which delegates to **`ApiTokenAuthenticationProvider.authenticate`**.
3. On the JWKS branch the provider:
   - Validates the JWT (JWKS).
   - Reads the **`client_id`** claim.
   - Loads a SW360 **`User`** via **`Sw360UserService.getUserFromClientId(clientId)`** (Thrift → CouchDB lookup by OIDC client id).
4. It then called **`authenticatedOidcUser(user, clientId)`**, which did:
   - `user.getOidcClientInfos().get(credentials).getAccess()` **without null checks**.

**Failure modes that led to NPE**

- **`user == null`**: The backend can return **no user** for that `client_id` (e.g. token valid in IdP but client not linked in SW360). The old code did not treat a **null** return like a failed lookup; it only wrapped **exceptions** in **`AuthenticationServiceException`**.
- **`getOidcClientInfos()` is null** or **has no entry for `client_id`**: Possible with inconsistent data or edge cases; **`.get(...)`** returns **null**, then **`.getAccess()`** NPEs.
- **`getAccess()` null**: Unlikely for normal Thrift data but unguarded.

An NPE is a **`RuntimeException`**, **not** an **`AuthenticationException`**, so the filter’s **`catch (AuthenticationException)`** did **not** handle it → request typically ended as **500** instead of a controlled auth failure.

### Fix (what I changed)

1. **`getUserFromClientId`**: After the service call, if **`user == null`**, throw **`AuthenticationServiceException`** with the same message already used when lookup fails via exception (*“Your entered OIDC token is not associated with any user for authorization.”*).
2. **`authenticatedOidcUser`**: Resolve **`ClientMetadata`** safely:
   - Read **`oidcClientInfos`** once into a local **`Map`**.
   - If the map is missing, or there is **no** entry for the **`client_id`**, or **`getAccess()`** is null, throw the same **`AuthenticationServiceException`** (consistent, non-leaking failure mode).
3. Only then build **`GrantedAuthority`** from **`UserAccess`** and return **`PreAuthenticatedAuthenticationToken`** as before.

### Suggest reviewer

@GMishx @KoukiHama @rudra-superrr @bibhuti230185 


### How to test?

1. Build: `mvn -pl rest/resource-server -am test-compile -Dbase.deploy.dir=/tmp/sw360-deploy`.
2. If you can simulate a user document **without** metadata for that client id, confirm the same controlled failure (no NPE).



### Checklist

**Must:**

- [x ] All related issues are referenced in commit messages and in PR

