### PR TITLE
fix(rest): include linked packages in project summaryAdministration

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3901,7 +3901,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         sw360Project.setReleaseIdToUsage(null);
         sw360Project.setLinkedProjects(null);
         sw360Project.setAttachments(null);
-        sw360Project.setPackageIds(null);
         HalResource<Project> userHalResource = createHalProject(sw360Project, sw360User);
         setAdditionalFieldsToHalResource(sw360Project,userHalResource);
         sw360Project.unsetLinkedProjects();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -18,6 +18,7 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.ProjectPackageRelationship;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.ObligationStatus;
@@ -1270,6 +1271,24 @@ public class ProjectTest extends TestIntegrationBase {
                         new HttpEntity<>(null, headers),
                         byte[].class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    public void should_get_summary_administration_with_linked_packages() throws IOException, TException {
+        Map<String, ProjectPackageRelationship> linkedPackages = new HashMap<>();
+        linkedPackages.put(package1.getId(), new ProjectPackageRelationship().setComment("Linked from test"));
+        project1.setPackageIds(linkedPackages);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/" + project1.getId() + "/summaryAdministration",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
+        assertTrue(responseBody.path("_embedded").has("sw360:packages"));
     }
 
     // ========== VULNERABILITY MANAGEMENT ==========

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2538,6 +2538,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("phaseOutSince").description("The project phase-out date"),
                                 fieldWithPath("clearingRequestId").description("Clearing Request id associated with project."),
                                 fieldWithPath("licenseInfoHeaderText").description("LicenseInfoHeaderText associated with project."),
+                                subsectionWithPath("packageIds").description("Map of package IDs linked to the project, including relationship metadata").optional(),
                                 subsectionWithPath("externalUrls").description("A place to store additional data used by external URLs"),
                                 subsectionWithPath("_embedded.createdBy").description("The user who created this project"),
                                 subsectionWithPath("_embedded.projectResponsible").description("The project responsible displayed").type(JsonFieldType.OBJECT).optional(),
@@ -2546,6 +2547,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.modifiedBy").description("The user who modified the project").type(JsonFieldType.OBJECT).optional(),
                                 subsectionWithPath("_embedded.leadArchitect").description("The user who leadArchitect of this project").type(JsonFieldType.OBJECT).optional(),
                                 subsectionWithPath("_embedded.sw360:moderators").description("An array of moderators"),
+                                subsectionWithPath("_embedded.sw360:packages").description("Linked package resources for the project").type(JsonFieldType.ARRAY).optional(),
                                 subsectionWithPath("_embedded.sw360:vendors").description("An array of all component vendors with full name and link to their <<resources-vendor-get,Vendor resource>>"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"))
                         		));


### PR DESCRIPTION

Fixes missing Linked Packages in project details by preserving
project packageIds for the summaryAdministration response.

Issue: #3990

### What changed
- Removed clearing of packageIds in ProjectController summaryAdministration flow.
- Kept existing embedded package generation path active for project details.
- Added integration test coverage for summaryAdministration with linked packages.
- Updated REST Docs expectations to include packageIds and embedded packages.

### Why this fixes the bug
The summaryAdministration endpoint was nulling packageIds before HAL
resource construction, which prevented linked packages from being
embedded in the response used by the details page.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] If code is AI-generated, mention the tool and model used
