### PR TITLE
fix(rest): guard attachment checkStatus approval behind CLEARING_ADMIN role

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -32,6 +32,7 @@ import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.Duration;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
@@ -41,6 +42,8 @@ import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxdocument.SPDXDocumentService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.springframework.security.access.AccessDeniedException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.core.ThriftServiceProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -266,6 +269,11 @@ public class Sw360AttachmentService {
 
         CheckStatus checkStatus = newAttachment.getCheckStatus();
         if (checkStatus != null) {
+            if ((checkStatus == CheckStatus.ACCEPTED || checkStatus == CheckStatus.REJECTED)
+                    && !PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, sw360User)) {
+                throw new AccessDeniedException(
+                        "Setting checkStatus to ACCEPTED or REJECTED requires CLEARING_ADMIN role");
+            }
             attachment.setCheckStatus(checkStatus);
         }
 
@@ -398,6 +406,11 @@ public class Sw360AttachmentService {
             attachmentToUpdate.setCreatedComment(createdComment);
         }
         if (checkStatus != null) {
+            if ((checkStatus == CheckStatus.ACCEPTED || checkStatus == CheckStatus.REJECTED)
+                    && !PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)) {
+                throw new AccessDeniedException(
+                        "Setting checkStatus to ACCEPTED or REJECTED requires CLEARING_ADMIN role");
+            }
             attachmentToUpdate.setCheckStatus(checkStatus);
             String checkedComment = reqBodyAttachment.getCheckedComment();
             if (checkStatus != CheckStatus.NOTCHECKED) {


### PR DESCRIPTION
While digging through the attachment update flow in the REST layer, I noticed that `Sw360AttachmentService` lets any user with write access on a release set an attachment's `checkStatus` to `ACCEPTED` or `REJECTED`; no role check at all. This turns out to be a pretty serious gap because `ComponentDatabaseHandler` calls `autosetReleaseClearingState` on every release update, and that method promotes the release straight to `ClearingState.APPROVED` the moment it finds a `CLEARING_REPORT` or `COMPONENT_LICENSE_INFO_XML` attachment whose `checkStatus` is `ACCEPTED`. So a regular user who created a release could just upload a file, patch the attachment status to `ACCEPTED` via the REST API, and their release would show up as fully cleared, without a clearing expert ever looking at it.

The fix is small: before applying `ACCEPTED` or `REJECTED` to an attachment in both `uploadAttachment()` and `updateAttachment()`, we now check that the caller holds at least `CLEARING_ADMIN`. If they don't, we throw `AccessDeniedException` which the existing `RestExceptionHandler` maps to HTTP 403. Nothing else in the flow needed changing; `autosetReleaseClearingState` itself is fine, it just needed trustworthy input.

- No new dependencies added.
- No schema or Thrift IDL changes.

Issue: NA

### Suggest Reviewer
@GMishx  
(this touches the clearing state promotion logic so anyone familiar with the attachment approval flow would be a good fit.)

### How To Test?

1. Create a release as a regular `USER` (non-clearing-admin).
2. Upload an attachment of type `CLEARING_REPORT` via `POST /api/releases/{id}/attachments`.
3. Try patching `checkStatus` to `ACCEPTED` via `PATCH /api/releases/{id}/attachment/{attachmentContentId}` with the same user token; you should get **HTTP 403**.
4. Repeat step 3 with a `CLEARING_ADMIN` token; it should go through and the release `clearingState` should become `APPROVED`.
5. Also verify that setting `checkStatus` to `NOTCHECKED` still works for any user with write access (unchanged behaviour).

No new automated tests added in this PR, but the above steps are quick to reproduce manually against a local SW360 instance.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR