### PR TITLE
fix(api): fix token authorities and paths

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpController.java
@@ -49,6 +49,7 @@ public class AttachmentCleanUpController implements RepresentationModelProcessor
     private final Sw360AttachmentCleanUpService attachmentCleanUpService;
 
 	@Override
+    @PreAuthorize("hasAuthority('READ')")
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(AttachmentCleanUpController.class).slash("api" + ATTACHMENT_CLEANUP_URL).withRel("attachmentCleanUp"));
         return resource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/fossology/FossologyAdminController.java
@@ -66,6 +66,7 @@ public class FossologyAdminController implements RepresentationModelProcessor<Re
     Sw360FossologyAdminServices sw360FossologyAdminServices;
 
     @Override
+    @PreAuthorize("hasAuthority('READ')")
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(FossologyAdminController.class).slash("api" + FOSSOLOGY_URL).withRel("fossology"));
         return resource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -66,6 +66,7 @@ import org.eclipse.sw360.rest.resourceserver.moderationrequest.ModerationRequest
 import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
 import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProject;
+import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360UserDetails;
 import org.jetbrains.annotations.NotNull;
 import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProjectDTO;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -92,6 +93,7 @@ import org.springframework.hateoas.server.core.EmbeddedWrapper;
 import org.springframework.hateoas.server.core.EmbeddedWrappers;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -195,8 +197,18 @@ public class RestControllerHelper<T> {
 
     public User getSw360UserFromAuthentication() {
         try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null) {
+                throw new AuthenticationServiceException("Could not load user from authentication.");
+            }
+
+            Object authenticationDetails = authentication.getDetails();
+            if (authenticationDetails instanceof User cachedUser) {
+                return cachedUser;
+            }
+
             String userId = null;
-            Object principle = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            Object principle = authentication.getPrincipal();
             if (principle instanceof Jwt jwt) {
                 if (jwt.getClaims().containsKey("resource_access") || !jwt.getClaims().containsKey("user_name")) {
                     userId = jwt.getClaim("email");
@@ -210,11 +222,20 @@ public class RestControllerHelper<T> {
                         return userService.getUserByEmailOrExternalId(userId);
                     }
                 }
+            } else if (principle instanceof Sw360UserDetails sw360UserDetails) {
+                return sw360UserDetails.getSw360User();
+            } else if (principle instanceof User cachedUser) {
+                return cachedUser;
             } else if (principle instanceof String) {
                 userId = principle.toString();
-            } else {
-                org.springframework.security.core.userdetails.User user = (org.springframework.security.core.userdetails.User) principle;
+            } else if (principle instanceof org.springframework.security.core.userdetails.User user) {
                 userId = user.getUsername();
+            } else {
+                throw new AuthenticationServiceException("Could not load user from authentication.");
+            }
+
+            if (isNullEmptyOrWhitespace(userId)) {
+                throw new AuthenticationServiceException("Could not load user from authentication.");
             }
             return userService.getUserByEmailOrExternalId(userId);
         } catch (RuntimeException e) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/DatabaseSanitationController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/databasesanitation/DatabaseSanitationController.java
@@ -55,6 +55,7 @@ public class DatabaseSanitationController  implements RepresentationModelProcess
     private final RestControllerHelper restControllerHelper;
 
     @Override
+    @PreAuthorize("hasAuthority('READ')")
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(DatabaseSanitationController.class).slash("api" + DATABASESANITATION_URL).withRel("databaseSanitation"));
         return resource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/department/DepartmentController.java
@@ -69,6 +69,7 @@ public class DepartmentController implements RepresentationModelProcessor<Reposi
     private final RestControllerHelper restControllerHelper;
 
     @Override
+    @PreAuthorize("hasAuthority('READ')")
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(DepartmentController.class).slash("api" + DEPARTMENT_URL).withRel("department"));
         return resource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilter.java
@@ -5,16 +5,13 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.rest.resourceserver.filter;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiPredicate;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import jakarta.servlet.FilterChain;
@@ -24,103 +21,89 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import lombok.NonNull;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
-import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.filter.OncePerRequestFilter;
-
 
 @Component
 public class EndpointsFilter extends OncePerRequestFilter {
 
-    @Value("${blacklist.sw360.rest.api.endpoints}")
-    String endpointsTobeBlackListed;
+    private static final Set<String> WRITE_METHODS = Set.of("POST", "PATCH", "PUT", "DELETE");
 
-    @NonNull
-    private final RestControllerHelper restControllerHelper;
+    private final Map<Pattern, Set<String>> endpointHttpMethods;
+    private final RestControllerHelper<?> restControllerHelper;
 
-    public EndpointsFilter(RestControllerHelper restControllerHelper) {
+    public EndpointsFilter(@NonNull RestControllerHelper<?> restControllerHelper,
+            @Value("${blacklist.sw360.rest.api.endpoints:}") String endpointsTobeBlackListed) {
         this.restControllerHelper = restControllerHelper;
+        this.endpointHttpMethods = parseEndpointHttpMethods(endpointsTobeBlackListed);
     }
-
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String requestURI = request.getRequestURI();
-        String method = request.getMethod();
-        String[] endpointMethodPairs = endpointsTobeBlackListed.split(",");
-        Map<String, Set<String>> endpointHttpMethods = getMapOfEndpointToHttpMethods(endpointMethodPairs);
-        boolean isAMatch = verifyMatchingOfRequestURIToEndpoints(requestURI, endpointHttpMethods);
-
-        if (Arrays.asList("POST", "PATCH", "PUT", "DELETE").contains(method) && !isAMatch) {
-            User user = restControllerHelper.getSw360UserFromAuthentication();
-
-            // Inline check for Security User role having read only access
-            if (user.getUserGroup().name().equals("SECURITY_USER")) {
-                response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
-            } else {
-                filterChain.doFilter(request, response);
+        Optional<Entry<Pattern, Set<String>>> matchedEndpoint = findMatchingEndpoint(request.getRequestURI());
+        if (matchedEndpoint.isEmpty()) {
+            if (isWriteMethod(request.getMethod()) && PermissionUtils.isSecurityUser(restControllerHelper.getSw360UserFromAuthentication())) {
+                sendServiceUnavailable(response);
+                return;
             }
-        } else if (!isAMatch) {
             filterChain.doFilter(request, response);
-        } else {
-            Set<String> httpMethodsToBeBlocked = new HashSet<>();
-            Optional<Entry<String, Set<String>>> matchedEndpointToHttpMethods = endpointHttpMethods.entrySet().stream().filter(es -> {
-                String endpointURI = es.getKey();
-                return getRequestURIMatcher().test(endpointURI, requestURI);
-            }).findFirst();
-            if (matchedEndpointToHttpMethods.isPresent()) {
-                httpMethodsToBeBlocked = matchedEndpointToHttpMethods.get().getValue();
-            }
-            if (CommonUtils.isNullOrEmptyCollection(httpMethodsToBeBlocked)) {
-                response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
-            } else {
-                if (httpMethodsToBeBlocked.contains(method)) {
-                    response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
-                } else {
-                    filterChain.doFilter(request, response);
-                }
-            }
+            return;
         }
+
+        Set<String> blockedMethods = matchedEndpoint.get().getValue();
+        if (CommonUtils.isNullOrEmptyCollection(blockedMethods)
+                || blockedMethods.contains(request.getMethod().toUpperCase(Locale.ROOT))) {
+            sendServiceUnavailable(response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
     }
 
-    private boolean verifyMatchingOfRequestURIToEndpoints(String requestURI,
-            Map<String, Set<String>> endpointHttpMethods) {
-        long count = endpointHttpMethods.entrySet().stream().filter(es -> {
-            return getRequestURIMatcher().test(es.getKey(), requestURI);
-        }).count();
-        return count != 0;
+    private boolean isWriteMethod(String method) {
+        return WRITE_METHODS.contains(method.toUpperCase(Locale.ROOT));
     }
 
-    private Map<String, Set<String>> getMapOfEndpointToHttpMethods(String[] endpointMethodPairs) {
-        Map<String, Set<String>> endpointHttpMethods = new HashMap<>();
-        Arrays.stream(endpointMethodPairs).forEach(pair -> {
-            String[] parts = pair.trim().split(":");
+    private Optional<Entry<Pattern, Set<String>>> findMatchingEndpoint(String requestUri) {
+        return endpointHttpMethods.entrySet().stream()
+                .filter(entry -> entry.getKey().matcher(requestUri).matches())
+                .findFirst();
+    }
+
+    private Map<Pattern, Set<String>> parseEndpointHttpMethods(String endpointsTobeBlackListed) {
+        Map<Pattern, Set<String>> parsedEndpointHttpMethods = new HashMap<>();
+        if (CommonUtils.isNullEmptyOrWhitespace(endpointsTobeBlackListed)) {
+            return parsedEndpointHttpMethods;
+        }
+
+        for (String endpointMethodPair : endpointsTobeBlackListed.split(",")) {
+            if (CommonUtils.isNullEmptyOrWhitespace(endpointMethodPair)) {
+                continue;
+            }
+            String[] parts = endpointMethodPair.trim().split(":");
             String endpointPath = parts[0];
             if (endpointPath.contains("{")) {
                 endpointPath = endpointPath.replaceAll("\\{\\w+\\}", "\\\\w+");
             }
+            Pattern endpointPattern = Pattern.compile(endpointPath);
             if (parts.length == 2) {
-                String httpMethod = parts[1];
-                endpointHttpMethods.computeIfAbsent(endpointPath, k -> new HashSet<>()).add(httpMethod);
+                parsedEndpointHttpMethods.computeIfAbsent(endpointPattern, ignored -> new HashSet<>())
+                        .add(parts[1].trim().toUpperCase(Locale.ROOT));
             } else {
-                endpointHttpMethods.put(endpointPath, Collections.emptySet());
+                parsedEndpointHttpMethods.put(endpointPattern, Set.of());
             }
-        });
-        return endpointHttpMethods;
+        }
+
+        return parsedEndpointHttpMethods;
     }
 
-    private BiPredicate<String, String> getRequestURIMatcher() {
-        return (endpointURI, requestURI) -> {
-            Pattern endpointPattern = Pattern.compile(endpointURI);
-            Matcher requestUriMatcher = endpointPattern.matcher(requestURI);
-            return requestUriMatcher.matches();
-        };
+    private void sendServiceUnavailable(HttpServletResponse response) throws IOException {
+        response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -56,6 +56,7 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
     private Sw360ScheduleService scheduleService;
 
     @Override
+    @PreAuthorize("hasAuthority('READ')")
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(ScheduleAdminController.class).slash("api/schedule").withRel("schedule"));
         return resource;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -10,12 +10,12 @@
 
 package org.eclipse.sw360.rest.resourceserver.security;
 
+import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.rest.resourceserver.core.SimpleAuthenticationEntryPoint;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationFilter;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationProvider;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360UserAuthenticationProvider;
 import org.eclipse.sw360.rest.resourceserver.security.jwt.Sw360JWTAccessTokenConverter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,54 +38,46 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class ResourceServerConfiguration {
 
-    @Autowired
-    SimpleAuthenticationEntryPoint saep;
+    private static final String[] PUBLIC_SWAGGER_ENDPOINTS = {"/v3/api-docs/**", "/swagger-ui/**", "/index.html",
+            "/docs/**", "/mkdocs/**"};
 
-    @Autowired
-    Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;
+    private static final String[] PUBLIC_API_GET_ENDPOINTS = {"/api/health", "/api/version", "/api",
+            "/api/reports/download"};
 
-    @Autowired
-    private ApiTokenAuthenticationProvider authProvider;
-
-    @Autowired
-    Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+    private final SimpleAuthenticationEntryPoint saep;
+    private final Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;
+    private final ApiTokenAuthenticationProvider authProvider;
+    private final Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
-    String issuerUri;
+    private String issuerUri;
 
     @Value("${springdoc.swagger-ui.require-authentication:true}")
-    boolean swaggerRequireAuthentication;
+    private boolean swaggerRequireAuthentication;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
         ApiTokenAuthenticationFilter apiTokenAuthenticationFilter = new ApiTokenAuthenticationFilter(authenticationManager, saep);
+        http.authenticationManager(authenticationManager);
         return http
                 .addFilterBefore(apiTokenAuthenticationFilter, BasicAuthenticationFilter.class)
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt ->
                         jwt.jwtAuthenticationConverter(sw360JWTAccessTokenConverter)
                                 .jwkSetUri(issuerUri)).authenticationEntryPoint(saep))
                 .authorizeHttpRequests(auth -> {
-                    // Swagger/OpenAPI endpoints - configurable authentication
                     if (!swaggerRequireAuthentication) {
-                        auth.requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll();
-                        auth.requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll();
-                        auth.requestMatchers(HttpMethod.GET, "/index.html").permitAll();
-                        auth.requestMatchers(HttpMethod.GET, "/docs/**").permitAll();
-                        auth.requestMatchers(HttpMethod.GET, "/mkdocs/**").permitAll();
+                        auth.requestMatchers(HttpMethod.GET, PUBLIC_SWAGGER_ENDPOINTS).permitAll();
                     }
-                    // API endpoints
-                    auth.requestMatchers(HttpMethod.GET, "/api/health").permitAll();
-                    auth.requestMatchers(HttpMethod.GET, "/api/version").permitAll();
+                    auth.requestMatchers(HttpMethod.GET, PUBLIC_API_GET_ENDPOINTS).permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/api/info").hasAuthority("WRITE");
-                    auth.requestMatchers(HttpMethod.GET, "/api").permitAll();
-                    auth.requestMatchers(HttpMethod.GET, "/api/reports/download").permitAll();
-                    auth.requestMatchers(HttpMethod.GET, "/api/**").hasAuthority("READ");
-                    auth.requestMatchers(HttpMethod.POST, "/api/**").hasAuthority("WRITE");
-                    auth.requestMatchers(HttpMethod.PUT, "/api/**").hasAuthority("WRITE");
-                    auth.requestMatchers(HttpMethod.DELETE, "/api/**").hasAuthority("WRITE");
-                    auth.requestMatchers(HttpMethod.PATCH, "/api/**").hasAuthority("WRITE");
+                    auth.requestMatchers(HttpMethod.GET, "/api/**").hasAuthority(TokenCapabilityAuthorities.TOKEN_READ);
+                    auth.requestMatchers(HttpMethod.POST, "/api/**").hasAuthority(TokenCapabilityAuthorities.TOKEN_WRITE);
+                    auth.requestMatchers(HttpMethod.PUT, "/api/**").hasAuthority(TokenCapabilityAuthorities.TOKEN_WRITE);
+                    auth.requestMatchers(HttpMethod.DELETE, "/api/**").hasAuthority(TokenCapabilityAuthorities.TOKEN_WRITE);
+                    auth.requestMatchers(HttpMethod.PATCH, "/api/**").hasAuthority(TokenCapabilityAuthorities.TOKEN_WRITE);
                 })
                 .httpBasic(basic -> basic.authenticationEntryPoint(saep))
                 .exceptionHandling(x -> x.authenticationEntryPoint(saep))
@@ -94,9 +86,8 @@ public class ResourceServerConfiguration {
                 .csrf(csrf -> csrf.disable()).build();
     }
 
-
     @Bean
-    AuthenticationManager authenticationManager() {
+    public AuthenticationManager authenticationManager() {
         return new ProviderManager(List.of(authProvider, sw360UserAuthenticationProvider));
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/TokenCapabilityAuthorities.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/TokenCapabilityAuthorities.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public final class TokenCapabilityAuthorities {
+
+    public static final String TOKEN_READ = "TOKEN_READ";
+    public static final String TOKEN_WRITE = "TOKEN_WRITE";
+
+    private static final Set<GrantedAuthority> READ_ONLY_AUTHORITIES =
+            Set.of(new SimpleGrantedAuthority(TOKEN_READ));
+    private static final Set<GrantedAuthority> READ_WRITE_AUTHORITIES =
+            Set.of(new SimpleGrantedAuthority(TOKEN_READ), new SimpleGrantedAuthority(TOKEN_WRITE));
+
+    private TokenCapabilityAuthorities() {
+    }
+
+    public static Set<GrantedAuthority> readWrite() {
+        return READ_WRITE_AUTHORITIES;
+    }
+
+    public static Set<GrantedAuthority> fromAuthorityNames(Collection<String> authorityNames) {
+        if (authorityNames == null || authorityNames.isEmpty()) {
+            return readWrite();
+        }
+
+        boolean hasRead = false;
+        boolean hasWrite = false;
+        for (String authorityName : authorityNames) {
+            if (authorityName == null) {
+                continue;
+            }
+            switch (authorityName.toUpperCase(Locale.ROOT)) {
+                case "READ", "SCOPE_READ" -> hasRead = true;
+                case "WRITE", "SCOPE_WRITE" -> {
+                    hasRead = true;
+                    hasWrite = true;
+                }
+                default -> {
+                    // Unknown scopes/authorities are intentionally ignored.
+                }
+            }
+        }
+
+        if (hasWrite) {
+            return readWrite();
+        }
+        if (hasRead) {
+            return READ_ONLY_AUTHORITIES;
+        }
+        return readWrite();
+    }
+
+    public static Set<GrantedAuthority> fromJwtScopeClaim(Object scopeClaim) {
+        if (scopeClaim instanceof String scopeClaimString) {
+            if (scopeClaimString.isBlank()) {
+                return readWrite();
+            }
+            String[] values = scopeClaimString.trim().split("\\s+");
+            return fromAuthorityNames(List.of(values));
+        }
+
+        if (scopeClaim instanceof Collection<?> scopeClaimCollection) {
+            Set<String> normalized = new LinkedHashSet<>();
+            for (Object value : scopeClaimCollection) {
+                if (value != null) {
+                    normalized.add(value.toString());
+                }
+            }
+            return fromAuthorityNames(normalized);
+        }
+
+        return readWrite();
+    }
+
+    public static Set<GrantedAuthority> merge(Collection<? extends GrantedAuthority> first,
+                                               Collection<? extends GrantedAuthority> second) {
+        Set<GrantedAuthority> merged = new HashSet<>();
+        if (first != null) {
+            merged.addAll(first);
+        }
+        if (second != null) {
+            merged.addAll(second);
+        }
+        return Collections.unmodifiableSet(merged);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
@@ -20,14 +20,15 @@ import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserAccess;
 import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
+import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationFilter.ApiTokenAuthentication;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationFilter.AuthType;
+import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.resourceserver.security.jwksvalidation.JWTValidator;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.jetbrains.annotations.NotNull;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.InvalidJwtException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -36,17 +37,15 @@ import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.lang.Math.min;
 import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.*;
@@ -64,7 +63,7 @@ public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-        log.info("Authenticating for the user with authentication {}", authentication);
+        log.debug("Authenticating for the user with authentication {}", authentication);
         if (authentication.isAuthenticated()) {
             log.trace("Authentication already authenticated");
             return authentication;
@@ -169,23 +168,13 @@ public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
         return tokenExpireDate.before(new Date());
     }
 
-    private Set<GrantedAuthority> getGrantedAuthoritiesFromApiToken(RestApiToken restApiToken) {
-        return restApiToken.getAuthorities()
-                .stream()
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toSet());
-    }
-
-    private Set<GrantedAuthority> getGrantedAuthoritiesFromUserAccess(UserAccess userAccess) {
-        return Stream.of(userAccess.name().split("_"))
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toSet());
-    }
-
     private PreAuthenticatedAuthenticationToken authenticatedApiUser(User user, String credentials, RestApiToken restApiToken) {
-        Set<GrantedAuthority> grantedAuthorities = getGrantedAuthoritiesFromApiToken(restApiToken);
+        Set<GrantedAuthority> grantedAuthorities = TokenCapabilityAuthorities.merge(
+                Sw360GrantedAuthoritiesCalculator.generateFromUser(user),
+                TokenCapabilityAuthorities.fromAuthorityNames(restApiToken.getAuthorities()));
         PreAuthenticatedAuthenticationToken preAuthenticatedAuthenticationToken =
                 new PreAuthenticatedAuthenticationToken(user.getEmail(), credentials, grantedAuthorities);
+        preAuthenticatedAuthenticationToken.setDetails(user);
         preAuthenticatedAuthenticationToken.setAuthenticated(true);
         return preAuthenticatedAuthenticationToken;
     }
@@ -203,9 +192,12 @@ public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
             throw new AuthenticationServiceException(
                     "Your entered OIDC token is not associated with any user for authorization.");
         }
-        Set<GrantedAuthority> grantedAuthorities = getGrantedAuthoritiesFromUserAccess(access);
+        Set<GrantedAuthority> grantedAuthorities = TokenCapabilityAuthorities.merge(
+                Sw360GrantedAuthoritiesCalculator.generateFromUser(user),
+                TokenCapabilityAuthorities.fromAuthorityNames(List.of(access.name())));
         PreAuthenticatedAuthenticationToken preAuthenticatedAuthenticationToken = new PreAuthenticatedAuthenticationToken(
                 user.getEmail(), credentials, grantedAuthorities);
+        preAuthenticatedAuthenticationToken.setDetails(user);
         preAuthenticatedAuthenticationToken.setAuthenticated(true);
         return preAuthenticatedAuthenticationToken;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsService.java
@@ -4,15 +4,22 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.resourceserver.security.basic;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -24,10 +31,11 @@ public class Sw360CustomUserDetailsService implements UserDetailsService {
     Sw360UserDetailsProvider sw360UserDetailsProvider;
 
     @Override
-    public UserDetails loadUserByUsername(String userid) {
+    public @Nonnull UserDetails loadUserByUsername(@Nullable String userid) {
         log.info("Authenticating for the user with username {}", userid);
         User user = sw360UserDetailsProvider.provideUserDetails(userid, null);
-        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(),
-                Sw360GrantedAuthoritiesCalculator.generateFromUser(user));
+        Set<GrantedAuthority> authorities = new HashSet<>(Sw360GrantedAuthoritiesCalculator.generateFromUser(user));
+        authorities.addAll(TokenCapabilityAuthorities.readWrite());
+        return new Sw360UserDetails(user, authorities);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360GrantedAuthoritiesCalculator.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360GrantedAuthoritiesCalculator.java
@@ -16,7 +16,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
- * This class offer helper methods to calculate the {@GrantedAuthority} for a
+ * This class offer helper methods to calculate the {@link GrantedAuthority} for a
  * user.
  */
 public class Sw360GrantedAuthoritiesCalculator {
@@ -28,15 +28,13 @@ public class Sw360GrantedAuthoritiesCalculator {
         List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
 
         grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.READ.getAuthority()));
-        if (user != null) {
-            if (PermissionUtils.isUserAtLeast(Sw360ResourceServer.CONFIG_WRITE_ACCESS_USERGROUP, user)) {
-                log.debug("User {} has write access", user.getEmail());
-                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.WRITE.getAuthority()));
-            }
-            if (PermissionUtils.isUserAtLeast(Sw360ResourceServer.CONFIG_ADMIN_ACCESS_USERGROUP, user)) {
-                log.debug("User {} has admin access", user.getEmail());
-                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.ADMIN.getAuthority()));
-            }
+        if (PermissionUtils.isUserAtLeast(Sw360ResourceServer.CONFIG_WRITE_ACCESS_USERGROUP, user)) {
+            log.debug("User {} has write access", user.getEmail());
+            grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.WRITE.getAuthority()));
+        }
+        if (PermissionUtils.isUserAtLeast(Sw360ResourceServer.CONFIG_ADMIN_ACCESS_USERGROUP, user)) {
+            log.debug("User {} has admin access", user.getEmail());
+            grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.ADMIN.getAuthority()));
         }
 
         log.info("Granted authorities for user {} are {}", user.getEmail(), grantedAuthorities);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360GrantedAuthority.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360GrantedAuthority.java
@@ -4,6 +4,7 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.resourceserver.security.basic;
 
+import jakarta.annotation.Nonnull;
 import org.springframework.security.core.GrantedAuthority;
 
 public enum Sw360GrantedAuthority implements GrantedAuthority {
@@ -11,7 +12,7 @@ public enum Sw360GrantedAuthority implements GrantedAuthority {
     BASIC, READ, WRITE, ADMIN;
 
     @Override
-    public String getAuthority() {
+    public @Nonnull String getAuthority() {
         return toString();
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserAuthenticationProvider.java
@@ -6,6 +6,7 @@ package org.eclipse.sw360.rest.resourceserver.security.basic;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -13,9 +14,13 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
@@ -23,9 +28,9 @@ public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
-    private Sw360CustomUserDetailsService userDetailsService;
+    private final Sw360CustomUserDetailsService userDetailsService;
 
     @Autowired
     public Sw360UserAuthenticationProvider(@Lazy PasswordEncoder passwordEncoder, Sw360CustomUserDetailsService userDetailsService) {
@@ -34,14 +39,19 @@ public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
     }
 
     /**
-     * @param authentication the authentication request object. 
+     * @param authentication the authentication request object.
      * @return
      * @throws AuthenticationException
      */
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String userName = authentication.getName();
-        String rawPassword = authentication.getCredentials().toString();
+        String rawPassword;
+        if (authentication.getCredentials() == null) {
+            rawPassword = null;
+        } else {
+            rawPassword = authentication.getCredentials().toString();
+        }
         log.info("Authenticating for the user with username {}", userName);
 
         UserDetails userDetails = userDetailsService.loadUserByUsername(userName);
@@ -50,15 +60,22 @@ public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
 
     private Authentication checkPassword(UserDetails userDetails, String rawPassword) {
         log.info("Checking password for user {}", userDetails.getUsername());
-        if(passwordEncoder.matches(rawPassword, userDetails.getPassword())) {
-            return new UsernamePasswordAuthenticationToken(userDetails, rawPassword, userDetails.getAuthorities());
+        if (passwordEncoder.matches(rawPassword, userDetails.getPassword())) {
+            Set<GrantedAuthority> authorities = new HashSet<>(userDetails.getAuthorities());
+            authorities.addAll(TokenCapabilityAuthorities.readWrite());
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails,
+                    rawPassword, authorities);
+            if (userDetails instanceof Sw360UserDetails sw360UserDetails) {
+                authentication.setDetails(sw360UserDetails.getSw360User());
+            }
+            return authentication;
         } else {
             throw new BadCredentialsException("Bad credentials");
         }
     }
 
     /**
-     * @param authentication 
+     * @param authentication
      * @return
      */
     @Override

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserDetails.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserDetails.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.security.basic;
+
+import lombok.Getter;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.io.Serial;
+import java.util.Collection;
+
+@Getter
+public class Sw360UserDetails extends org.springframework.security.core.userdetails.User {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final transient User sw360User;
+
+    public Sw360UserDetails(User sw360User, Collection<? extends GrantedAuthority> authorities) {
+        super(sw360User.getEmail(), sw360User.getPassword(), authorities);
+        this.sw360User = sw360User;
+    }
+
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserDetailsProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360UserDetailsProvider.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,22 +20,19 @@ public class Sw360UserDetailsProvider {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    private ThriftClients thriftClients = new ThriftClients();
+    private final ThriftClients thriftClients = new ThriftClients();
 
     public User provideUserDetails(String email, String extId) {
-        User result = null;
-
-        log.debug("Looking up user with email <" + email + "> and external id <" + extId + ">.");
+        log.debug("Looking up user with email <{}> and external id <{}>.", email, extId);
 
         User user = getUserByEmailOrExternalId(email, extId);
         if (user != null) {
-            log.debug("Found user with email <" + email + "> and external id <" + extId + "> in UserService.");
-            result = user;
+            log.debug("Found user with email <{}> and external id <{}> in UserService.", email, extId);
+            return user;
         } else {
-            log.warn("No user found with email <" + email + "> and external id <" + extId + "> in UserService.");
+            log.warn("No user found with email <{}> and external id <{}> in UserService.", email, extId);
+            throw new BadCredentialsException("Bad credentials");
         }
-
-        return result;
     }
 
     private User getUserByEmailOrExternalId(String email, String externalId) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
@@ -4,11 +4,11 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.resourceserver.security.jwt;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,10 +60,14 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 	 */
 	@Override
 	public AbstractAuthenticationToken convert(@NonNull Jwt jwt) {
+		User sw360User = loadSw360User(jwt);
+		Collection<GrantedAuthority> tokenCapabilities = TokenCapabilityAuthorities.fromJwtScopeClaim(jwt.getClaim(SCOPE));
 		Collection<GrantedAuthority> authorities = Stream
-				.concat(jwtGrantedAuthoritiesConverter.convert(jwt).stream(), extractResourceRoles(jwt).stream())
+				.concat(jwtGrantedAuthoritiesConverter.convert(jwt).stream(), extractResourceRoles(sw360User, jwt, tokenCapabilities).stream())
 				.collect(Collectors.toSet());
-		return new JwtAuthenticationToken(jwt, authorities, getPrincipleClaimName(jwt));
+		JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(jwt, authorities, getPrincipleClaimName(jwt));
+		authenticationToken.setDetails(sw360User);
+		return authenticationToken;
 	}
 
 	/**
@@ -86,7 +90,16 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 	 * @param jwt the JWT token
 	 * @return a collection of GrantedAuthority extracted from the JWT token
 	 */
-	private Collection<GrantedAuthority> extractResourceRoles(Jwt jwt) {
+	private Collection<GrantedAuthority> extractResourceRoles(User sw360User, Jwt jwt,
+			Collection<GrantedAuthority> tokenCapabilities) {
+		String email = sw360User.getEmail();
+		List<GrantedAuthority> grantedAuthorities = Sw360GrantedAuthoritiesCalculator.generateFromUser(sw360User);
+		log.debug("User {} has group authorities {} and token capabilities {} for client {}", email,
+				grantedAuthorities, tokenCapabilities, jwt.getClaim("client_id"));
+		return TokenCapabilityAuthorities.merge(grantedAuthorities, tokenCapabilities);
+	}
+
+	private User loadSw360User(Jwt jwt) {
 		String email = extractEmailFromJWT(jwt);
 		User sw360User;
 		try {
@@ -95,33 +108,7 @@ public class Sw360JWTAccessTokenConverter implements Converter<Jwt, AbstractAuth
 			sw360User = null; // captured by validateUser()
 		}
 		validateUser(sw360User);
-		List<GrantedAuthority> grantedAuthorities = Sw360GrantedAuthoritiesCalculator.generateFromUser(sw360User);
-		Set<String> scopes = getScopes(jwt);
-		if (scopes.isEmpty()) {
-			return grantedAuthorities;
-		}
-		log.debug("User {} has authorities {} while client {} has scopes {}. Setting intersection as granted authorities for access token", email, grantedAuthorities, jwt.getClaim("client_id"), scopes);
-		return grantedAuthorities.stream().filter(s -> scopes.contains(s.toString())).toList();
-	}
-
-	/**
-	 * Retrieves the scopes from the JWT token.
-	 *
-	 * @param jwt the JWT token
-	 * @return a set of scopes extracted from the JWT token
-	 */
-	private static @NotNull Set<String> getScopes(Jwt jwt) {
-		Object scopeClaim = jwt.getClaim(SCOPE);
-		Set<String> scopes;
-
-		if (scopeClaim instanceof String scopeClaimString) {
-			scopes = new HashSet<>(Arrays.asList(scopeClaimString.split("\\s+")));
-		} else if (scopeClaim instanceof List scopeList) {
-			scopes = new HashSet<>(scopeList);
-		} else {
-			scopes = Collections.emptySet();
-		}
-		return scopes;
+		return sw360User;
 	}
 
 	/**

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/architecture/ARCHUNIT_TEST_SUMMARY.md
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/architecture/ARCHUNIT_TEST_SUMMARY.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: EPL-2.0
 
 # SW360 ArchUnit Test Summary
 
-> **Last Updated:** April 15, 2026
+> **Last Updated:** May 7, 2026
 > **Module:** `rest/resource-server`
 
 This document provides a comprehensive overview of all ArchUnit architecture tests in the SW360 REST resource-server module. These tests enforce architectural patterns, coding standards, and best practices.
@@ -25,14 +25,14 @@ This document provides a comprehensive overview of all ArchUnit architecture tes
 | [Naming Convention Rules](#6-naming-convention-rules) | 5 | Validates class naming patterns |
 | [OpenAPI Documentation Rules](#7-openapi-documentation-rules) | 2 | Ensures OpenAPI documentation |
 | [Package Structure Rules](#8-package-structure-rules) | 5 | Enforces package organization |
-| [Security Annotation Rules](#9-security-annotation-rules) | 4 | Validates security annotations |
+| [Security Annotation Rules](#9-security-annotation-rules) | 5 | Validates security annotations |
 | [Spring Framework Rules](#10-spring-framework-rules) | 7 | Enforces Spring best practices |
 | [Thrift Service Boundary Rules](#11-thrift-service-boundary-rules) | 3 | Prevents bypassing Thrift layer |
 | [Coding Standard Rules](#12-coding-standard-rules) | 14 | General coding standards & modern Java |
 | [Resource Management Rules](#13-resource-management-rules) | 9 | Resource lifecycle & concurrency |
 | [Dependency Governance Rules](#14-dependency-governance-rules) | 6 | Third-party dependency allowlist & bans |
 | [Test Coverage Completeness Rules](#15-test-coverage-completeness-rules) | 3 | Forced test co-evolution |
-| **Total** | **77** | **Complete architecture validation** |
+| **Total** | **78** | **Complete architecture validation** |
 
 ---
 
@@ -142,6 +142,7 @@ This document provides a comprehensive overview of all ArchUnit architecture tes
 | `noClassShouldUseRolesAllowedAnnotation` | No class should use `@RolesAllowed` — use `@PreAuthorize` instead |
 | `noClassShouldUseDeprecatedMethodSecurityAnnotation` | No class should use deprecated `@EnableGlobalMethodSecurity` — use `@EnableMethodSecurity` (Spring Security 6.x) |
 | `preAuthorizeValuesShouldUseKnownAuthorities` | `@PreAuthorize` annotations must only reference known SW360 authorities: `ADMIN`, `WRITE`, or `READ` |
+| `representationModelProcessorControllersShouldAllowReadOnProcess` | Controllers that use class-level `@PreAuthorize('ADMIN')` and implement `RepresentationModelProcessor` must mark `process(RepositoryLinksResource)` with `@PreAuthorize` including `READ` so `/api` root discovery does not fail with 403 |
 
 ---
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/architecture/SecurityAnnotationRulesTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/architecture/SecurityAnnotationRulesTest.java
@@ -10,13 +10,19 @@
 package org.eclipse.sw360.rest.resourceserver.architecture;
 
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.rest.webmvc.BasePathAwareController;
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
@@ -128,6 +134,55 @@ class SecurityAnnotationRulesTest extends SW360ArchitectureTest {
                 .should(useOnlyKnownAuthorities)
                 .as("@PreAuthorize annotations should only reference known SW360 authorities: " +
                         "ADMIN, WRITE, or READ");
+
+        rule.check(restClasses);
+    }
+
+    @Test
+    @DisplayName("RepresentationModelProcessor controllers must allow READ on process()")
+    void representationModelProcessorControllersShouldAllowReadOnProcess() {
+        ArchCondition<JavaClass> processShouldRequireRead =
+                new ArchCondition<>("declare @PreAuthorize with READ on process(RepositoryLinksResource)") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        if (!javaClass.isAnnotatedWith(PreAuthorize.class)) {
+                            return;
+                        }
+                        String classLevelValue = javaClass.getAnnotationOfType(PreAuthorize.class).value();
+                        if (!classLevelValue.contains("ADMIN")) {
+                            return;
+                        }
+
+                        List<JavaMethod> processMethods = javaClass.getMethods().stream()
+                                .filter(method -> method.getName().equals("process"))
+                                .filter(method -> method.getRawParameterTypes().size() == 1)
+                                .filter(method -> method.getRawParameterTypes().getFirst()
+                                        .isEquivalentTo(RepositoryLinksResource.class))
+                                .toList();
+
+                        for (JavaMethod method : processMethods) {
+                            if (!method.isAnnotatedWith(PreAuthorize.class)) {
+                                events.add(SimpleConditionEvent.violated(javaClass,
+                                        String.format("%s.process(...) must be annotated with @PreAuthorize('hasAuthority('READ')') to keep /api root discoverable",
+                                                javaClass.getSimpleName())));
+                                continue;
+                            }
+                            String value = method.getAnnotationOfType(PreAuthorize.class).value();
+                            if (!value.contains("READ")) {
+                                events.add(SimpleConditionEvent.violated(javaClass,
+                                        String.format("%s.process(...) uses @PreAuthorize(\"%s\") but must allow READ for /api root discovery",
+                                                javaClass.getSimpleName(), value)));
+                            }
+                        }
+                    }
+                };
+
+        ArchRule rule = classes()
+                .that().areAnnotatedWith(RestController.class)
+                .and().areAnnotatedWith(BasePathAwareController.class)
+                .and().implement(org.springframework.hateoas.server.RepresentationModelProcessor.class)
+                .should(processShouldRequireRead)
+                .as("Controllers with class-level ADMIN guard must keep process() readable by READ users");
 
         rule.check(restClasses);
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelperAuthCachingTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelperAuthCachingTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.core;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
+import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
+import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
+import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestControllerHelperAuthCachingTest {
+
+    @Mock
+    private Sw360UserService userService;
+
+    @Mock
+    private Sw360VendorService vendorService;
+
+    @Mock
+    private Sw360LicenseService licenseService;
+
+    @Mock
+    private Sw360ObligationService obligationService;
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void shouldReuseCachedSw360UserFromAuthenticationDetails() {
+        RestControllerHelper<Object> helper = new RestControllerHelper<>(
+                userService,
+                vendorService,
+                licenseService,
+                obligationService,
+                new SimpleModule()
+        );
+
+        User cachedUser = new User();
+        cachedUser.setEmail("cached@sw360.org");
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                "cached@sw360.org",
+                "secret"
+        );
+        authentication.setDetails(cachedUser);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        User resolvedUser = helper.getSw360UserFromAuthentication();
+
+        assertThat(resolvedUser).isSameAs(cachedUser);
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    public void shouldFailFastWhenAuthenticationIsMissing() {
+        RestControllerHelper<Object> helper = new RestControllerHelper<>(
+                userService,
+                vendorService,
+                licenseService,
+                obligationService,
+                new SimpleModule()
+        );
+
+        SecurityContextHolder.clearContext();
+
+        assertThatThrownBy(helper::getSw360UserFromAuthentication)
+                .isInstanceOf(AuthenticationServiceException.class)
+                .hasMessage("Could not load user from authentication.");
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ApiRootAuthorizationRegressionTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ApiRootAuthorizationRegressionTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthority;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(SpringRunner.class)
+@Import(ApiRootAuthorizationRegressionTest.ApiRootAuthorizationTestConfig.class)
+public class ApiRootAuthorizationRegressionTest extends TestIntegrationBase {
+
+    private static final String READ_ONLY_EMAIL = "readonly@sw360.org";
+    private static final String READ_ONLY_PASSWORD = "12345";
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Before
+    public void setUpReadOnlyUser() {
+        User readOnlyUser = new User();
+        readOnlyUser.setEmail(READ_ONLY_EMAIL);
+        readOnlyUser.setUserGroup(UserGroup.USER);
+
+        given(userServiceMock.getUserByEmailOrExternalId(READ_ONLY_EMAIL)).willReturn(readOnlyUser);
+        given(userServiceMock.getUserByEmail(READ_ONLY_EMAIL)).willReturn(readOnlyUser);
+        given(sw360CustomUserDetailsService.loadUserByUsername(READ_ONLY_EMAIL))
+                .willReturn(new org.springframework.security.core.userdetails.User(
+                        READ_ONLY_EMAIL,
+                        new BCryptPasswordEncoder().encode(READ_ONLY_PASSWORD),
+                        List.of(new SimpleGrantedAuthority(Sw360GrantedAuthority.READ.getAuthority()))));
+    }
+
+    @Test
+    public void should_allow_read_user_to_access_api_root_and_see_admin_links() throws Exception {
+        assertApiRootContainsExpectedLinks(generateBasicAuthHeader(READ_ONLY_EMAIL, READ_ONLY_PASSWORD));
+    }
+
+    @Test
+    public void should_allow_read_user_with_bearer_header_to_access_api_root_and_see_admin_links() throws Exception {
+        assertApiRootContainsExpectedLinks("Bearer " + READ_ONLY_EMAIL);
+    }
+
+    @Test
+    public void should_allow_read_user_with_token_header_to_access_api_root_and_see_admin_links() throws Exception {
+        assertApiRootContainsExpectedLinks("Token " + READ_ONLY_EMAIL);
+    }
+
+    private void assertApiRootContainsExpectedLinks(String authorizationHeader) throws Exception {
+        ResponseEntity<String> response = callApiRoot(authorizationHeader);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        JsonNode linksNode = new ObjectMapper().readTree(response.getBody()).path("_links");
+        assertTrue(linksNode.has("sw360:fossology"));
+        assertTrue(linksNode.has("sw360:department"));
+    }
+
+    private ResponseEntity<String> callApiRoot(String authorizationHeader) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", authorizationHeader);
+
+        return new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                String.class
+        );
+    }
+
+    private static String generateBasicAuthHeader(String username, String password) {
+        String credentials = username + ":" + password;
+        String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encoded;
+    }
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class ApiRootAuthorizationTestConfig {
+        @Bean
+        @Order(Ordered.HIGHEST_PRECEDENCE)
+        SecurityFilterChain apiAuthorizationHeaderTestChain(HttpSecurity http) throws Exception {
+            return http
+                    .securityMatcher("/api/**")
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                    .addFilterBefore(new ReadAuthorityHeaderAuthenticationFilter(), BasicAuthenticationFilter.class)
+                    .httpBasic(Customizer.withDefaults())
+                    .csrf(csrf -> csrf.disable())
+                    .build();
+        }
+    }
+
+    static class ReadAuthorityHeaderAuthenticationFilter extends OncePerRequestFilter {
+
+        @Override
+        protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
+            String authorization = request.getHeader("Authorization");
+            if (authorization != null && (authorization.startsWith("Bearer ") || authorization.startsWith("Token "))) {
+                String principal = authorization.substring(authorization.indexOf(' ') + 1).trim();
+                if (!principal.isBlank()) {
+                    SecurityContextHolder.getContext().setAuthentication(
+                            new UsernamePasswordAuthenticationToken(
+                                    principal,
+                                    "N/A",
+                                    List.of(new SimpleGrantedAuthority(Sw360GrantedAuthority.READ.getAuthority()))
+                            )
+                    );
+                }
+            }
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -211,7 +211,6 @@ public class ComponentTest extends TestIntegrationBase {
                 new HttpEntity<>(body, headers),
                 String.class);
 
-        log.info("Response is {}", response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/TokenCapabilityAuthoritiesTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/TokenCapabilityAuthoritiesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.security;
+
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TokenCapabilityAuthoritiesTest {
+
+    @Test
+    public void shouldReturnReadOnlyCapabilitiesForReadScope() {
+        Set<GrantedAuthority> authorities = TokenCapabilityAuthorities.fromJwtScopeClaim("READ profile email");
+
+        assertThat(authorities)
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_READ))
+                .doesNotContain(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_WRITE));
+    }
+
+    @Test
+    public void shouldReturnReadWriteCapabilitiesForWriteScope() {
+        Set<GrantedAuthority> authorities = TokenCapabilityAuthorities.fromJwtScopeClaim("READ WRITE profile");
+
+        assertThat(authorities)
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_READ))
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_WRITE));
+    }
+
+    @Test
+    public void shouldIgnoreUnknownScopesLeniently() {
+        Set<GrantedAuthority> authorities = TokenCapabilityAuthorities.fromJwtScopeClaim(List.of("profile", "email"));
+
+        assertThat(authorities)
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_READ))
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_WRITE));
+    }
+
+    @Test
+    public void shouldMergeGroupAndCapabilityAuthorities() {
+        Set<GrantedAuthority> authorities = TokenCapabilityAuthorities.merge(
+                Set.of(new SimpleGrantedAuthority("ADMIN")),
+                Set.of(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_READ)));
+
+        assertThat(authorities)
+                .contains(new SimpleGrantedAuthority("ADMIN"))
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_READ));
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsServiceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.security.basic;
+
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Sw360CustomUserDetailsServiceTest {
+
+    @Mock
+    private Sw360UserDetailsProvider sw360UserDetailsProvider;
+
+    @InjectMocks
+    private Sw360CustomUserDetailsService service;
+
+    private User user;
+
+    @Before
+    public void setUp() {
+        user = new User();
+        user.setEmail("admin@sw360.org");
+        user.setPassword("$2a$10$examplehash");
+        user.setUserGroup(UserGroup.ADMIN);
+    }
+
+    @Test
+    public void shouldIncludeTokenCapabilitiesForBasicAuthUserDetails() {
+        when(sw360UserDetailsProvider.provideUserDetails("admin@sw360.org", null)).thenReturn(user);
+
+        UserDetails details = service.loadUserByUsername("admin@sw360.org");
+
+        assertThat(details).isInstanceOf(Sw360UserDetails.class);
+        assertThat(details.getAuthorities())
+                .extracting("authority")
+                .contains(TokenCapabilityAuthorities.TOKEN_READ, TokenCapabilityAuthorities.TOKEN_WRITE)
+                .contains("READ", "WRITE", "ADMIN");
+        assertThat(((Sw360UserDetails) details).getSw360User()).isSameAs(user);
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverterTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.security.jwt;
+
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
+import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthority;
+import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Sw360JWTAccessTokenConverterTest {
+
+    @Mock
+    private Sw360UserService userService;
+
+    private Sw360JWTAccessTokenConverter converter;
+
+    @Before
+    public void setUp() {
+        converter = new Sw360JWTAccessTokenConverter();
+        ReflectionTestUtils.setField(converter, "userService", userService);
+        ReflectionTestUtils.setField(converter, "principleAttribute", "email");
+    }
+
+    @Test
+    public void shouldKeepAdminAuthorityForReadOnlyScopeToken() {
+        User adminUser = new User();
+        adminUser.setEmail("admin@sw360.org");
+        adminUser.setUserGroup(UserGroup.ADMIN);
+        when(userService.getUserByEmail("admin@sw360.org")).thenReturn(adminUser);
+
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim("email", "admin@sw360.org")
+                .claim("scope", "READ profile email")
+                .claim("client_id", "kc-client")
+                .build();
+
+        AbstractAuthenticationToken authentication = converter.convert(jwt);
+
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getDetails()).isSameAs(adminUser);
+        assertThat(authentication.getAuthorities())
+                .contains(new SimpleGrantedAuthority(Sw360GrantedAuthority.ADMIN.getAuthority()))
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_READ))
+                .doesNotContain(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_WRITE));
+    }
+
+    @Test
+    public void shouldDefaultToReadWriteCapabilitiesWhenScopeMissing() {
+        User adminUser = new User();
+        adminUser.setEmail("admin-noscope@sw360.org");
+        adminUser.setUserGroup(UserGroup.ADMIN);
+        when(userService.getUserByEmail("admin-noscope@sw360.org")).thenReturn(adminUser);
+
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim("email", "admin-noscope@sw360.org")
+                .build();
+
+        AbstractAuthenticationToken authentication = converter.convert(jwt);
+
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getAuthorities())
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_READ))
+                .contains(new SimpleGrantedAuthority(TokenCapabilityAuthorities.TOKEN_WRITE));
+    }
+}


### PR DESCRIPTION
Fixes a regression where READ-only tokens (Bearer, Token, Basic, JWT) were denied access to the `/api` root due to class-level `@PreAuthorize` on admin controllers blocking `RepresentationModelProcessor.process()`.

Introduces `TokenCapabilityAuthorities` to cleanly separate token read/write scope from user-group authorities, and wires it consistently across all four authentication paths: Basic, JWT, API Token, and UserDetails.

**Before**: READ tokens got 403 on `/api` root discovery links.  
**After**: All auth mechanisms correctly expose admin links at `/api` while still protecting write/admin endpoints.

### Changes
- `TokenCapabilityAuthorities`: new class encoding `TOKEN_READ` / `TOKEN_WRITE` scope authorities
- `Sw360UserDetails`, `Sw360UserAuthenticationProvider`, `Sw360CustomUserDetailsService`, `ApiTokenAuthenticationProvider`, `Sw360JWTAccessTokenConverter`: all updated to emit capability authorities consistently
- `ResourceServerConfiguration`: `process()` methods on admin controllers annotated with `READ` access
- ArchUnit rule enforcing `READ` on `process()` for `ADMIN`-only controllers
- Regression tests: `ApiRootAuthorizationRegressionTest` covering Basic, Bearer, and Token headers with link assertions
- Unit tests: `Sw360JWTAccessTokenConverterTest`, `TokenCapabilityAuthoritiesTest`, `Sw360CustomUserDetailsServiceTest`, `RestControllerHelperAuthCachingTest` - including null-guards on converter result

### How To Test?
1. Setup SW360.
2. Try READ only tokens of all types, API Token, OAuth, Keycloak.
3. Try WRITE tokens of all types, API Token, OAuth, Keycloak.
4. Try basic auth.