### PR TITLE
fix(LicenseInfo): use SPDX ID for obligation-to-license mapping

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -708,7 +708,16 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
 
         LicenseInfo licenseInfo = licenseResult.getLicenseInfo();
         licenseInfo.getLicenseNamesWithTexts()
-                .forEach(license -> license.setObligationsAtProject(licenseIdToObligations.get(license.getLicenseName())));
+                .forEach(license -> {
+                    Set<ObligationAtProject> obligations = null;
+                    if (license.isSetLicenseSpdxId()) {
+                        obligations = licenseIdToObligations.get(license.getLicenseSpdxId());
+                    }
+                    if (obligations == null) {
+                        obligations = licenseIdToObligations.get(license.getLicenseName());
+                    }
+                    license.setObligationsAtProject(obligations);
+                });
         licenseInfo.setTotalObligations(obligationResult.getObligationsAtProjectSize());
         licenseObligationMappingCache.put(licenseResult.getAttachmentContentId(), licenseResult);
         return licenseResult;


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

## Problem
The existing license-to-obligation mapping only matched obligations using licenseName. This caused obligations to be missed for licenses since the obligation is mapped using the SPDX ID (licenseSpdxId) rather than the license name in fossology.

## Solution
Updated createLicenseToObligationMapping to perform a two-step lookup when associating obligations with a license:
- Primary lookup: if the license has a SPDX ID set (isSetLicenseSpdxId()), attempt to resolve obligations using licenseSpdxId first.
- Fallback lookup: if no obligations are found via SPDX ID (or SPDX ID is not set), fall back to matching by licenseName as before.
