### PR TITLE
fix(rest): harden headers and fix CORS origin

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -104,7 +104,11 @@ file to tweak SW360 behaviour.
 * `SCHEDULER_AUTOSTART_SERVICES`: Comma-separated list (no spaces) of services
     to autostart (default: `cvesearchService`). Leave empty to not start any
     service.
-* `SW360_CORS_ALLOWED_ORIGIN`: CORS allowed origins (default: `*`).
+* `SW360_CORS_ALLOWED_ORIGIN`: CORS allowed origins. By default, it is set to
+    `*` for ease of local development. **To secure your deployment for
+    production**, you must update this value within
+    `config/sw360/.env.backend` to reflect the specific origin(s) of your
+    frontend server.
 * `SW360_THRIFT_SERVER_URL`: URL where Thrift server is running (default:
     `http://localhost:8080`).
 * `SW360_BASE_URL`: Base URL for SW360 server (default: `http://localhost:8080`).

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
@@ -16,6 +16,7 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.common.PropertyUtils;
 import org.eclipse.sw360.rest.common.Sw360CORSFilter;
+import org.eclipse.sw360.rest.common.Sw360SecurityFilter;
 import org.eclipse.sw360.rest.common.Sw360XssFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -23,7 +24,7 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import({Sw360CORSFilter.class, Sw360XssFilter.class})
+@Import({Sw360CORSFilter.class, Sw360XssFilter.class, Sw360SecurityFilter.class})
 public class Sw360AuthorizationServer extends SpringBootServletInitializer {
 
     private static final String SW360_PROPERTIES_FILE_PATH = "/sw360.properties";

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -28,6 +28,7 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.common.PropertyUtils;
 import org.eclipse.sw360.rest.common.Sw360CORSFilter;
+import org.eclipse.sw360.rest.common.Sw360SecurityFilter;
 import org.eclipse.sw360.rest.common.Sw360XssFilter;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -51,7 +52,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import java.util.*;
 
 @SpringBootApplication
-@Import({Sw360CORSFilter.class, Sw360XssFilter.class})
+@Import({Sw360CORSFilter.class, Sw360XssFilter.class, Sw360SecurityFilter.class})
 public class Sw360ResourceServer extends SpringBootServletInitializer {
 
     public static final String REST_BASE_PATH = "/api";

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360CORSFilter.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360CORSFilter.java
@@ -43,30 +43,46 @@ public abstract class Sw360CORSFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        if (allowedOrigin != null && !allowedOrigin.isBlank()) {
-            HttpServletRequest httpServletRequest = (HttpServletRequest)servletRequest;
-            HttpServletResponse httpServletResponse = (HttpServletResponse)servletResponse;
-            setCORSHeader(httpServletResponse);
-            if(httpServletRequest.getMethod().equalsIgnoreCase(HttpMethod.OPTIONS.name())) {
-                httpServletResponse.setStatus(HttpServletResponse.SC_OK);
-                return;
-            } else {
-                filterChain.doFilter(servletRequest, servletResponse);
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+
+        if (isCorsEnabled()) {
+            String origin = httpServletRequest.getHeader(HttpHeaders.ORIGIN);
+            boolean isValidOrigin = false;
+
+            if ("*".equals(allowedOrigin.trim())) {
+                isValidOrigin = true;
+                httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+            } else if (origin != null) {
+                String[] origins = allowedOrigin.split(",");
+                for (String o : origins) {
+                    if (o.trim().equalsIgnoreCase(origin)) {
+                        isValidOrigin = true;
+                        httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+                        break;
+                    }
+                }
             }
-        } else {
-            filterChain.doFilter(servletRequest, servletResponse);
+
+            if (isValidOrigin) {
+                httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, ALLOWED_HTTP_METHODS);
+                httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_MAX_AGE, accessControlMaxAge);
+                httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, ALLOWED_HTTP_HEADERS);
+                httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, accessControlAllowCredentials);
+
+                if (httpServletRequest.getMethod().equalsIgnoreCase(HttpMethod.OPTIONS.name())) {
+                    httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+                    return;
+                }
+            }
         }
+
+        filterChain.doFilter(servletRequest, servletResponse);
     }
 
-    @Override
-    public void destroy() {}
-
-    private void setCORSHeader(HttpServletResponse httpServletResponse) {
-        httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, allowedOrigin);
-        httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, ALLOWED_HTTP_METHODS);
-        httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_MAX_AGE, accessControlMaxAge);
-        httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, ALLOWED_HTTP_HEADERS);
-        httpServletResponse.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, accessControlAllowCredentials);
+    private boolean isCorsEnabled() {
+        return allowedOrigin != null && !allowedOrigin.isBlank()
+                && !"#{null}".equals(allowedOrigin) && !"null".equalsIgnoreCase(allowedOrigin.trim());
     }
 
     private static String allowedHttpMethods() {

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360SecurityFilter.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360SecurityFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.common;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import java.io.IOException;
+
+/**
+ * Put security headers in the API responses.
+ */
+@Configuration
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+public class Sw360SecurityFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void doFilter(
+            ServletRequest servletRequest, ServletResponse servletResponse,
+            FilterChain filterChain
+    ) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+        setSecurityHeaders(httpServletRequest, httpServletResponse);
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private void setSecurityHeaders(HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader("X-Frame-Options", "DENY");
+        response.setHeader("X-XSS-Protection", "0");
+
+        String path = request.getRequestURI();
+        if (path != null && (path.contains("/swagger-ui") || path.contains("/v3/api-docs"))) {
+            // Relaxed CSP for Swagger UI to function
+            response.setHeader("Content-Security-Policy", "default-src 'self'; object-src 'none'; base-uri 'none'; script-src 'self'; require-trusted-types-for 'script'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; frame-ancestors 'none';");
+        } else {
+            // Strict CSP for API responses
+            response.setHeader("Content-Security-Policy", "default-src 'none'; object-src 'none'; base-uri 'none'; frame-ancestors 'none';");
+        }
+    }
+}

--- a/third-party/keycloak-tf/r-sw360-realm.tf
+++ b/third-party/keycloak-tf/r-sw360-realm.tf
@@ -54,7 +54,7 @@ resource "keycloak_realm" "sw360" {
   security_defenses {
     headers {
       x_frame_options                     = "SAMEORIGIN"
-      content_security_policy             = "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
+      content_security_policy             = "frame-src 'self'; frame-ancestors 'self'; object-src 'none'; base-uri 'none'; default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; require-trusted-types-for 'script';"
       content_security_policy_report_only = ""
       x_content_type_options              = "nosniff"
       x_robots_tag                        = "none"


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

This PR consolidates resolution for weak content security policies and incorrect CORS header behaviors across the backend ecosystem. 
1. Creates `Sw360SecurityFilter` to enforce strict HSTS and API-secured `Content-Security-Policy` frames without bleeding into CORS mechanisms.
2. Fixes `Sw360CORSFilter.java` which previously failed to parse comma-separated arrays of trusted origins properly and was prone to evaluating missing variables as string literals (causing `Access-Control-Allow-Origin: #{null}`).
3. Locks down the CSP in the `keycloak-tf` configurations.
4. Documents CORS config extensions natively in backend Docker documentation.

> * Did you add or update any new dependencies that are required for your change?
> No.

### How To Test?
1. Start the stack and launch `curl -I http://localhost:8080/resource/api/health`. Verify that headers `Strict-Transport-Security`, `X-Content-Type-Options`, and `X-Frame-Options: DENY` are emitted.
2. Start Keycloak TF configuration locally and verify expanded CSP settings in realm.
3. Launch the environment setting `SW360_CORS_ALLOWED_ORIGIN="http://localhost:3000,http://localhost:4000"` and send an XHR request indicating `Origin: http://localhost:4000`. The response should correctly reflect exactly `http://localhost:4000`.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] If code is AI-generated, mention the tool and model used (Generative AI Assistant - DeepMind Antigravity)