### PR TITLE
fix(rest): PATCH /api/licenses/{id} returns 200 OK on write failure

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -290,7 +290,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             @ApiResponse(responseCode = "405",
                     description = "Reject license update due to: an already checked license is not allowed" +
                             " to become unchecked again"),
-            @ApiResponse(responseCode = "500", description = "License update failed (permission denied or business rule violation).")
+            @ApiResponse(responseCode = "400", description = "License update failed (permission denied or business rule violation).")
     })
     @PatchMapping(value = LICENSES_URL + "/{id}")
     public ResponseEntity<EntityModel<License>> updateLicense(
@@ -312,7 +312,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }
         if (requestStatus != RequestStatus.SUCCESS) {
-            throw new RuntimeException("Error updating license");
+            throw new RuntimeException("License update failed with status: " + requestStatus);
         }
         HalResource<License> halResource = createHalLicense(licenseUpdate);
         return new ResponseEntity<>(halResource, HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -312,7 +312,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }
         if (requestStatus != RequestStatus.SUCCESS) {
-            throw new RuntimeException("License update failed with status: " + requestStatus);
+            throw new BadRequestClientException("License update failed with status: " + requestStatus);
         }
         HalResource<License> halResource = createHalLicense(licenseUpdate);
         return new ResponseEntity<>(halResource, HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -289,7 +289,8 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             ),
             @ApiResponse(responseCode = "405",
                     description = "Reject license update due to: an already checked license is not allowed" +
-                            " to become unchecked again")
+                            " to become unchecked again"),
+            @ApiResponse(responseCode = "500", description = "License update failed (permission denied or business rule violation).")
     })
     @PatchMapping(value = LICENSES_URL + "/{id}")
     public ResponseEntity<EntityModel<License>> updateLicense(
@@ -309,6 +310,9 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
         RequestStatus requestStatus = licenseService.updateLicense(licenseUpdate, sw360User);
         if (requestStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
+        }
+        if (requestStatus != RequestStatus.SUCCESS) {
+            throw new RuntimeException("Error updating license");
         }
         HalResource<License> halResource = createHalLicense(licenseUpdate);
         return new ResponseEntity<>(halResource, HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -146,7 +146,7 @@ public class Sw360LicenseService {
         }
         RequestStatus status = sw360LicenseClient.updateLicense(license, sw360User, sw360User);
         if (status == RequestStatus.FAILURE) {
-            throw new RuntimeException("Error updating license");
+            throw new RuntimeException("License update failed with status: " + status);
         }
         return status;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -224,6 +224,7 @@ public class Sw360LicenseService {
         }
     }
 
+    // visible for testing
     LicenseService.Iface getThriftLicenseClient() throws TTransportException {
         THttpClient thriftClient = new THttpClient(thriftServerUrl + "/licenses/thrift");
         TProtocol protocol = new TCompactProtocol(thriftClient);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -224,7 +224,7 @@ public class Sw360LicenseService {
         }
     }
 
-    private LicenseService.Iface getThriftLicenseClient() throws TTransportException {
+    LicenseService.Iface getThriftLicenseClient() throws TTransportException {
         THttpClient thriftClient = new THttpClient(thriftServerUrl + "/licenses/thrift");
         TProtocol protocol = new TCompactProtocol(thriftClient);
         return new LicenseService.Client(protocol);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -144,7 +144,11 @@ public class Sw360LicenseService {
                 license.setObligations(obligations);
             }
         }
-        return sw360LicenseClient.updateLicense(license, sw360User, sw360User);
+        RequestStatus status = sw360LicenseClient.updateLicense(license, sw360User, sw360User);
+        if (status == RequestStatus.FAILURE) {
+            throw new RuntimeException("Error updating license");
+        }
+        return status;
     }
 
     public Set<String> getIdObligationsContainWhitelist(User sw360User, String licenseId, Set<String> diffIds) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -146,7 +146,7 @@ public class Sw360LicenseService {
         }
         RequestStatus status = sw360LicenseClient.updateLicense(license, sw360User, sw360User);
         if (status == RequestStatus.FAILURE) {
-            throw new RuntimeException("License update failed with status: " + status);
+            throw new BadRequestClientException("License update failed with status: " + status);
         }
         return status;
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Aman Kumar, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.license;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Sw360LicenseServiceTest {
+
+    @Mock
+    private LicenseService.Iface licenseClient;
+
+    private Sw360LicenseService licenseService;
+
+    @Before
+    public void setUp() throws TException {
+        licenseService = spy(new Sw360LicenseService());
+        doReturn(licenseClient).when(licenseService).getThriftLicenseClient();
+    }
+
+    @Test
+    public void updateLicense_throwsBadRequestClientException_whenClientReturnsFailure() throws TException {
+        when(licenseClient.updateLicense(any(), any(), any())).thenReturn(RequestStatus.FAILURE);
+
+        assertThatThrownBy(() -> licenseService.updateLicense(new License(), new User()))
+                .isInstanceOf(BadRequestClientException.class)
+                .hasMessageContaining(RequestStatus.FAILURE.toString());
+    }
+
+    @Test
+    public void updateLicense_returnsSuccess_whenClientReturnsSuccess() throws TException {
+        when(licenseClient.updateLicense(any(), any(), any())).thenReturn(RequestStatus.SUCCESS);
+
+        RequestStatus result = licenseService.updateLicense(new License(), new User());
+
+        assertThat(result).isEqualTo(RequestStatus.SUCCESS);
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
@@ -38,6 +38,9 @@ public class Sw360LicenseServiceTest {
 
     @Before
     public void setUp() throws TException {
+        // Constructing with new() leaves @Value fields (e.g. thriftServerUrl) null.
+        // Safe here because getThriftLicenseClient() is stubbed before any field read.
+        // Tests that exercise paths using thriftServerUrl directly will need ReflectionTestUtils.setField().
         licenseService = spy(new Sw360LicenseService());
         doReturn(licenseClient).when(licenseService).getThriftLicenseClient();
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -467,4 +467,20 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                 .accept(MediaTypes.HAL_JSON))
         .andExpect(status().isOk());
     }
+
+    @Test
+    public void should_return_400_when_license_update_fails() throws Exception {
+        given(this.licenseServiceMock.updateLicense(any(), any()))
+                .willThrow(new RuntimeException("License update failed with status: FAILURE"));
+
+        Map<String, String> licenseRequestBody = new HashMap<>();
+        licenseRequestBody.put("fullName", "Apache License 4.0");
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/licenses/" + license.getId())
+                        .contentType(MediaTypes.HAL_JSON)
+                        .content(this.objectMapper.writeValueAsString(licenseRequestBody))
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
@@ -471,8 +472,10 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_return_400_when_license_update_fails() throws Exception {
+        // Overrides the @Before stub (SUCCESS) for this test only — Mockito applies the last stub wins rule.
+        String expectedMessage = "License update failed with status: " + RequestStatus.FAILURE;
         given(this.licenseServiceMock.updateLicense(any(), any()))
-                .willThrow(new BadRequestClientException("License update failed with status: FAILURE"));
+                .willThrow(new BadRequestClientException(expectedMessage));
 
         Map<String, String> licenseRequestBody = new HashMap<>();
         licenseRequestBody.put("fullName", "Apache License 4.0");
@@ -482,6 +485,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                         .content(this.objectMapper.writeValueAsString(licenseRequestBody))
                         .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                         .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(expectedMessage));
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -15,6 +15,7 @@ import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
@@ -471,7 +472,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
     @Test
     public void should_return_400_when_license_update_fails() throws Exception {
         given(this.licenseServiceMock.updateLicense(any(), any()))
-                .willThrow(new RuntimeException("License update failed with status: FAILURE"));
+                .willThrow(new BadRequestClientException("License update failed with status: FAILURE"));
 
         Map<String, String> licenseRequestBody = new HashMap<>();
         licenseRequestBody.put("fullName", "Apache License 4.0");


### PR DESCRIPTION
`PATCH /api/licenses/{id}` was silently returning `200 OK` even when the backend rejected the write. If `LicenseDatabaseHandler.updateLicense()` returned `RequestStatus.FAILURE` ; either because the user lacked write permission or because a business rule was violated (e.g. attempting to uncheck an already-checked license through a concurrent request that bypassed the controller-level guard); `Sw360LicenseService.updateLicense()` handed that status back raw without throwing, and `LicenseController.updateLicense()` only checked for `SENT_TO_MODERATOR`, so everything else fell through to `return 200 OK` with the pre-update license body.

The fix has two parts. First, `Sw360LicenseService.updateLicense()` now throws `BadRequestClientException` when the backend returns `FAILURE`, matching the pattern already used in `deleteLicenseById()` in the same class. This means `FAILURE` never reaches the controller. Second, the controller adds a `requestStatus != SUCCESS` guard as a forward-compatibility catch-all: if the backend ever returns a currently unhandled status (`IN_USE`, `ACCESS_DENIED`, `NOOP`, etc.), the guard prevents a silent `200` from slipping through again. These are two distinct concerns; the service throw handles the known `FAILURE` case today, the controller guard handles unknown statuses in the future.

The `@ApiResponses` annotation is updated to document the `400` response that was always possible but never declared. Error messages include the actual `RequestStatus` value so callers can see what the backend returned.

This is related to the broader pattern I've been fixing in #4070, where the PATCH path silently does the wrong thing; there it was data corruption due to Thrift IDL defaults, here it's a rejected write that looks like success to the caller. Also worth noting that the recently opened #4096 tackles a similar class of problem from the other direction: exception rewrapping that hides real 404/403 status codes. The issue here is the complement of that; not an exception being lost, but a return value never being checked.

Issue: NA

### Suggest Reviewer
@GMishx @amritkv @rudra-superrr @bibhuti230185

### How To Test?

1. As a user without write permission on a license, call:
```
PATCH /api/licenses/{id}
{ "fullName": "some change" }
```
**Before:** `200 OK` with the license body; write silently rejected, caller has no idea.
**After:** `400 Bad Request` with `"License update failed with status: FAILURE"` in the response body.

2. Create a license, mark it `checked: true`, then try to set `checked: false` via two near-simultaneous PATCH requests where the second one fetches the unchecked state just before the first commits; the controller-level guard doesn't fire but the backend returns `FAILURE` at the DB layer.
**Before:** `200 OK`.
**After:** `400 Bad Request`.

3. A unit test (`Sw360LicenseServiceTest`) verifies that when the Thrift client returns `RequestStatus.FAILURE`, the service throws `BadRequestClientException` with the status value in the message. A controller-level spec test (`LicenseSpecTest`) verifies the `400` response and response body when the service throws.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR