### PR TITLE
fix(rest): make visibility field case-insensitive in REST API

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -65,6 +65,7 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.ObligationStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
@@ -3072,12 +3073,16 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.registerModule(sw360Module);
 
-        if (requestBody.containsKey(mapOfProjectFieldsToRequestBody.get(Project._Fields.VISBILITY))) {
+        String visibilityKey = mapOfProjectFieldsToRequestBody.get(Project._Fields.VISBILITY);
+        if (requestBody.containsKey(visibilityKey)) {
             try {
-                String visibility = (String) requestBody
-                        .get(mapOfProjectFieldsToRequestBody.get(Project._Fields.VISBILITY));
-                requestBody.put(mapOfProjectFieldsToRequestBody.get(Project._Fields.VISBILITY),
-                        visibility.toUpperCase());
+                Object rawVisibility = requestBody.get(visibilityKey);
+                if (rawVisibility instanceof String) {
+                    Visibility parsed = parseVisibility((String) rawVisibility);
+                    if (parsed != null) {
+                        requestBody.put(visibilityKey, parsed.name());
+                    }
+                }
             } catch (IllegalArgumentException e) {
                 log.error("Error processing visibility field", e);
                 log.error("Failed requestBody: {}", requestBody);
@@ -3099,6 +3104,34 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Set<Attachment> attachments = attachmentService.getAttachmentsFromRequest(requestBody.get(Project._Fields.ATTACHMENTS.getFieldName()), mapper);
         projectFromRequest.setAttachments(attachments);
         return projectFromRequest;
+    }
+
+    /**
+     * Case-insensitive parser for the {@link Visibility} enum used in REST request bodies.
+     *
+     * <p>Accepts any case (e.g. {@code "private"}, {@code "Private"}, {@code "PRIVATE"}) and
+     * normalises to the canonical Thrift enum constant. Returns {@code null} for null/blank
+     * input so callers can preserve "field absent" semantics. Throws a descriptive
+     * {@link IllegalArgumentException} listing valid values for unknown input.</p>
+     *
+     * <p>Fixes <a href="https://github.com/eclipse-sw360/sw360/issues/2569">issue #2569</a>.</p>
+     *
+     * @param value the raw visibility string from the request body, may be {@code null}
+     * @return matching {@link Visibility} or {@code null} if input is null/blank
+     */
+    static Visibility parseVisibility(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Visibility.valueOf(value.trim().toUpperCase(Locale.US));
+        } catch (IllegalArgumentException e) {
+            String validValues = Arrays.stream(Visibility.values())
+                    .map(Enum::name)
+                    .collect(Collectors.joining(", "));
+            throw new IllegalArgumentException(
+                    "Invalid visibility value: '" + value + "'. Valid values are: " + validValues);
+        }
     }
 
     public static TSerializer getJsonSerializer() {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/ProjectControllerVisibilityTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/ProjectControllerVisibilityTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright SW360 Contributor, 2025. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.project;
+
+import org.eclipse.sw360.datahandler.thrift.Visibility;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link ProjectController#parseVisibility(String)}.
+ *
+ * <p>Regression coverage for
+ * <a href="https://github.com/eclipse-sw360/sw360/issues/2569">issue #2569</a>:
+ * the REST {@code visibility} field must be parsed case-insensitively.</p>
+ */
+public class ProjectControllerVisibilityTest {
+
+    @Test
+    public void parseVisibility_acceptsExactCanonicalUppercase() {
+        assertEquals(Visibility.PRIVATE, ProjectController.parseVisibility("PRIVATE"));
+        assertEquals(Visibility.EVERYONE, ProjectController.parseVisibility("EVERYONE"));
+        assertEquals(Visibility.ME_AND_MODERATORS,
+                ProjectController.parseVisibility("ME_AND_MODERATORS"));
+        assertEquals(Visibility.BUISNESSUNIT_AND_MODERATORS,
+                ProjectController.parseVisibility("BUISNESSUNIT_AND_MODERATORS"));
+    }
+
+    @Test
+    public void parseVisibility_acceptsLowercase() {
+        assertEquals(Visibility.PRIVATE, ProjectController.parseVisibility("private"));
+        assertEquals(Visibility.EVERYONE, ProjectController.parseVisibility("everyone"));
+        assertEquals(Visibility.ME_AND_MODERATORS,
+                ProjectController.parseVisibility("me_and_moderators"));
+    }
+
+    @Test
+    public void parseVisibility_acceptsMixedCase() {
+        assertEquals(Visibility.PRIVATE, ProjectController.parseVisibility("Private"));
+        assertEquals(Visibility.EVERYONE, ProjectController.parseVisibility("Everyone"));
+        assertEquals(Visibility.ME_AND_MODERATORS,
+                ProjectController.parseVisibility("Me_And_Moderators"));
+    }
+
+    @Test
+    public void parseVisibility_trimsWhitespace() {
+        assertEquals(Visibility.PRIVATE, ProjectController.parseVisibility("  private  "));
+    }
+
+    @Test
+    public void parseVisibility_returnsNullForNull() {
+        assertNull(ProjectController.parseVisibility(null));
+    }
+
+    @Test
+    public void parseVisibility_returnsNullForBlank() {
+        assertNull(ProjectController.parseVisibility(""));
+        assertNull(ProjectController.parseVisibility("   "));
+    }
+
+    @Test
+    public void parseVisibility_throwsHelpfulErrorForInvalidValue() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> ProjectController.parseVisibility("not_a_value"));
+        // Error message must include the offending input and the list of valid enum names.
+        assertTrue(ex.getMessage().contains("not_a_value"));
+        assertTrue(ex.getMessage().contains("PRIVATE"));
+        assertTrue(ex.getMessage().contains("EVERYONE"));
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -1962,6 +1962,51 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.createdBy").description("The user who created this project")
                         )));
     }
+
+    /**
+     * Regression test for <a href="https://github.com/eclipse-sw360/sw360/issues/2569">issue #2569</a>:
+     * the {@code visibility} field in the create-project payload must be parsed
+     * case-insensitively. Sending lowercase {@code "private"} (or any other case)
+     * must succeed exactly the same way as sending uppercase {@code "PRIVATE"}.
+     */
+    @Test
+    public void should_create_project_with_lowercase_visibility() throws Exception {
+        Map<String, Object> project = new HashMap<>();
+        project.put("name", "Test Project");
+        project.put("version", "1.0");
+        // Lowercase visibility — must be accepted (issue #2569)
+        project.put("visibility", "private");
+        project.put("description", "This is the description of my Test Project");
+        project.put("projectType", ProjectType.PRODUCT.toString());
+
+        this.mockMvc.perform(post("/api/projects")
+                .contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(project))
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("_embedded.createdBy.email", Matchers.is("admin@sw360.org")));
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/eclipse-sw360/sw360/issues/2569">issue #2569</a>:
+     * mixed-case visibility (e.g. {@code "Private"}) must also be accepted.
+     */
+    @Test
+    public void should_create_project_with_mixed_case_visibility() throws Exception {
+        Map<String, Object> project = new HashMap<>();
+        project.put("name", "Test Project");
+        project.put("version", "1.0");
+        project.put("visibility", "Private");
+        project.put("description", "This is the description of my Test Project");
+        project.put("projectType", ProjectType.PRODUCT.toString());
+
+        this.mockMvc.perform(post("/api/projects")
+                .contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(project))
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)))
+                .andExpect(status().isCreated());
+    }
+
     @Test
     public void should_document_create_duplicate_project() throws Exception {
         Map<String, Object> projectReqs = new HashMap<>();


### PR DESCRIPTION
The convertToProject() method in ProjectController used String.toUpperCase() without an explicit Locale, and lacked validation against the Visibility enum. This caused two problems:

  * Locale-dependent uppercasing (Turkish 'i' bug).
  * Confusing failures when a client sent a value like 'private' or 'Private' instead of the canonical 'PRIVATE'.

Introduce a small static helper, ProjectController#parseVisibility(String), that:
  * trims whitespace,
  * uppercases using Locale.US,
  * validates against Visibility.values(),
  * throws IllegalArgumentException with the list of valid values when the input is unknown.

Add unit tests for the helper and two MockMvc regression tests that POST a project with lowercase / mixed-case visibility values.

Fixes #2569

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
