### PR TITLE
feat(project): add endpoint and tests for project detail tab pill counts

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3156,13 +3156,13 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             tags = {"Projects"}
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Project detail tab pill counts successfully retrieved"),
+        @ApiResponse(responseCode = "200", description = "Project detail tab pill counts successfully retrieved",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProjectDetailTabCounts.class))),
         @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to access this project",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class)))
     })
     @GetMapping(value = PROJECTS_URL + "/{id}/tabCounts")
-    public void getProjectDetailTabCounts(
-            HttpServletResponse response,
+    public ResponseEntity<ProjectDetailTabCounts> getProjectDetailTabCounts(
             @Parameter(description = "Project ID", example = "376521")
             @PathVariable("id") String id
     ) throws TException {
@@ -3170,13 +3170,20 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         restControllerHelper.throwIfSecurityUser(sw360User);
         Project sw360Project = projectService.getProjectForUserById(id, sw360User);
 
-        List<VulnerabilityDTO> vulnerabilities = vulnerabilityService.getVulnerabilitiesByProjectId(id, sw360User);
-        int vulnerabilityCount = vulnerabilities == null ? 0 : vulnerabilities.size();
-        int vulnerabilityRatedCount = vulnerabilities == null ? 0
+        int vulnerabilityCount;
+        int vulnerabilityRatedCount;
+        if (!sw360Project.isEnableVulnerabilitiesDisplay()) {
+            vulnerabilityCount = -1;
+            vulnerabilityRatedCount = -1;
+        } else {
+            List<VulnerabilityDTO> vulnerabilities = vulnerabilityService.getVulnerabilitiesByProjectId(id, sw360User);
+            vulnerabilityCount = vulnerabilities == null ? 0 : vulnerabilities.size();
+            vulnerabilityRatedCount = vulnerabilities == null ? 0
                 : (int) vulnerabilities.stream()
                 .filter(vulnerability -> !isNullEmptyOrWhitespace(vulnerability.getProjectRelevance())
                         && !"NOT_CHECKED".equalsIgnoreCase(vulnerability.getProjectRelevance()))
                 .count();
+        }
         int obligationCount = 0;
         int obligationNonOpenCount = 0;
         if (!isNullEmptyOrWhitespace(sw360Project.getLinkedObligationId())) {
@@ -3190,18 +3197,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
         }
 
-        try {
-            response.setContentType("application/json; charset=UTF-8");
-            response.setCharacterEncoding("UTF-8");
-            JsonObject row = new JsonObject();
-            row.addProperty("vulnerabilityCount", vulnerabilityCount);
-            row.addProperty("vulnerabilityRatedCount", vulnerabilityRatedCount);
-            row.addProperty("obligationCount", obligationCount);
-            row.addProperty("obligationNonOpenCount", obligationNonOpenCount);
-            response.getWriter().write(row.toString());
-        } catch (IOException e) {
-            throw new SW360Exception(e.getMessage());
-        }
+        return new ResponseEntity<>(new ProjectDetailTabCounts(vulnerabilityCount, vulnerabilityRatedCount,
+                obligationCount, obligationNonOpenCount), HttpStatus.OK);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3152,6 +3152,59 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     }
 
     @Operation(
+            description = "Get project detail tab pill counts.",
+            tags = {"Projects"}
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Project detail tab pill counts successfully retrieved"),
+        @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to access this project",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class)))
+    })
+    @GetMapping(value = PROJECTS_URL + "/{id}/tabCounts")
+    public void getProjectDetailTabCounts(
+            HttpServletResponse response,
+            @Parameter(description = "Project ID", example = "376521")
+            @PathVariable("id") String id
+    ) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        restControllerHelper.throwIfSecurityUser(sw360User);
+        Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+
+        List<VulnerabilityDTO> vulnerabilities = vulnerabilityService.getVulnerabilitiesByProjectId(id, sw360User);
+        int vulnerabilityCount = vulnerabilities == null ? 0 : vulnerabilities.size();
+        int vulnerabilityRatedCount = vulnerabilities == null ? 0
+                : (int) vulnerabilities.stream()
+                .filter(vulnerability -> !isNullEmptyOrWhitespace(vulnerability.getProjectRelevance())
+                        && !"NOT_CHECKED".equalsIgnoreCase(vulnerability.getProjectRelevance()))
+                .count();
+        int obligationCount = 0;
+        int obligationNonOpenCount = 0;
+        if (!isNullEmptyOrWhitespace(sw360Project.getLinkedObligationId())) {
+            ObligationList obligationList = projectService.getObligationData(sw360Project.getLinkedObligationId(), sw360User);
+            if (obligationList != null) {
+                obligationCount = obligationList.getLinkedObligationStatusSize();
+                obligationNonOpenCount = (int) obligationList.getLinkedObligationStatus().values().stream()
+                        .filter(statusInfo -> statusInfo != null && statusInfo.getStatus() != null
+                                && !ObligationStatus.OPEN.equals(statusInfo.getStatus()))
+                        .count();
+            }
+        }
+
+        try {
+            response.setContentType("application/json; charset=UTF-8");
+            response.setCharacterEncoding("UTF-8");
+            JsonObject row = new JsonObject();
+            row.addProperty("vulnerabilityCount", vulnerabilityCount);
+            row.addProperty("vulnerabilityRatedCount", vulnerabilityRatedCount);
+            row.addProperty("obligationCount", obligationCount);
+            row.addProperty("obligationNonOpenCount", obligationNonOpenCount);
+            response.getWriter().write(row.toString());
+        } catch (IOException e) {
+            throw new SW360Exception(e.getMessage());
+        }
+    }
+
+    @Operation(
             description = "Get license clearing info for a project.",
             tags = {"Projects"}
     )

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3156,8 +3156,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             tags = {"Projects"}
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Project detail tab pill counts successfully retrieved",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProjectDetailTabCounts.class))),
+        @ApiResponse(responseCode = "200", description = "Project detail tab pill counts successfully retrieved"),
         @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to access this project",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class)))
     })

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Siemens AG, 2026.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.project;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Counts for project detail tab pills")
+public class ProjectDetailTabCounts {
+
+    @Schema(description = "Count of vulnerabilities linked to the project. Returns -1 when vulnerability display is disabled for the project.")
+    private final int vulnerabilityCount;
+
+    @Schema(description = "Count of vulnerabilities with project relevance other than NOT_CHECKED. Returns -1 when vulnerability display is disabled for the project.")
+    private final int vulnerabilityRatedCount;
+
+    @Schema(description = "Count of obligations linked to the project")
+    private final int obligationCount;
+
+    @Schema(description = "Count of obligations whose status is not OPEN")
+    private final int obligationNonOpenCount;
+
+    public ProjectDetailTabCounts(int vulnerabilityCount, int vulnerabilityRatedCount, int obligationCount,
+            int obligationNonOpenCount) {
+        this.vulnerabilityCount = vulnerabilityCount;
+        this.vulnerabilityRatedCount = vulnerabilityRatedCount;
+        this.obligationCount = obligationCount;
+        this.obligationNonOpenCount = obligationNonOpenCount;
+    }
+
+    public int getVulnerabilityCount() {
+        return vulnerabilityCount;
+    }
+
+    public int getVulnerabilityRatedCount() {
+        return vulnerabilityRatedCount;
+    }
+
+    public int getObligationCount() {
+        return obligationCount;
+    }
+
+    public int getObligationNonOpenCount() {
+        return obligationNonOpenCount;
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
@@ -12,7 +12,11 @@ package org.eclipse.sw360.rest.resourceserver.project;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Counts for project detail tab pills")
 public class ProjectDetailTabCounts {
@@ -35,21 +39,5 @@ public class ProjectDetailTabCounts {
         this.vulnerabilityRatedCount = vulnerabilityRatedCount;
         this.obligationCount = obligationCount;
         this.obligationNonOpenCount = obligationNonOpenCount;
-    }
-
-    public int getVulnerabilityCount() {
-        return vulnerabilityCount;
-    }
-
-    public int getVulnerabilityRatedCount() {
-        return vulnerabilityRatedCount;
-    }
-
-    public int getObligationCount() {
-        return obligationCount;
-    }
-
-    public int getObligationNonOpenCount() {
-        return obligationNonOpenCount;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -87,13 +87,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ProjectTest extends TestIntegrationBase {
@@ -923,6 +921,44 @@ public class ProjectTest extends TestIntegrationBase {
                         new HttpEntity<>(null, headers),
                         String.class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    public void should_get_project_detail_tab_counts() throws IOException, TException {
+        given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
+        VulnerabilityDTO vulnerability1 = new VulnerabilityDTO();
+        vulnerability1.setProjectRelevance("APPLICABLE");
+        VulnerabilityDTO vulnerability2 = new VulnerabilityDTO();
+        vulnerability2.setProjectRelevance("NOT_CHECKED");
+        VulnerabilityDTO vulnerability3 = new VulnerabilityDTO();
+        vulnerability3.setProjectRelevance("IRRELEVANT");
+        given(this.vulnerabilityServiceMock.getVulnerabilitiesByProjectId(eq(project1.getId()), any()))
+                .willReturn(Arrays.asList(vulnerability1, vulnerability2, vulnerability3));
+
+        ObligationList obligationList = new ObligationList();
+        Map<String, ObligationStatusInfo> linkedObligationStatus = new HashMap<>();
+        ObligationStatusInfo obligationStatusInfo1 = new ObligationStatusInfo();
+        obligationStatusInfo1.setStatus(ObligationStatus.OPEN);
+        ObligationStatusInfo obligationStatusInfo2 = new ObligationStatusInfo();
+        obligationStatusInfo2.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        linkedObligationStatus.put("obligation-1", obligationStatusInfo1);
+        linkedObligationStatus.put("obligation-2", obligationStatusInfo2);
+        obligationList.setLinkedObligationStatus(linkedObligationStatus);
+        given(this.projectServiceMock.getObligationData(eq(project1.getLinkedObligationId()), any())).willReturn(obligationList);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/" + project1.getId() + "/tabCounts",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
+        assertEquals(3, responseBody.get("vulnerabilityCount").asInt());
+        assertEquals(2, responseBody.get("vulnerabilityRatedCount").asInt());
+        assertEquals(2, responseBody.get("obligationCount").asInt());
+        assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -925,6 +925,7 @@ public class ProjectTest extends TestIntegrationBase {
 
     @Test
     public void should_get_project_detail_tab_counts() throws IOException, TException {
+        project1.setEnableVulnerabilitiesDisplay(true);
         given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
         VulnerabilityDTO vulnerability1 = new VulnerabilityDTO();
         vulnerability1.setProjectRelevance("APPLICABLE");
@@ -957,6 +958,37 @@ public class ProjectTest extends TestIntegrationBase {
         JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
         assertEquals(3, responseBody.get("vulnerabilityCount").asInt());
         assertEquals(2, responseBody.get("vulnerabilityRatedCount").asInt());
+        assertEquals(2, responseBody.get("obligationCount").asInt());
+        assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
+    }
+
+    @Test
+    public void should_get_project_detail_tab_counts_with_hidden_vulnerabilities() throws IOException, TException {
+        project1.setEnableVulnerabilitiesDisplay(false);
+        given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
+
+        ObligationList obligationList = new ObligationList();
+        Map<String, ObligationStatusInfo> linkedObligationStatus = new HashMap<>();
+        ObligationStatusInfo obligationStatusInfo1 = new ObligationStatusInfo();
+        obligationStatusInfo1.setStatus(ObligationStatus.OPEN);
+        ObligationStatusInfo obligationStatusInfo2 = new ObligationStatusInfo();
+        obligationStatusInfo2.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        linkedObligationStatus.put("obligation-1", obligationStatusInfo1);
+        linkedObligationStatus.put("obligation-2", obligationStatusInfo2);
+        obligationList.setLinkedObligationStatus(linkedObligationStatus);
+        given(this.projectServiceMock.getObligationData(eq(project1.getLinkedObligationId()), any())).willReturn(obligationList);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/" + project1.getId() + "/tabCounts",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
+        assertEquals(-1, responseBody.get("vulnerabilityCount").asInt());
+        assertEquals(-1, responseBody.get("vulnerabilityRatedCount").asInt());
         assertEquals(2, responseBody.get("obligationCount").asInt());
         assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2478,6 +2478,22 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_document_get_project_detail_tab_counts() throws Exception {
+        mockMvc.perform(get("/api/projects/" + project8.getId() + "/tabCounts")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON)
+                        .contentType(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("vulnerabilityCount").description("Count of vulnerabilities linked to the project"),
+                                fieldWithPath("vulnerabilityRatedCount").description("Count of vulnerabilities with project relevance other than NOT_CHECKED"),
+                                fieldWithPath("obligationCount").description("Count of obligations linked to the project"),
+                                fieldWithPath("obligationNonOpenCount").description("Count of obligations whose status is not OPEN")
+                        )));
+    }
+
+    @Test
     public void should_document_get_license_clearing_details_count() throws Exception {
         this.mockMvc.perform(get("/api/projects/" + project.getId()+ "/clearingDetailsCount")
                         .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2486,8 +2486,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
                         responseFields(
-                                fieldWithPath("vulnerabilityCount").description("Count of vulnerabilities linked to the project"),
-                                fieldWithPath("vulnerabilityRatedCount").description("Count of vulnerabilities with project relevance other than NOT_CHECKED"),
+                                fieldWithPath("vulnerabilityCount").description("Count of vulnerabilities linked to the project; returns -1 when vulnerability display is disabled for the project"),
+                                fieldWithPath("vulnerabilityRatedCount").description("Count of vulnerabilities with project relevance other than NOT_CHECKED; returns -1 when vulnerability display is disabled for the project"),
                                 fieldWithPath("obligationCount").description("Count of obligations linked to the project"),
                                 fieldWithPath("obligationNonOpenCount").description("Count of obligations whose status is not OPEN")
                         )));


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This PR adds a new lightweight endpoint for project detail tab pill counts.

It introduces `GET /api/projects/{id}/tabCounts` and returns:
- `vulnerabilityCount`
- `vulnerabilityRatedCount`
- `obligationCount`
- `obligationNonOpenCount`

This helps the frontend load the sidebar pill values without calling the heavier tab endpoints.

Issue:
- https://github.com/eclipse-sw360/sw360/issues/4025
- https://github.com/eclipse-sw360/sw360-frontend/pull/1578

### How To Test?
```bash
curl -u 'admin@sw360.org:12345' \
  http://localhost:8080/resource/api/projects/<projectId>/tabCounts
{
  "vulnerabilityCount": 0,
  "vulnerabilityRatedCount": 0,
  "obligationCount": 0,
  "obligationNonOpenCount": 0
}
```

### Additional tests:
- Added integration test
- Added REST Docs coverage

### Screenshot
<img width="1462" height="200" alt="image" src="https://github.com/user-attachments/assets/63dd7146-6fd4-48cc-a07a-ad0415a9bf2d" />

@deo002 
