### PR TITLE
fix(changelog): fix timestamp format to show just the date

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ChangeLogsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ChangeLogsDatabaseHandler.java
@@ -63,6 +63,11 @@ public class ChangeLogsDatabaseHandler {
         List<ChangeLogs> filteredLogs = entry.getValue().stream()
                 .filter(Objects::nonNull)
                 .filter(this::isNotEmptyChangeLog)
+                .peek(c -> {
+                    if (c.isSetChangeTimestamp()) {
+                        c.setChangeTimestamp(c.getChangeTimestamp().split(" ", 2)[0]);
+                    }
+                })
                 .toList();
 
         return Collections.singletonMap(entry.getKey(), filteredLogs);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> ```changeTimestamp``` format was changed to just return the date

### How To Test?
Make a curl request and check that the changeTimestamp field just returns the date.
```
curl -X 'GET' \
  'http://localhost:8080/resource/api/changelog/document/{id}?page=0&page_entries=10&sort=changeTimestamp%2Casc' \
  -H 'accept: application/hal+json' \
  -H 'Authorization: Basic abc'
```

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
