### PR TITLE
fix(docker): update env_file to include CouchDB default secrets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
     image: "${SW360_IMAGE:-ghcr.io/eclipse-sw360/sw360}:${SW360_VERSION:-latest}"
     restart: unless-stopped
     container_name: sw360
-    env_file: config/sw360/.env.backend
+    env_file:
+      - config/sw360/.env.backend
+      - config/couchdb/default_secrets
     secrets:
       - COUCHDB_SECRETS
       - SW360_SECRETS


### PR DESCRIPTION
## Summary
This PR fixes a recurring Docker startup authentication issue by ensuring SW360 receives CouchDB credentials during configuration generation.

While testing Docker Compose locally, login attempts repeatedly returned unauthorized errors even with correct credentials. At first this looked like a credential problem, but the actual root cause was different.

This issue has appeared multiple times and has also been discussed in Slack. This change addresses that repeated authentication failure.

## Root Cause
SW360 started with empty CouchDB username/password values, which caused repeated authentication failures and eventually triggered CouchDB account lockout.

## Change
- Updated [docker-compose.yml](docker-compose.yml) so the SW360 service also loads [config/couchdb/default_secrets](config/couchdb/default_secrets) via env_file.

## Impact
- Authorization webapp deploys successfully.
- OAuth token endpoint works at `/authorization/oauth2/token`.

## Verification
1. Run `docker compose down -v --remove-orphans.`
2. Run `docker compose up -d`
3. Request a token using client credentials and confirm HTTP 200

## Notes
- No Java code changes.
- Docker Compose configuration change only.

@GMishx @deo002 