### PR TITLE
feat(resourceserver): add FOSSology status endpoint for release

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/FossologyReleaseInfo.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/FossologyReleaseInfo.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+ * Copyright Sandip Mandal<sandipmandal02.sm@gmail.com>, 2026.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.release;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Data Transfer Object for FOSSology release information.
+ * Reflects the three-step FOSSology workflow: upload → scan → report.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FossologyReleaseInfo {
+
+    /**
+     * Report formats supported by FOSSology, available once scanning is complete.
+     */
+    public static final List<String> REPORT_FORMATS = List.of(
+            "spdx2", "spdx2tv", "spdx3json", "spdx3rdf", "spdx3jsonld",
+            "dep5", "readmeoss", "unifiedreport", "clixml", "cyclonedx"
+    );
+
+    @JsonProperty("uploadId")
+    private String uploadId;
+
+    @JsonProperty("uploadStatus")
+    private String uploadStatus;
+
+    @JsonProperty("scanStatus")
+    private String scanStatus;
+
+    @JsonProperty("reportStatus")
+    private String reportStatus;
+
+    @JsonProperty("processStatus")
+    private String processStatus;
+
+    @JsonProperty("sourceAttachmentId")
+    private String sourceAttachmentId;
+
+    @JsonProperty("reportAttachmentId")
+    private String reportAttachmentId;
+
+    @JsonProperty("availableReportFormats")
+    private List<String> availableReportFormats;
+
+    @JsonProperty("lastUpdated")
+    private String lastUpdated;
+
+    public FossologyReleaseInfo() {
+    }
+
+    public String getUploadId() { return uploadId; }
+    public void setUploadId(String uploadId) { this.uploadId = uploadId; }
+
+    public String getUploadStatus() { return uploadStatus; }
+    public void setUploadStatus(String uploadStatus) { this.uploadStatus = uploadStatus; }
+
+    public String getScanStatus() { return scanStatus; }
+    public void setScanStatus(String scanStatus) { this.scanStatus = scanStatus; }
+
+    public String getReportStatus() { return reportStatus; }
+    public void setReportStatus(String reportStatus) { this.reportStatus = reportStatus; }
+
+    public String getProcessStatus() { return processStatus; }
+    public void setProcessStatus(String processStatus) { this.processStatus = processStatus; }
+
+    public String getSourceAttachmentId() { return sourceAttachmentId; }
+    public void setSourceAttachmentId(String sourceAttachmentId) { this.sourceAttachmentId = sourceAttachmentId; }
+
+    public String getReportAttachmentId() { return reportAttachmentId; }
+    public void setReportAttachmentId(String reportAttachmentId) { this.reportAttachmentId = reportAttachmentId; }
+
+    public List<String> getAvailableReportFormats() { return availableReportFormats; }
+    public void setAvailableReportFormats(List<String> availableReportFormats) { this.availableReportFormats = availableReportFormats; }
+
+    public String getLastUpdated() { return lastUpdated; }
+    public void setLastUpdated(String lastUpdated) { this.lastUpdated = lastUpdated; }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String uploadId;
+        private String uploadStatus;
+        private String scanStatus;
+        private String reportStatus;
+        private String processStatus;
+        private String sourceAttachmentId;
+        private String reportAttachmentId;
+        private List<String> availableReportFormats;
+        private String lastUpdated;
+
+        public Builder uploadId(String uploadId) { this.uploadId = uploadId; return this; }
+        public Builder uploadStatus(String uploadStatus) { this.uploadStatus = uploadStatus; return this; }
+        public Builder scanStatus(String scanStatus) { this.scanStatus = scanStatus; return this; }
+        public Builder reportStatus(String reportStatus) { this.reportStatus = reportStatus; return this; }
+        public Builder processStatus(String processStatus) { this.processStatus = processStatus; return this; }
+        public Builder sourceAttachmentId(String sourceAttachmentId) { this.sourceAttachmentId = sourceAttachmentId; return this; }
+        public Builder reportAttachmentId(String reportAttachmentId) { this.reportAttachmentId = reportAttachmentId; return this; }
+        public Builder availableReportFormats(List<String> formats) { this.availableReportFormats = formats; return this; }
+        public Builder lastUpdated(String lastUpdated) { this.lastUpdated = lastUpdated; return this; }
+
+        public FossologyReleaseInfo build() {
+            FossologyReleaseInfo info = new FossologyReleaseInfo();
+            info.setUploadId(uploadId);
+            info.setUploadStatus(uploadStatus);
+            info.setScanStatus(scanStatus);
+            info.setReportStatus(reportStatus);
+            info.setProcessStatus(processStatus);
+            info.setSourceAttachmentId(sourceAttachmentId);
+            info.setReportAttachmentId(reportAttachmentId);
+            info.setAvailableReportFormats(availableReportFormats == null ? null : List.copyOf(availableReportFormats));
+            info.setLastUpdated(lastUpdated);
+            return info;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "FossologyReleaseInfo{" +
+                "uploadId='" + uploadId + '\'' +
+                ", uploadStatus='" + uploadStatus + '\'' +
+                ", scanStatus='" + scanStatus + '\'' +
+                ", reportStatus='" + reportStatus + '\'' +
+                ", processStatus='" + processStatus + '\'' +
+                '}';
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -49,6 +49,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.common.FossologyUtils;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
@@ -111,6 +112,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -2132,5 +2134,86 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         log.info("Invalidating release caches. Reason: {}", reason);
         cacheManager.invalidate(CachedEndpoint.RELEASES_ALL_DETAILS);
         cacheManager.invalidate(CachedEndpoint.RELEASES_WITHOUT_DETAILS);
+    }
+
+    @Operation(
+            summary = "Get FOSSology processing information for a release.",
+            description = "Returns the FOSSology workflow status for a release, covering all three steps: " +
+                    "upload, scan, and report. Also lists available report formats once scanning is complete, " +
+                    "and the SW360 attachment ID of any downloaded report.",
+            tags = {"Releases"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "FOSSology information retrieved successfully",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = FossologyReleaseInfo.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Release not found"
+                    )
+            }
+    )
+    @GetMapping(value = RELEASES_URL + "/{id}/fossology")
+    public ResponseEntity<FossologyReleaseInfo> getFossologyInfo(
+            @Parameter(description = "The ID of the release.")
+            @PathVariable("id") String releaseId) throws TException {
+
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        restControllerHelper.throwIfSecurityUser(user);
+        Release release = releaseService.getReleaseForUserById(releaseId, user);
+
+        return ResponseEntity.ok(buildFossologyReleaseInfo(release));
+    }
+
+    private FossologyReleaseInfo buildFossologyReleaseInfo(Release release) {
+        FossologyReleaseInfo.Builder builder = FossologyReleaseInfo.builder();
+
+        ExternalToolProcess process = releaseService.getExternalToolProcess(release);
+        if (process == null) {
+            return builder.build();
+        }
+
+        builder.processStatus(process.getProcessStatus().name());
+
+        if (process.isSetAttachmentId()) {
+            builder.sourceAttachmentId(process.getAttachmentId());
+        }
+
+        boolean scanDone = false;
+        if (process.getProcessSteps() != null) {
+            for (ExternalToolProcessStep step : process.getProcessSteps()) {
+                String stepName = step.getStepName();
+                ExternalToolProcessStatus stepStatus = step.getStepStatus();
+                if (stepStatus == null) {
+                    continue;
+                }
+                if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(stepName)) {
+                    builder.uploadStatus(stepStatus.name());
+                    if (stepStatus == ExternalToolProcessStatus.DONE && step.getResult() != null) {
+                        builder.uploadId(step.getResult());
+                    }
+                } else if (FossologyUtils.FOSSOLOGY_STEP_NAME_SCAN.equals(stepName)) {
+                    builder.scanStatus(stepStatus.name());
+                    scanDone = stepStatus == ExternalToolProcessStatus.DONE;
+                } else if (FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(stepName)) {
+                    builder.reportStatus(stepStatus.name());
+                    if (stepStatus == ExternalToolProcessStatus.DONE && step.getResult() != null) {
+                        builder.reportAttachmentId(step.getResult());
+                    }
+                }
+            }
+        }
+
+        if (scanDone) {
+            builder.availableReportFormats(FossologyReleaseInfo.REPORT_FORMATS);
+        }
+
+        if (release.isSetModifiedOn()) {
+            builder.lastUpdated(release.getModifiedOn());
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
Issue: #4050 

Adds a new endpoint `GET /releases/{id}/fossology` to return FOSSology processing info for a release. The existing `checkFossologyProcessStatus` endpoint returns a generic response and does not clearly show each step. This endpoint provides a clear view of the workflow with upload, scan and report status.

The data is read from `ExternalToolProcess` already stored in SW360. No live FOSSology API calls are made.

### How To Test?

1. Trigger FOSSology processing for a release  
2. Call `GET /releases/{id}/fossology`  
3. Check that the response includes uploadStatus, scanStatus, reportStatus,  
   uploadId, sourceAttachmentId and availableReportFormats (after scan is done)

No new tests added since this only reads existing data.

### Suggest Reviewer

@GMishx 
@deo002 

### Checklist

Must:

* [x] All related issues are referenced in commit messages and in PR format