### PR TITLE
Add obligations of status deferred to parent project to all obligations endpoint

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3473,7 +3473,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         // Handle includeSubprojects flag for "All Obligations" tab
         if (includeSubprojectObligations) {
-            // Get obligations from current project and all sub-projects with FULFILLED_AND_PARENT_MUST_ALSO_FULFILL status
+            // Get obligations from current project and all sub-projects with FULFILLED_AND_PARENT_MUST_ALSO_FULFILL
+            // and DEFERRED_TO_PARENT_PROJECT status
             obligationStatusMap = getInheritedObligationsFromProjectHierarchy(sw360Project, sw360User);
 
             // Enrich obligation status info with release data
@@ -3683,8 +3684,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     // Add project name/info to help identify source project
                     for (Map.Entry<String, ObligationStatusInfo> entry : projectObligations.entrySet()) {
                         ObligationStatusInfo statusInfo = entry.getValue();
-                        // Only add obligations with FULFILLED_AND_PARENT_MUST_ALSO_FULFILL status
-                        if (statusInfo.getStatus() == ObligationStatus.FULFILLED_AND_PARENT_MUST_ALSO_FULFILL) {
+                        // Add obligations with FULFILLED_AND_PARENT_MUST_ALSO_FULFILL and DEFERRED_TO_PARENT_PROJECT status
+                        if (
+                                statusInfo.getStatus() == ObligationStatus.FULFILLED_AND_PARENT_MUST_ALSO_FULFILL
+                                        || statusInfo.getStatus() == ObligationStatus.DEFERRED_TO_PARENT_PROJECT
+                        ) {
                             // Approach 3: Keep both with different keys
                             // Create a unique key combining project ID and obligation ID
                             String obligationId = entry.getKey();


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Description
Add obligations of status deferred to parent project to all obligations endpoint

### How To Test?
- Update obligation status of a license obligation of a sub-project to ```Deferred to Parent Project```.
- Make the following curl request and the result must have the updated obligation.
```
curl 'http://localhost:8080/resource/api/projects/{id}/licenseObligations?page=0&page_entries=10&sort=&includeSubprojectObligations=true' \
  -H 'Authorization: Basic YWRtaW5Ac3czNjAub3JnOjEyMzQ1'
```


### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
