### PR TITLE
fix(rest): add detailed exception handling for patchClearingRequest

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -377,7 +377,7 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
                     schema = @Schema(implementation = ClearingRequest.class))
             @RequestBody Map<String, Object> reqBodyMap,
             HttpServletRequest request
-    ) {
+    ) throws SW360Exception {
         try{
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
@@ -444,8 +444,14 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             }
 
             return new ResponseEntity<>(halClearingRequest, HttpStatus.OK);
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             throw new BadRequestClientException(e.getMessage(), e);
+        } catch (ResourceNotFoundException e) {
+            throw new ResourceNotFoundException("Clearing request not found.");
+        } catch (SW360Exception e) {
+            throw e;
+        } catch (TException e) {
+            throw new SW360Exception("An error occurred while processing the request.");
         }
     }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
@@ -324,7 +324,7 @@ public class ClearingRequestTest extends TestIntegrationBase {
     }
 
     @Test
-    public void should_reject_agreed_date_update_for_non_admin() throws IOException, TException {
+    public void should_forbid_agreed_date_update_for_non_admin() throws IOException, TException {
         // Non-admin user
         User nonAdmin = new User();
         nonAdmin.setEmail("user@sw360.org");
@@ -346,7 +346,7 @@ public class ClearingRequestTest extends TestIntegrationBase {
                 String.class
         );
 
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
     }
 
     @Test
@@ -371,7 +371,7 @@ public class ClearingRequestTest extends TestIntegrationBase {
     }
 
     @Test
-    public void should_wrap_access_denied_from_service_as_bad_request() throws IOException, TException {
+    public void should_return_forbidden_when_service_returns_access_denied() throws IOException, TException {
         given(clearingServiceMock.getClearingRequestById(anyString(), any())).willReturn(cr);
         given(projectServiceMock.getProjectForUserById(anyString(), any())).willReturn(new org.eclipse.sw360.datahandler.thrift.projects.Project());
         given(projectServiceMock.getClearingInfo(any(org.eclipse.sw360.datahandler.thrift.projects.Project.class), any())).willReturn(new org.eclipse.sw360.datahandler.thrift.projects.Project());
@@ -390,7 +390,7 @@ public class ClearingRequestTest extends TestIntegrationBase {
                 String.class
         );
 
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION



### Summary

`patchClearingRequest` used a single `catch (Exception)` and always rethrew a **`BadRequestClientException`**, which the REST layer maps to **HTTP 400**. That meant real **403 Forbidden**, **404 Not Found**, and **500 Internal Server Error** situations were all reported as **400 Bad Request**.

### Why that matters

HTTP status codes tell clients and monitoring tools what went wrong (permission vs missing resource vs server fault). Turning everything into **400** hides those distinctions and makes retries, auth handling, and alerts harder to get right.

### What I did instead

The broad catch was replaced with **narrow catches** that only map true client/validation problems to **`BadRequestClientException`**, and **let the right exceptions propagate** so `RestExceptionHandler` can return **403**, **404**, or **500** as intended.

### Pattern I followed

This matches the approach already used on **`addCommentToClearingRequest`** in the same controller: handle **`IllegalArgumentException`** → **`BadRequestClientException`**, normalize **`ResourceNotFoundException`**, **rethrow `SW360Exception`**, and wrap remaining **`TException`** in a generic **`SW360Exception`** message, so status handling stays consistent with that endpoint.