### PR TITLE
perf(licenseinfo): use value key for attachment cache

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -75,11 +75,40 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     protected List<OutputGenerator<?>> outputGenerators;
     protected ComponentDatabaseHandler componentDatabaseHandler;
     protected ProjectDatabaseHandler projectDatabaseHandler;
-    protected Cache<Object[], List<LicenseInfoParsingResult>> licenseInfoCache;
+    protected Cache<LicenseInfoCacheKey, List<LicenseInfoParsingResult>> licenseInfoCache;
     protected Cache<String, LicenseInfoParsingResult> licenseInfoCacheForEvaluation;
     protected Cache<String, List<ObligationParsingResult>> obligationCache;
     protected Cache<String, List<ObligationParsingResult>> obligationCacheForEvaluation;
     protected Cache<String, LicenseInfoParsingResult> licenseObligationMappingCache;
+
+    @VisibleForTesting
+    static final class LicenseInfoCacheKey {
+        private final String attachmentContentId;
+        private final boolean includeConcludedLicense;
+
+        LicenseInfoCacheKey(String attachmentContentId, boolean includeConcludedLicense) {
+            this.attachmentContentId = attachmentContentId;
+            this.includeConcludedLicense = includeConcludedLicense;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            LicenseInfoCacheKey that = (LicenseInfoCacheKey) o;
+            return includeConcludedLicense == that.includeConcludedLicense
+                    && Objects.equals(attachmentContentId, that.attachmentContentId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(attachmentContentId, includeConcludedLicense);
+        }
+    }
 
     public LicenseInfoHandler() throws MalformedURLException {
         this(new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS),
@@ -575,14 +604,11 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
             return Collections.singletonList(noSourceParsingResult(MSG_NO_RELEASE_GIVEN));
         }
 
+        LicenseInfoCacheKey cacheKey = new LicenseInfoCacheKey(attachmentContentId, includeConcludedLicense);
         if (licenseInfoCache != null) {
-            for (Entry<Object[], List<LicenseInfoParsingResult>> entry : licenseInfoCache.asMap().entrySet()) {
-                Object[] key = entry.getKey();
-                List<LicenseInfoParsingResult> cachedValue = entry.getValue();
-                if (attachmentContentId.equals(key[0].toString()) && includeConcludedLicense == (boolean) key[1]
-                        && cachedValue != null) {
-                    return cachedValue;
-                }
+            List<LicenseInfoParsingResult> cachedValue = licenseInfoCache.getIfPresent(cacheKey);
+            if (cachedValue != null) {
+                return cachedValue;
             }
         }
 
@@ -621,8 +647,9 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
             results = assignReleaseToLicenseInfoParsingResults(results, release);
             results = assignComponentToLicenseInfoParsingResults(results, release, user);
 
-            Object[] cacheKey = new Object[] { attachmentContentId, includeConcludedLicense };
-            licenseInfoCache.put(cacheKey, results);
+            if (licenseInfoCache != null) {
+                licenseInfoCache.put(cacheKey, results);
+            }
             return results;
         } catch (WrappedTException exception) {
             throw exception.getCause();
@@ -1026,11 +1053,10 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
             throws TException {
         try {
             if (licenseInfoCacheForEvaluation != null) {
-                for (Entry<String, LicenseInfoParsingResult> entry : licenseInfoCacheForEvaluation.asMap().entrySet()) {
-                    LicenseInfoParsingResult cachedValue = entry.getValue();
-                    if (attachment.getAttachmentContentId().equals(entry.getKey()) && cachedValue != null) {
-                        return cachedValue;
-                    }
+                LicenseInfoParsingResult cachedValue =
+                        licenseInfoCacheForEvaluation.getIfPresent(attachment.getAttachmentContentId());
+                if (cachedValue != null) {
+                    return cachedValue;
                 }
             }
 

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
@@ -58,6 +58,23 @@ public class LicenseInfoHandlerTest {
     }
 
     @Test
+    public void testLicenseInfoCacheUsesValueBasedKey() {
+        LicenseInfoParsingResult result = new LicenseInfoParsingResult();
+        ImmutableList<LicenseInfoParsingResult> cachedResults = ImmutableList.of(result);
+        LicenseInfoHandler.LicenseInfoCacheKey cacheKey =
+                new LicenseInfoHandler.LicenseInfoCacheKey("attachmentContentId", true);
+
+        handler.licenseInfoCache.put(cacheKey, cachedResults);
+
+        LicenseInfoHandler.LicenseInfoCacheKey equalCacheKey =
+                new LicenseInfoHandler.LicenseInfoCacheKey("attachmentContentId", true);
+        LicenseInfoHandler.LicenseInfoCacheKey differentCacheKey =
+                new LicenseInfoHandler.LicenseInfoCacheKey("attachmentContentId", false);
+        Assert.assertSame(cachedResults, handler.licenseInfoCache.getIfPresent(equalCacheKey));
+        Assert.assertNull(handler.licenseInfoCache.getIfPresent(differentCacheKey));
+    }
+
+    @Test
     public void testThatEmptyLicensesAreFiltered() {
         LicenseInfoParsingResult emptyResult = new LicenseInfoParsingResult();
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Replaces the `Object[]` license info cache key with a value-based key so attachment license info lookups can use direct Guava cache access instead of scanning all cache entries. Also switches the evaluation cache lookup to `getIfPresent()`.

No new dependencies were added.

Issue: Fixes #3852

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

Run:

```bash
mvn -pl backend/licenseinfo -Dtest=LicenseInfoHandlerTest test \
    -Dbase.deploy.dir=$TOMCAT_HOME \
    -Dhelp-docs=false
```

Implemented a unit test proving equal cache key values resolve the same cached result without relying on array reference equality.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
