### PR TITLE
fix(csrf): enable and document CSRF

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/SecurityConfig.java
@@ -78,7 +78,9 @@ public class SecurityConfig {
                 .requestMatchers("/client-management/**").hasAuthority("ADMIN")
                 .anyRequest().authenticated()
         ).httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults());
-        return httpSecurity.csrf(csrf -> csrf.disable()).build();
+        return httpSecurity.csrf(
+                csrf -> csrf.ignoringRequestMatchers("/client-management/**")
+        ).build();
     }
 
     @Bean

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -86,7 +86,8 @@ public class ResourceServerConfiguration {
                 .exceptionHandling(x -> x.authenticationEntryPoint(saep))
                 .headers(headers -> headers.xssProtection(xXssConfig -> xXssConfig.headerValue(XXssProtectionHeaderWriter.HeaderValue.DISABLED))
                         .contentSecurityPolicy(cps -> cps.policyDirectives("script-src 'self'")))
-                .csrf(csrf -> csrf.disable()).build();
+                // Keep CSRF enabled by default and ignore stateless API endpoints using Authorization headers.
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**")).build();
     }
 
     @Bean

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/security/Sw360AuthorizationServerConfiguration.java
@@ -45,8 +45,9 @@ public class Sw360AuthorizationServerConfiguration {
 						.requestMatchers(HttpMethod.GET, "/api/info").permitAll()
 						.anyRequest().authenticated()
 		).httpBasic(Customizer.withDefaults()).formLogin(Customizer.withDefaults())
-				.exceptionHandling(x -> x.authenticationEntryPoint(saep));
-		return httpSecurity.csrf(csrf -> csrf.disable()).build();
+				.exceptionHandling(x -> x.authenticationEntryPoint(saep))
+				.csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"));
+		return httpSecurity.build();
 	}
 
 	@Autowired

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ApiRootAuthorizationRegressionTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ApiRootAuthorizationRegressionTest.java
@@ -134,7 +134,6 @@ public class ApiRootAuthorizationRegressionTest extends TestIntegrationBase {
                     .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
                     .addFilterBefore(new ReadAuthorityHeaderAuthenticationFilter(), BasicAuthenticationFilter.class)
                     .httpBasic(Customizer.withDefaults())
-                    .csrf(csrf -> csrf.disable())
                     .build();
         }
     }

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360SecurityFilter.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360SecurityFilter.java
@@ -53,8 +53,8 @@ public class Sw360SecurityFilter implements Filter {
         response.setHeader("X-XSS-Protection", "0");
 
         String path = request.getRequestURI();
-        if (path != null && (path.contains("/swagger-ui") || path.contains("/v3/api-docs"))) {
-            // Relaxed CSP for Swagger UI to function
+        if (path != null && (path.contains("/swagger-ui") || path.contains("/v3/api-docs") || path.contains("/authorization/login"))) {
+            // Relaxed CSP for Swagger UI, authorization server login, and interactive pages
             response.setHeader("Content-Security-Policy", "default-src 'self'; object-src 'none'; base-uri 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; frame-ancestors 'none'; upgrade-insecure-requests;");
         } else {
             // Strict CSP for API responses


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Enable CSRF in authorization server as it has a browser login form. Ignore CSRF for `/api` endpoints in resource server as they are purely stateless and authenticated with Authorization header.

Enable CSRF in test cases as it does not affect anything.

Also, use relaxed CSP for `/authorization/login` page.

Issue:
1. https://github.com/eclipse-sw360/sw360/security/code-scanning/79
2. https://github.com/eclipse-sw360/sw360/security/code-scanning/102
3. https://github.com/eclipse-sw360/sw360/security/code-scanning/104
4. https://github.com/eclipse-sw360/sw360/security/code-scanning/105

### How To Test?
Check if API works and OAuth works.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
