### PR TITLE
Potential fix for code scanning alert no. 95: Cross-site scripting

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -229,7 +229,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(externalId)
                 .toUri();
 
-        return ResponseEntity.created(location).body(vulnerabilityAsMap);
+        return ResponseEntity.created(location).body(vulnerabilityApiDTO);
     }
 
     @PreAuthorize("hasAuthority('WRITE')")


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-sw360/sw360/security/code-scanning/95](https://github.com/eclipse-sw360/sw360/security/code-scanning/95)

General fix: do not send raw user-provided request data back in the response body. Return a sanitized/validated DTO or persisted entity representation generated by the server.

Best fix here: in `createVulnerability(...)`, replace `body(vulnerabilityAsMap)` with `body(vulnerabilityApiDTO)`. `vulnerabilityApiDTO` is typed and populated from the parsed request object and then updated through server-side logic (`setDataForVulnerability(...)`), making it a safer and more controlled output than the raw map. This preserves functionality (still returns created resource data and Location header) while removing direct reflection of untrusted input.

File/region to change:
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java`
- Around lines 229–233 in `createVulnerability(...)`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
