### PR TITLE
fix(db): csv-reader resource leak in UserDatabaseHandler

### DIFF
--- a/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -233,9 +233,8 @@ public class UserDatabaseHandler {
     public Map<String, List<String>> readFileCsv(String filePath) {
         Map<String, List<String>> listMap = new HashMap<>();
         List<String> emailCsv = new ArrayList<>();
-        try {
-            File file = new File(filePath);
-            CSVReader reader = new CSVReaderBuilder(new FileReader(file)).withSkipLines(1).build();
+        try (FileReader fileReader = new FileReader(new File(filePath));
+            CSVReader reader = new CSVReaderBuilder(fileReader).withSkipLines(1).build()) {
             List<String[]> rows = reader.readAll();
             String mapTemp = "";
             for (String[] row : rows) {


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

`CSVReader` and `FileReader`  in `readFileCsv()`, are now under a try-with resources. Prevents resource leak.

Fixes: #3966 
