### PR TITLE
fix(changelog): add sorting by change timestamp in changelog

### DIFF
--- a/backend/changelogs/src/main/java/org/eclipse/sw360/changelogs/ChangeLogsHandler.java
+++ b/backend/changelogs/src/main/java/org/eclipse/sw360/changelogs/ChangeLogsHandler.java
@@ -15,9 +15,12 @@ import static org.eclipse.sw360.datahandler.common.SW360Assert.assertUser;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.db.ChangeLogsDatabaseHandler;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogsService;
@@ -54,6 +57,13 @@ public class ChangeLogsHandler implements ChangeLogsService.Iface {
     public ChangeLogs getChangeLogsById(String id) throws SW360Exception {
         assertNotEmpty(id);
         return handler.getChangeLogsById(id);
+    }
+
+    @Override
+    public Map<PaginationData, List<ChangeLogs>> getChangeLogsByDocumentIdPaginated(User user, String docId, PaginationData pageData) throws SW360Exception, TException {
+        assertNotEmpty(docId);
+        assertUser(user);
+        return handler.getChangeLogsByDocumentIdPaginated(user, docId, pageData);
     }
 
     @Override

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ChangeLogsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ChangeLogsDatabaseHandler.java
@@ -16,11 +16,13 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangedFields;
@@ -29,7 +31,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Class for accessing the CouchDB database for Change logs objects
@@ -39,13 +40,6 @@ import com.google.common.collect.ImmutableSet;
 public class ChangeLogsDatabaseHandler {
     private final DatabaseConnectorCloudant db;
     private final ChangeLogsRepository changeLogsRepository;
-    private static final ImmutableSet<String> setOfIgnoredFieldValues = ImmutableSet.<String>builder()
-            .add("\"\"")
-            .add("[]")
-            .add("{}").build();
-    private static final ImmutableSet<String> setOfIgnoredFieldNames = ImmutableSet.<String>builder()
-            .add("revision")
-            .add("documentState").build();
 
     public ChangeLogsDatabaseHandler(Cloudant client, String dbName) throws MalformedURLException {
         db = new DatabaseConnectorCloudant(client, dbName);
@@ -62,10 +56,22 @@ public class ChangeLogsDatabaseHandler {
         return changeLogsByDocId;
     }
 
+    public Map<PaginationData, List<ChangeLogs>> getChangeLogsByDocumentIdPaginated(User user, String docId, PaginationData pageData) {
+        Map<PaginationData, List<ChangeLogs>> result = changeLogsRepository.getChangeLogsByDocumentIdPaginated(docId, pageData);
+
+        Map.Entry<PaginationData, List<ChangeLogs>> entry = result.entrySet().iterator().next();
+        List<ChangeLogs> filteredLogs = entry.getValue().stream()
+                .filter(Objects::nonNull)
+                .filter(this::isNotEmptyChangeLog)
+                .toList();
+
+        return Collections.singletonMap(entry.getKey(), filteredLogs);
+    }
+
     public ChangeLogs getChangeLogsById(String id) throws SW360Exception {
         ChangeLogs changeLogs = changeLogsRepository.get(id);
         assertNotNull(changeLogs);
-        removeNullToEmtpyChanges(changeLogs);
+        removeNullToEmptyChanges(changeLogs);
         changeLogs.setChangeTimestamp(changeLogs.changeTimestamp.split(" ")[0]);
         return changeLogs;
     }
@@ -81,17 +87,17 @@ public class ChangeLogsDatabaseHandler {
         }
     }
 
-    private ChangeLogs removeNullToEmtpyChanges(ChangeLogs changeLog) {
+    private ChangeLogs removeNullToEmptyChanges(ChangeLogs changeLog) {
         Set<ChangedFields> changes = changeLog.getChanges();
         if (CommonUtils.isNotEmpty(changes)) {
             Set<ChangedFields> collectFiltered = changes.stream().filter(ch -> {
                 String fieldName = ch.getFieldName();
                 String oldFieldValue = ch.getFieldValueOld();
                 String newFieldValue = ch.getFieldValueNew();
-                if ((fieldName != null && setOfIgnoredFieldNames.contains(fieldName))
+                if ((fieldName != null && ChangeLogsRepository.SET_OF_IGNORED_FIELD_NAMES.contains(fieldName))
                         || (oldFieldValue == null && newFieldValue == null)
-                        || (oldFieldValue == null && setOfIgnoredFieldValues.contains(newFieldValue))
-                        || (newFieldValue == null && setOfIgnoredFieldValues.contains(oldFieldValue))
+                        || (oldFieldValue == null && ChangeLogsRepository.SET_OF_IGNORED_FIELD_VALUES.contains(newFieldValue))
+                        || (newFieldValue == null && ChangeLogsRepository.SET_OF_IGNORED_FIELD_VALUES.contains(oldFieldValue))
                         || (oldFieldValue != null && newFieldValue != null && newFieldValue.equals(oldFieldValue))) {
                     return false;
                 }
@@ -105,6 +111,6 @@ public class ChangeLogsDatabaseHandler {
 
     private boolean isNotEmptyChangeLog(ChangeLogs changeLog) {
         return changeLog.getOperation() == Operation.CREATE
-                || CommonUtils.isNotEmpty(removeNullToEmtpyChanges(changeLog).getChanges());
+                || CommonUtils.isNotEmpty(removeNullToEmptyChanges(changeLog).getChanges());
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ChangeLogsRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ChangeLogsRepository.java
@@ -9,16 +9,22 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 
+import com.google.common.collect.ImmutableSet;
+
 import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
+import org.eclipse.sw360.datahandler.thrift.changelogs.Operation;
 
 /**
  * CRUD access for the ChangeLogs class
@@ -26,6 +32,49 @@ import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
  * @author jaideep.palit@siemens.com
  */
 public class ChangeLogsRepository extends DatabaseRepositoryCloudantClient<ChangeLogs> {
+
+    public static final ImmutableSet<String> SET_OF_IGNORED_FIELD_VALUES = ImmutableSet.<String>builder()
+            .add("\"\"")
+            .add("[]")
+            .add("{}").build();
+
+    public static final ImmutableSet<String> SET_OF_IGNORED_FIELD_NAMES = ImmutableSet.<String>builder()
+            .add("revision")
+            .add("documentState").build();
+
+    private static String getJsArray(Set<String> set) {
+        return "[" + set.stream().map(s -> "'" + s.replace("'", "\\'") + "'").collect(Collectors.joining(",")) + "]";
+    }
+
+    private static final String IS_NOT_EMPTY_CHANGE_LOG =
+            """
+            function isNotEmptyChangeLog(doc) {
+              if (doc.operation === '%s') {
+                return true;
+              }
+              if (!doc.changes || doc.changes.length === 0) {
+                return false;
+              }
+              var ignoredFieldValues = %s;
+              var ignoredFieldNames = %s;
+              var hasValidChanges = false;
+              for (var i = 0; i < doc.changes.length; i++) {
+                var ch = doc.changes[i];
+                var fieldName = ch.fieldName;
+                var oldFieldValue = ch.fieldValueOld;
+                var newFieldValue = ch.fieldValueNew;
+                if ((fieldName != null && ignoredFieldNames.indexOf(fieldName) !== -1)
+                    || (oldFieldValue == null && newFieldValue == null)
+                    || (oldFieldValue == null && ignoredFieldValues.indexOf(newFieldValue) !== -1)
+                    || (newFieldValue == null && ignoredFieldValues.indexOf(oldFieldValue) !== -1)
+                    || (oldFieldValue != null && newFieldValue != null && newFieldValue === oldFieldValue)) {
+                  continue;
+                }
+                hasValidChanges = true;
+                break;
+              }
+              return hasValidChanges;
+            }""".formatted(Operation.CREATE.name(), getJsArray(SET_OF_IGNORED_FIELD_VALUES), getJsArray(SET_OF_IGNORED_FIELD_NAMES));
 
     private static final String ALL = "function(doc) { if (doc.type == 'changeLogs') emit(doc._id, null) }";
     private static final String BY_DOCUMENT_ID =
@@ -52,6 +101,20 @@ public class ChangeLogsRepository extends DatabaseRepositoryCloudantClient<Chang
                     "    emit(doc.changeTimestamp, null);" +
                     "  }" +
                     "}";
+    private static final String BY_DOCUMENT_ID_AND_TIMESTAMP = """
+            function(doc) {
+              %s
+              if (doc.type === 'changeLogs' && isNotEmptyChangeLog(doc)) {
+                if (doc.documentId) {
+                  emit([doc.documentId, doc.changeTimestamp], null);
+                }
+                if (doc.parentDocId && doc.parentDocId !== doc.documentId) {
+                  emit([doc.parentDocId, doc.changeTimestamp], null);
+                }
+              }
+            }""".formatted(IS_NOT_EMPTY_CHANGE_LOG);
+
+    public static final String PAGINATION_IDX = "PaginationIdx";
 
     public ChangeLogsRepository(DatabaseConnectorCloudant db) {
         super(db, ChangeLogs.class);
@@ -60,6 +123,7 @@ public class ChangeLogsRepository extends DatabaseRepositoryCloudantClient<Chang
         views.put("byParentDocumentId", createMapReduce(BY_PARENT_DOCUMENT_ID, null));
         views.put("byUserEdited", createMapReduce(BY_USER_EDITED, null));
         views.put("byTimestamp", createMapReduce(BY_TIMESTAMP, null));
+        views.put("byDocumentIdAndTimestamp", createMapReduce(BY_DOCUMENT_ID_AND_TIMESTAMP, null));
         views.put("all", createMapReduce(ALL, null));
         initStandardDesignDocument(views, db);
     }
@@ -78,5 +142,10 @@ public class ChangeLogsRepository extends DatabaseRepositoryCloudantClient<Chang
 
     public List<ChangeLogs> getChangeLogsByTimestamp(String timestamp) {
         return queryView("byTimestamp", timestamp).stream().collect(Collectors.toList());
+    }
+
+    public Map<PaginationData, List<ChangeLogs>> getChangeLogsByDocumentIdPaginated(String docId, PaginationData pageData) {
+        List<ChangeLogs> results = queryViewWithComplexKeysPaginated("byDocumentIdAndTimestamp", docId, pageData);
+        return Collections.singletonMap(pageData, results);
     }
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -13,11 +13,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -244,6 +245,35 @@ public class DatabaseRepositoryCloudantClient<T> {
         return queryView(query.build());
     }
 
+    public List<T> queryViewPaginated(
+            String queryName, Object[] startKeys, Object[] endKeys, PaginationData pageData, boolean isReduced
+    ) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final int offset = pageData.getDisplayStart();
+        final boolean ascending = pageData.isAscending();
+
+        PostViewOptions.Builder query = connector.getPostViewQueryBuilder(type, queryName)
+                .reduce(false)
+                .descending(!ascending)
+                .includeDocs(true);
+
+        if (ascending) {
+            query.startKey(startKeys)
+                    .endKey(endKeys);
+        } else {
+            query.startKey(endKeys)
+                    .endKey(startKeys);
+        }
+
+        if (rowsPerPage != -1) {
+            query.limit(rowsPerPage).skip(offset);
+        }
+
+        paginationSetTotalRowCount(pageData, isReduced, query.build());
+
+        return queryView(query.build());
+    }
+
     public List<T> queryView(String viewName, String key) {
         PostViewOptions query = connector.getPostViewQueryBuilder(type, viewName)
                 .keys(Collections.singletonList(key))
@@ -274,6 +304,12 @@ public class DatabaseRepositoryCloudantClient<T> {
         paginationSetTotalRowCount(pageData, isReduced, query.build());
 
         return queryView(query.build());
+    }
+
+    public List<T> queryViewWithComplexKeysPaginated(String queryName, String key, PaginationData pageData) {
+        Object[] startKeys = new Object[] { key };
+        Object[] endKeys = new Object[] { key, new HashMap<String, Object>()  };
+        return queryViewPaginated(queryName, startKeys, endKeys, pageData, false);
     }
 
     public Set<String> queryForIds(PostViewOptions query) {

--- a/libraries/datahandler/src/main/thrift/changelogs.thrift
+++ b/libraries/datahandler/src/main/thrift/changelogs.thrift
@@ -17,6 +17,7 @@ namespace php sw360.thrift.changelogs
 typedef users.User User
 typedef sw360.SW360Exception SW360Exception
 typedef sw360.RequestStatus RequestStatus
+typedef sw360.PaginationData PaginationData
 enum Operation {
     CREATE = 0,
     UPDATE = 1,
@@ -74,16 +75,25 @@ struct ChangedFields
     3: optional string fieldValueNew,
 }
 
+enum ChangelogSortColumn {
+    BY_CHANGE_TIMESTAMP = 0,
+}
+
 service ChangeLogsService {
      /**
      * get Change Log by Id
      */
     ChangeLogs getChangeLogsById(1: string changeLogId) throws (1: SW360Exception exp);
-    
+
      /**
      * get all Change Logs associated with Document Id
      */
     list<ChangeLogs> getChangeLogsByDocumentId(1: User user,2: string docId) throws (1: SW360Exception exp);
+
+     /**
+     * get all Change Logs associated with Document Id paginated
+     */
+    map<PaginationData, list<ChangeLogs>> getChangeLogsByDocumentIdPaginated(1: User user,2: string docId,3: PaginationData pageData) throws (1: SW360Exception exp);
 
     /**
      * delete all Change Logs associated with Document,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
@@ -12,10 +12,11 @@ package org.eclipse.sw360.rest.resourceserver.changelog;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import java.net.URISyntaxException;
-import java.util.LinkedHashMap;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,6 +35,7 @@ import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
@@ -105,10 +107,12 @@ public class ChangeLogController implements RepresentationModelProcessor<Reposit
     ) throws TException, URISyntaxException, PaginationParameterException,
             ResourceClassNotFoundException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        List<ChangeLogs> changelogs = sw360ChangeLogService.getChangeLogsByDocumentId(docId, sw360User);
-        changelogs.stream().forEach(cl -> cl.setChangeTimestamp(cl.getChangeTimestamp().split(" ")[0]));
-        PaginationResult<ChangeLogs> paginationResult = restControllerHelper.createPaginationResult(request, pageable,
-                changelogs, SW360Constants.TYPE_CHANGELOG);
+        Map<PaginationData, List<ChangeLogs>> changelogsResult = sw360ChangeLogService.getChangeLogsByDocumentIdPaginated(docId, sw360User, pageable);
+        List<ChangeLogs> changelogs = changelogsResult.values().iterator().next();
+        int totalCount = Math.toIntExact(changelogsResult.keySet().stream()
+                .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));
+        PaginationResult<ChangeLogs> paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                request, pageable, changelogs, SW360Constants.TYPE_CHANGELOG, totalCount);
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.registerModule(sw360Module);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/Sw360ChangeLogService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/Sw360ChangeLogService.java
@@ -9,8 +9,11 @@
  */
 package org.eclipse.sw360.rest.resourceserver.changelog;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -18,11 +21,17 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogsService;
+import org.eclipse.sw360.datahandler.thrift.changelogs.ChangelogSortColumn;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -43,5 +52,29 @@ public class Sw360ChangeLogService {
 
     public List<ChangeLogs> getChangeLogsByDocumentId(String docId, User sw360User) throws TException {
         return getThriftChangeLogClient().getChangeLogsByDocumentId(sw360User, docId);
+    }
+
+    public Map<PaginationData, List<ChangeLogs>> getChangeLogsByDocumentIdPaginated(String docId, User sw360User, Pageable pageable) throws TException {
+        PaginationData pageData = pageableToPaginationData(pageable);
+        return getThriftChangeLogClient().getChangeLogsByDocumentIdPaginated(sw360User, docId, pageData);
+    }
+
+    /**
+     * Converts a Pageable object to a PaginationData object.
+     *
+     * @param pageable the Pageable object to convert
+     * @return a PaginationData object representing the pagination information
+     */
+    private static PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
+        ChangelogSortColumn column = ChangelogSortColumn.BY_CHANGE_TIMESTAMP;
+        boolean ascending = false;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            ascending = order.isAscending();
+        }
+        return new PaginationData().setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ChangeLogTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ChangeLogTest.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangedFields;
 import org.eclipse.sw360.datahandler.thrift.changelogs.Operation;
@@ -24,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -38,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -109,7 +112,10 @@ public class ChangeLogTest extends TestIntegrationBase {
         changeLogs.add(changeLog);
         changeLogs.add(changeLog2);
 
-        given(changeLogServiceMock.getChangeLogsByDocumentId(anyString(), any())).willReturn(changeLogs);
+        given(changeLogServiceMock.getChangeLogsByDocumentIdPaginated(anyString(), any(), any())).willReturn(Collections.singletonMap(
+                new PaginationData().setRowsPerPage(2).setDisplayStart(0).setTotalRowCount(2),
+                changeLogs
+        ));
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
@@ -133,7 +139,10 @@ public class ChangeLogTest extends TestIntegrationBase {
 
     @Test
     public void should_return_empty_change_logs_for_unknown_document() throws IOException, TException {
-        given(changeLogServiceMock.getChangeLogsByDocumentId(anyString(), any())).willReturn(List.of());
+        given(changeLogServiceMock.getChangeLogsByDocumentIdPaginated(anyString(), any(), any())).willReturn(Collections.singletonMap(
+                new PaginationData().setRowsPerPage(0).setDisplayStart(0).setTotalRowCount(0),
+                Collections.<ChangeLogs>emptyList()
+        ));
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
@@ -152,7 +161,7 @@ public class ChangeLogTest extends TestIntegrationBase {
 
     @Test
     public void should_handle_service_exception() throws IOException, TException {
-        given(changeLogServiceMock.getChangeLogsByDocumentId(anyString(), any())).willThrow(new TException("thrift error"));
+        given(changeLogServiceMock.getChangeLogsByDocumentIdPaginated(anyString(), any(), any())).willThrow(new TException("thrift error"));
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
@@ -192,7 +201,10 @@ public class ChangeLogTest extends TestIntegrationBase {
         changeLog.setChanges(changes);
 
         changeLogs.add(changeLog);
-        given(changeLogServiceMock.getChangeLogsByDocumentId(anyString(), any())).willReturn(changeLogs);
+        given(changeLogServiceMock.getChangeLogsByDocumentIdPaginated(anyString(), any(), any())).willReturn(Collections.singletonMap(
+                new PaginationData().setRowsPerPage(0).setDisplayStart(0).setTotalRowCount(0),
+                changeLogs
+        ));
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> requestEntity = new HttpEntity<>(headers);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ChangeLogSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ChangeLogSpecTest.java
@@ -27,8 +27,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Collections;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangedFields;
@@ -114,7 +116,10 @@ public class ChangeLogSpecTest extends TestRestDocsSpecBase {
         changeLogs.add(changeLog);
         changeLogs.add(changeLog2);
 
-        given(this.changeLogServiceMock.getChangeLogsByDocumentId(any(), any())).willReturn(changeLogs);
+        given(this.changeLogServiceMock.getChangeLogsByDocumentIdPaginated(any(), any(), any())).willReturn(Collections.singletonMap(
+                new PaginationData().setRowsPerPage(2).setDisplayStart(0).setTotalRowCount(2),
+                changeLogs
+        ));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

- Created a view which gives us changelogs with documentId or parentDocumentId equal to the given id. Passed [id, timestamp] as the key. 
- Created a query to fetch all changelogs between the smallest and largest possible timestamp based on the key we had given to the view. Implemented pagination and sorting for this query.

Issue: /changelog/document/{id} must be sortable by changeTimestamp.

### Suggest Reviewer
@GMishx 

### How To Test?
Make curl requests to the changelog endpoint:
```
curl -X 'GET' \
  'http://localhost:8080/resource/api/changelog/document/{id}?page=0&page_entries=10&sort=changeTimestamp%2Casc' \
  -H 'accept: application/hal+json' \
  -H 'Authorization: Basic abc'
```
```
curl -X 'GET' \
  'http://localhost:8080/resource/api/changelog/document/{id}?page=0&page_entries=10&sort=changeTimestamp%2Cdesc' \
  -H 'accept: application/hal+json' \
  -H 'Authorization: Basic abc'
```

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
