### PR TITLE
feat(projects): get sorted groups

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -55,6 +55,9 @@ import static org.eclipse.sw360.datahandler.common.SW360Utils.getBUFromOrganisat
  * @author ksoranko@verifa.io
  */
 public class ProjectRepository extends SummaryAwareRepository<Project> {
+    private static final Comparator<String> PROJECT_GROUP_COMPARATOR =
+            String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder());
+
     private static final String ALL = "function(doc) { if (doc.type == 'project') emit(null, doc._id) }";
 
     private static final String FULL_MY_PROJECTS_VIEW =
@@ -535,7 +538,10 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
     }
 
     public Set<String> getGroups() {
-        return getConnector().getDistinctSortedStringKeys(Project.class, "buprojects");
+        return getConnector().getDistinctSortedStringKeys(Project.class, "buprojects")
+                .stream()
+                .sorted(PROJECT_GROUP_COMPARATOR)
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @NotNull


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Sort the response of `GET /api/projects/groups`

Closes #2641