### PR TITLE
Fix: PATCH /api/components/{id} silently resets visibility to EVERYONE 

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -65,7 +65,6 @@ import org.eclipse.sw360.rest.resourceserver.vendor.VendorController;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.jetbrains.annotations.NotNull;
@@ -137,7 +136,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     private final Sw360VulnerabilityService vulnerabilityService;
 
     @NonNull
-    private final com.fasterxml.jackson.databind.Module sw360Module;
+    private final ObjectMapper objectMapper;
 
     @Operation(
             summary = "List all of the service's components.",
@@ -461,10 +460,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     }
 
     private ComponentDTO convertToComponentDTO(Map<String, Object> requestBody) {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.registerModule(sw360Module);
-        return mapper.convertValue(requestBody, ComponentDTO.class);
+        return objectMapper.convertValue(requestBody, ComponentDTO.class);
     }
 
     private String extractModerationComment(ComponentDTO updateComponentDto) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -65,6 +65,7 @@ import org.eclipse.sw360.rest.resourceserver.vendor.VendorController;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.jetbrains.annotations.NotNull;
@@ -460,7 +461,14 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     }
 
     private ComponentDTO convertToComponentDTO(Map<String, Object> requestBody) {
-        return objectMapper.convertValue(requestBody, ComponentDTO.class);
+        // objectMapper.copy() inherits all registered modules (sw360Module + xssPreventionModule)
+        // from the shared bean. The copy is configured with FAIL_ON_UNKNOWN_PROPERTIES=false so
+        // that extra/unrecognised keys in the PATCH body (e.g. "invalid_property", legacy names)
+        // are silently ignored — matching the behaviour of every other convertValue call in the
+        // codebase. The shared bean is never mutated.
+        return objectMapper.copy()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .convertValue(requestBody, ComponentDTO.class);
     }
 
     private String extractModerationComment(ComponentDTO updateComponentDto) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -65,6 +65,8 @@ import org.eclipse.sw360.rest.resourceserver.vendor.VendorController;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Pageable;
@@ -133,6 +135,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
 
     @NonNull
     private final Sw360VulnerabilityService vulnerabilityService;
+
+    @NonNull
+    private final com.fasterxml.jackson.databind.Module sw360Module;
 
     @Operation(
             summary = "List all of the service's components.",
@@ -423,8 +428,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             @Parameter(description = "The id of the component to be updated.")
             @PathVariable("id") String id,
             @Parameter(description = "Updated component fields. Add 'comment' field in body for moderation request.")
-            @RequestBody ComponentDTO updateComponentDto
+            @RequestBody Map<String, Object> reqBodyMap
     ) throws TException {
+        ComponentDTO updateComponentDto = convertToComponentDTO(reqBodyMap);
         final User user = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(user);
         Component sw360Component = validateAndGetComponent(id, updateComponentDto, user);
@@ -443,7 +449,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             );
         }
 
-        sw360Component = restControllerHelper.updateComponent(sw360Component, updateComponentDto);
+        sw360Component = restControllerHelper.updateComponent(sw360Component, updateComponentDto, reqBodyMap);
         RequestStatus updateComponentStatus = componentService.updateComponent(sw360Component, user);
 
         if (updateComponentStatus == RequestStatus.SENT_TO_MODERATOR) {
@@ -452,6 +458,13 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
 
         HalResource<Component> halResource = createHalComponent(sw360Component, user);
         return ResponseEntity.ok(halResource);
+    }
+
+    private ComponentDTO convertToComponentDTO(Map<String, Object> requestBody) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.registerModule(sw360Module);
+        return mapper.convertValue(requestBody, ComponentDTO.class);
     }
 
     private String extractModerationComment(ComponentDTO updateComponentDto) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -34,7 +34,6 @@ import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
-import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
@@ -695,14 +694,18 @@ public class RestControllerHelper<T> {
         return projectToUpdate;
     }
 
-    public Component updateComponent(Component componentToUpdate, ComponentDTO requestBodyComponent) {
+    public Component updateComponent(Component componentToUpdate, ComponentDTO requestBodyComponent,
+            Map<String, Object> reqBodyMap) {
         Component component = convertToComponent(requestBodyComponent);
-        for(Component._Fields field:Component._Fields.values()) {
+        for (Component._Fields field : Component._Fields.values()) {
             if (IMMUTABLE_COMPONENT_FIELDS.contains(field)) {
                 continue;
             }
             Object fieldValue = component.getFieldValue(field);
-            if(fieldValue != null) {
+            if (fieldValue != null) {
+                if (!reqBodyMap.containsKey(field.getFieldName())) {
+                    continue;
+                }
                 componentToUpdate.setFieldValue(field, fieldValue);
             }
         }
@@ -791,17 +794,7 @@ public class RestControllerHelper<T> {
         component.setBlog(componentDTO.getBlog());
         component.setAttachments(componentDTO.getAttachments());
         component.setVcs(componentDTO.getVcs());
-
-        // Copy visbility only when the caller explicitly set a non-default value.
-        // The Thrift-generated no-arg constructor initialises visbility to EVERYONE
-        // (from the IDL default `= sw360.Visibility.EVERYONE`). Jackson does not
-        // invoke the setter for fields absent from the PATCH body, so at this point
-        // we cannot tell whether the caller omitted visbility or sent EVERYONE.
-        // Treating EVERYONE as the "not provided" sentinel prevents silently
-        // overwriting an existing restricted visibility setting on every PATCH.
-        if (componentDTO.getVisbility() != null && componentDTO.getVisbility() != Visibility.EVERYONE) {
-            component.setVisbility(componentDTO.getVisbility());
-        }
+        component.setVisbility(componentDTO.getVisbility());
 
         return component;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -34,6 +34,7 @@ import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
@@ -790,6 +791,17 @@ public class RestControllerHelper<T> {
         component.setBlog(componentDTO.getBlog());
         component.setAttachments(componentDTO.getAttachments());
         component.setVcs(componentDTO.getVcs());
+
+        // Copy visbility only when the caller explicitly set a non-default value.
+        // The Thrift-generated no-arg constructor initialises visbility to EVERYONE
+        // (from the IDL default `= sw360.Visibility.EVERYONE`). Jackson does not
+        // invoke the setter for fields absent from the PATCH body, so at this point
+        // we cannot tell whether the caller omitted visbility or sent EVERYONE.
+        // Treating EVERYONE as the "not provided" sentinel prevents silently
+        // overwriting an existing restricted visibility setting on every PATCH.
+        if (componentDTO.getVisbility() != null && componentDTO.getVisbility() != Visibility.EVERYONE) {
+            component.setVisbility(componentDTO.getVisbility());
+        }
 
         return component;
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -995,6 +995,32 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_preserve_visibility_when_patch_omits_visbility_field() throws Exception {
+        angularComponent.setVisbility(Visibility.ME_AND_MODERATORS);
+
+        mockMvc.perform(patch("/api/components/17653524")
+                .contentType(MediaTypes.HAL_JSON)
+                .content("{\"description\": \"Updated description\"}")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.visbility").value("ME_AND_MODERATORS"));
+    }
+
+    @Test
+    public void should_update_visibility_when_patch_explicitly_sets_visbility_to_EVERYONE() throws Exception {
+        angularComponent.setVisbility(Visibility.ME_AND_MODERATORS);
+
+        mockMvc.perform(patch("/api/components/17653524")
+                .contentType(MediaTypes.HAL_JSON)
+                .content("{\"visbility\": \"EVERYONE\"}")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.visbility").value("EVERYONE"));
+    }
+
+    @Test
     public void should_document_merge_components() throws Exception {
         ComponentMergeSelector mergeSelection = ComponentMergeSelector.from(angularTargetComponent);
         mockMvc.perform(patch("/api/components/mergecomponents")


### PR DESCRIPTION
Any `PATCH /api/components/{id}` request that omits the `visbility` field silently overwrites the component's existing visibility to `EVERYONE`, regardless of what it was before. A component previously restricted to `ME_AND_MODERATORS` or `PRIVATE` becomes world-visible after any routine PATCH; updating a description, a homepage, anything; with no warning in the response.

The fix follows the same pattern already used by `updateProject()`: accept the raw `Map<String, Object>` request body, guard each field with `reqBodyMap.containsKey()`, and only apply fields the caller actually sent.

- **Root cause:** The Thrift IDL declares `optional Visibility visbility = sw360.Visibility.EVERYONE` on `ComponentDTO`. Thrift's Java generator initialises this field to `Visibility.EVERYONE` in the generated no-arg constructor, so after Jackson deserialises a PATCH body that omits `visbility`, the DTO already carries `EVERYONE` ; indistinguishable from an explicit `"visbility": "EVERYONE"`. The merge loop in `updateComponent()` checks `fieldValue != null`, and `EVERYONE` is not null, so it unconditionally overwrites the stored visibility on every PATCH. With a plain Java POJO the default would be `null`, the guard would hold, and the bug would not exist. This is a direct consequence of Thrift IDL default injection, and is part of the motivation behind the proposed GSoC 2026 project [*Migrate SW360 from Apache Thrift to direct Spring Bean injection*](https://summerofcode.withgoogle.com/programs/2025/projects/).
- No new dependencies added or updated.

Issue: Fixes silent visibility reset on `PATCH /api/components/{id}` ; `visbility` silently overwritten to `EVERYONE` whenever the field is omitted from the request body.

---

### Changes

| File | What changed |
|---|---|
| `ComponentController.java` | `patchComponent()` now takes `@RequestBody Map<String, Object> reqBodyMap`; deserialises to `ComponentDTO` via `convertToComponentDTO()` using the shared `ObjectMapper` (preserves `xssPreventionModule`) with `FAIL_ON_UNKNOWN_PROPERTIES=false` |
| `RestControllerHelper.java` | `updateComponent()` receives `reqBodyMap` and skips any field not present via `reqBodyMap.containsKey(field.getFieldName())`; `convertToComponent()` now unconditionally copies `visbility` from the DTO |
| `ComponentSpecTest.java` | Two regression tests added covering the two cases below |

---

### Suggest Reviewer

@GMishx @amritkv @rudra-superrr @bibhuti230185 

---

### How To Test?

1. Create a component with restricted visibility:
```
POST /api/components
{ "name": "TestComp", "componentType": "OSS", "visbility": "ME_AND_MODERATORS" }
```
2. PATCH without a `visbility` field:
```
PATCH /api/components/{id}
{ "description": "routine update" }
```
**Before:** `GET` returns `"visbility": "EVERYONE"` ; restriction silently lost.
**After:** `GET` returns `"visbility": "ME_AND_MODERATORS"` ; preserved.

3. PATCH with an explicit `"visbility": "EVERYONE"` ; should update correctly (this case was also broken by the previous sentinel-based attempt at a fix and is now covered by the regression tests).

---

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR