### PR TITLE
fix(rest): handle broken pipe gracefully

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -27,6 +27,7 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
@@ -37,9 +38,12 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.io.IOException;
 import java.time.Instant;
+import java.util.Locale;
 
 @ControllerAdvice
 public class RestExceptionHandler {
@@ -64,6 +68,24 @@ public class RestExceptionHandler {
     @ExceptionHandler({HttpMessageNotReadableException.class, BadRequestClientException.class})
     public ResponseEntity<ErrorMessage> handleMessageNotReadableException(RuntimeException e) {
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpMessageNotWritableException.class)
+    public ResponseEntity<ErrorMessage> handleMessageNotWritableException(HttpMessageNotWritableException e) {
+        if (isClientAbortException(e)) {
+            logClientAbort(e);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+        return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(AsyncRequestNotUsableException.class)
+    public ResponseEntity<ErrorMessage> handleAsyncRequestNotUsableException(AsyncRequestNotUsableException e) {
+        if (isClientAbortException(e)) {
+            logClientAbort(e);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+        return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler({MissingServletRequestParameterException.class, MissingServletRequestPartException.class})
@@ -109,6 +131,34 @@ public class RestExceptionHandler {
     @ExceptionHandler({SW360Exception.class})
     public ResponseEntity<ErrorMessage> handleSw360Exception(SW360Exception e) {
         return new ResponseEntity<>(new ErrorMessage(new Exception(e.getWhy()), HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    static boolean isClientAbortException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof AsyncRequestNotUsableException) {
+                return true;
+            }
+            if (current instanceof IOException) {
+                String message = current.getMessage();
+                if (message != null) {
+                    String normalized = message.toLowerCase(Locale.ROOT);
+                    if (normalized.contains("broken pipe") || normalized.contains("connection reset by peer")) {
+                        return true;
+                    }
+                }
+            }
+            if (current.getClass().getName().endsWith("ClientAbortException")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private void logClientAbort(Exception e) {
+        LOGGER.warn("Client disconnected while writing response: {}", e.getMessage());
+        LOGGER.debug("Client abort details", e);
     }
 
     @Data

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/SimpleAuthenticationEntryPoint.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/SimpleAuthenticationEntryPoint.java
@@ -11,11 +11,13 @@
 package org.eclipse.sw360.rest.resourceserver.core;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 
+import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -26,18 +28,35 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SimpleAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final Logger LOGGER = LogManager.getLogger(SimpleAuthenticationEntryPoint.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response,
-            AuthenticationException authException) throws IOException {
+    public void commence(
+            @Nonnull HttpServletRequest request,
+            @Nonnull HttpServletResponse response,
+            @Nonnull AuthenticationException authException
+    ) throws IOException {
+        if (response.isCommitted()) {
+            return;
+        }
+
         RestExceptionHandler.ErrorMessage message = new RestExceptionHandler.ErrorMessage(authException, HttpStatus.UNAUTHORIZED);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setCharacterEncoding("utf-8");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        ObjectMapper objectMapper = new ObjectMapper();
-        String resBody = objectMapper.writeValueAsString(message);
-        PrintWriter printWriter = response.getWriter();
-        printWriter.print(resBody);
-        printWriter.flush();
-        printWriter.close();
+
+        try {
+            OBJECT_MAPPER.writeValue(response.getOutputStream(), message);
+            response.flushBuffer();
+        } catch (IOException e) {
+            if (RestExceptionHandler.isClientAbortException(e)) {
+                LOGGER.warn("Client disconnected while writing unauthorized response: {}", e.getMessage());
+                LOGGER.debug("Client abort details", e);
+                return;
+            }
+            throw e;
+        }
     }
 }

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -11,8 +11,14 @@
 
 server:
   port: 8091
+  compression:
+    enabled: true
+    min-response-size: 2KB
+    mime-types: application/json,application/hal+json,text/plain,text/html,text/xml,application/xml
   servlet:
     context-path: /resource/api
+  tomcat:
+    connection-timeout: 60s
 
 management:
   endpoints:
@@ -42,6 +48,9 @@ management:
 spring:
   application:
     name: resource
+  mvc:
+    async:
+      request-timeout: 120s
   servlet:
     multipart:
       max-file-size: 500MB

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandlerTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.core;
+
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RestExceptionHandlerTest {
+
+    private final RestExceptionHandler restExceptionHandler = new RestExceptionHandler();
+
+    @Test
+    public void isClientAbortException_returnsTrue_forNestedBrokenPipe() {
+        HttpMessageNotWritableException exception =
+                new HttpMessageNotWritableException("write failed", new IOException("Broken pipe"));
+
+        assertThat(RestExceptionHandler.isClientAbortException(exception)).isTrue();
+    }
+
+    @Test
+    public void handleMessageNotWritableException_returnsNoContent_forClientAbort() {
+        HttpMessageNotWritableException exception =
+                new HttpMessageNotWritableException("write failed", new IOException("Broken pipe"));
+
+        ResponseEntity<RestExceptionHandler.ErrorMessage> response =
+                restExceptionHandler.handleMessageNotWritableException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    public void handleMessageNotWritableException_returnsInternalServerError_forNonClientAbort() {
+        HttpMessageNotWritableException exception =
+                new HttpMessageNotWritableException("serialization failed", new IllegalStateException("boom"));
+
+        ResponseEntity<RestExceptionHandler.ErrorMessage> response =
+                restExceptionHandler.handleMessageNotWritableException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+}

--- a/rest/resource-server/src/test/resources/application.yml
+++ b/rest/resource-server/src/test/resources/application.yml
@@ -2,8 +2,14 @@
 #SPDX-License-Identifier: EPL-2.0
 
 server:
+  compression:
+    enabled: true
+    min-response-size: 2KB
+    mime-types: application/json,application/hal+json,text/plain,text/html,text/xml,application/xml
   servlet:
     context-path: /
+  tomcat:
+    connection-timeout: 60s
 
 management:
   endpoints:
@@ -35,6 +41,9 @@ spring:
     active: SECURITY_MOCK
   application:
     name: resource
+  mvc:
+    async:
+      request-timeout: 120s
   servlet:
     multipart:
       max-file-size: 500MB


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary
This fix separates client-disconnect write failures (`Broken pipe`, `AsyncRequestNotUsableException`) from actual serialization failures in the REST exception handler, and improves server transfer tolerance for large JSON payloads.

### Problem
Previously, when clients disconnected during response serialization, the server logged misleading 400/500 errors with full stacktraces as if they were application failures. This added noise to logs and masked real issues.

### Solution
1. **Exception Classification**: Added `isClientAbortException()` detector in `RestExceptionHandler` to identify client-abort patterns by cause chain inspection.
2. **Graceful Response Handling**: For client aborts, return empty `204 No Content` and log warning + debug details instead of attempting error body write.
3. **Transfer Tolerance**: Enabled response compression and increased timeouts to reduce disconnect likelihood during large response serialization:
   - Gzip compression for JSON/HAL (min 2KB)
   - Tomcat connection timeout: 60s
   - Async request timeout: 120s
4. **Hardened Auth Entry Point**: `SimpleAuthenticationEntryPoint.commence()` now gracefully handles client disconnects when writing 401 responses.

### Changes
- **RestExceptionHandler.java**: Added handlers for `HttpMessageNotWritableException` and `AsyncRequestNotUsableException`; added static client-abort detector.
- **SimpleAuthenticationEntryPoint.java**: Hardened response writing with committed-response guard and client-abort exception handling.
- **application.yml**: Enabled server compression and adjusted timeouts.
- **RestExceptionHandlerTest.java** (new): Tests for broken-pipe detection and response behavior.

### Testing
Run focused resource-server tests:
```bash
mvn -pl rest/resource-server -P deploy -Dbase.deploy.dir=/tmp test -DskipITs
```

Manual verification:
- Check logs for `"Client disconnected while writing response"` (WARN) instead of `"Broken pipe"` (ERROR with stacktrace).
- Verify large response endpoints continue to work without spurious 500 errors.

### Checklist
- [x] All related issues are referenced (none — housekeeping fix)
- [x] Code generated with GitHub Copilot (assistant mode)
- [x] Unit tests added for new behavior
- [x] No new dependencies
- [x] EPL-2.0 license headers on new files