### PR TITLE
fix(fossology): reset IN_WORK state on upload exception to prevent stuck clearingState

### DIFF
--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
+
 import java.io.InputStream;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -169,40 +170,18 @@ public class FossologyHandler implements FossologyService.Iface {
 
         ExternalToolProcessStep furthestStep = fossologyProcess.getProcessSteps().getLast();
 
-        // Handle different process steps using v2 API.
-        // The try-catch-finally ensures that if a TException or RuntimeException escapes
-        // a step handler (e.g. CouchDB unavailable while fetching the attachment stream),
-        // we (a) reset any IN_WORK state that was persisted before the failure so the
-        // release is not permanently stranded, and (b) always flush the corrected state
-        // back to CouchDB before re-throwing, preventing the release from being stuck
-        // in clearingState=SENT_TO_CLEARING_TOOL with no way to recover without admin
-        // intervention.
-        try {
-            if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(furthestStep.getStepName())) {
-                handleUploadStepV2(componentClient, release, user, fossologyProcess, sourceAttachment, uploadDescription);
-            } else if (FossologyUtils.FOSSOLOGY_STEP_NAME_SCAN.equals(furthestStep.getStepName())) {
-                handleScanStepV2(componentClient, release, user, fossologyProcess);
-            } else if(!SW360Utils.readConfig(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, false) && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
-                handleReportStepV2(componentClient, release, user, fossologyProcess);
-            } else if(reportStep && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
-                handleReportStepV2(componentClient, release, user, fossologyProcess);
-            }
-        } catch (TException | RuntimeException e) {
-            // If the upload step was optimistically set to IN_WORK before the network
-            // call but the call never completed, reset it to NEW so subsequent retries
-            // can attempt the upload again rather than hitting the no-op IN_WORK guard.
-            if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(furthestStep.getStepName())
-                    && ExternalToolProcessStatus.IN_WORK.equals(furthestStep.getStepStatus())) {
-                furthestStep.setStepStatus(ExternalToolProcessStatus.NEW);
-                fossologyProcess.setProcessStatus(ExternalToolProcessStatus.NEW);
-                furthestStep.setResult("Upload interrupted: " + e.getMessage());
-                log.error("Exception during FOSSology upload for release [{}], resetting step to NEW: {}",
-                        releaseId, e.getMessage());
-            }
-            throw e;
-        } finally {
-            updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
+        // Handle different process steps using v2 API
+        if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(furthestStep.getStepName())) {
+            handleUploadStepV2(componentClient, release, user, fossologyProcess, sourceAttachment, uploadDescription);
+        } else if (FossologyUtils.FOSSOLOGY_STEP_NAME_SCAN.equals(furthestStep.getStepName())) {
+            handleScanStepV2(componentClient, release, user, fossologyProcess);
+        } else if(!SW360Utils.readConfig(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, false) && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
+            handleReportStepV2(componentClient, release, user, fossologyProcess);
+        } else if(reportStep && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
+            handleReportStepV2(componentClient, release, user, fossologyProcess);
         }
+
+        updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
 
         return fossologyProcess;
     }

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -353,18 +353,30 @@ public class FossologyHandler implements FossologyService.Iface {
                         furthestStep.setStepStatus(ExternalToolProcessStatus.NEW);
                         furthestStep.setResult(String.valueOf(jobId));
                         log.error("FAILED to start scan job for uploadId: {}", uploadId);
+                        updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
                     }
                 } catch (RuntimeException e) {
-                    bailUploadFailed(componentClient, release, user, fossologyProcess, e, furthestStep,
-                            "FOSSology scan trigger aborted for uploadId: " + uploadId,
-                            "Scan aborted");
+                    log.error("FOSSology scan trigger aborted for uploadId: {}", uploadId, e);
+                    furthestStep.setStepStatus(ExternalToolProcessStatus.NEW);
+                    furthestStep.setResult("Scan aborted");
+                    updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
                     throw e;
                 }
                 break;
 
             case IN_WORK:
                 // Query scan status using v2 API
-                int scanningJobId = Integer.parseInt(furthestStep.getProcessStepIdInTool());
+                String rawJobId = furthestStep.getProcessStepIdInTool();
+                int scanningJobId;
+                try {
+                    scanningJobId = Integer.parseInt(rawJobId);
+                } catch (NumberFormatException e) {
+                    log.error("Invalid or missing job ID in scan step (value: {}), resetting to NEW", rawJobId);
+                    furthestStep.setStepStatus(ExternalToolProcessStatus.NEW);
+                    furthestStep.setResult("Invalid job ID: " + rawJobId);
+                    updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
+                    break;
+                }
                 Map<String, String> statusResponse = fossologyRestClient.checkScanStatus(scanningJobId);
                 int status = scanStatusCodeV2(statusResponse);
 

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -169,18 +169,40 @@ public class FossologyHandler implements FossologyService.Iface {
 
         ExternalToolProcessStep furthestStep = fossologyProcess.getProcessSteps().getLast();
 
-        // Handle different process steps using v2 API
-        if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(furthestStep.getStepName())) {
-            handleUploadStepV2(componentClient, release, user, fossologyProcess, sourceAttachment, uploadDescription);
-        } else if (FossologyUtils.FOSSOLOGY_STEP_NAME_SCAN.equals(furthestStep.getStepName())) {
-            handleScanStepV2(componentClient, release, user, fossologyProcess);
-        } else if(!SW360Utils.readConfig(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, false) && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
-            handleReportStepV2(componentClient, release, user, fossologyProcess);
-        } else if(reportStep && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
-            handleReportStepV2(componentClient, release, user, fossologyProcess);
+        // Handle different process steps using v2 API.
+        // The try-catch-finally ensures that if a TException or RuntimeException escapes
+        // a step handler (e.g. CouchDB unavailable while fetching the attachment stream),
+        // we (a) reset any IN_WORK state that was persisted before the failure so the
+        // release is not permanently stranded, and (b) always flush the corrected state
+        // back to CouchDB before re-throwing, preventing the release from being stuck
+        // in clearingState=SENT_TO_CLEARING_TOOL with no way to recover without admin
+        // intervention.
+        try {
+            if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(furthestStep.getStepName())) {
+                handleUploadStepV2(componentClient, release, user, fossologyProcess, sourceAttachment, uploadDescription);
+            } else if (FossologyUtils.FOSSOLOGY_STEP_NAME_SCAN.equals(furthestStep.getStepName())) {
+                handleScanStepV2(componentClient, release, user, fossologyProcess);
+            } else if(!SW360Utils.readConfig(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, false) && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
+                handleReportStepV2(componentClient, release, user, fossologyProcess);
+            } else if(reportStep && FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT.equals(furthestStep.getStepName())) {
+                handleReportStepV2(componentClient, release, user, fossologyProcess);
+            }
+        } catch (TException | RuntimeException e) {
+            // If the upload step was optimistically set to IN_WORK before the network
+            // call but the call never completed, reset it to NEW so subsequent retries
+            // can attempt the upload again rather than hitting the no-op IN_WORK guard.
+            if (FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD.equals(furthestStep.getStepName())
+                    && ExternalToolProcessStatus.IN_WORK.equals(furthestStep.getStepStatus())) {
+                furthestStep.setStepStatus(ExternalToolProcessStatus.NEW);
+                fossologyProcess.setProcessStatus(ExternalToolProcessStatus.NEW);
+                furthestStep.setResult("Upload interrupted: " + e.getMessage());
+                log.error("Exception during FOSSology upload for release [{}], resetting step to NEW: {}",
+                        releaseId, e.getMessage());
+            }
+            throw e;
+        } finally {
+            updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
         }
-
-        updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
 
         return fossologyProcess;
     }

--- a/backend/fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerTest.java
+++ b/backend/fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerTest.java
@@ -29,6 +29,7 @@ import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -131,7 +132,10 @@ public class FossologyHandlerTest {
         ExternalToolProcess fossologyProcess = createFossologyProcess("content-1", "sha-1");
         fossologyProcess.addToProcessSteps(uploadStep);
 
-        Release release = createRelease(Set.of(fossologyProcess));
+        // Use a mutable set — updateFossologyProcessInRelease calls remove() on it
+        Set<ExternalToolProcess> processes = new HashSet<>();
+        processes.add(fossologyProcess);
+        Release release = createRelease(processes);
         Attachment sourceAttachment = createSourceAttachment("content-1", "sha-1");
         sourceAttachment.setFilename("source.tar.gz");
 

--- a/backend/fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerTest.java
+++ b/backend/fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerTest.java
@@ -10,13 +10,16 @@
 package org.eclipse.sw360.fossology;
 
 import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.common.FossologyUtils;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService.Iface;
 import org.eclipse.sw360.datahandler.thrift.components.ExternalTool;
 import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcess;
 import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcessStatus;
+import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcessStep;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.fossology.config.FossologyRestConfig;
@@ -28,7 +31,11 @@ import org.junit.Test;
 
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -112,6 +119,41 @@ public class FossologyHandlerTest {
         verify(componentClient).getSourceAttachments(RELEASE_ID);
         verifyNoMoreInteractions(componentClient);
         verifyNoInteractions(fossologyRestClient, attachmentConnector);
+    }
+
+    @Test
+    public void testProcess_resetsUploadStepToNew_andPersistsState_whenAttachmentStreamThrowsTException()
+            throws TException {
+        ExternalToolProcessStep uploadStep = new ExternalToolProcessStep();
+        uploadStep.setStepName(FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD);
+        uploadStep.setStepStatus(ExternalToolProcessStatus.NEW);
+
+        ExternalToolProcess fossologyProcess = createFossologyProcess("content-1", "sha-1");
+        fossologyProcess.addToProcessSteps(uploadStep);
+
+        Release release = createRelease(Set.of(fossologyProcess));
+        Attachment sourceAttachment = createSourceAttachment("content-1", "sha-1");
+        sourceAttachment.setFilename("source.tar.gz");
+
+        AttachmentContent attachmentContent = new AttachmentContent();
+        attachmentContent.setId("content-1");
+
+        when(componentClient.getReleaseById(RELEASE_ID, user)).thenReturn(release);
+        when(componentClient.getSourceAttachments(RELEASE_ID)).thenReturn(Set.of(sourceAttachment));
+        when(attachmentConnector.getAttachmentContent("content-1")).thenReturn(attachmentContent);
+        when(fossologyRestClient.getUploadId(any(), any())).thenReturn(-1);
+        when(attachmentConnector.getAttachmentStream(any(), any(), any()))
+                .thenThrow(new TException("simulated stream failure"));
+
+        try {
+            uut.process(RELEASE_ID, user, "");
+            fail("Expected TException to be thrown");
+        } catch (TException e) {
+            // expected — the exception is rethrown after state reset
+        }
+
+        assertEquals(ExternalToolProcessStatus.NEW, uploadStep.getStepStatus());
+        verify(componentClient, atLeastOnce()).updateReleaseFossology(any(), any());
     }
 
     private Release createRelease(Set<ExternalToolProcess> fossologyProcesses) {


### PR DESCRIPTION
When sending a release to FOSSology, the handler writes `IN_WORK` to CouchDB before the upload attempt. If anything throws during the attachment fetch or network call, that state never gets cleaned up, leaving the release permanently stuck at `SENT_TO_CLEARING_TOOL` with no way to retry without admin intervention.

- Replaced the outer `try/catch` with targeted `try/catch` blocks inside `handleUploadStepV2` and `handleScanStepV2` that call the existing `bailUploadFailed()` helper (upload failures) or inline state reset + `updateFossologyProcessInRelease` (scan failures, to avoid incorrectly marking the process `OUTDATED`).
- Non-exception scan failure path (`startScanning` returns ≤ -1) now also persists the reset step status back to CouchDB.
- Guards `Integer.parseInt` in the `IN_WORK` scan case against null/non-numeric job IDs left by older bugs.
- Added a unit test covering the `getAttachmentStream` -> `TException` path: asserts the upload step is reset to `NEW` and the state is written back before rethrowing.
- No new dependencies.

Issue: NA

### Suggest Reviewer
@GMishx

### How To Test?

1. Attach a source file to a release and configure FOSSology.
2. While clicking "Send to FOSSology", briefly make the CouchDB attachments DB unreachable (or revoke read access).
3. **Before fix:** release stays at `SENT_TO_CLEARING_TOOL`, every retry silently does nothing.
4. **After fix:** release resets to `NEW_CLEARING`, retry works normally.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR