### PR TITLE
fix(auth): improve user validation messages for authentication failures

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
@@ -92,7 +92,10 @@ public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
         } else {
             String tokenHash = BCrypt.hashpw(tokenFromAuthentication, API_TOKEN_HASH_SALT);
             User sw360User = getUserFromTokenHash(tokenHash);
-            if (sw360User == null || sw360User.isDeactivated()) {
+            if (sw360User == null) {
+                throw new BadCredentialsException("User does not exist or invalid credentials");
+            }
+            if (sw360User.isDeactivated()) {
                 throw new DisabledException("User is deactivated");
             }
             Optional<RestApiToken> restApiToken = getApiTokenFromUser(tokenHash, sw360User);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
@@ -40,7 +40,8 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 
 	private static final Logger log = LogManager.getLogger(Sw360JWTAccessTokenConverter.class);
 	public static final String USER_NAME = "user_name";
-	public static final String USER_IS_DEACTIVATED_OR_NOT_AVAILABLE = "User is deactivated or not available.";
+	public static final String USER_NOT_AVAILABLE = "User does not exist or invalid credentials.";
+	public static final String USER_IS_DEACTIVATED = "User is deactivated.";
 	public static final String SCOPE = "scope";
 
 	private final JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
@@ -143,8 +144,11 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 	 */
 	private static void validateUser(String email, User sw360User) {
 		if (email != null && CommonUtils.isNotNullEmptyOrWhitespace(email)) {
-			if (sw360User == null || sw360User.isDeactivated()) {
-				throw new BadCredentialsException(USER_IS_DEACTIVATED_OR_NOT_AVAILABLE);
+			if (sw360User == null) {
+				throw new BadCredentialsException(USER_NOT_AVAILABLE);
+			}
+			if (sw360User.isDeactivated()) {
+				throw new BadCredentialsException(USER_IS_DEACTIVATED);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Fix misleading authentication errors by separating user-not-found and deactivated-user checks.

Authentication currently returns a deactivated-user style message even when the SW360 user does not exist, which is confusing for integrations.

### Change
- Split null-user and deactivated-user validation in API token authentication flow.
- Split null-user and deactivated-user validation in JWT authentication flow.
- Return accurate exception messages for each case.

## Result
- Non-existent users now get a proper invalid-credentials style message.
- Deactivated users get a deactivated-user message.
- Error handling is clearer and less misleading.
@deo002 sir , @GMishx sir