### PR TITLE
feat(report): authenticating the report download link.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -477,7 +477,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @Parameter(description = "Extended by releases.")
             @RequestParam(value = "extendedByReleases", required = false, defaultValue = "false") boolean extendedByReleases
     ) throws SW360Exception {
-        final User user = restControllerHelper.getUserByEmail(request.getParameter("user"));
+        final User user = restControllerHelper.getSw360UserFromAuthentication();
         try {
             ByteBuffer buffer = null;
             String fileName = sw360ReportService.getDocumentName(user, null, module);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -101,6 +101,9 @@ public class SW360ReportService {
     @NonNull
     private final Sw360LicenseInfoService licenseInfoService;
 
+    @org.springframework.beans.factory.annotation.Value("${sw360.frontend-url:http://localhost:3000}")
+    private String frontendUrl;
+
     private static final Logger log = LogManager.getLogger(SW360ReportService.class);
     private static final Set<String> SUPPORTED_FORMATS = Set.of("xlsx", "csv", "json", "xml");
     ThriftClients thriftClients = new ThriftClients();
@@ -268,9 +271,11 @@ public class SW360ReportService {
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {
                 String projectPath = projectclient.getReportInEmail(user, withLinkedReleases, projectId);
-                String backendURL = base + "api/reports/download?user=" + user.getEmail() + "&module=projects"
-                        + "&extendedByReleases=" + withLinkedReleases + "&projectId=" + projectId + "&token=";
-                URL emailURL = new URI(backendURL + URLEncoder.encode(projectPath, StandardCharsets.UTF_8)).toURL();
+                String downloadUrl = frontendUrl + "/reports/download?module=projects"
+                        + "&extendedByReleases=" + withLinkedReleases + "&projectId=" + projectId + "&token="
+                        + URLEncoder.encode(projectPath, StandardCharsets.UTF_8);
+                URL emailURL = new URI(downloadUrl).toURL();
+                log.debug("Report download link for user {}: {}", user.getEmail(), emailURL);
                 if (!CommonUtils.isNullEmptyOrWhitespace(projectPath)) {
                     sendExportSpreadsheetSuccessMail(emailURL.toString(), user.getEmail());
                 }
@@ -298,9 +303,11 @@ public class SW360ReportService {
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {
                 String componentPath = componentclient.getComponentReportInEmail(sw360User, withLinkedReleases);
-                String backendURL = base + "api/reports/download?user=" + sw360User.getEmail() + "&module=components"
-                        + "&extendedByReleases=" + withLinkedReleases + "&token=";
-                URL emailURL = new URI(backendURL + URLEncoder.encode(componentPath, StandardCharsets.UTF_8)).toURL();
+                String downloadUrl = frontendUrl + "/reports/download?module=components"
+                        + "&extendedByReleases=" + withLinkedReleases + "&token="
+                        + URLEncoder.encode(componentPath, StandardCharsets.UTF_8);
+                URL emailURL = new URI(downloadUrl).toURL();
+                log.debug("Report download link for user {}: {}", sw360User.getEmail(), emailURL);
                 if (!CommonUtils.isNullEmptyOrWhitespace(componentPath)) {
                     sendComponentExportSpreadsheetSuccessMail(emailURL.toString(), sw360User.getEmail());
                 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -46,8 +46,7 @@ public class ResourceServerConfiguration {
     private static final String[] PUBLIC_SWAGGER_ENDPOINTS = {"/v3/api-docs/**", "/swagger-ui/**", "/index.html",
             "/docs/**", "/mkdocs/**"};
 
-    private static final String[] PUBLIC_API_GET_ENDPOINTS = {"/api/health", "/api/version", "/api",
-            "/api/reports/download"};
+    private static final String[] PUBLIC_API_GET_ENDPOINTS = {"/api/health", "/api/version", "/api"};
 
     private final SimpleAuthenticationEntryPoint saep;
     private final Sw360JWTAccessTokenConverter sw360JWTAccessTokenConverter;

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -79,6 +79,7 @@ jwt:
 sw360:
   thrift-server-url: ${SW360_THRIFT_SERVER_URL:http://localhost:8080}
   base-url: ${SW360_BASE_URL:http://localhost:8080}
+  frontend-url: ${SW360_FRONTEND_URL:http://localhost:3000}
   test-user-id: admin@sw360.org
   test-user-password: 12345
   couchdb-url: ${SW360_COUCHDB_URL:http://localhost:5984}


### PR DESCRIPTION
Issue: The GET /api/reports/download endpoint was configured with permitAll() in the security configuration, allowing unauthenticated access to report downloads. The email sent to users contained a direct backend URL with the user's email as a query parameter ([?user=...](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), meaning anyone with the link could download reports without authentication.

Solution: 
- Removed permitAll() for the /api/reports/download endpoint — it now requires a valid JWT token (READ authority)
- Changed the controller to authenticate users via JWT ([getSw360UserFromAuthentication()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) instead of reading the email from a query parameter
- Updated the email link to point to the frontend (SW360_FRONTEND_URL) instead of the backend directly — the frontend already holds the user's session token and proxies the authenticated request to the backend
- Added [sw360.frontend-url](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) config property (defaults to http://localhost:3000)
- REST API clients with a valid JWT can still download reports directly as before

Note: This PR requires the corresponding frontend change to be deployed alongside it (https://github.com/eclipse-sw360/sw360-frontend/pull/1684). The frontend branch adds a /reports/download page that receives the email link, extracts query parameters, attaches the user's JWT from the session, and proxies the download request to the backend. Without the frontend change, the email links will lead to a 404.

