### PR TITLE
feat(projects): allow empty groups and tag search

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import jakarta.annotation.Nonnull;
 import org.eclipse.sw360.components.summary.ProjectSummary;
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
@@ -47,6 +48,7 @@ import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorClou
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.or;
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_ADMIN_PRIVATE_ACCESS_ENABLED;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.getBUFromOrganisation;
+import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.EMPTY_SEARCH_FIELDS;
 
 /**
  * CRUD access for the Project class
@@ -738,9 +740,9 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {
                 if (Project._Fields.ADDITIONAL_DATA.getFieldName().equals(entry.getKey())) {
                     andConditions.add(all(entry.getKey(), entry.getValue().stream().toList()));
-                } else if (Project._Fields.BUSINESS_UNIT.getFieldName().equals(entry.getKey())
-                        && entry.getValue().contains(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN)) {
-                    andConditions.add(buildBusinessUnitRestriction(entry.getValue()));
+                } else if (EMPTY_SEARCH_FIELDS.contains(entry.getKey())
+                        && entry.getValue().contains(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN)) {
+                    andConditions.add(buildEmptyProjectFieldRestriction(entry.getKey(), entry.getValue()));
                 } else if (!entry.getValue().stream().findFirst().orElse("").isEmpty()) {
                     String value = entry.getValue().stream().findFirst().get();
                     if (Project._Fields.NAME.getFieldName().equals(entry.getKey())) {
@@ -754,23 +756,26 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         return and(andConditions);
     }
 
-    private Map<String, Object> buildBusinessUnitRestriction(Set<String> values) {
-        List<Map<String, Object>> businessUnitConditions = new ArrayList<>();
+    private Map<String, Object> buildEmptyProjectFieldRestriction(
+            @Nonnull String fieldName,
+            @Nonnull Set<String> values
+    ) {
+        List<Map<String, Object>> fieldConditions = new ArrayList<>();
 
-        if (values.contains(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN)) {
-            businessUnitConditions.add(eq(Project._Fields.BUSINESS_UNIT.getFieldName(), ""));
-            businessUnitConditions.add(eq(Project._Fields.BUSINESS_UNIT.getFieldName(), (String) null));
-            businessUnitConditions.add(exists(Project._Fields.BUSINESS_UNIT.getFieldName(), false));
+        if (values.contains(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN)) {
+            fieldConditions.add(eq(fieldName, ""));
+            fieldConditions.add(eq(fieldName, null));
+            fieldConditions.add(exists(fieldName, false));
         }
 
         values.stream()
                 .filter(Objects::nonNull)
                 .filter(value -> !value.isEmpty())
-                .filter(value -> !SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN.equals(value))
-                .map(value -> eq(Project._Fields.BUSINESS_UNIT.getFieldName(), value))
-                .forEach(businessUnitConditions::add);
+                .filter(value -> !SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(value))
+                .map(value -> eq(fieldName, value))
+                .forEach(fieldConditions::add);
 
-        return businessUnitConditions.size() == 1 ? businessUnitConditions.getFirst() : or(businessUnitConditions);
+        return fieldConditions.size() == 1 ? fieldConditions.getFirst() : or(fieldConditions);
     }
 
     /**

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -14,6 +14,7 @@ import org.eclipse.sw360.components.summary.ProjectSummary;
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.SummaryAwareRepository;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
@@ -30,7 +31,6 @@ import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
 import com.ibm.cloud.cloudant.v1.model.PostFindOptions;
 import com.ibm.cloud.cloudant.v1.model.PostViewOptions;
 import com.ibm.cloud.cloudant.v1.model.ViewResult;
-import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
@@ -42,6 +42,7 @@ import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorClou
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.elemMatch;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.eq;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.eqIgnoreCase;
+import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.exists;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.and;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.or;
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_ADMIN_PRIVATE_ACCESS_ENABLED;
@@ -737,6 +738,9 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {
                 if (Project._Fields.ADDITIONAL_DATA.getFieldName().equals(entry.getKey())) {
                     andConditions.add(all(entry.getKey(), entry.getValue().stream().toList()));
+                } else if (Project._Fields.BUSINESS_UNIT.getFieldName().equals(entry.getKey())
+                        && entry.getValue().contains(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN)) {
+                    andConditions.add(buildBusinessUnitRestriction(entry.getValue()));
                 } else if (!entry.getValue().stream().findFirst().orElse("").isEmpty()) {
                     String value = entry.getValue().stream().findFirst().get();
                     if (Project._Fields.NAME.getFieldName().equals(entry.getKey())) {
@@ -748,6 +752,25 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
             }
         }
         return and(andConditions);
+    }
+
+    private Map<String, Object> buildBusinessUnitRestriction(Set<String> values) {
+        List<Map<String, Object>> businessUnitConditions = new ArrayList<>();
+
+        if (values.contains(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN)) {
+            businessUnitConditions.add(eq(Project._Fields.BUSINESS_UNIT.getFieldName(), ""));
+            businessUnitConditions.add(eq(Project._Fields.BUSINESS_UNIT.getFieldName(), (String) null));
+            businessUnitConditions.add(exists(Project._Fields.BUSINESS_UNIT.getFieldName(), false));
+        }
+
+        values.stream()
+                .filter(Objects::nonNull)
+                .filter(value -> !value.isEmpty())
+                .filter(value -> !SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN.equals(value))
+                .map(value -> eq(Project._Fields.BUSINESS_UNIT.getFieldName(), value))
+                .forEach(businessUnitConditions::add);
+
+        return businessUnitConditions.size() == 1 ? businessUnitConditions.getFirst() : or(businessUnitConditions);
     }
 
     /**

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -48,7 +48,7 @@ public class ProjectSearchHandler {
                 "function(doc) {" +
                 OBJ_ARRAY_TO_STRING_INDEX +
                 "    if(!doc.type || doc.type != 'project') return;" +
-                "    var businessUnit = '" + SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN + "';" +
+                "    var businessUnit = '" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "';" +
                 "    if(doc.businessUnit !== undefined && doc.businessUnit != null && doc.businessUnit.length > 0) {" +
                 "      businessUnit = doc.businessUnit;" +
                 "    }" +
@@ -79,9 +79,11 @@ public class ProjectSearchHandler {
                 "    if(doc.clearingState) {" +
                 "      index('text', 'clearingState', doc.clearingState, {'store': true});" +
                 "    }" +
-                "    if(doc.tag !== undefined && doc.tag != null && doc.tag.length >0) {" +
-                "      index('text', 'tag', doc.tag, {'store': true});" +
+                "    var tag = '" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "';" +
+                "    if(doc.tag !== undefined && doc.tag != null && doc.tag.length > 0) {" +
+                "      tag = doc.tag;" +
                 "    }" +
+                "    index('text', 'tag', tag, {'store': true});" +
                 "    arrayToStringIndex(doc.additionalData, 'additionalData');" +
                 "    if(doc.releaseRelationNetwork !== undefined && doc.releaseRelationNetwork != null && doc.releaseRelationNetwork.length > 0) {" +
                 "      index('text', 'releaseRelationNetwork', doc.releaseRelationNetwork, {'store': true});" +

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -13,6 +13,7 @@ import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -47,9 +48,11 @@ public class ProjectSearchHandler {
                 "function(doc) {" +
                 OBJ_ARRAY_TO_STRING_INDEX +
                 "    if(!doc.type || doc.type != 'project') return;" +
-                "    if(doc.businessUnit !== undefined && doc.businessUnit != null && doc.businessUnit.length >0) {" +
-                "      index('text', 'businessUnit', doc.businessUnit, {'store': true});" +
+                "    var businessUnit = '" + SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN + "';" +
+                "    if(doc.businessUnit !== undefined && doc.businessUnit != null && doc.businessUnit.length > 0) {" +
+                "      businessUnit = doc.businessUnit;" +
                 "    }" +
+                "    index('text', 'businessUnit', businessUnit, {'store': true});" +
                 "    if(doc.projectType !== undefined && doc.projectType != null && doc.projectType.length >0) {" +
                 "      index('text', 'projectType', doc.projectType, {'store': true});" +
                 "      index('string', 'projectType_sort', doc.projectType);" +

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -773,7 +773,10 @@ public class DatabaseConnectorCloudant {
         try {
             ViewResult response = this.instance.getClient().postView(viewOptions).execute().getResult();
             return response.getRows().stream()
-                    .map(r -> r.getKey().toString()).collect(Collectors.toCollection(TreeSet::new));
+                    .filter(Objects::nonNull)
+                    .map(ViewResultRow::getKey)
+                    .map(CommonUtils::nullToEmptyString)
+                    .collect(Collectors.toCollection(TreeSet::new));
         } catch (ServiceResponseException e) {
             log.error("Error in getting project groups", e);
         }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -60,6 +60,7 @@ public class SW360Constants {
     public static final String PROJECT_IDS = "projectIds";
     public static final String RELEASE_IDS = "releaseIds";
     public static final String PACKAGE_IDS = "packageIds";
+    public static final String PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN = "__EMPTY__";
 
     // Proper values of the "type" member to deserialize to CouchDB
     public static final String TYPE_OBLIGATION = "obligation";

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -60,7 +60,7 @@ public class SW360Constants {
     public static final String PROJECT_IDS = "projectIds";
     public static final String RELEASE_IDS = "releaseIds";
     public static final String PACKAGE_IDS = "packageIds";
-    public static final String PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN = "__EMPTY__";
+    public static final String PROJECT_SEARCH_EMPTY_TOKEN = "__EMPTY__";
 
     // Proper values of the "type" member to deserialize to CouchDB
     public static final String TYPE_OBLIGATION = "obligation";

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
@@ -42,7 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
@@ -442,6 +442,12 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     }
 
     private static @NotNull String formatSubquery(@NotNull Set<String> filterSet, final String fieldName) {
+        List<String> queryParts = new ArrayList<>();
+        if (Project._Fields.BUSINESS_UNIT.getFieldName().equals(fieldName)
+                && filterSet.contains(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN)) {
+            queryParts.add("%s:\"%s\"".formatted(fieldName, SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN));
+        }
+
         final Function<String, String> addType = input -> {
             // Handle pre-formatted queries from prepareWildcardQuery
             if (input.startsWith("\"") && input.endsWith("\"")) {
@@ -463,8 +469,11 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             }
         };
 
-        Stream<String> searchFilters = filterSet.stream().map(addType);
-        return "( " + OR.join(searchFilters.collect(Collectors.toList())) + " ) ";
+        queryParts.addAll(filterSet.stream()
+                .filter(value -> !SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN.equals(value))
+                .map(addType)
+                .toList());
+        return "( " + OR.join(queryParts) + " ) ";
     }
 
     public static @NotNull String prepareWildcardQuery(@NotNull String query) {

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -56,6 +56,15 @@ import static com.google.common.base.Strings.nullToEmpty;
  */
 public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConnector {
 
+    /**
+     * Fields in projects which can be searched with
+     * ${@code SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN}
+     */
+    public static final Set<String> EMPTY_SEARCH_FIELDS = Set.of(
+            Project._Fields.BUSINESS_UNIT.getFieldName(),
+            Project._Fields.TAG.getFieldName()
+    );
+
     private static final Logger log = LogManager.getLogger(NouveauLuceneAwareDatabaseConnector.class);
 
     private static final Joiner AND = Joiner.on(" AND ");
@@ -443,9 +452,9 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
 
     private static @NotNull String formatSubquery(@NotNull Set<String> filterSet, final String fieldName) {
         List<String> queryParts = new ArrayList<>();
-        if (Project._Fields.BUSINESS_UNIT.getFieldName().equals(fieldName)
-                && filterSet.contains(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN)) {
-            queryParts.add("%s:\"%s\"".formatted(fieldName, SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN));
+        if (EMPTY_SEARCH_FIELDS.contains(fieldName)
+                && filterSet.contains(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN)) {
+            queryParts.add("%s:\"%s\"".formatted(fieldName, SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN));
         }
 
         final Function<String, String> addType = input -> {
@@ -470,7 +479,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         };
 
         queryParts.addAll(filterSet.stream()
-                .filter(value -> !SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN.equals(value))
+                .filter(value -> !SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(value))
                 .map(addType)
                 .toList());
         return "( " + OR.join(queryParts) + " ) ";

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -264,7 +264,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "name", required = false) String name,
             @Parameter(description = "The type of the project")
             @RequestParam(value = "type", required = false) String projectType,
-            @Parameter(description = "The group of the project")
+            @Parameter(description = "The group of the project. Use '__EMPTY__' to search for projects with null, " +
+                    "empty, or missing businessUnit.")
             @RequestParam(value = "group", required = false) String group,
             @Parameter(description = "The tag of the project")
             @RequestParam(value = "tag", required = false) String tag,
@@ -4679,20 +4680,29 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             summary = "Get all project groups.",
-            description = "Get all the unique groups used by projects.",
+            description = "Get all the unique groups used by projects. The first entry '__EMPTY__' can be used to " +
+                    "search for projects with null, empty, or missing businessUnit.",
             tags = {"Projects"}
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Project groups successfully retrieved")
     })
     @GetMapping(value = PROJECTS_URL + "/groups")
-    public Set<String> getAllProjectGroups() {
+    public List<String> getAllProjectGroups() {
         Set<String> groups;
         try {
             groups = projectService.getGroups();
         } catch (TException e) {
             groups = Collections.emptySet();
         }
-        return groups;
+
+        LinkedHashSet<String> responseGroups = new LinkedHashSet<>();
+        responseGroups.add(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN);
+        groups.stream()
+                .filter(Objects::nonNull)
+                .filter(group -> !group.isEmpty())
+                .filter(group -> !SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN.equals(group))
+                .forEach(responseGroups::add);
+        return new ArrayList<>(responseGroups);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -267,7 +267,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "The group of the project. Use '__EMPTY__' to search for projects with null, " +
                     "empty, or missing businessUnit.")
             @RequestParam(value = "group", required = false) String group,
-            @Parameter(description = "The tag of the project")
+            @Parameter(description = "The tag of the project. Use '__EMPTY__' to search for projects with null, " +
+                    "empty, or missing tag.")
             @RequestParam(value = "tag", required = false) String tag,
             @Parameter(description = "Flag to get projects with all details.")
             @RequestParam(value = "allDetails", required = false) boolean allDetails,
@@ -4697,11 +4698,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
 
         LinkedHashSet<String> responseGroups = new LinkedHashSet<>();
-        responseGroups.add(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN);
+        responseGroups.add(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN);
         groups.stream()
                 .filter(Objects::nonNull)
                 .filter(group -> !group.isEmpty())
-                .filter(group -> !SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN.equals(group))
+                .filter(group -> !SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(group))
                 .forEach(responseGroups::add);
         return new ArrayList<>(responseGroups);
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
@@ -86,6 +87,7 @@ import java.util.Map;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -644,6 +646,27 @@ public class ProjectTest extends TestIntegrationBase {
                         new HttpEntity<>(null, headers),
                         String.class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    public void should_get_project_groups_with_empty_token_first() throws IOException, TException {
+        given(this.projectServiceMock.getGroups()).willReturn(new java.util.LinkedHashSet<>(Arrays.asList("", "Group A", "Group B")));
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/groups",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        List<String> groups = new ObjectMapper().readValue(response.getBody(), new com.fasterxml.jackson.core.type.TypeReference<List<String>>() {
+        });
+
+        assertEquals(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN, groups.getFirst());
+        assertFalse(groups.contains(""));
+        assertEquals(Arrays.asList(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN, "Group A", "Group B"), groups);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -664,9 +664,9 @@ public class ProjectTest extends TestIntegrationBase {
         List<String> groups = new ObjectMapper().readValue(response.getBody(), new com.fasterxml.jackson.core.type.TypeReference<List<String>>() {
         });
 
-        assertEquals(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN, groups.getFirst());
+        assertEquals(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN, groups.getFirst());
         assertFalse(groups.contains(""));
-        assertEquals(Arrays.asList(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN, "Group A", "Group B"), groups);
+        assertEquals(Arrays.asList(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN, "Group A", "Group B"), groups);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -663,6 +663,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.searchProjectByTag(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.searchProjectByType(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.searchProjectByGroup(any(), any())).willReturn(new ArrayList<Project>(projectList));
+        given(this.projectServiceMock.getGroups()).willReturn(new java.util.LinkedHashSet<>(Arrays.asList("", "sw360 AR", "sw360 EX DF")));
         given(this.projectServiceMock.refineSearch(any(), any(), any())).willReturn(
                 Collections.singletonMap(
                         new PaginationData().setRowsPerPage(projectListByName.size()).setDisplayStart(0).setTotalRowCount(projectListByName.size()),
@@ -1107,6 +1108,23 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("page.totalElements").description("Total number of all existing projects"),
                                 fieldWithPath("page.totalPages").description("Total number of pages"),
                                 fieldWithPath("page.number").description("Number of the current page")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_project_groups() throws Exception {
+        mockMvc.perform(get("/api/projects/groups")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN))
+                .andExpect(jsonPath("$").isArray())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("[]").description("Ordered list of unique project group keys. The first entry is always the synthetic token '"
+                                        + SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN
+                                        + "', which clients can use to search for projects with null, empty, or missing businessUnit. "
+                                        + "This synthetic token is not a real business unit and should be ignored for statistics or aggregations.")
                         )));
     }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -1117,12 +1117,12 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0]").value(SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN))
+                .andExpect(jsonPath("$[0]").value(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN))
                 .andExpect(jsonPath("$").isArray())
                 .andDo(this.documentationHandler.document(
                         responseFields(
                                 fieldWithPath("[]").description("Ordered list of unique project group keys. The first entry is always the synthetic token '"
-                                        + SW360Constants.PROJECT_SEARCH_MISSING_BUSINESS_UNIT_TOKEN
+                                        + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN
                                         + "', which clients can use to search for projects with null, empty, or missing businessUnit. "
                                         + "This synthetic token is not a real business unit and should be ignored for statistics or aggregations.")
                         )));


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

1. Prevent NPE if groups contain `null` values.
2. Allow search of empty `businessUnit` and `tag` values in projects.
3. Use special value `__EMPTY__`.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. Fetch project groups from `/projects/groups`
    - Should contain `__EMPTY__` as first group for frontend to use.
2. Search projects with empty group `/projects?group=__EMPTY__`
3. Search projects with empty tag `/projects?tag=__EMPTY__`
4. Search both together.
5. Search with `luceneSearch=true` and `luceneSearch=false`.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
