### PR TITLE
fix(backend): add SLF4J provider to backend WARs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -78,6 +78,11 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

The `log4j-slf4j2-impl` bridge was version-managed in the root POM
(`dependencyManagement`) but never declared as a dependency in the
backend module hierarchy. As a result, every backend WAR deployed to
Tomcat was missing the SLF4J → Log4j2 bridge, triggering:

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
```

This silenced all libraries that use SLF4J as their logging API.

### Changes

- **`backend/pom.xml`**: Add `log4j-slf4j2-impl` with `runtime` scope.
  Since all backend WAR modules inherit from this POM, they now
  correctly bundle the SLF4J provider.

No new dependencies are introduced — the artifact was already managed
in the root POM.

### How To Test?

1. `mvn clean install -DskipTests`
2. Deploy backend WARs to Tomcat 11
3. Verify that the startup log no longer contains:
   - `SLF4J(W): No SLF4J providers were found`
   - `SLF4J(W): Class path contains multiple SLF4J providers`

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] If code is AI-generated, mention the tool and model used: Gemini (Antigravity)