### PR TITLE
fix(rest): register JwtAuthenticationProvider

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -66,7 +66,7 @@ file to tweak SW360 behaviour.
 * `ENABLE_DISKSPACE`: Enable disk space health check (default: `false`).
 * `JWKS_ISSUER_URI`: URI for JWKS issuer (default:
     `http://localhost:8080/authorization/oauth2/jwks`). Use
-    `http://localhost:8083/realms/sw360/protocol/openid-connect/certs` for
+    `http://localhost:8083/realms/sw360` for
     KeyCloak based setup.
 * `JWKS_SET_URI`: URI for JWKS set (default:
     `http://localhost:8080/authorization/oauth2/jwks`).

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -28,6 +28,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
@@ -51,6 +53,7 @@ public class ResourceServerConfiguration {
     private final Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;
     private final ApiTokenAuthenticationProvider authProvider;
     private final Sw360UserAuthenticationProvider sw360UserAuthenticationProvider;
+    private final JwtDecoder jwtDecoder;
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
@@ -88,7 +91,9 @@ public class ResourceServerConfiguration {
 
     @Bean
     public AuthenticationManager authenticationManager() {
-        return new ProviderManager(List.of(authProvider, sw360UserAuthenticationProvider));
+        JwtAuthenticationProvider jwtAuthenticationProvider = new JwtAuthenticationProvider(jwtDecoder);
+        jwtAuthenticationProvider.setJwtAuthenticationConverter(sw360JWTAccessTokenConverter);
+        return new ProviderManager(List.of(jwtAuthenticationProvider, authProvider, sw360UserAuthenticationProvider));
     }
 
     @Bean

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -59,7 +59,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          #issuer-uri: http://localhost:8083/realms/sw360/protocol/openid-connect/certs
+          #issuer-uri: http://localhost:8083/realms/sw360
           #jwk-set-uri: https://localhost:8083/realms/sw360/protocol/openid-connect/certs
           issuer-uri: http://localhost:8080/authorization/oauth2/jwks
           jwk-set-uri: http://localhost:8080/authorization/oauth2/jwks


### PR DESCRIPTION
When http.authenticationManager() is explicitly called, Spring Security's internal JwtAuthenticationProvider is not auto-configured. The injected ProviderManager only contained ApiToken and UserAuthentication providers, causing BearerTokenAuthenticationFilter to fail with ProviderNotFoundException.

Wire JwtDecoder and JwtAuthenticationProvider explicitly as the first provider in ProviderManager, ensuring JWT Bearer tokens are validated before falling back to API Token or Basic auth.