### PR TITLE
fix(rest): Preserve 404/403 and others when mapping controller exceptions

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
@@ -34,6 +34,8 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -121,6 +123,10 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
         } catch (SW360Exception e) {
             throw new BadRequestClientException(e.getWhy(), e);
         } catch (BadRequestClientException e) {
+            throw e;
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
             throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -230,6 +230,10 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             HttpStatus status1 = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
             return new ResponseEntity<>(resources, status1);
 
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }
@@ -299,6 +303,10 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             }
             HttpStatus status = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
             return new ResponseEntity<>(resources, status);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -33,6 +33,7 @@ import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundExceptio
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ImportBomRequestPreparation;
 import org.eclipse.sw360.datahandler.thrift.RestrictedResource;
 import org.eclipse.sw360.datahandler.thrift.Source;
@@ -465,17 +466,12 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     }
 
 
-    private Component validateAndGetComponent(String id, ComponentDTO updateComponentDto, User user) {
+    private Component validateAndGetComponent(String id, ComponentDTO updateComponentDto, User user) throws TException {
         if (isNullOrEmpty(id)) {
             throw new BadRequestClientException("Component ID cannot be null or empty");
         }
 
-        Component sw360Component;
-        try {
-            sw360Component = componentService.getComponentForUserById(id, user);
-        } catch (Exception e) {
-            throw new ResourceNotFoundException("Component not found with ID: " + id);
-        }
+        Component sw360Component = componentService.getComponentForUserById(id, user);
 
         if (sw360Component == null) {
             throw new ResourceNotFoundException("Component not found with ID: " + id);
@@ -1120,6 +1116,14 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             attachment = attachmentService.uploadAttachment(file, new Attachment(), sw360User);
             try {
                 requestSummary = componentService.importSBOM(sw360User, attachment.getAttachmentContentId());
+            } catch (ResourceNotFoundException e) {
+                throw e;
+            } catch (AccessDeniedException e) {
+                throw e;
+            } catch (SW360Exception e) {
+                throw e;
+            } catch (TException e) {
+                throw e;
             } catch (Exception e) {
                 throw new RuntimeException(e.getMessage());
             }
@@ -1178,6 +1182,14 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             attachment = attachmentService.uploadAttachment(file, new Attachment(), sw360User);
             try {
                 importBomRequestPreparation = componentService.prepareImportSBOM(sw360User, attachment.getAttachmentContentId());
+            } catch (ResourceNotFoundException e) {
+                throw e;
+            } catch (AccessDeniedException e) {
+                throw e;
+            } catch (SW360Exception e) {
+                throw e;
+            } catch (TException e) {
+                throw e;
             } catch (Exception e) {
                 throw new RuntimeException(e.getMessage());
             }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
@@ -30,6 +30,8 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -171,6 +173,10 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             departmentService.writePathFolderConfig(pathFolder, sw360User);
             return ResponseEntity.ok("Path updated successfully.");
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception("Error updating path: " + e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
@@ -29,6 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -102,6 +104,10 @@ public class EccController implements RepresentationModelProcessor<RepositoryLin
             }
             HttpStatus status = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
             return new ResponseEntity<>(resources, status);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -553,6 +553,12 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             licenseService.uploadLicense(sw360User, file, overwriteIfExternalIdMatches,
                     overwriteIfIdMatchesEvenWithoutExternalIdMatch);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
 	    }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -334,6 +334,10 @@ public class Sw360LicenseService {
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             try {
                 return sw360LicenseClient.addLicenseType(lType, sw360User);
+            } catch (TException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw e;
             } catch (Exception e) {
                 throw new TException(e.getMessage());
             }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/ObligationController.java
@@ -49,6 +49,7 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -160,6 +161,10 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             Obligation sw360Obligation = obligationService.getObligationById(id, sw360User);
             HalResource<Obligation> halResource = createHalObligation(sw360Obligation);
             return new ResponseEntity<>(halResource, HttpStatus.OK);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             throw new ResourceNotFoundException("Obligation does not exists! id=" + id);
         }
@@ -209,14 +214,22 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
         for(String id : idsToDelete) {
             try {
                 Obligation obligation = obligationService.getObligationById(id, user);
+                if (obligation == null) {
+                    results.add(new MultiStatus(id, HttpStatus.NOT_FOUND));
+                    continue;
+                }
                 RequestStatus requestStatus = obligationService.deleteObligation(obligation.getId(), user);
                 if(requestStatus == RequestStatus.SUCCESS) {
                     results.add(new MultiStatus(id, HttpStatus.OK));
                 } else {
                     results.add(new MultiStatus(id, HttpStatus.INTERNAL_SERVER_ERROR));
                 }
-            } catch (Exception e) {
+            } catch (ResourceNotFoundException e) {
                 results.add(new MultiStatus(id, HttpStatus.NOT_FOUND));
+            } catch (AccessDeniedException e) {
+                results.add(new MultiStatus(id, HttpStatus.FORBIDDEN));
+            } catch (Exception e) {
+                results.add(new MultiStatus(id, HttpStatus.INTERNAL_SERVER_ERROR));
             }
         }
         return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
@@ -291,6 +304,12 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
             Obligation updatedObligation = obligationService.updateObligation(obligation, sw360User);
             log.debug("Obligation  {} updated successfully", updatedObligation);
             return new ResponseEntity<>("Obligation with id " + updatedObligation.getId() + " has been updated successfully", HttpStatus.OK);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Error updating obligation with id {}", id, e);
             throw new SW360Exception("Unable to process the request");
@@ -328,6 +347,10 @@ public class ObligationController implements RepresentationModelProcessor<Reposi
     private void checkIfObligationExists(String id) throws ResourceNotFoundException {
         try {
             obligationService.getObligationById(id, null);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Error getting obligation with id {}", id, e);
             throw new ResourceNotFoundException("Obligation not found");

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2073,6 +2073,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 attachment = attachmentService.uploadAttachment(file, attachment, sw360User);
                 uploadedAttachments.add(attachment);
                 project.addToAttachments(attachment);
+            } catch (ResourceNotFoundException e) {
+                throw e;
+            } catch (AccessDeniedException e) {
+                throw e;
             } catch (Exception e) {
                 log.error("Failed to upload attachment: {}", filename, e);
                 throw new SW360Exception("Failed to upload attachment: " + filename);
@@ -2109,6 +2113,14 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
             return ResponseEntity.ok(halResource);
 
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
+        } catch (DataIntegrityViolationException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Error updating project attachments", e);
             throw new SW360Exception("Error updating project attachments");
@@ -4023,6 +4035,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             if (sw360Project.getProjectResponsible() != null) {
                 restControllerHelper.addEmbeddedProjectResponsible(userHalResource,sw360Project.getProjectResponsible());
             }
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -2100,6 +2100,12 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                      usagesToUpdate.size(), projectId);
             makeAttachmentUsages(usagesToUpdate);
 
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Failed to process ignored licenses for project {}: {}", projectId, e.getMessage(), e);
             throw new TException("Failed to process ignored licenses", e);
@@ -2220,16 +2226,8 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             String parentProjectId = projectHierarchy[i];
             String childProjectId = projectHierarchy[i + 1];
 
-            // Get parent project
-            Project parentProject;
-            try {
-                parentProject = getProjectForUserById(parentProjectId, user);
-            } catch (Exception e) {
-                throw new BadRequestClientException(String.format(
-                    "Invalid project hierarchy in ignoredLicenses key '%s': " +
-                    "Parent project '%s' not found or not accessible",
-                    originalKey, parentProjectId));
-            }
+            // Get parent project (getProjectForUserById maps SW360 404/403 to ResourceNotFoundException / AccessDeniedException)
+            Project parentProject = getProjectForUserById(parentProjectId, user);
 
             // Check if child project exists in parent's linked projects
             Map<String, ProjectProjectRelationship> linkedProjects = parentProject.getLinkedProjects();
@@ -2255,26 +2253,11 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
      */
     private void validateReleaseOwnership(String releaseId, String projectId, String originalKey, User user)
             throws TException {
-        // Get the project
-        Project project;
-        try {
-            project = getProjectForUserById(projectId, user);
-        } catch (Exception e) {
-            throw new BadRequestClientException(String.format(
-                "Invalid project in ignoredLicenses key '%s': Project '%s' not found or not accessible",
-                originalKey, projectId));
-        }
+        // Validate project access (getProjectForUserById maps SW360 404/403 to ResourceNotFoundException / AccessDeniedException)
+        getProjectForUserById(projectId, user);
 
         // Get all release IDs for this project including sub-projects (transitive=true)
-        Set<String> allReleaseIds;
-        try {
-            allReleaseIds = getReleaseIds(projectId, user, true);
-        } catch (TException e) {
-            log.error("Failed to fetch release IDs for project {}: {}", projectId, e.getMessage());
-            throw new BadRequestClientException(String.format(
-                "Failed to validate release ownership in ignoredLicenses key '%s': Unable to fetch releases for project '%s'",
-                originalKey, projectId));
-        }
+        Set<String> allReleaseIds = getReleaseIds(projectId, user, true);
 
         // Check if release exists in project or any of its sub-projects
         if (!allReleaseIds.contains(releaseId)) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -42,6 +42,7 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.FileCopyUtils;
@@ -214,6 +215,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             } else {
                 downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
             }
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e);
             throw new SW360Exception(e.getMessage());
@@ -232,6 +239,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             } else {
                 downloadExcelReport(response, sw360User, module, null, defaultByteBufferVal, reportBean);
             }
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e);
             throw new SW360Exception(e.getMessage());
@@ -243,6 +256,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             downloadExcelReport(response, sw360User, module, null, defaultByteBufferVal, reportBean);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e);
             throw new SW360Exception(e.getMessage());
@@ -254,6 +273,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e);
             throw new SW360Exception(e.getMessage());
@@ -265,6 +290,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }
@@ -275,6 +306,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e);
             throw new SW360Exception(e.getMessage());
@@ -317,6 +354,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             }
             response.setHeader(CONTENT_DISPOSITION, String.format(ATTACHMENT_FILENAME_S, fileName));
             copyDataStreamToResponse(response, buff);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e);
             throw new SW360Exception(e.getMessage());
@@ -330,6 +373,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             ByteBuffer buffer = sw360ReportService.downloadSourceCodeBundle(projectId, sw360User, reportBean.isWithSubProject());
             downloadExcelReport(response, sw360User, module, projectId,
                     buffer, reportBean);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }
@@ -404,6 +453,12 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
             response.setHeader(CONTENT_DISPOSITION, String.format(ATTACHMENT_FILENAME_S, fileName));
             copyDataStreamToResponse(response, buffer);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -144,6 +144,10 @@ public class SW360ReportService {
             List<Map<String, String>> records = exporter.makeRecords(projects);
             List<String> headers = extendedByReleases ? ProjectExporter.HEADERS_EXTENDED_BY_RELEASES : ProjectExporter.HEADERS;
             return convertToFormat(records, headers, fmt);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (TException e) {
             throw e;
         } catch (Exception e) {
@@ -249,6 +253,10 @@ public class SW360ReportService {
                 if (!CommonUtils.isNullEmptyOrWhitespace(projectPath)) {
                     sendExportSpreadsheetSuccessMail(emailURL.toString(), user.getEmail());
                 }
+            } catch (ResourceNotFoundException exp) {
+                throw exp;
+            } catch (AccessDeniedException exp) {
+                throw exp;
             } catch (Exception exp) {
                 throw new TException(exp.getMessage());
             }
@@ -275,6 +283,10 @@ public class SW360ReportService {
                 if (!CommonUtils.isNullEmptyOrWhitespace(componentPath)) {
                     sendComponentExportSpreadsheetSuccessMail(emailURL.toString(), sw360User.getEmail());
                 }
+            } catch (ResourceNotFoundException exp) {
+                throw exp;
+            } catch (AccessDeniedException exp) {
+                throw exp;
             } catch (Exception exp) {
                 throw new TException(exp.getMessage());
             }
@@ -539,6 +551,10 @@ public class SW360ReportService {
             releases = releaseStringMap.stream().map(ReleaseClearingStatusData::getRelease)
                     .sorted(Comparator.comparing(SW360Utils::printFullname)).collect(Collectors.toList());
             exporter = new ReleaseExporter(componentclient, releases, user, releaseStringMap);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (Exception e) {
             throw new TException(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
@@ -75,6 +75,9 @@ public class Sw360ScheduleService {
         } catch (TException e) {
             log.error("Error occurred while triggering CVE search: " + e.getMessage(), e);
             throw e;
+        } catch (RuntimeException e) {
+            log.error("Error occurred while triggering CVE search: " + e.getMessage(), e);
+            throw e;
         } catch (Exception e) {
             log.error("Unexpected error occurred while triggering CVE search: " + e.getMessage(), e);
             throw new TException("Unexpected error", e);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -341,6 +341,12 @@ public class VendorController implements RepresentationModelProcessor<Repository
             String filename = String.format("vendors-%s.xlsx", SW360Utils.getCreatedOn());
             response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
             copyDataStreamToResponse(response, buffer);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
+        } catch (BadRequestClientException e) {
+            throw e;
         } catch (Exception e) {
             throw new TException(e.getMessage());
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -582,6 +582,10 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             return ResponseEntity.ok(createPagination);
         } catch (BadRequestClientException e) {
             throw e;
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (AccessDeniedException e) {
+            throw e;
         } catch (SW360Exception e) {
             throw new TException(e.why);
         } catch (Exception ex) {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -296,7 +297,7 @@ public class ComponentTest extends TestIntegrationBase {
 
     @Test
     public void should_update_component_invalid() throws IOException, TException {
-        Mockito.doThrow(TException.class).when(this.componentServiceMock)
+        Mockito.doThrow(new ResourceNotFoundException("Component not found")).when(this.componentServiceMock)
                 .getComponentForUserById(any(), any());
         String updatedComponentName = "updatedComponentName";
         HttpHeaders headers = getHeaders(port);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
@@ -416,7 +416,8 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error status", responseBody.contains("404"));
+        assertTrue("Response should contain server error status for unexpected failure",
+                responseBody.contains("500"));
     }
 
     @Test


### PR DESCRIPTION

## Summary

REST controllers and a few services used broad `catch (Exception e)` blocks that **rewrapped or replaced** almost any failure with `SW360Exception`, `TException`, `RuntimeException`, or a **generic “not found”** message. That **hid real HTTP semantics**: failures that the backend already expressed as **404 Not Found**, **403 Forbidden**, or **400 Bad Request** were often turned into **500 Internal Server Error** or the wrong client error.

This change **rethrows typed Spring and Thrift exceptions** (`ResourceNotFoundException`, `AccessDeniedException`, `BadRequestClientException`, and where relevant `SW360Exception`, `TException`, `DataIntegrityViolationException`, `IOException`, `RuntimeException`) **before** any generic handler, so `RestExceptionHandler` (and existing multi-status logic) can return the **correct status and body**.


**Dependencies:** None.



## Rationale by area

### `FossologyAdminController`
- **Why:** `saveConfig` can surface not-found or access-denied conditions from the stack. Those must not be wrapped into `SW360Exception` (typically mapped to **500**).
- **Change:** Catch `ResourceNotFoundException` and `AccessDeniedException` and rethrow so the API returns **404** and **403** as intended.

### `ClearingRequestController` (two methods)
- **Why:** Listing clearing requests and comments can fail with 404/403 from services; wrapping as `SW360Exception` loses that.
- **Change:** Explicit rethrow for `ResourceNotFoundException` and `AccessDeniedException` before the generic `SW360Exception` wrap.

### `ComponentController`
- **`validateAndGetComponent`**
  - **Why:** The previous `catch (Exception e)` turned **every** failure (including wrong type, Thrift, I/O, etc.) into `ResourceNotFoundException` with a fixed “component not found” message, which was **incorrect and misleading**.
  - **Change:** Call `getComponentForUserById` without that blanket catch; treat **null** as not found only when that is the real contract.
- **`importSBOM` / `prepareImportSBOM`**
  - **Why:** Broad `catch (Exception)` to `RuntimeException` masked **404/403**, domain `SW360Exception`, and `TException`.
  - **Change:** Rethrow `ResourceNotFoundException`, `AccessDeniedException`, `SW360Exception`, and `TException`; only unknown errors stay in the generic path.

### `DepartmentController`
- **Why:** Path update errors can be 404/403; they must not all become a generic `SW360Exception` with a prefixed message.
- **Change:** Rethrow `ResourceNotFoundException` and `AccessDeniedException` before wrapping other failures.

### `EccController`
- **Why:** Same as other list/detail endpoints: preserve **404** and **403** from the service layer.
- **Change:** Rethrow those exceptions before `SW360Exception` wrapping.

### `LicenseController` + `Sw360LicenseService`
- **`LicenseController.uploadLicenses`**
  - **Why:** Client bad requests (`BadRequestClientException`) and 404/403 must not be lumped into `SW360Exception`.
  - **Change:** Rethrow `ResourceNotFoundException`, `AccessDeniedException`, and `BadRequestClientException` first.
- **`Sw360LicenseService.addLicenseType`**
  - **Why:** `TException` and `RuntimeException` were being wrapped in a **new** `TException`, which can **lose type, cause chain, and handler behavior**.
  - **Change:** Rethrow `TException` and `RuntimeException`; only truly unexpected checked exceptions get wrapped.

### `ObligationController`
- **`getObligation` / `checkIfObligationExists`**
  - **Why:** Generic `catch` turned **any** error into “obligation does not exist” (**404**), including cases that were **403** or other failures.
  - **Change:** Rethrow `ResourceNotFoundException` and `AccessDeniedException` first; keep a controlled fallback for other errors where appropriate.
- **`deleteObligations` (multi-status)**
  - **Why:** Per-id failures were all **500** in the multi-status payload.
  - **Change:** Map `ResourceNotFoundException` to per-item **404**, `AccessDeniedException` to **403**; other errors remain **500**.
- **`editObligation`**
  - **Why:** Same passthrough pattern for 404/403/400 vs generic processing error.

### `ProjectController`
- **Attachment upload / update flows**
  - **Why:** Upload or project update can fail with 404/403 or client bad request; `DataIntegrityViolationException` maps to **409** in `RestExceptionHandler` and must not be wrapped as a generic `SW360Exception`.
  - **Change:** Rethrow those types before logging and wrapping unknown errors.
- **`setAdditionalFieldsToHalResource`**
  - **Why:** Embedded user/project resolution can throw 404/403; those should propagate.
  - **Change:** Rethrow `ResourceNotFoundException` and `AccessDeniedException` before generic `SW360Exception`.

### `Sw360ProjectService`
- **`handleIgnoredLicenses`**
  - **Why:** Processing ignored licenses can surface 404/403/bad request from the project hierarchy; wrapping everything in `TException` hid HTTP semantics for callers/controllers.
  - **Change:** Rethrow `ResourceNotFoundException`, `AccessDeniedException`, and `BadRequestClientException` first.
- **`validateProjectHierarchyChain` / `validateReleaseOwnership`**
  - **Why:** `catch (Exception e)` around `getProjectForUserById` converted **real 404/403** into a **generic `BadRequestClientException`** (“invalid hierarchy”), with the **wrong status and message**.
  - **Change:** Rely on `getProjectForUserById` to map backend codes to `ResourceNotFoundException` / `AccessDeniedException` and let them propagate. Stop treating **all** exceptions from `getReleaseIds` as validation failures; let **Thrift** errors propagate instead of forcing a single bad-request narrative.

### `SW360ReportController` / `SW360ReportService`
- **Why:** Report generation and Excel download paths call deep services that throw 404/403 and sometimes `BadRequestClientException`; wrapping as `SW360Exception`/`TException` turned them into **500**.
- **Change:** Consistent rethrow of `ResourceNotFoundException`, `AccessDeniedException`, and `BadRequestClientException` (and `TException` / `IOException` in service where already distinguished) before generic error translation.

### `Sw360ScheduleService`
- **Why:** `RuntimeException` (for example from validation or infrastructure) was being wrapped as a generic `TException` “Unexpected error”, **losing** the original exception class and sometimes the right handling.
  - **Change:** Rethrow `RuntimeException` after logging; keep wrapping only for unexpected checked `Exception`s if that remains the contract.

### `VendorController.exportVendor`
- **Why:** Same as other export endpoints: preserve 404/403/400 from the stack.
- **Change:** Rethrow `ResourceNotFoundException`, `AccessDeniedException`, and `BadRequestClientException` before `TException` wrapping.

### `VulnerabilityController`
- **Why:** Order matters: ensure **400/404/403** are not swallowed by a branch that converts `SW360Exception` to `TException` until those are ruled out.
- **Change:** Rethrow `BadRequestClientException`, `ResourceNotFoundException`, and `AccessDeniedException` first; keep the existing `SW360Exception` to `TException(e.why)` behavior for remaining domain errors.



