### PR TITLE
Potential fix for code scanning alert no. 95: Cross-site scripting

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -61,7 +62,6 @@ import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.springframework.data.domain.Pageable;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService.VulnerabilityOperation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -78,11 +78,9 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import com.fasterxml.jackson.annotation.JsonInclude;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 
@@ -194,14 +192,12 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             responses = {
                     @ApiResponse(
                             responseCode = "201",
-                            content = @Content(mediaType = "application/hal+json",
-                                    schema = @Schema(implementation = VulnerabilityApiDTO.class)),
-                            description = "Redirection to the created vulnerability."
+                            description = "Link to the created vulnerability."
                     )
             }
     )
     @PostMapping(VULNERABILITIES_URL)
-    public ResponseEntity createVulnerability(
+    public ResponseEntity<VulnerabilityApiDTO> createVulnerability(
             @Parameter(description = "The vulnerability to be created.",
                     schema = @Schema(implementation = VulnerabilityApiDTO.class)
             )
@@ -240,14 +236,12 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             responses = {
                     @ApiResponse(
                             responseCode = "201",
-                            content = @Content(mediaType = "application/hal+json",
-                                    schema = @Schema(implementation = VulnerabilityApiDTO.class)),
-                            description = "Redirection to the created vulnerability."
+                            description = "Link to the created vulnerability."
                     )
             }
     )
     @PatchMapping(VULNERABILITIES_URL + "/{externalId}")
-    public ResponseEntity updateVulnerability(
+    public ResponseEntity<VulnerabilityApiDTO> updateVulnerability(
             @Parameter(description = "The external ID of the vulnerability to be updated.")
             @PathVariable String externalId,
             @Parameter(description = "The updated vulnerability.",
@@ -273,8 +267,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(externalId)
                 .toUri();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        return ResponseEntity.created(location).body(mapper.convertValue(vulnerabilityAsMap, Map.class));
+        return ResponseEntity.created(location).body(vulnerabilityApiDTO);
     }
 
     @PreAuthorize("hasAuthority('WRITE')")
@@ -285,15 +278,12 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             responses = {
                     @ApiResponse(
                             responseCode = "207",
-                            content = @Content(mediaType = "application/hal+json",
-                                    schema = @Schema(type = "array",
-                                            implementation = MultiStatus.class)),
                             description = "External ID and status."
                     )
             }
     )
     @DeleteMapping(VULNERABILITIES_URL + "/{externalId}")
-    public ResponseEntity deleteVulnerability(
+    public ResponseEntity<List<MultiStatus>> deleteVulnerability(
             @Parameter(description = "The external ID of the vulnerability to be deleted.")
             @PathVariable String externalId
     ) {
@@ -316,7 +306,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
                         .map(ReleaseVulnerabilityRelation::getReleaseId)
                         .collect(Collectors.toSet());
 
-                releaseIdsInRelation.stream().forEach(releaseId -> {
+                releaseIdsInRelation.forEach(releaseId -> {
                     try {
                         Release release = releaseService.getReleaseForUserById(releaseId, user);
                         if (release != null) {
@@ -365,14 +355,12 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            content = @Content(mediaType = "application/hal+json",
-                                    schema = @Schema(implementation = ReleaseVulnerabilityRelation.class)),
                             description = "Updated relation information."
                     )
             }
     )
     @PostMapping(value = VULNERABILITIES_URL + "/{externalId}/releaseVulnerabilityRelation")
-    public ResponseEntity postVulnerabilityToReleases(
+    public ResponseEntity<ReleaseVulnerabilityRelation> postVulnerabilityToReleases(
             @Parameter(description = "The external ID of the vulnerability to be linked to a release.")
             @PathVariable String externalId,
             @Parameter(description = "The release to be linked to a vulnerability.")
@@ -420,6 +408,13 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
                             content = @Content(mediaType = "application/hal+json",
                                     schema = @Schema(implementation = ReleaseVulnerabilityRelation.class)),
                             description = "Updated relation information."
+                    ),
+                    @ApiResponse(
+                            responseCode = "207",
+                            content = @Content(mediaType = "application/hal+json",
+                                    schema = @Schema(type = "array",
+                                            implementation = MultiStatus.class)),
+                            description = "Operation partial. Check response."
                     )
             }
     )
@@ -452,14 +447,14 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
         }
 
-        Optional<ReleaseVulnerabilityRelation> releaseVulnerabilityRelationOpt = null;
+        Optional<ReleaseVulnerabilityRelation> releaseVulnerabilityRelationOpt = Optional.empty();
         if (CommonUtils.isNotEmpty(vulnerabilityWithReleaseRelations.getReleaseRelation())) {
             releaseVulnerabilityRelationOpt = vulnerabilityWithReleaseRelations.getReleaseRelation().stream()
                     .filter(Objects::nonNull).filter(vulRelRelation -> releaseId.equals(vulRelRelation.getReleaseId()))
                     .findFirst();
         }
 
-        if (releaseVulnerabilityRelationOpt == null || releaseVulnerabilityRelationOpt.isEmpty()) {
+        if (releaseVulnerabilityRelationOpt.isEmpty()) {
             results.add(new MultiStatus(resourceId, HttpStatus.NOT_FOUND));
             log.error("Vulnerability Release Relation does not exists");
             return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
@@ -526,16 +521,17 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
                             responseCode = "200",
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(type = "array",
-                                            example = "[\n" +
-                                                    "{\n" +
-                                                    "  \"releaseId\": \"123\",\n" +
-                                                    "  \"name\": \"releaseName\",\n" +
-                                                    "  \"projectOrigin\": \"projectOrigin\",\n" +
-                                                    "  \"svmTrackingStatus\": \"svmComponentId\",\n" +
-                                                    "  \"shortStatus\": \"svmShortStatus\",\n" +
-                                                    "  \"type\": \"OSS\"\n" +
-                                                    "}\n" +
-                                                    "]"
+                                            example = """
+                                                    [
+                                                      {
+                                                        "releaseId": "123",
+                                                        "name": "releaseName",
+                                                        "projectOrigin": "projectOrigin",
+                                                        "svmTrackingStatus": "svmComponentId",
+                                                        "shortStatus": "svmShortStatus",
+                                                        "type": "OSS"
+                                                      }
+                                                    ]"""
                                     ))
                     )
             }
@@ -574,7 +570,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
                     vulTrackingStatusList.add(vulnerabilityTrackingStatus);
                 }
             });
-            if (sortBy.isEmpty() || sortBy.isBlank()) {
+            if (CommonUtils.isNullEmptyOrWhitespace(sortBy)) {
                 sortBy = "name";
             }
             getSortedList(sortBy, sortOrder, vulTrackingStatusList);
@@ -612,17 +608,17 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     }
 
     private void getSortedList(String sortBy, String sortOrder, List<Map<String, String>> vulTrackingStatusList) {
-        Collections.sort(vulTrackingStatusList, new Comparator<Map<String, String>>() {
-            public int compare(Map<String, String> m1, Map<String, String> m2) {
-                String val1 = m1.get(sortBy);
-                String val2 = m2.get(sortBy);
-                if (val1 == null) val1 = "";
-                if (val2 == null) val2 = "";
-                if ("asc".equalsIgnoreCase(sortOrder)) {
-                    return val1.compareTo(val2);
-                } else {
-                    return val2.compareTo(val1);
-                }
+        if (CommonUtils.isNullEmptyOrWhitespace(sortOrder)) {
+            sortOrder = "desc";
+        }
+        String lowerSortOrder = sortOrder.toLowerCase(Locale.ROOT);
+        vulTrackingStatusList.sort((m1, m2) -> {
+            String val1 = m1.getOrDefault(sortBy, "");
+            String val2 = m2.getOrDefault(sortBy, "");
+            if ("asc".equals(lowerSortOrder)) {
+                return val1.compareTo(val2);
+            } else {
+                return val2.compareTo(val1);
             }
         });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-sw360/sw360/security/code-scanning/96](https://github.com/eclipse-sw360/sw360/security/code-scanning/96)

General fix: do not send raw user-provided request data back in the response body. Return a sanitized/validated DTO or persisted entity representation generated by the server.