### PR TITLE
fix(keycloak): gson dependency issue.

### DIFF
--- a/keycloak/sw360-keycloak-common/pom.xml
+++ b/keycloak/sw360-keycloak-common/pom.xml
@@ -105,6 +105,7 @@
                                     <include>org.eclipse.sw360:nouveau-handler</include>
 
                                     <include>com.ibm.cloud:*</include>
+                                    <include>com.google.code.gson:gson</include>
                                     <include>org.apache.thrift:libthrift</include>
                                     <include>com.google.guava:guava</include>
                                     <include>com.fasterxml.jackson.*:*</include>
@@ -144,6 +145,10 @@
                                 <relocation>
                                     <pattern>com.ibm.cloud</pattern>
                                     <shadedPattern>org.eclipse.sw360.shaded.cloudant</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>org.eclipse.sw360.shaded.gson</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.logging.log4j</pattern>


### PR DESCRIPTION

Issue: The SW360 Keycloak providers (event-listener, user-storage-provider) fail to initialize with NoClassDefFoundError: Could not initialize class org.eclipse.sw360.keycloak.common.Sw360UserService.

Root cause: The sw360-keycloak-common shaded JAR was missing the Gson dependency (com.google.code.gson:gson). The IBM Cloudant SDK uses Gson internally to parse HTTP responses from CouchDB. Without it, the SDK throws "Error processing the HTTP response" during the Sw360UserService static initializer, and the JVM permanently marks the class as unloadable.

Fix: Added com.google.code.gson:gson to the shade plugin's <artifactSet><includes> and added a corresponding <relocation> entry to relocate com.google.gson → org.eclipse.sw360.shaded.gson to avoid classpath conflicts with Keycloak's runtime.
