### PR TITLE
feat(test): jacoco reports in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -126,13 +126,22 @@ jobs:
             -DRunPrivateProjectAccessTest=false \
             -DRunRestForceUpdateTest=false \
             -Dsurefire.excludes="**/architecture/*Test.java" \
+            jacoco:report \
             -fae
 
       - name: Run PrivateProjectAccessTest
         run: |
           mvn install -pl :build-configuration -am -Dbase.deploy.dir=.
-          mvn -pl :datahandler test -Dtest=ProjectPermissionsVisibilityTest -DRunPrivateProjectAccessTest=true -DRunRestForceUpdateTest=true -Dbase.deploy.dir=.
+          mvn -pl :datahandler test -Dtest=ProjectPermissionsVisibilityTest -DRunPrivateProjectAccessTest=true -DRunRestForceUpdateTest=true -Dbase.deploy.dir=. jacoco:report
 
       - name: Run BulkReleaseDeletingTest
         run: |
-          mvn -pl :backend-components test -Dtest=BulkDeleteUtilTest -DRunPrivateProjectAccessTest=true -DRunBulkReleaseDeletingTest=true -Dbase.deploy.dir=.
+          mvn -pl :backend-components test -Dtest=BulkDeleteUtilTest -DRunPrivateProjectAccessTest=true -DRunBulkReleaseDeletingTest=true -Dbase.deploy.dir=. jacoco:report
+
+      - name: Upload JaCoCo Reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jacoco-report
+          path: "**/target/site/jacoco/"
+          retention-days: 7

--- a/backend/cvesearch/src/test/java/org/eclipse/sw360/cvesearch/TestWithCveSearchConnection.java
+++ b/backend/cvesearch/src/test/java/org/eclipse/sw360/cvesearch/TestWithCveSearchConnection.java
@@ -15,6 +15,8 @@ import org.eclipse.sw360.cvesearch.datasource.CveSearchApi;
 import org.eclipse.sw360.cvesearch.datasource.CveSearchApiImpl;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.cvesearch.service.CveSearchHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assume;
 import org.junit.Before;
 
@@ -23,6 +25,7 @@ import java.util.Properties;
 import static org.eclipse.sw360.cvesearch.datasource.CveSearchDataTestHelper.isUrlReachable;
 
 public abstract class TestWithCveSearchConnection {
+    private static final Logger log = LogManager.getLogger(TestWithCveSearchConnection.class);
     private String PUBLIC_CVE_SEARCH_SERVER = "https://cve.circl.lu";
 
     protected CveSearchApi cveSearchApi;
@@ -34,7 +37,7 @@ public abstract class TestWithCveSearchConnection {
 
         Assume.assumeTrue("The public CVE Search server is unreliable and tests are only executed if a different instance is configured.", ! PUBLIC_CVE_SEARCH_SERVER.equals(host));
         Assume.assumeTrue("CVE Search host is reachable", isUrlReachable(host));
-        System.out.println("The CVE Search host is: " + host);
+        log.info("The CVE Search host is: {}", host);
 
         cveSearchApi = new CveSearchApiImpl(host);
     }

--- a/backend/licenses/src/test/java/org/eclipse/sw360/licenses/TestLicenseClient.java
+++ b/backend/licenses/src/test/java/org/eclipse/sw360/licenses/TestLicenseClient.java
@@ -12,6 +12,8 @@ package org.eclipse.sw360.licenses;
 import com.google.common.collect.ImmutableList;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -26,6 +28,7 @@ import java.util.List;
  * @author cedric.bodet@tngtech.com
  */
 public class TestLicenseClient {
+    private static final Logger log = LogManager.getLogger(TestLicenseClient.class);
 
     public static void main(String[] args) throws TException, IOException {
         THttpClient thriftClient = new THttpClient("http://127.0.0.1:8080/licenses/thrift");
@@ -34,10 +37,10 @@ public class TestLicenseClient {
 
         List<License> licenses = client.getLicenseSummary();
 
-        System.out.println("Fetched " + licenses.size() + " licenses from license service");
+        log.info("Fetched {} licenses from license service", licenses.size());
 
         final List<License> licenseList = client.getDetailedLicenseSummary("", ImmutableList.of("AFL-2.1","Artistic-1.0"));
-        System.out.println(licenseList.toString());
+        log.info(licenseList.toString());
 
     }
 

--- a/backend/moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
+++ b/backend/moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
@@ -13,6 +13,8 @@ package org.eclipse.sw360.moderation;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -26,6 +28,7 @@ import java.util.List;
  * author: Gerrit.Grenzebach@tngtech.com
  */
 public class TestModerationClient {
+    private static final Logger log = LogManager.getLogger(TestModerationClient.class);
 
     public static void main(String[] args) throws TException, IOException {
         THttpClient thriftClient = new THttpClient("http://127.0.0.1:8080//moderation/thrift");
@@ -34,10 +37,6 @@ public class TestModerationClient {
 
         List<ModerationRequest> requestsByModerator = client.getRequestsByModerator(new User().setId("58245y9845").setEmail("cedric.bodet@tngtech.com").setDepartment("BB"));
 
-
-        System.out.println("Fetched " + requestsByModerator.size() + " moderation requests from moderation service");
-
-
+        log.info("Fetched {} moderation requests from moderation service", requestsByModerator.size());
     }
-
 }

--- a/backend/search/src/test/java/org/eclipse/sw360/search/TestSearchClient.java
+++ b/backend/search/src/test/java/org/eclipse/sw360/search/TestSearchClient.java
@@ -11,6 +11,8 @@ package org.eclipse.sw360.search;
 
 import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.eclipse.sw360.datahandler.thrift.search.SearchService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -25,6 +27,7 @@ import java.util.List;
  * @author cedric.bodet@tngtech.com
  */
 public class TestSearchClient {
+    private static final Logger log = LogManager.getLogger(TestSearchClient.class);
 
     private static final String searchtext = "s*";
 
@@ -39,9 +42,9 @@ public class TestSearchClient {
 
         //  http://localhost:5984/_fti/local/sw360db/_design/lucene/all?q=type:project%20AND%20P1*
 
-        System.out.println("Fetched " + results.size() + " from search service");
+        log.info("Fetched {} from search service", results.size());
         for (SearchResult result : results) {
-            System.out.println(result.getId() + "(" + result.getType() + "): " + result.getName() + " (" + result.getScore() + ")");
+            log.info("{}({}): {} ({})", result.getId(), result.getType(), result.getName(), result.getScore());
         }
     }
 

--- a/backend/users/src/test/java/org/eclipse/sw360/users/TestUserClient.java
+++ b/backend/users/src/test/java/org/eclipse/sw360/users/TestUserClient.java
@@ -10,6 +10,8 @@
 package org.eclipse.sw360.users;
 
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -23,12 +25,13 @@ import java.io.IOException;
  * @author cedric.bodet@tngtech.com
  */
 public class TestUserClient {
+    private static final Logger log = LogManager.getLogger(TestUserClient.class);
 
     public static void main(String[] args) throws TException, IOException {
         THttpClient thriftClient = new THttpClient("http://127.0.0.1:8080/users/thrift");
         TProtocol protocol = new TCompactProtocol(thriftClient);
         UserService.Iface client = new UserService.Client(protocol);
 
-        System.out.println(client.getByEmail("cedric.bodet@tngtech.com"));
+        log.info("{}", client.getByEmail("cedric.bodet@tngtech.com"));
     }
 }

--- a/backend/utils/src/main/java/org/eclipse/sw360/UtilsEntryPoint.java
+++ b/backend/utils/src/main/java/org/eclipse/sw360/UtilsEntryPoint.java
@@ -9,6 +9,8 @@
  */
 package org.eclipse.sw360;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.eclipse.sw360.attachments.db.RemoteAttachmentDownloader;
 import org.apache.commons.cli.*;
 
@@ -18,6 +20,7 @@ import java.net.MalformedURLException;
  * @author daniele.fognini@tngtech.com
  */
 public class UtilsEntryPoint {
+    private static final Logger log = LogManager.getLogger(UtilsEntryPoint.class);
 
     private static final String OPTION_HELP = "h";
     private static final String OPTION_DOWNLOAD = "d";
@@ -28,7 +31,7 @@ public class UtilsEntryPoint {
         try {
             cmd = parseArgs(args);
         } catch (ParseException e) {
-            System.out.println(e.getMessage());
+            log.error(e.getMessage());
             printHelp();
             return;
         }

--- a/backend/vendors/src/test/java/org/eclipse/sw360/vendors/TestVendorClient.java
+++ b/backend/vendors/src/test/java/org/eclipse/sw360/vendors/TestVendorClient.java
@@ -15,6 +15,8 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -28,6 +30,7 @@ import java.util.List;
  * @author cedric.bodet@tngtech.com
  */
 public class TestVendorClient {
+    private static final Logger log = LogManager.getLogger(TestVendorClient.class);
 
     @SuppressWarnings("unused")
     public static void InitDatabase() throws SW360Exception {
@@ -52,15 +55,15 @@ public class TestVendorClient {
 
         reportFindings(vendors);
 
-        System.out.println("Now looking for matches starting with 'm' from vendor service");
+        log.info("Now looking for matches starting with 'm' from vendor service");
 
         reportFindings(client.searchVendors("m", pageData).values().iterator().next());
     }
 
     private static void reportFindings(List<Vendor> vendors) {
-        System.out.println("Fetched " + vendors.size() + " from vendor service");
+        log.info("Fetched {} from vendor service", vendors.size());
         for (Vendor vendor : vendors) {
-            System.out.println(vendor.getId() + ": " + vendor.getFullname() + " (" + vendor.getShortname() + ")");
+            log.info("{}: {} ({})", vendor.getId(), vendor.getFullname(), vendor.getShortname());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -813,6 +813,14 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <build>
     <pluginManagement>
       <plugins>
@@ -851,6 +859,7 @@
             <excludes>
               <exclude>org/xmlsoap/schemas/**</exclude>
               <exclude>org/apache/ws/commons/schema/**</exclude>
+              <exclude>**/thrift/**/*</exclude>
             </excludes>
           </configuration>
           <executions>
@@ -915,8 +924,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
           <configuration>
-            <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
-            <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+            <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -XX:+EnableDynamicAgentLoading</argLine>
+            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
           </configuration>
         </plugin>
         <plugin>
@@ -977,6 +986,18 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>${versions-maven-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
@@ -25,6 +25,8 @@ import java.util.List;
 import com.nimbusds.jwt.SignedJWT;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -59,6 +61,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureTestRestTemplate
 @ActiveProfiles({"dev", "test"})
 public abstract class IntegrationTestBase {
+    private static final Logger log = LogManager.getLogger(IntegrationTestBase.class);
 
     @Value("${local.server.port}")
     protected int port;
@@ -184,8 +187,8 @@ public abstract class IntegrationTestBase {
         } else {
             actualAuthorities.add(authoritiesJsonNode.asText());
         }
-        System.out.println("ACTUAL: " + actualAuthorities);
-        System.out.println("EXPECTED: " + StringUtils.join(expectedAuthority, ", "));
+        log.info("ACTUAL: {}", actualAuthorities);
+        log.info("EXPECTED: {}", StringUtils.join(expectedAuthority, ", "));
         assertThat(actualAuthorities, containsInAnyOrder(expectedAuthority));
 
         return jwtClaimsJsonNode;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -13,6 +13,8 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
@@ -20,7 +22,6 @@ import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
-import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
@@ -80,6 +81,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 
 @RunWith(SpringRunner.class)
 public class ComponentTest extends TestIntegrationBase {
+    private static final Logger log = LogManager.getLogger(ComponentTest.class);
 
     @LocalServerPort
     private int port;
@@ -209,7 +211,7 @@ public class ComponentTest extends TestIntegrationBase {
                 new HttpEntity<>(body, headers),
                 String.class);
 
-        System.out.println("Response is" + response);
+        log.info("Response is {}", response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
     }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This PR does:
1. Remove all `System.out` and `System.err` and replace them with logger.
2. Fix the surefire configuration:
    1. Single `argLine` was split in two causing overwrite and fix that.
    2. Provide path to mockito jar and add it as a top level test dependency.
    3. Prevent jGiven from polluting the output channel and giving warning `[WARNING] Corrupted channel by directly writing to native stream in forked JVM 1.`
3. Generate JaCoCo reports in CI and save them for 7 days as artifacts.
4. Ignore Thrift generated classes from Coverage reports.