### PR TITLE
feat(Component): Added pagination and sorting  for release overview in components

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -347,6 +347,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return releaseRepository.getReleasesFullDocsFromComponentId(id, user);
     }
 
+    public Map<PaginationData, List<Release>> getReleasesFromComponentIdWithPagination(String id, User user, PaginationData pageData) throws TException {
+        return releaseRepository.getReleasesFromComponentIdWithPagination(id, user, pageData);
+    }
+
     public List<Component> getMyComponents(String user) {
         Collection<Component> myComponents = componentRepository.getMyComponents(user);
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -177,6 +177,10 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
 
     private static final String RELEASE_BY_ALL_IDX = "ReleaseByAllIdx";
     private static final String RELEASE_BY_ATTACHMENT_TYPE_IDX = "ReleaseByAttachmentTypeIdx";
+    private static final String RELEASE_BY_COMPONENT_NAME_IDX = "ReleaseByComponentNameIdx";
+    private static final String RELEASE_BY_COMPONENT_VERSION_IDX = "ReleaseByComponentVersionIdx";
+    private static final String RELEASE_BY_COMPONENT_CLEARING_STATE_IDX = "ReleaseByComponentClearingStateIdx";
+    private static final String RELEASE_BY_COMPONENT_MAINLINE_STATE_IDX = "ReleaseByComponentMainlineStateIdx";
 
     public ReleaseRepository(DatabaseConnectorCloudant db, VendorRepository vendorRepository) {
         super(Release.class, db, new ReleaseSummary(vendorRepository));
@@ -212,6 +216,26 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
                 Release._Fields.TYPE.getFieldName(),
                 Release._Fields.CLEARING_STATE.getFieldName(),
                 Release._Fields.ATTACHMENTS.getFieldName() + "." + Attachment._Fields.ATTACHMENT_TYPE.getFieldName()
+        }, db);
+
+        // Per-sort-column indexes for getReleasesFromComponentIdWithPagination.
+        // Each index starts with componentId followed by the sort field so that
+        // CouchDB/Cloudant can satisfy both the selector and the sort clause.
+        createIndex(RELEASE_BY_COMPONENT_NAME_IDX, "releaseByComponentName", new String[] {
+                Release._Fields.COMPONENT_ID.getFieldName(),
+                Release._Fields.NAME.getFieldName()
+        }, db);
+        createIndex(RELEASE_BY_COMPONENT_VERSION_IDX, "releaseByComponentVersion", new String[] {
+                Release._Fields.COMPONENT_ID.getFieldName(),
+                Release._Fields.VERSION.getFieldName()
+        }, db);
+        createIndex(RELEASE_BY_COMPONENT_CLEARING_STATE_IDX, "releaseByComponentClearingState", new String[] {
+                Release._Fields.COMPONENT_ID.getFieldName(),
+                Release._Fields.CLEARING_STATE.getFieldName()
+        }, db);
+        createIndex(RELEASE_BY_COMPONENT_MAINLINE_STATE_IDX, "releaseByComponentMainlineState", new String[] {
+                Release._Fields.COMPONENT_ID.getFieldName(),
+                Release._Fields.MAINLINE_STATE.getFieldName()
         }, db);
     }
 
@@ -314,6 +338,66 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
         Set<String> releaseIds = queryForIdsAsValue("releasesByComponentId", id);
         return new ArrayList<Release>(getFullDocsById(releaseIds));
     }
+
+    /**
+     * Returns paginated releases for a given component, sorted by the column
+     * in {@code pageData}:
+     *   0 = name (default), 1 = version, 2 = clearingState, 3 = mainlineState.
+     */
+    public Map<PaginationData, List<Release>> getReleasesFromComponentIdWithPagination(
+            String id, User user, PaginationData pageData) {
+
+        final Map<String, Object> selector = eq(Release._Fields.COMPONENT_ID.getFieldName(), id);
+        final Map<String, String> sortSelector = getComponentReleaseSortSelector(pageData);
+        final String indexName = getComponentReleaseIndexName(pageData);
+
+        PostFindOptions.Builder qb = getConnector().getQueryBuilder()
+                .selector(selector)
+                .useIndex(Collections.singletonList(indexName));
+
+        List<Release> releases = getConnector().getQueryResultPaginated(
+                qb, Release.class, pageData, sortSelector);
+
+        return Collections.singletonMap(pageData, releases);
+    }
+
+    /**
+     * Returns the CouchDB index name that covers {@code componentId} + the sort
+     * field requested in {@code pageData}, so CouchDB can satisfy both the
+     * equality selector and the ORDER BY clause without a "no_usable_index" error.
+     */
+    private static @NotNull String getComponentReleaseIndexName(PaginationData pageData) {
+        return switch (ReleaseSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ReleaseSortColumn.BY_VERSION       -> RELEASE_BY_COMPONENT_VERSION_IDX;
+            case ReleaseSortColumn.BY_CLEARING_STATE -> RELEASE_BY_COMPONENT_CLEARING_STATE_IDX;
+            case ReleaseSortColumn.BY_MAINLINE_STATE -> RELEASE_BY_COMPONENT_MAINLINE_STATE_IDX;
+            case null, default                       -> RELEASE_BY_COMPONENT_NAME_IDX;
+        };
+    }
+
+    private static @NotNull String getViewFromPagination(PaginationData pageData) {
+        return switch (ReleaseSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ReleaseSortColumn.BY_NAME -> "byname";
+            case ReleaseSortColumn.BY_VERSION -> "releaseByVersion";
+            case null -> "all";
+            default -> "byCreatedOn";
+        };
+    }
+
+    private static @NotNull Map<String, String> getComponentReleaseSortSelector(PaginationData pageData) {
+        boolean ascending = pageData.isAscending();
+        return switch (ReleaseSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ReleaseSortColumn.BY_VERSION ->
+                    Collections.singletonMap(Release._Fields.VERSION.getFieldName(), ascending ? "asc" : "desc");
+            case ReleaseSortColumn.BY_CLEARING_STATE ->
+                    Collections.singletonMap(Release._Fields.CLEARING_STATE.getFieldName(), ascending ? "asc" : "desc");
+            case ReleaseSortColumn.BY_MAINLINE_STATE ->
+                    Collections.singletonMap(Release._Fields.MAINLINE_STATE.getFieldName(), ascending ? "asc" : "desc");
+            case null, default ->
+                    Collections.singletonMap(Release._Fields.NAME.getFieldName(), ascending ? "asc" : "desc");
+        };
+    }
+
 
     public List<Release> getReleasesFromComponentId(String id, User user) {
         Set<String> releaseIds = queryForIdsAsValue("releasesByComponentId", id);
@@ -445,6 +529,10 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
                     Collections.singletonMap(Release._Fields.NAME.getFieldName(), ascending ? "asc" : "desc");
             case ReleaseSortColumn.BY_VERSION ->
                     Collections.singletonMap(Release._Fields.VERSION.getFieldName(), ascending ? "asc" : "desc");
+            case ReleaseSortColumn.BY_CLEARING_STATE ->
+                    Collections.singletonMap(Release._Fields.CLEARING_STATE.getFieldName(), ascending ? "asc" : "desc");
+            case ReleaseSortColumn.BY_MAINLINE_STATE ->
+                    Collections.singletonMap(Release._Fields.MAINLINE_STATE.getFieldName(), ascending ? "asc" : "desc");
             case null, default ->
                     Collections.singletonMap(Release._Fields.CREATED_ON.getFieldName(), ascending ? "asc" : "desc"); // Default sort by creation date
         };

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -532,6 +532,14 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
+    public Map<PaginationData, List<Release>> getReleasesFromComponentIdWithPagination(String id, User user, PaginationData pageData) throws TException {
+        assertUser(user);
+        assertId(id);
+
+        return handler.getReleasesFromComponentIdWithPagination(id, user, pageData);
+    }
+
+    @Override
     public Set<Component> getUsingComponentsForRelease(String releaseId) throws TException {
         return handler.getUsingComponents(releaseId);
     }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -91,6 +91,7 @@ public class SW360Constants {
     public static final String TYPE_SPDX_PACKAGE_INFO = "packageInformation";
     public static final String TYPE_PACKAGE = "package";
     public static final String TYPE_ECC = "ecc";
+    public static final String TYPE_RELEASELINK = "releaseLink";
     public static final String PLEASE_ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP = "Please enable flexible project " +
             "release relationship configuration to use this function (enable.flexible.project.release.relationship = true)";
 

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
@@ -27,6 +27,7 @@ import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -52,6 +53,7 @@ public class ResourceComparatorGenerator<T> {
     private static final Map<License._Fields, Comparator<License>> licenseMap = generateLicenseMap();
     private static final Map<Obligation._Fields, Comparator<Obligation>> obligationMap = generateObligationMap();
     private static final Map<Package._Fields, Comparator<Package>> packageMap = generatePackageMap();
+    private static final Map<ReleaseLink._Fields, Comparator<ReleaseLink>> releaseLinkMap = generateReleaseLinkMap();
     private static final Map<SearchResult._Fields, Comparator<SearchResult>> searchResultMap = generateSearchResultMap();
     private static final Map<ChangeLogs._Fields, Comparator<ChangeLogs>> changeLogMap = generateChangeLogMap();
     private static final Map<VulnerabilityDTO._Fields, Comparator<VulnerabilityDTO>> vDtoMap = generateVulDtoMap();
@@ -163,6 +165,15 @@ public class ResourceComparatorGenerator<T> {
         Map<Package._Fields, Comparator<Package>> packageMap = new HashMap<>();
         packageMap.put(Package._Fields.NAME, Comparator.comparing(Package::getName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
         return Collections.unmodifiableMap(packageMap);
+    }
+
+    private static Map<ReleaseLink._Fields, Comparator<ReleaseLink>> generateReleaseLinkMap() {
+        Map<ReleaseLink._Fields, Comparator<ReleaseLink>> releaseLinkMap = new HashMap<>();
+        releaseLinkMap.put(ReleaseLink._Fields.NAME, Comparator.comparing(ReleaseLink::getName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        releaseLinkMap.put(ReleaseLink._Fields.VERSION, Comparator.comparing(ReleaseLink::getVersion, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        releaseLinkMap.put(ReleaseLink._Fields.CLEARING_STATE, Comparator.comparing(rl -> Optional.ofNullable(rl.getClearingState()).map(Object::toString).orElse(null), Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        releaseLinkMap.put(ReleaseLink._Fields.MAINLINE_STATE, Comparator.comparing(rl -> Optional.ofNullable(rl.getMainlineState()).map(Object::toString).orElse(null), Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        return Collections.unmodifiableMap(releaseLinkMap);
     }
 
     private static Map<SearchResult._Fields, Comparator<SearchResult>> generateSearchResultMap() {
@@ -280,6 +291,8 @@ public class ResourceComparatorGenerator<T> {
                 return (Comparator<T>)defaultObligationComparator();
             case SW360Constants.TYPE_COMMENT:
                 return (Comparator<T>)defaultCommentComparator();
+            case SW360Constants.TYPE_RELEASELINK:
+                return (Comparator<T>)defaultReleaseLinkComparator();
             default:
                 throw new ResourceClassNotFoundException("No default comparator for resource class with name " + type);
         }
@@ -448,6 +461,15 @@ public class ResourceComparatorGenerator<T> {
                     }
                 }
                 return generateLicenseComparatorWithFields(type, licenseFields);
+            case SW360Constants.TYPE_RELEASELINK:
+                List<ReleaseLink._Fields> releaseLinkFields = new ArrayList<>();
+                for (String property : properties) {
+                    ReleaseLink._Fields field = ReleaseLink._Fields.findByName(property);
+                    if (field != null) {
+                        releaseLinkFields.add(field);
+                    }
+                }
+                return (Comparator<T>) generateReleaseLinkComparatorWithFields(releaseLinkFields);
             default:
                 throw new ResourceClassNotFoundException("No comparator for resource class with name " + type);
         }
@@ -892,5 +914,21 @@ public class ResourceComparatorGenerator<T> {
     }
     public Comparator<Comment> defaultCommentComparator() {
         return commentMap.get(Comment._Fields.COMMENTED_ON);
+    }
+
+    private Comparator<ReleaseLink> generateReleaseLinkComparatorWithFields(List<ReleaseLink._Fields> fields) {
+        Comparator<ReleaseLink> comparator = defaultReleaseLinkComparator();
+        for (ReleaseLink._Fields field : fields) {
+            Comparator<ReleaseLink> fieldComparator = releaseLinkMap.get(field);
+            if (fieldComparator != null) {
+                comparator = fieldComparator;
+                break;
+            }
+        }
+        return comparator;
+    }
+
+    private Comparator<ReleaseLink> defaultReleaseLinkComparator() {
+        return releaseLinkMap.get(ReleaseLink._Fields.NAME);
     }
 }

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -476,6 +476,8 @@ enum ReleaseSortColumn {
     BY_CREATEDON = -1,
     BY_NAME = 0,
     BY_VERSION = 1,
+    BY_CLEARING_STATE = 2,
+    BY_MAINLINE_STATE = 3,
 }
 
 enum BulkOperationNodeType {
@@ -870,6 +872,8 @@ service ComponentService {
     list<Release> getReleasesByComponentId(1: string id, 2: User user);
 
     list<Release> getReleasesFullDocsFromComponentId(1: string id, 2: User user);
+
+    map<PaginationData, list<Release>> getReleasesFromComponentIdWithPagination(1: string id, 2: User user, 3: PaginationData pageData);
 
     /**
      * get components belonging to linked releases of the release specified by releaseId

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -595,21 +595,45 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
 
     @Operation(
             summary = "Get all releases of a component.",
-            description = "Get all releases of a component.",
+            description = "Get all releases of a component with pagination support.",
             tags = {"Components"}
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Component releases successfully retrieved.")
     })
     @GetMapping(value = COMPONENTS_URL + "/{id}/releases")
-    public ResponseEntity<CollectionModel<ReleaseLink>> getReleaseLinksByComponentId(
+    public ResponseEntity<CollectionModel<EntityModel<ReleaseLink>>> getReleaseLinksByComponentId(
             @Parameter(description = "The id of the component.")
-            @PathVariable("id") String id
-    ) throws TException {
+            @PathVariable("id") String id,
+            @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
+            Pageable pageable,
+            HttpServletRequest request
+    ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        final List<ReleaseLink> releaseLinks = componentService.convertReleaseToReleaseLink(id, sw360User);
-        CollectionModel<ReleaseLink> resources = CollectionModel.of(releaseLinks);
-        return new ResponseEntity<>(resources, HttpStatus.OK);
+
+        Map<PaginationData, List<ReleaseLink>> paginatedReleaseLinks =
+                componentService.getReleaseLinksByComponentIdWithPagination(id, sw360User, pageable);
+
+        List<ReleaseLink> releaseLinks = new ArrayList<>(paginatedReleaseLinks.values().iterator().next());
+        int totalCount = Math.toIntExact(paginatedReleaseLinks.keySet().stream()
+                .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));
+
+        PaginationResult<ReleaseLink> paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                request, pageable, releaseLinks, SW360Constants.TYPE_RELEASELINK, totalCount);
+
+        List<EntityModel<ReleaseLink>> resources = paginationResult.getResources().stream()
+                .map(EntityModel::of)
+                .collect(Collectors.toList());
+
+        if (resources.isEmpty()) {
+            CollectionModel<EntityModel<ReleaseLink>> empty =
+                    restControllerHelper.emptyPageResource(ReleaseLink.class, paginationResult);
+            return new ResponseEntity<>(empty, HttpStatus.OK);
+        }
+
+        CollectionModel<EntityModel<ReleaseLink>> collectionModel =
+                restControllerHelper.generatePagesResource(paginationResult, resources);
+        return new ResponseEntity<>(collectionModel, HttpStatus.OK);
     }
 
     @PreAuthorize("hasAuthority('WRITE')")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -31,6 +31,7 @@ import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
@@ -210,6 +211,53 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
     public List<Release> getReleasesByComponentId(String id,User user) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.getReleasesFullDocsFromComponentId(id, user);
+    }
+
+    public Map<PaginationData, List<ReleaseLink>> getReleaseLinksByComponentIdWithPagination(String id, User user, Pageable pageable) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        PaginationData pageData = pageableToPaginationDataForReleases(pageable);
+        Map<PaginationData, List<Release>> paginatedReleases = sw360ComponentClient.getReleasesFromComponentIdWithPagination(id, user, pageData);
+
+        PaginationData resultPageData = paginatedReleases.keySet().iterator().next();
+        List<Release> releases = paginatedReleases.values().iterator().next();
+
+        List<ReleaseLink> releaseLinks = convertReleasesToReleaseLinks(releases);
+        Map<PaginationData, List<ReleaseLink>> result = new HashMap<>();
+        result.put(resultPageData, releaseLinks);
+        return result;
+    }
+
+    private List<ReleaseLink> convertReleasesToReleaseLinks(List<Release> releases) {
+        List<ReleaseLink> releaseLinks = new ArrayList<>();
+        releases.forEach(release -> {
+            ReleaseLink releaseLink = new ReleaseLink();
+            releaseLink.setId(release.getId());
+            releaseLink.setName(release.getName());
+            releaseLink.setVersion(release.getVersion());
+            releaseLink.setClearingState(release.getClearingState());
+            releaseLink.setCreatedBy(release.getCreatedBy());
+
+            ClearingReport clearingReport = new ClearingReport();
+            Set<Attachment> attachments = getAttachmentForClearingReport(release);
+            if (!attachments.equals(Collections.emptySet())) {
+                Set<Attachment> attachmentsAccepted = getAttachmentsStatusAccept(attachments);
+                if (!attachmentsAccepted.isEmpty()) {
+                    clearingReport.setClearingReportStatus(ClearingReportStatus.DOWNLOAD);
+                    clearingReport.setAttachments(attachmentsAccepted);
+                    releaseLink.setClearingReport(clearingReport);
+                } else {
+                    clearingReport.setClearingReportStatus(ClearingReportStatus.NO_STATUS);
+                    releaseLink.setClearingReport(clearingReport);
+                }
+            } else {
+                clearingReport.setClearingReportStatus(ClearingReportStatus.NO_REPORT);
+                releaseLink.setClearingReport(clearingReport);
+            }
+
+            releaseLink.setMainlineState(release.getMainlineState());
+            releaseLinks.add(releaseLink);
+        });
+        return releaseLinks;
     }
 
     public List<ReleaseLink> convertReleaseToReleaseLink(String id,User user) throws TException {
@@ -445,6 +493,33 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
                 case "mainLicenseIds" -> ComponentSortColumn.BY_MAINLICENSE;
                 case "type" -> ComponentSortColumn.BY_TYPE;
                 default -> column; // Default to BY_CREATEDON if no match
+            };
+            ascending = order.isAscending();
+        }
+        return new PaginationData().setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
+    }
+
+    /**
+     * Converts a Pageable object to a PaginationData object using ReleaseSortColumn mapping.
+     * Sort properties: name (0), version (1), clearingState (2), mainlineState (3).
+     *
+     * @param pageable the Pageable object to convert
+     * @return a PaginationData object representing the pagination information
+     */
+    private static PaginationData pageableToPaginationDataForReleases(@NotNull Pageable pageable) {
+        ReleaseSortColumn column = ReleaseSortColumn.BY_NAME;
+        boolean ascending = true;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            column = switch (property) {
+                case "name" -> ReleaseSortColumn.BY_NAME;
+                case "version" -> ReleaseSortColumn.BY_VERSION;
+                case "clearingState" -> ReleaseSortColumn.BY_CLEARING_STATE;
+                case "mainlineState" -> ReleaseSortColumn.BY_MAINLINE_STATE;
+                default -> column;
             };
             ascending = order.isAscending();
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -66,6 +66,7 @@ import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProject;
 import org.jetbrains.annotations.NotNull;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProjectDTO;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
 import org.eclipse.sw360.rest.resourceserver.obligation.ObligationController;
@@ -437,8 +438,12 @@ public class RestControllerHelper<T> {
             Sw360ReleaseService sw360ReleaseService,
             User user) throws TException {
         for (String releaseId : releases) {
-            final Release release = sw360ReleaseService.getReleaseForUserById(releaseId, user);
-            addEmbeddedRelease(halResource, release);
+            try {
+                final Release release = sw360ReleaseService.getReleaseForUserById(releaseId, user);
+                addEmbeddedRelease(halResource, release);
+            } catch (ResourceNotFoundException e) {
+                LOGGER.warn("Unable to find a release while adding embedded release. ID = {}", releaseId, e);
+            }
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -155,7 +155,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
             releaseById.setAdditionalData(sortedAdditionalData);
         } catch (SW360Exception sw360Exp) {
             if (sw360Exp.getErrorCode() == 404) {
-                throw new ResourceNotFoundException("Release does not exists! id=" + releaseId);
+                throw new ResourceNotFoundException("Release does not exists! id=" + releaseId, sw360Exp);
             } else {
                 throw sw360Exp;
             }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
@@ -773,25 +774,28 @@ public class ComponentTest extends TestIntegrationBase {
 
     @Test
     public void should_get_releases_by_component() throws Exception {
-        List<Release> releases = new ArrayList<>();
-        Release release1 = new Release();
-        release1.setId("release-1");
-        release1.setName("Angular");
-        release1.setVersion("2.3.0");
-        release1.setMainlineState(MainlineState.OPEN);
-        release1.setClearingState(ClearingState.APPROVED);
-        releases.add(release1);
+        List<ReleaseLink> releaseLinks = new ArrayList<>();
+        ReleaseLink releaseLink1 = new ReleaseLink();
+        releaseLink1.setId("release-1");
+        releaseLink1.setName("Angular");
+        releaseLink1.setVersion("2.3.0");
+        releaseLink1.setMainlineState(MainlineState.OPEN);
+        releaseLink1.setClearingState(ClearingState.APPROVED);
+        releaseLinks.add(releaseLink1);
 
-        Release release2 = new Release();
-        release2.setId("release-2");
-        release2.setName("Angular");
-        release2.setVersion("2.4.0");
-        release2.setMainlineState(MainlineState.MAINLINE);
-        release2.setClearingState(ClearingState.UNDER_CLEARING);
-        releases.add(release2);
+        ReleaseLink releaseLink2 = new ReleaseLink();
+        releaseLink2.setId("release-2");
+        releaseLink2.setName("Angular");
+        releaseLink2.setVersion("2.4.0");
+        releaseLink2.setMainlineState(MainlineState.MAINLINE);
+        releaseLink2.setClearingState(ClearingState.UNDER_CLEARING);
+        releaseLinks.add(releaseLink2);
 
-        Mockito.doReturn(releases).when(componentServiceMock)
-                .getReleasesByComponentId(eq("component-1"), any());
+        Mockito.doReturn(Collections.singletonMap(
+                new PaginationData().setRowsPerPage(releaseLinks.size()).setDisplayStart(0).setTotalRowCount(releaseLinks.size()),
+                releaseLinks
+        )).when(componentServiceMock)
+                .getReleaseLinksByComponentIdWithPagination(eq("component-1"), any(), any());
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
@@ -802,13 +806,13 @@ public class ComponentTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         JsonNode responseNode = new ObjectMapper().readTree(response.getBody());
-        JsonNode releaseLinks = responseNode.get("_embedded").get("sw360:releaseLinks");
-        assertTrue(releaseLinks.isArray());
-        assertEquals(2, releaseLinks.size());
-        assertEquals("Angular", releaseLinks.get(0).get("name").textValue());
-        assertEquals("2.3.0", releaseLinks.get(0).get("version").textValue());
-        assertEquals("OPEN", releaseLinks.get(0).get("mainlineState").textValue());
-        assertEquals("APPROVED", releaseLinks.get(0).get("clearingState").textValue());
+        JsonNode releaseLinksNode = responseNode.get("_embedded").get("sw360:releaseLinks");
+        assertTrue(releaseLinksNode.isArray());
+        assertEquals(2, releaseLinksNode.size());
+        assertEquals("Angular", releaseLinksNode.get(0).get("name").textValue());
+        assertEquals("2.3.0", releaseLinksNode.get(0).get("version").textValue());
+        assertEquals("OPEN", releaseLinksNode.get(0).get("mainlineState").textValue());
+        assertEquals("APPROVED", releaseLinksNode.get(0).get("clearingState").textValue());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.ImportBomRequestPreparation;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.VerificationState;
@@ -482,6 +483,10 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         releaseLinks.add(releaseLink2);
 
         given(this.componentServiceMock.convertReleaseToReleaseLink(any(),any())).willReturn(releaseLinks);
+        given(this.componentServiceMock.getReleaseLinksByComponentIdWithPagination(any(), any(), any()))
+                .willReturn(Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(releaseLinks.size()).setDisplayStart(0).setTotalRowCount(releaseLinks.size()),
+                        releaseLinks));
 
         List<String> releaseIds = releaseList.stream().map(Release::getId).collect(Collectors.toList());
         given(this.vulnerabilityServiceMock.getVulnerabilityDTOByExternalId(any(), any())).willReturn(vulDtosUpdated);
@@ -1351,7 +1356,9 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
                         links(
-                                linkWithRel("curies").description("Curies are used for online documentation")
+                                linkWithRel("curies").description("Curies are used for online documentation"),
+                                linkWithRel("first").description("Link to the first page"),
+                                linkWithRel("last").description("Link to the last page")
                         ),
                         responseFields(
                                 subsectionWithPath("_embedded.sw360:releaseLinks.[]id").description("The Id of the releaseLinks"),
@@ -1362,7 +1369,12 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:releaseLinks.[]clearingReport.clearingReportStatus").description("The clearingReportStatus of the clearingReport "+Arrays.asList(ClearingReportStatus.values())),
                                 subsectionWithPath("_embedded.sw360:releaseLinks.[]clearingState").description("The clearingState of the releaseLinks "+ Arrays.asList(ClearingState.values())),
                                 subsectionWithPath("_embedded.sw360:releaseLinks").description("An array of <<resources-releases, releases resources>>"),
-                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                                subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
+                                subsectionWithPath("page").description("Pagination information"),
+                                subsectionWithPath("page.size").description("Number of results per page"),
+                                subsectionWithPath("page.totalElements").description("Total number of results"),
+                                subsectionWithPath("page.totalPages").description("Total number of pages"),
+                                subsectionWithPath("page.number").description("Current page number (0-indexed)")
                         )));
     }
 


### PR DESCRIPTION

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4106*)
> * Did you add or update any new dependencies that are required for your change?

Closes: https://github.com/eclipse-sw360/sw360/issues/4106

### Suggest Reviewer
> @GMishx 

### How To Test?

Start SW360.
Create a component with several releases.
Call:
        GET /api/components/{id}/releases
        GET /api/components/{id}/releases?page=0&pageEntries=5&sort=name,asc
        GET /api/components/{id}/releases?page=0&pageEntries=5&sort=clearingState,desc
        GET /api/components/{id}/releases?page=0&pageEntries=5&sort=mainlineState,asc
        GET /api/components/{id}/releases?page=0&pageEntries=5&sort=version,asc
All requests should return 200 OK with a paginated HAL response.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
