### PR TITLE
refactor: replace @Autowired field/method injection with constructor …

### DIFF
--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
@@ -71,7 +70,6 @@ public class FossologyHandler implements FossologyService.Iface {
 
     boolean reportStep = false;
 
-    @Autowired
     public FossologyHandler(ThriftClients thriftClients, FossologyRestConfig fossologyRestConfig,
             FossologyRestClient fossologyRestClient, AttachmentConnector attachmentConnector) {
         this.thriftClients = thriftClients;

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyServlet.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyServlet.java
@@ -11,7 +11,6 @@ package org.eclipse.sw360.fossology;
 
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 import org.apache.thrift.protocol.TCompactProtocol;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -25,7 +24,6 @@ import java.net.MalformedURLException;
 @Controller
 public class FossologyServlet extends SpringTServlet {
 
-    @Autowired
     public FossologyServlet(FossologyHandler fossologyHandler) throws MalformedURLException {
         // Create a service processor using the provided handler
         super(new FossologyService.Processor<>(fossologyHandler), new TCompactProtocol.Factory());

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyRestConfig.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyRestConfig.java
@@ -17,7 +17,6 @@ import org.eclipse.sw360.datahandler.thrift.ConfigFor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.net.MalformedURLException;
@@ -52,7 +51,6 @@ public class FossologyRestConfig {
 
     private static final String BASEURL_VERSION_SUFFIX = "/api/v2";
 
-    @Autowired
     public FossologyRestConfig(ConfigContainerRepository repository) throws SW360Exception {
         this.repository = repository;
         // eager loading (or initial insert)

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
@@ -21,7 +21,6 @@ import org.eclipse.sw360.fossology.rest.model.FossologyV2Models.CombinedUploadJo
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -92,7 +91,6 @@ public class FossologyRestClient {
 
     private final String expectedVersionPrefix = "2.";
 
-    @Autowired
     public FossologyRestClient(ObjectMapper objectMapper, FossologyRestConfig restConfig, RestTemplate restTemplate) {
         this.objectMapper = objectMapper;
         this.restConfig = restConfig;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -16,12 +16,12 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,21 +47,19 @@ import com.google.common.collect.Sets;
 @RestController
 @RequestMapping(path = "/" + OAuthClientController.ENDPOINT_URL)
 @PreAuthorize("hasAuthority('ADMIN')")
+@RequiredArgsConstructor
 public class OAuthClientController {
 
     public static final String ENDPOINT_URL = "client-management";
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${security.oauth2.resource.id}")
     private String resourceId;
 
-    @Autowired
-    private KeyManager keyManager;
+    private final KeyManager keyManager;
 
-    @Autowired
-    private OAuthClientRepository repo;
+    private final OAuthClientRepository repo;
 
     @GetMapping(path = "")
     public ResponseEntity<List<OAuthClientResource>> getAllClients() {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
@@ -25,6 +25,7 @@ import org.springframework.security.oauth2.server.authorization.settings.ClientS
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class Sw360ClientDetailsService implements RegisteredClientRepository {
 
     private final Logger log = LogManager.getLogger(this.getClass());
@@ -32,8 +33,7 @@ public class Sw360ClientDetailsService implements RegisteredClientRepository {
     @Value("${security.accesstoken.validity}")
     private Integer accessTokenValidity;
 
-    @Autowired
-    private OAuthClientRepository clientRepo;
+    private final OAuthClientRepository clientRepo;
 
     @Override
     public RegisteredClient findByClientId(String clientId) {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360OidcUserInfoService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360OidcUserInfoService.java
@@ -4,9 +4,9 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.authserver.client.service;
 
+import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.stereotype.Service;
 
@@ -18,13 +18,13 @@ import java.util.Map;
  * @author smruti.sahoo@siemens.com
  */
 @Service
+@RequiredArgsConstructor
 public class Sw360OidcUserInfoService {
 
 	public static final String USER_GROUP = "userGroup";
 	public static final String DEPARTMENT = "department";
 	public static final String PRIMARY_ROLES = "primaryRoles";
-	@Autowired
-	private Sw360UserDetailsProvider sw360UserDetailsProvider;
+	private final Sw360UserDetailsProvider sw360UserDetailsProvider;
 
 	public OidcUserInfo loadUser(String username) {
 

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360UserDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360UserDetailsService.java
@@ -9,22 +9,21 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class Sw360UserDetailsService implements UserDetailsService {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    @Autowired
-    private Sw360UserDetailsProvider userProvider;
+    private final Sw360UserDetailsProvider userProvider;
 
-    @Autowired
-    private Sw360GrantedAuthoritiesCalculator authoritiesCalculator;
+    private final Sw360GrantedAuthoritiesCalculator authoritiesCalculator;
 
     /**
      * @param username the username identifying the user whose data is required.

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
@@ -9,16 +9,15 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
+import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360ClientDetailsService;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360OidcUserInfoService;
 import org.eclipse.sw360.rest.authserver.security.authproviders.Sw360UserAuthenticationProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -41,16 +40,14 @@ import java.util.UUID;
  */
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Autowired
-    Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+    private final Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
 
-    @Autowired
-    Sw360ClientDetailsService sw360ClientDetailsService;
+    private final Sw360ClientDetailsService sw360ClientDetailsService;
 
-    @Autowired
-    private Sw360OidcUserInfoService sw360OidcUserInfoService;
+    private final Sw360OidcUserInfoService sw360OidcUserInfoService;
 
     @Bean
     @Order(1)
@@ -62,6 +59,7 @@ public class SecurityConfig {
         httpSecurity
                 .securityMatcher(endpointsMatcher)
                 .with(authorizationServerConfigurer, Customizer.withDefaults())
+                .authenticationProvider(sw360UserAuthenticationProvider)
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login")))
                 .csrf(csrf -> csrf.ignoringRequestMatchers(endpointsMatcher))
@@ -77,7 +75,8 @@ public class SecurityConfig {
                 authz -> authz
                 .requestMatchers("/client-management/**").hasAuthority("ADMIN")
                 .anyRequest().authenticated()
-        ).httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults());
+        ).authenticationProvider(sw360UserAuthenticationProvider)
+                .httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults());
         return httpSecurity.csrf(csrf -> csrf.disable()).build();
     }
 
@@ -105,11 +104,6 @@ public class SecurityConfig {
     @Bean
     public JwtDecoder jwtDecoder(JWKSource<SecurityContext> jwkSource) {
         return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
-    }
-
-    @Autowired
-    public void authenticationManagerBuilder(AuthenticationManagerBuilder authenticationManagerBuilder) {
-        authenticationManagerBuilder.authenticationProvider(sw360UserAuthenticationProvider);
     }
 
     @Bean

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
@@ -10,7 +10,6 @@ import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import lombok.RequiredArgsConstructor;
-import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360ClientDetailsService;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360OidcUserInfoService;
 import org.eclipse.sw360.rest.authserver.security.authproviders.Sw360UserAuthenticationProvider;
@@ -104,11 +103,6 @@ public class SecurityConfig {
     @Bean
     public JwtDecoder jwtDecoder(JWKSource<SecurityContext> jwkSource) {
         return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
-    }
-
-    @Bean
-    public ThriftClients thriftClients() {
-        return new ThriftClients();
     }
 
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360TokenCustomizerConfig.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360TokenCustomizerConfig.java
@@ -4,8 +4,8 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.authserver.security;
 
+import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360OidcUserInfoService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
@@ -22,6 +22,7 @@ import java.util.Arrays;
  * @author smruti.sahoo@siemens.com
  */
 @Configuration
+@RequiredArgsConstructor
 public class Sw360TokenCustomizerConfig {
 
 	public static final String USER_NAME = "user_name";
@@ -29,8 +30,7 @@ public class Sw360TokenCustomizerConfig {
 	public static final String AUD = "aud";
 	public static final String SUB = "sub";
 	public static final String SW360_REST_API = "sw360-REST-API";
-	@Autowired
-	private Sw360OidcUserInfoService sw360OidcUserInfoService;
+	private final Sw360OidcUserInfoService sw360OidcUserInfoService;
 
 	@Bean
 	public OAuth2TokenCustomizer<JwtEncodingContext> tokenCustomizer() {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
@@ -16,7 +16,7 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 /**
@@ -24,12 +24,12 @@ import org.springframework.stereotype.Service;
  * check if a user identified by an email address or an external id exists.
  */
 @Service
+@RequiredArgsConstructor
 public class Sw360UserDetailsProvider {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    @Autowired
-    private ThriftClients thriftClients;
+    private final ThriftClients thriftClients;
 
     public User provideUserDetails(String email, String extId) {
         User result = null;

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/ThriftClientsConfiguration.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/ThriftClientsConfiguration.java
@@ -1,0 +1,25 @@
+/*
+SPDX-FileCopyrightText: © 2026 Contributors to the SW360 Portal Project
+SPDX-License-Identifier: EPL-2.0
+
+*/
+package org.eclipse.sw360.rest.authserver.security;
+
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Defines the Thrift client factory in its own configuration so services such as
+ * {@link Sw360UserDetailsProvider} can depend on {@link ThriftClients} without a circular
+ * dependency: {@link SecurityConfig} must not declare this bean while also injecting the
+ * authentication provider chain that ultimately needs {@link ThriftClients}.
+ */
+@Configuration
+public class ThriftClientsConfiguration {
+
+    @Bean
+    public ThriftClients thriftClients() {
+        return new ThriftClients();
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/authproviders/Sw360UserAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/authproviders/Sw360UserAuthenticationProvider.java
@@ -5,7 +5,7 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.rest.authserver.security.authproviders;
 
 import org.eclipse.sw360.rest.authserver.client.service.Sw360UserDetailsService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,13 +16,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
 
-    @Autowired
-    private Sw360UserDetailsService userDetailsService;
+    private final Sw360UserDetailsService userDetailsService;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * @param authentication the authentication request object.

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
@@ -18,7 +18,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -74,8 +73,13 @@ public class Sw360CustomHeaderAuthenticationFilter extends GenericFilterBean {
 
     private boolean active;
 
-    @Autowired
-    private Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+    private final Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+
+    public Sw360CustomHeaderAuthenticationFilter(
+            Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider
+    ) {
+        this.sw360CustomHeaderUserDetailsProvider = sw360CustomHeaderUserDetailsProvider;
+    }
 
     @PostConstruct
     public void postSw360CustomHeaderAuthenticationFilterConstruction() {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
@@ -21,7 +21,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.StringTransformer;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -55,16 +54,23 @@ public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationPr
     @Value("${security.customheader.headername.enabled:#{false}}")
     private boolean customHeaderEnabled;
 
-    @Autowired
-    private Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+    private final Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
 
-    @Autowired
-    private RegisteredClientRepository clientDetailsService;
+    private final RegisteredClientRepository clientDetailsService;
 
-    @Autowired
-    private Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator;
+    private final Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator;
 
     private boolean active;
+
+    public Sw360CustomHeaderAuthenticationProvider(
+            Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider,
+            RegisteredClientRepository clientDetailsService,
+            Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator
+    ) {
+        this.sw360CustomHeaderUserDetailsProvider = sw360CustomHeaderUserDetailsProvider;
+        this.clientDetailsService = clientDetailsService;
+        this.sw360UserAndClientAuthoritiesCalculator = sw360UserAndClientAuthoritiesCalculator;
+    }
 
     @PostConstruct
     public void postSw360CustomHeaderAuthenticationProviderConstruction() {

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
@@ -37,13 +37,13 @@ import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
 import org.junit.Before;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
@@ -87,8 +87,7 @@ public abstract class IntegrationTestBase {
     @MockitoBean
     Sw360UserDetailsService sw360UserDetailsService;
 
-    @Autowired
-    protected PasswordEncoder encoder;
+    protected final PasswordEncoder encoder = new BCryptPasswordEncoder();
 
     @Before
     public void setup() throws TException {

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepositoryTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepositoryTest.java
@@ -14,7 +14,6 @@ import org.eclipse.sw360.rest.authserver.IntegrationTestBase;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
@@ -36,11 +35,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class OAuthClientRepositoryTest extends IntegrationTestBase {
 
-    @Autowired
     private OAuthClientRepository uut;
 
     @Before
     public void setup() {
+        uut = clientRepo;
         uut.getAll().stream().forEach(uut::remove);
     }
 

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientControllerTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientControllerTest.java
@@ -15,7 +15,6 @@ import org.eclipse.sw360.rest.authserver.IntegrationTestBase;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.*;
 import org.springframework.web.client.RestClientException;
@@ -29,8 +28,7 @@ import static org.mockito.Mockito.when;
 
 public class OAuthClientControllerTest extends IntegrationTestBase {
 
-    @Autowired
-    private TestRestTemplate template;
+    private final TestRestTemplate template = new TestRestTemplate();
 
     @Test
     public void testGetAll_basicAuth_unknownUser_fail() throws RestClientException, URISyntaxException {
@@ -43,7 +41,7 @@ public class OAuthClientControllerTest extends IntegrationTestBase {
         headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
 
         responseEntity = template.withBasicAuth("my-unknown-user", "12345").exchange(
-                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("http://localhost:" + port + "/client-management")), String.class);
 
         // then:
         assertThat(responseEntity.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
@@ -60,7 +58,7 @@ public class OAuthClientControllerTest extends IntegrationTestBase {
         headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
 
         responseEntity = template.withBasicAuth(adminTestUser.email, "12345")
-                .exchange(new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")),
+                .exchange(new RequestEntity<String>(headers, HttpMethod.GET, new URI("http://localhost:" + port + "/client-management")),
                         String.class);
 
         // then:
@@ -78,7 +76,7 @@ public class OAuthClientControllerTest extends IntegrationTestBase {
         headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
 
         responseEntity = template.withBasicAuth(normalTestUser.email, "12345")
-                .exchange(new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")),
+                .exchange(new RequestEntity<String>(headers, HttpMethod.GET, new URI("http://localhost:" + port + "/client-management")),
                         String.class);
 
         // then:
@@ -97,7 +95,7 @@ public class OAuthClientControllerTest extends IntegrationTestBase {
         headers.set("authenticated-email", "my-unknown-user");
 
         responseEntity = template.exchange(
-                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("http://localhost:" + port + "/client-management")), String.class);
 
         // then:
         assertThat(responseEntity.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
@@ -116,7 +114,7 @@ public class OAuthClientControllerTest extends IntegrationTestBase {
         headers.set("authenticated-email", adminTestUser.email);
 
         responseEntity = template.exchange(
-                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("http://localhost:" + port + "/client-management")), String.class);
 
         // then:
         assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
@@ -135,7 +133,7 @@ public class OAuthClientControllerTest extends IntegrationTestBase {
         headers.set("authenticated-email", normalTestUser.email);
 
         responseEntity = template.exchange(
-                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("http://localhost:" + port + "/client-management")), String.class);
 
         // then:
         assertThat(responseEntity.getStatusCode(), is(HttpStatus.FORBIDDEN));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CacheAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CacheAdminController.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
@@ -45,7 +44,7 @@ import java.util.Map;
  * for all READ-only users on <em>all</em> endpoints — not just admin endpoints.</p>
  */
 @BasePathAwareController
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
@@ -38,7 +38,6 @@ import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -72,8 +71,9 @@ public class ChangeLogController implements RepresentationModelProcessor<Reposit
     private static final Logger log = LogManager.getLogger(ChangeLogController.class);
 
     public static final String CHANGE_LOG_URL = "/changelog";
-    @Autowired
-    private Sw360ChangeLogService sw360ChangeLogService;
+
+    @NonNull
+    private final Sw360ChangeLogService sw360ChangeLogService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -45,7 +45,6 @@ import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -76,8 +75,8 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
 
     private static final Logger log = LogManager.getLogger(ClearingRequestController.class);
 
-    @Autowired
-    private Sw360ClearingRequestService sw360ClearingRequestService;
+    @NonNull
+    private final Sw360ClearingRequestService sw360ClearingRequestService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -52,7 +52,6 @@ import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -94,8 +93,8 @@ public class ModerationRequestController implements RepresentationModelProcessor
     private static final String REQUESTING_USER = "requestingUser";
     public static final String MODERATION_REQUEST_URL = "/moderationrequest";
 
-    @Autowired
-    private Sw360ModerationRequestService sw360ModerationRequestService;
+    @NonNull
+    private final Sw360ModerationRequestService sw360ModerationRequestService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
@@ -37,7 +37,6 @@ import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -64,8 +63,8 @@ public class SearchController implements RepresentationModelProcessor<Repository
 
     public static final String SEARCH_URL = "/search";
 
-    @Autowired
-    private Sw360SearchService sw360SearchService;
+    @NonNull
+    private final Sw360SearchService sw360SearchService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -15,7 +15,7 @@ import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthentic
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationProvider;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360UserAuthenticationProvider;
 import org.eclipse.sw360.rest.resourceserver.security.jwt.Sw360JWTAccessTokenConverter;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,19 +38,16 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class ResourceServerConfiguration {
 
-    @Autowired
-    SimpleAuthenticationEntryPoint saep;
+    private final SimpleAuthenticationEntryPoint saep;
 
-    @Autowired
-    Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;
+    private final Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;
 
-    @Autowired
-    private ApiTokenAuthenticationProvider authProvider;
+    private final ApiTokenAuthenticationProvider authProvider;
 
-    @Autowired
-    Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+    private final Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     String issuerUri;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsService.java
@@ -7,7 +7,6 @@ package org.eclipse.sw360.rest.resourceserver.security.basic;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
@@ -20,8 +19,7 @@ public class Sw360CustomUserDetailsService implements UserDetailsService {
 
     private static final Logger log = LogManager.getLogger(Sw360CustomUserDetailsService.class);
 
-    @Autowired
-    Sw360UserDetailsProvider sw360UserDetailsProvider;
+    private final Sw360UserDetailsProvider sw360UserDetailsProvider;
 
     @Override
     public UserDetails loadUserByUsername(String userid) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserAuthenticationProvider.java
@@ -6,7 +6,6 @@ package org.eclipse.sw360.rest.resourceserver.security.basic;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -23,11 +22,10 @@ public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
-    private Sw360CustomUserDetailsService userDetailsService;
+    private final Sw360CustomUserDetailsService userDetailsService;
 
-    @Autowired
     public Sw360UserAuthenticationProvider(@Lazy PasswordEncoder passwordEncoder, Sw360CustomUserDetailsService userDetailsService) {
         this.passwordEncoder = passwordEncoder;
         this.userDetailsService = userDetailsService;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
@@ -6,13 +6,13 @@ package org.eclipse.sw360.rest.resourceserver.security.jwt;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
  */
 @Profile("!SECURITY_MOCK")
 @Component
+@RequiredArgsConstructor
 public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
 	private static final Logger log = LogManager.getLogger(Sw360JWTAccessTokenConverter.class);
@@ -50,8 +51,7 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 	@Value("${jwt.auth.converter.principle-attribute:email}")
 	private String principleAttribute;
 
-	@Autowired
-	private Sw360UserService userService;
+	private final Sw360UserService userService;
 
 	/**
 	 * Converts the JWT token into an AbstractAuthenticationToken.

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
@@ -13,14 +13,12 @@ package org.eclipse.sw360.rest.resourceserver.configuration.security;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.rest.resourceserver.core.SimpleAuthenticationEntryPoint;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360UserAuthenticationProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -31,8 +29,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class Sw360AuthorizationServerConfiguration {
 
-	@Autowired
-	Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+	private final Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
 
 	@Order(1)
 	@Bean
@@ -44,14 +41,10 @@ public class Sw360AuthorizationServerConfiguration {
 						.requestMatchers(HttpMethod.GET, "/api/version").permitAll()
 						.requestMatchers(HttpMethod.GET, "/api/info").permitAll()
 						.anyRequest().authenticated()
-		).httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults())
+		).authenticationProvider(sw360UserAuthenticationProvider)
+				.httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults())
 				.exceptionHandling(x -> x.authenticationEntryPoint(saep));
 		return httpSecurity.csrf(csrf -> csrf.disable()).build();
-	}
-
-	@Autowired
-	public void authenticationManagerBuilder(AuthenticationManagerBuilder authenticationManagerBuilder) {
-        authenticationManagerBuilder.authenticationProvider(sw360UserAuthenticationProvider);
 	}
 
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
@@ -19,12 +19,12 @@ import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360CustomUserDetai
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthority;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.junit.Before;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ContextConfiguration;
@@ -48,8 +48,7 @@ abstract public class TestIntegrationBase {
     @MockitoBean
     Sw360CustomUserDetailsService sw360CustomUserDetailsService;
 
-    @Autowired
-    private PasswordEncoder encoder;
+    private final PasswordEncoder encoder = new BCryptPasswordEncoder();
 
     @MockitoBean
     protected Sw360UserService userServiceMock;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/DatabaseSanitationSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/DatabaseSanitationSpecTest.java
@@ -35,11 +35,11 @@ import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthorit
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -61,8 +61,7 @@ public class DatabaseSanitationSpecTest extends TestRestDocsSpecBase {
     private Project project, project1;
     private Attachment attachment,attachment1 ;
 
-    @Autowired
-    private PasswordEncoder encoder;
+    private final PasswordEncoder encoder = new BCryptPasswordEncoder();
 
     @Before
     public void before() throws TException, IOException {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
@@ -40,6 +40,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.ManualRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -61,13 +62,10 @@ public abstract class TestRestDocsSpecBase {
     @Value("${sw360.test-user-password}")
     private String testUserPassword;
 
-    @Autowired
     protected WebApplicationContext context;
 
-    @Autowired
     protected FilterChainProxy springSecurityFilterChain;
 
-    @Autowired
     protected ObjectMapper objectMapper;
 
     protected MockMvc mockMvc;
@@ -79,14 +77,24 @@ public abstract class TestRestDocsSpecBase {
     @MockitoBean
     Sw360CustomUserDetailsService sw360CustomUserDetailsService;
 
-    @Autowired
-    private PasswordEncoder encoder;
+    private final PasswordEncoder encoder = new BCryptPasswordEncoder();
 
     @MockitoBean
     protected Sw360UserService userServiceMock;
 
     @MockitoBean
     protected SW360ConfigurationsService sw360ConfigurationsServiceMock;
+
+    @Autowired
+    void setTestContextDependencies(
+            WebApplicationContext context,
+            FilterChainProxy springSecurityFilterChain,
+            ObjectMapper objectMapper
+    ) {
+        this.context = context;
+        this.springSecurityFilterChain = springSecurityFilterChain;
+        this.objectMapper = objectMapper;
+    }
 
     @Before
     public void setupRestDocs() {


### PR DESCRIPTION
Fixes: https://github.com/eclipse-sw360/sw360/issues/3696
## Summary
- Refactor Spring wiring to use constructor injection consistently (replace `@Autowired` field/method injection with single-constructor injection and `private final` dependencies).
- Keep behavior the same; this is a non-functional refactor to improve consistency, immutability, and testability across REST/backend modules.

## Issue
- Fixes/Refs: #3696 (`Refactor: replace field injection (@Autowired on fields) with constructor injection across the repo`)

## Dependencies
- No new or updated dependencies.

## Suggest Reviewer
- @GMishx  @heliocastro  @arunazhakesan  @KoukiHama 

## Checklist
- [x] All related issues are referenced in commit messages and in PR