### PR TITLE
fix(project): sort project groups response

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -188,6 +188,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     private static final Logger log = LogManager.getLogger(ProjectController.class);
     private static final Gson GSON = new Gson();
     private static final TSerializer THRIFT_JSON_SERIALIZER = getJsonSerializer();
+    private static final Comparator<String> PROJECT_GROUP_COMPARATOR =
+            String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder());
     private static final ImmutableMap<Project._Fields, String> mapOfFieldsTobeEmbedded = ImmutableMap.<Project._Fields, String>builder()
             .put(Project._Fields.EXTERNAL_URLS, "externalUrls")
             .put(Project._Fields.MODERATORS, "sw360:moderators")
@@ -4517,6 +4519,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         } catch (TException e) {
             groups = Collections.emptySet();
         }
-        return groups;
+        return groups.stream()
+                .sorted(PROJECT_GROUP_COMPARATOR)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -1316,6 +1316,21 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_return_project_groups_sorted() throws Exception {
+        given(this.projectServiceMock.getGroups()).willReturn(new HashSet<>(Arrays.asList("Zeta", "alpha", "Beta")));
+
+        mockMvc.perform(get("/api/projects/groups")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.contains("alpha", "Beta", "Zeta")))
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("[]").description("Sorted project groups")
+                        )));
+    }
+
+    @Test
     public void should_document_get_projects_by_tag() throws Exception {
         mockMvc.perform(get("/api/projects")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Sorts the project groups returned by `GET /api/projects/groups` at the REST boundary so the project advanced search group dropdown receives deterministic ordering even after the Thrift `set<string>` response loses repository ordering.

No new dependencies were added.

Issue: Fixes #2641

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

Run:

```bash
mvn -pl rest/resource-server -Dtest=ProjectSpecTest#should_return_project_groups_sorted test \
    -Dbase.deploy.dir=$TOMCAT_HOME \
    -Dhelp-docs=false
```

Implemented a REST docs test that mocks unsorted project groups and verifies the JSON response is sorted.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
