### PR TITLE
feat(rest): add PATCH /ecc/{releaseId} and eccStatus filter to GET /ecc

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/ecc/EccController.java
@@ -10,22 +10,29 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.collect.ImmutableMap;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
+import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -36,13 +43,16 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.client.HttpClientErrorException;
 
 @BasePathAwareController
 @RequiredArgsConstructor
@@ -54,6 +64,9 @@ public class EccController implements RepresentationModelProcessor<RepositoryLin
     private static final String TYPE_ECC = "ecc";
 
     public static final String ECC_URL = "/ecc";
+
+    private static final ImmutableMap<String, String> RESPONSE_BODY_FOR_MODERATION_REQUEST =
+            ImmutableMap.<String, String>builder().put("message", "Moderation request is created").build();
 
     @NonNull
     private final RestControllerHelper restControllerHelper;
@@ -69,7 +82,8 @@ public class EccController implements RepresentationModelProcessor<RepositoryLin
 
     @Operation(
             summary = "List ECC details.",
-            description = "List all of the service's ECC.",
+            description = "List all of the service's ECC. Optionally filter by eccStatus " +
+                    "(OPEN, IN_PROGRESS, APPROVED, REJECTED). Omitting eccStatus returns all releases.",
             tags = {"ECC"}
     )
     @ApiResponses(value = {
@@ -81,12 +95,20 @@ public class EccController implements RepresentationModelProcessor<RepositoryLin
     public ResponseEntity<CollectionModel<EntityModel<Release>>> getEccDetails(
             HttpServletRequest request,
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
-            Pageable pageable
+            Pageable pageable,
+            @Parameter(description = "Filter releases by ECC status. Omit to return all releases.")
+            @RequestParam(value = "eccStatus", required = false) ECCStatus eccStatus
     ) throws SW360Exception {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(user);
         try {
             List<Release> releases = releaseService.getReleasesForUser(user);
+            if (eccStatus != null) {
+                releases = releases.stream()
+                        .filter(r -> r.getEccInformation() != null
+                                && eccStatus.equals(r.getEccInformation().getEccStatus()))
+                        .toList();
+            }
             PaginationResult<Release> paginationResult = restControllerHelper.createPaginationResult(request, pageable,
                     releases, TYPE_ECC);
             final List<EntityModel<Release>> releaseResources = new ArrayList<>();
@@ -111,5 +133,54 @@ public class EccController implements RepresentationModelProcessor<RepositoryLin
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }
+    }
+
+    @PreAuthorize("hasAuthority('WRITE')")
+    @Operation(
+            summary = "Update ECC information for a release.",
+            description = "Update the ECC information of a specific release by its ID. " +
+                    "Only the ECC fields in the request body are applied; other release fields are untouched. " +
+                    "Returns 202 if the update requires moderator approval.",
+            tags = {"ECC"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "ECC information updated successfully.",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = Release.class))
+                    }),
+            @ApiResponse(
+                    responseCode = "202", description = "Moderation request is created.",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = "{\"message\": \"Moderation request is created\"}"
+                                    ))
+                    })
+    })
+    @PatchMapping(value = ECC_URL + "/{releaseId}")
+    public ResponseEntity<?> updateEccInformation(
+            @Parameter(description = "The ID of the release whose ECC information is to be updated.")
+            @PathVariable("releaseId") String releaseId,
+            @Parameter(description = "The ECC information fields to update.")
+            @RequestBody EccInformation eccInformation
+    ) throws TException {
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        Release release = releaseService.getReleaseForUserById(releaseId, user);
+        EccInformation existing = release.isSetEccInformation()
+                ? release.getEccInformation() : new EccInformation();
+        for (EccInformation._Fields field : EccInformation._Fields.values()) {
+            if (eccInformation.isSet(field)) {
+                existing.setFieldValue(field, eccInformation.getFieldValue(field));
+            }
+        }
+        release.setEccInformation(existing);
+        RequestStatus updateStatus = releaseService.updateRelease(release, user);
+        if (updateStatus == RequestStatus.SENT_TO_MODERATOR) {
+            return new ResponseEntity<>(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
+        }
+        Release updatedRelease = releaseService.getReleaseForUserById(releaseId, user);
+        return new ResponseEntity<>(EntityModel.of(updatedRelease), HttpStatus.OK);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -338,6 +338,8 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         } else if (requestStatus == RequestStatus.DUPLICATE) {
             throw new HttpClientErrorException(HttpStatus.CONFLICT,
                     "A release with the same name and version already exists.");
+        } else if (requestStatus == RequestStatus.ACCESS_DENIED) {
+            throw new AccessDeniedException("Not allowed to update release '" + SW360Utils.printName(release) + "'.");
         } else if (requestStatus != RequestStatus.SUCCESS && requestStatus != RequestStatus.SENT_TO_MODERATOR) {
             throw new RuntimeException(
                     "sw360 release with name '" + SW360Utils.printName(release) + " cannot be updated.");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/EccTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/EccTest.java
@@ -12,6 +12,8 @@
 package org.eclipse.sw360.rest.resourceserver.integration;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
 import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -22,11 +24,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -34,7 +39,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
@@ -48,29 +56,32 @@ public class EccTest extends TestIntegrationBase {
     private Sw360ReleaseService releaseServiceMock;
 
     private List<Release> releaseList;
+    private Release release1;
+    private Release release2;
 
     @Before
     public void before() throws TException {
         releaseList = new ArrayList<>();
 
-        // Create test releases with ECC information
-        Release release1 = new Release();
+        release1 = new Release();
         release1.setName("TestRelease1");
         release1.setVersion("1.0");
         release1.setId("rel123");
 
         EccInformation eccInfo1 = new EccInformation();
+        eccInfo1.setEccStatus(ECCStatus.OPEN);
         eccInfo1.setAssessorContactPerson("john.doe@example.com");
         eccInfo1.setAssessmentDate("2025-03-15");
         eccInfo1.setAssessorDepartment("Security Department");
         release1.setEccInformation(eccInfo1);
 
-        Release release2 = new Release();
+        release2 = new Release();
         release2.setName("TestRelease2");
         release2.setVersion("2.0");
         release2.setId("rel456");
 
         EccInformation eccInfo2 = new EccInformation();
+        eccInfo2.setEccStatus(ECCStatus.APPROVED);
         eccInfo2.setAssessorContactPerson("jane.smith@example.com");
         eccInfo2.setAssessmentDate("2025-03-20");
         eccInfo2.setAssessorDepartment("Export Control Team");
@@ -87,6 +98,8 @@ public class EccTest extends TestIntegrationBase {
         given(this.releaseServiceMock.getReleasesForUser(any())).willReturn(releaseList);
     }
 
+    // ── GET /ecc ─────────────────────────────────────────────────────────────
+
     @Test
     public void should_get_all_ecc_information() throws Exception {
         HttpHeaders headers = getHeaders(port);
@@ -97,8 +110,48 @@ public class EccTest extends TestIntegrationBase {
                         String.class);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        // Using the embedded relationship name "sw360:releases" since ECC returns release objects
+        // Using the embedded relationship name "sw360:releases" since ECC returns releases
         TestHelper.checkResponse(response.getBody(), "releases", 2);
+    }
+
+    @Test
+    public void should_return_all_ecc_when_no_status_filter() throws Exception {
+        // Omitting eccStatus must return all releases — backward-compatible behaviour
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/ecc",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        TestHelper.checkResponse(response.getBody(), "releases", 2);
+    }
+
+    @Test
+    public void should_filter_ecc_by_status_open() throws Exception {
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/ecc?eccStatus=OPEN",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        TestHelper.checkResponse(response.getBody(), "releases", 1);
+    }
+
+    @Test
+    public void should_filter_ecc_by_status_approved() throws Exception {
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/ecc?eccStatus=APPROVED",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        TestHelper.checkResponse(response.getBody(), "releases", 1);
     }
 
     @Test
@@ -143,5 +196,83 @@ public class EccTest extends TestIntegrationBase {
                         String.class);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    // ── PATCH /ecc/{releaseId} ────────────────────────────────────────────────
+
+    @Test
+    public void should_patch_ecc_information_successfully() throws Exception {
+        given(this.releaseServiceMock.getReleaseForUserById(eq("rel123"), any())).willReturn(release1);
+        given(this.releaseServiceMock.updateRelease(any(), any())).willReturn(RequestStatus.SUCCESS);
+
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = "{\"eccStatus\":\"APPROVED\",\"assessmentDate\":\"2026-04-25\"}";
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/ecc/rel123",
+                        HttpMethod.PATCH,
+                        new HttpEntity<>(body, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue("Response should contain eccInformation", response.getBody().contains("eccInformation"));
+        assertTrue("Untouched assessorContactPerson should survive", response.getBody().contains("john.doe@example.com"));
+    }
+
+    @Test
+    public void should_patch_ecc_information_sent_to_moderator() throws Exception {
+        given(this.releaseServiceMock.getReleaseForUserById(eq("rel123"), any())).willReturn(release1);
+        given(this.releaseServiceMock.updateRelease(any(), any())).willReturn(RequestStatus.SENT_TO_MODERATOR);
+
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = "{\"eccStatus\":\"APPROVED\"}";
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/ecc/rel123",
+                        HttpMethod.PATCH,
+                        new HttpEntity<>(body, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+    }
+
+    @Test
+    public void should_return_403_when_access_denied_on_patch() throws Exception {
+        given(this.releaseServiceMock.getReleaseForUserById(eq("rel123"), any())).willReturn(release1);
+        doThrow(new AccessDeniedException("Not allowed to update release 'TestRelease1 1.0'."))
+                .when(this.releaseServiceMock).updateRelease(any(), any());
+
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = "{\"eccStatus\":\"APPROVED\"}";
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/ecc/rel123",
+                        HttpMethod.PATCH,
+                        new HttpEntity<>(body, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    public void should_return_404_when_release_not_found_on_patch() throws Exception {
+        doThrow(new ResourceNotFoundException("Release not found"))
+                .when(this.releaseServiceMock).getReleaseForUserById(eq("nonexistent"), any());
+
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = "{\"eccStatus\":\"APPROVED\"}";
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/ecc/nonexistent",
+                        HttpMethod.PATCH,
+                        new HttpEntity<>(body, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/EccSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/EccSpecTest.java
@@ -6,8 +6,27 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+
+import org.springframework.restdocs.payload.JsonFieldType;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
 import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -19,20 +38,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class EccSpecTest extends TestRestDocsSpecBase {
@@ -46,23 +56,32 @@ public class EccSpecTest extends TestRestDocsSpecBase {
     @MockitoBean
     private Sw360ReleaseService releaseService;
 
+    private Release rel1;
+    private Release rel2;
+
     @Before
     public void before() throws TException, URISyntaxException {
         List<Release> releaseList = new ArrayList<>();
-        Release rel1 = new Release();
-        rel1.setName("testRealease");
+
+        rel1 = new Release();
+        rel1.setId("rel001");
+        rel1.setName("testRelease");
         rel1.setVersion("1.0");
 
         EccInformation eccInfo1 = new EccInformation();
+        eccInfo1.setEccStatus(ECCStatus.OPEN);
         eccInfo1.setAssessorContactPerson("john@siemens.com");
         eccInfo1.setAssessmentDate("24-01-2024");
         eccInfo1.setAssessorDepartment("Department");
         rel1.setEccInformation(eccInfo1);
 
-        Release rel2 = new Release();
-        rel2.setName("testRealease2");
+        rel2 = new Release();
+        rel2.setId("rel002");
+        rel2.setName("testRelease2");
         rel2.setVersion("2.0");
+
         EccInformation eccInfo2 = new EccInformation();
+        eccInfo2.setEccStatus(ECCStatus.APPROVED);
         eccInfo2.setAssessorContactPerson("john2@siemens.com");
         eccInfo2.setAssessmentDate("22-01-2024");
         eccInfo2.setAssessorDepartment("Department2");
@@ -72,6 +91,8 @@ public class EccSpecTest extends TestRestDocsSpecBase {
         releaseList.add(rel2);
 
         given(this.releaseService.getReleasesForUser(any())).willReturn(releaseList);
+        given(this.releaseService.getReleaseForUserById(eq("rel001"), any())).willReturn(rel1);
+        given(this.releaseService.updateRelease(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789").setUserGroup(UserGroup.ADMIN));
     }
@@ -89,7 +110,10 @@ public class EccSpecTest extends TestRestDocsSpecBase {
                         queryParameters(
                                 parameterWithName("page").description("Page of releases"),
                                 parameterWithName("page_entries").description("Amount of releases per page"),
-                                parameterWithName("sort").description("Defines order of the releases")
+                                parameterWithName("sort").description("Defines order of the releases"),
+                                parameterWithName("eccStatus").description("(Optional) Filter by ECC status: " +
+                                        "OPEN, IN_PROGRESS, APPROVED, REJECTED. Omit to return all releases.")
+                                        .optional()
                         ),
                         responseFields(
                                 subsectionWithPath("_embedded.sw360:releases.[]name").description("The name of the release"),
@@ -105,4 +129,45 @@ public class EccSpecTest extends TestRestDocsSpecBase {
                         )));
     }
 
+    @Test
+    public void should_document_patch_ecc() throws Exception {
+        String eccBody = "{"
+                + "\"eccStatus\": \"APPROVED\","
+                + "\"assessorContactPerson\": \"ecc-lead@siemens.com\","
+                + "\"assessorDepartment\": \"Export Control\","
+                + "\"assessmentDate\": \"2026-04-25\","
+                + "\"eccn\": \"EAR99\","
+                + "\"al\": \"N\""
+                + "}";
+
+        mockMvc.perform(patch("/api/ecc/{releaseId}", rel1.getId())
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(eccBody)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        pathParameters(
+                                parameterWithName("releaseId").description("The ID of the release to update")
+                        ),
+                        requestFields(
+                                fieldWithPath("eccStatus").description("ECC assessment status: OPEN, IN_PROGRESS, APPROVED, REJECTED").optional(),
+                                fieldWithPath("assessorContactPerson").description("Email of the ECC assessor").optional(),
+                                fieldWithPath("assessorDepartment").description("Department of the ECC assessor").optional(),
+                                fieldWithPath("assessmentDate").description("Date of the ECC assessment (YYYY-MM-dd)").optional(),
+                                fieldWithPath("eccn").description("Export Control Classification Number").optional(),
+                                fieldWithPath("al").description("German Ausfuhrliste value").optional(),
+                                fieldWithPath("eccComment").type(JsonFieldType.STRING).description("Free-text ECC comment").optional(),
+                                fieldWithPath("materialIndexNumber").type(JsonFieldType.STRING).description("Material index number").optional(),
+                                fieldWithPath("containsCryptography").type(JsonFieldType.BOOLEAN).description("Whether the release contains cryptography").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("type").description("The type of the document"),
+                                fieldWithPath("id").description("The ID of the release"),
+                                fieldWithPath("name").description("The name of the release"),
+                                fieldWithPath("version").description("The version of the release"),
+                                subsectionWithPath("eccInformation").description("The updated ECC information for the release"),
+                                subsectionWithPath("_links").description("Links to other resources")
+                        )));
+    }
 }


### PR DESCRIPTION
The `/ecc` endpoint was read-only with no filters; you couldn't update ECC info through it and had to download everything just to find releases by status.

Adds `PATCH /ecc/{releaseId}` for targeted ECC updates without touching the full release, and an optional `?eccStatus=` filter to `GET /ecc` so you can ask for just `OPEN` or `APPROVED` releases instead of filtering client-side.

Also fixes `ACCESS_DENIED` in `updateRelease()` surfacing as a generic error instead of a proper 403.

Issue: Fixes #4111 

### Suggest Reviewer
@GMishx 

### How To Test?

- `PATCH /api/ecc/{releaseId}` with a partial `EccInformation` body, confirm only ECC fields change and the response reflects the updated state
- `GET /api/ecc?eccStatus=OPEN`; should return only releases with `OPEN` status
- `GET /api/ecc` with no `eccStatus`; should behave exactly as before
- Integration tests added in `EccTest.java` cover success, 202, 403, and 404 cases

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR