### PR TITLE
feat(Scheduler): Added api to  manually  trigger the  schedulers and refactor the apis

### DIFF
--- a/backend/schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
+++ b/backend/schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
@@ -111,6 +111,40 @@ public class ScheduleHandler implements ScheduleService.Iface {
     }
 
     @Override
+    public RequestStatus triggerManualService(String serviceName, User user) throws TException {
+        if (!PermissionUtils.isAdmin(user)) {
+            return RequestStatus.ACCESS_DENIED;
+        }
+        try {
+            return switch (serviceName) {
+                case ThriftClients.CVESEARCH_SERVICE ->
+                        new ThriftClients().makeCvesearchClient().update();
+                case ThriftClients.SVMSYNC_SERVICE ->
+                        new ThriftClients().makeVMClient().synchronizeComponents().getRequestStatus();
+                case ThriftClients.SVMMATCH_SERVICE ->
+                        new ThriftClients().makeVMClient().triggerReverseMatch().getRequestStatus();
+                case ThriftClients.DELETE_ATTACHMENT_SERVICE ->
+                        new ThriftClients().makeAttachmentClient().deleteOldAttachmentFromFileSystem();
+                case ThriftClients.SVM_LIST_UPDATE_SERVICE ->
+                        new ThriftClients().makeProjectClient().exportForMonitoringList();
+                case ThriftClients.SVM_TRACKING_FEEDBACK_SERVICE ->
+                        new ThriftClients().makeComponentClient().updateReleasesWithSvmTrackingFeedback();
+                case ThriftClients.IMPORT_DEPARTMENT_SERVICE ->
+                        new ThriftClients().makeUserClient().importDepartmentSchedule();
+                case ThriftClients.SRC_UPLOAD_SERVICE ->
+                        new ThriftClients().makeComponentClient().uploadSourceCodeAttachmentToReleases();
+                default -> {
+                    log.error("Could not trigger service: {}. Reason: service is not registered.", serviceName);
+                    yield RequestStatus.FAILURE;
+                }
+            };
+        } catch (TException e) {
+            log.error("Error while manually triggering service '{}': {}", serviceName, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Override
     public RequestStatus unscheduleAllServices(User user) throws TException {
         if (!PermissionUtils.isAdmin(user)) {
             return RequestStatus.FAILURE;

--- a/libraries/datahandler/src/main/thrift/schedule.thrift
+++ b/libraries/datahandler/src/main/thrift/schedule.thrift
@@ -38,6 +38,13 @@ service ScheduleService {
     RequestStatus unscheduleService(1: string serviceName, 2: User user);
 
     /*
+     * manually triggers the service with the given serviceName immediately (one-time run)
+     * serviceName has to be registered in ThriftClients
+     * user has to be admin, otherwise FAILURE is returned
+     */
+    RequestStatus triggerManualService(1: string serviceName, 2: User user);
+
+    /*
      * all scheduled tasks are cancelled
      * user has to be admin, otherwise FAILURE is returned
      */

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.schedule;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
@@ -38,6 +39,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
 import java.util.Map;
 
 @BasePathAwareController
@@ -49,6 +51,18 @@ import java.util.Map;
 public class ScheduleAdminController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String SCHEDULE_URL = "/schedule";
 
+    private static final String SERVICE_NAME_DESCRIPTION = """
+            Name of the service. Allowed values:
+            - `cvesearchService` – CVE Search sync
+            - `svmsyncService` – SVM component sync
+            - `svmmatchService` – SVM reverse match
+            - `deleteattachmentService` – Delete old attachments
+            - `svmTrackingFeedbackService` – SVM tracking feedback
+            - `svmListUpdateService` – SVM monitoring list update
+            - `srcAttachmentUploadService` – Source attachment upload
+            - `importDepartmentService` – Import department schedule
+            """;
+
     @NonNull
     private final RestControllerHelper restControllerHelper;
 
@@ -59,6 +73,14 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(ScheduleAdminController.class).slash("api/schedule").withRel("schedule"));
         return resource;
+    }
+
+    private HttpStatus httpStatusFromRequestStatus(RequestStatus requestStatus) {
+        return switch (requestStatus) {
+            case SUCCESS -> HttpStatus.OK;
+            case ACCESS_DENIED -> HttpStatus.FORBIDDEN;
+            default -> HttpStatus.INTERNAL_SERVER_ERROR;
+        };
     }
 
     @Operation(
@@ -73,316 +95,12 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                                     example = "SUCCESS")))
     })
     @PostMapping(SCHEDULE_URL + "/unscheduleAllServices")
-    public ResponseEntity<?> unscheduleAllServices()throws TException {
+    public ResponseEntity<?> unscheduleAllServices() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestStatus requestStatus = scheduleService.cancelAllServices(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
+        return new ResponseEntity<>(requestStatus, httpStatusFromRequestStatus(requestStatus));
     }
 
-    @Operation(
-            summary = "Schedule the CVE service.",
-            description = "Manually schedule the CVE service.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/cveService")
-    public ResponseEntity<?> scheduleCve() throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.scheduleCveSearch(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestSummary, status);
-    }
-
-    @Operation(
-            summary = "Schedule the SVM sync.",
-            description = "Manually schedule the SVM Sync service.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/scheduleSvmSync")
-    public ResponseEntity<?> scheduleSvmSync()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.svmSync(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestSummary, status);
-    }
-
-    @Operation(
-            summary = "Unschedule the CVE service.",
-            description = "Unschedule the CVE service.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/unscheduleCve")
-    public ResponseEntity<?> unscheduleCveSearch() throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.cancelCveSearch(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Cancel scheduled SVM sync.",
-            description = "Cancel the scheduled SVM Sync service.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @DeleteMapping(SCHEDULE_URL + "/unscheduleSvmSync")
-    public ResponseEntity<?> unscheduleSvmSync() throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.cancelSvmSync(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Schedule the attachment deletion service.",
-            description = "Schedule service for attachment deletion from local FS.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/deleteAttachment")
-    public ResponseEntity<?> scheduleDeleteAttachment() throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.deleteAttachmentService(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestSummary, status);
-    }
-
-    @Operation(
-            summary = "Reverse SVM match.",
-            description = "Reverse SVM match.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/svmReverseMatch")
-    public ResponseEntity<?> svmReverseMatch() throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.scheduleSvmReverseMatch(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestSummary, status);
-    }
-
-    @Operation(
-            summary = "Unschedule the attachment deletion service.",
-            description = "Unschedule the service for attachment deletion from local FS.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/unScheduleDeleteAttachment")
-    public ResponseEntity<?> unscheduleDeleteAttachment()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.cancelDeleteAttachment(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Cancel scheduled reverse SVM match.",
-            description = "Cancel the scheduled reverse SVM match service.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @DeleteMapping(SCHEDULE_URL + "/unscheduleSvmReverseMatch")
-    public ResponseEntity<?> unscheduleSvmReverseMatch()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.cancelSvmReverseMatch(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Cancel the attachment deletion service.",
-            description = "Cancel service for attachment deletion from local FS.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/cancelAttachmentDeletion")
-    public ResponseEntity<?> attachmentDeleteLocalFS() throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.cancelAttachmentDeletionLocalFS(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Track the user feedback.",
-            description = "Track the user feedback.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/trackingFeedback")
-    public ResponseEntity<?> svmTrackingFeedback()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.svmReleaseTrackingFeedback(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestSummary, status);
-    }
-
-    @Operation(
-            summary = "Update the SVM list.",
-            description = "Update the SVM list.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/monitoringListUpdate")
-    public ResponseEntity<?> monitoringListUpdate()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.svmMonitoringListUpdate(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestSummary, status);
-    }
-
-    @Operation(
-            summary = "Cancel the SVM list update.",
-            description = "Cancel the scheduled SVM list update.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @DeleteMapping(SCHEDULE_URL + "/cancelMonitoringListUpdate")
-    public ResponseEntity<?> cancelMonitoringListUpdate()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.cancelSvmMonitoringListUpdate(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Schedule the CVE search.",
-            description = "Schedule the CVE search.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/cveSearch")
-    public ResponseEntity<?> cveSearch()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.triggerCveSearch(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Upload the source attachment.",
-            description = "Upload the source attachment.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/srcUpload")
-    public ResponseEntity<?> srcUpload()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = scheduleService.triggerSrcUpload(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestSummary, status);
-    }
-
-    @Operation(
-            summary = "Cancel the source attachment upload.",
-            description = "Cancel the source attachment upload.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @DeleteMapping(SCHEDULE_URL + "/cancelSrcUpload")
-    public ResponseEntity<?> cancelsrcUpload()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.unscheduleSrcUpload(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
-
-    @Operation(
-            summary = "Schedule the source upload for release components.",
-            description = "Schedules the source upload process for release components.",
-            tags = {"Admin"}
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "202", description = "Status in the response body.",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = String.class,
-                                    example = "SUCCESS")))
-    })
-    @PostMapping(SCHEDULE_URL + "/scheduleSourceUploadForReleaseComponents")
-    public ResponseEntity<?> scheduleSourceUploadForReleaseComponents()throws TException {
-        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestStatus requestStatus = scheduleService.triggerSourceUploadForReleaseComponents(sw360User);
-        HttpStatus status = HttpStatus.ACCEPTED;
-        return new ResponseEntity<>(requestStatus, status);
-    }
 
     @Operation(
             summary = "Check the status of a scheduled service.",
@@ -437,4 +155,181 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
         boolean isAnyServiceScheduled = scheduleService.isAnyServiceScheduled(sw360User) == RequestStatus.SUCCESS;
         return ResponseEntity.ok(isAnyServiceScheduled);
     }
+
+
+    @Operation(
+            summary = "Schedule a service.",
+            description = "Schedules a specific service for periodic execution by its service name.",
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Service scheduled successfully.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = RequestSummary.class))),
+            @ApiResponse(responseCode = "400", description = "Bad request due to missing or invalid service name.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "serviceName parameter is required"))),
+            @ApiResponse(responseCode = "500", description = "Failed to schedule the service.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "FAILURE")))
+    })
+    @PostMapping(SCHEDULE_URL + "/scheduleService")
+    public ResponseEntity<?> scheduleService(
+            @Parameter(description = SERVICE_NAME_DESCRIPTION,
+                    schema = @Schema(type = "string", allowableValues = {
+                            "cvesearchService", "svmsyncService", "svmmatchService",
+                            "deleteattachmentService", "svmTrackingFeedbackService",
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                    }), required = true)
+            @RequestParam(value = "serviceName") String serviceName
+    ) throws TException {
+        if (CommonUtils.isNullEmptyOrWhitespace(serviceName)) {
+            throw new BadRequestClientException("serviceName parameter is required");
+        }
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary requestSummary = scheduleService.scheduleService(sw360User, serviceName);
+        RequestStatus requestStatus = requestSummary.getRequestStatus();
+        return new ResponseEntity<>(requestSummary, httpStatusFromRequestStatus(requestStatus));
+    }
+
+
+    @Operation(
+            summary = "Unschedule a service.",
+            description = "Cancels the scheduled periodic execution of a specific service by its service name.",
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Service unscheduled successfully.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "SUCCESS"))),
+            @ApiResponse(responseCode = "400", description = "Bad request due to missing or invalid service name.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "serviceName parameter is required"))),
+            @ApiResponse(responseCode = "403", description = "Access denied. Admin privileges required.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "ACCESS_DENIED"))),
+            @ApiResponse(responseCode = "500", description = "Failed to unschedule the service.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "FAILURE")))
+    })
+    @DeleteMapping(SCHEDULE_URL + "/unscheduleService")
+    public ResponseEntity<?> unscheduleService(
+            @Parameter(description = SERVICE_NAME_DESCRIPTION,
+                    schema = @Schema(type = "string", allowableValues = {
+                            "cvesearchService", "svmsyncService", "svmmatchService",
+                            "deleteattachmentService", "svmTrackingFeedbackService",
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                    }), required = true)
+            @RequestParam(value = "serviceName") String serviceName
+    ) throws TException {
+        if (CommonUtils.isNullEmptyOrWhitespace(serviceName)) {
+            throw new BadRequestClientException("serviceName parameter is required");
+        }
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus requestStatus = scheduleService.unscheduleService(sw360User, serviceName);
+        return new ResponseEntity<>(requestStatus, httpStatusFromRequestStatus(requestStatus));
+    }
+
+
+    @Operation(
+            summary = "Manually trigger a service.",
+            description = "Immediately triggers a one-time execution of a specific service by its service name, independent of its schedule.",
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Service triggered successfully.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "SUCCESS"))),
+            @ApiResponse(responseCode = "400", description = "Bad request due to missing or invalid service name.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "serviceName parameter is required"))),
+            @ApiResponse(responseCode = "403", description = "Access denied. Admin privileges required.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "ACCESS_DENIED"))),
+            @ApiResponse(responseCode = "500", description = "Failed to trigger the service.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = String.class,
+                                    example = "FAILURE")))
+    })
+    @PostMapping(SCHEDULE_URL + "/triggerService")
+    public ResponseEntity<?> triggerService(
+            @Parameter(description = SERVICE_NAME_DESCRIPTION,
+                    schema = @Schema(type = "string", allowableValues = {
+                            "cvesearchService", "svmsyncService", "svmmatchService",
+                            "deleteattachmentService", "svmTrackingFeedbackService",
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                    }), required = true)
+            @RequestParam(value = "serviceName") String serviceName
+    ) throws TException {
+        if (CommonUtils.isNullEmptyOrWhitespace(serviceName)) {
+            throw new BadRequestClientException("serviceName parameter is required");
+        }
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestStatus requestStatus = scheduleService.triggerManualService(sw360User, serviceName);
+        return new ResponseEntity<>(requestStatus, httpStatusFromRequestStatus(requestStatus));
+    }
+
+    @Operation(
+            summary = "Get scheduler details for one or all services.",
+            description = """
+                    Returns scheduler details for the specified service, or for **all registered services** if `serviceName` is omitted.
+
+                    Each entry includes:
+                    - `serviceName`: Name of the service
+                    - `isScheduled`: Whether the service is currently scheduled
+                    - `firstOffsetSeconds`: First run offset from midnight (in seconds)
+                    - `intervalSeconds`: Repeat interval (in seconds)
+                    - `nextSynchronization`: Next scheduled run time
+                    """,
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Scheduler details returned successfully.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Map.class,
+                                    example = """
+                                            {
+                                              "cvesearchService": {
+                                                "isScheduled": true,
+                                                "firstOffsetSeconds": 0,
+                                                "intervalSeconds": 86400,
+                                                "nextSynchronization": "2026-05-13T00:00:00"
+                                              },
+                                              "svmsyncService": {
+                                                "isScheduled": false,
+                                                "firstOffsetSeconds": 3600,
+                                                "intervalSeconds": 86400,
+                                                "nextSynchronization": "N/A"
+                                              }
+                                            }"""))),
+            @ApiResponse(responseCode = "400", description = "Invalid service name provided."),
+            @ApiResponse(responseCode = "403", description = "Access denied. Admin privileges required.")
+    })
+    @GetMapping(value = SCHEDULE_URL + "/serviceDetails")
+    public ResponseEntity<Map<String, Map<String, Object>>> getServiceDetails(
+            @Parameter(description = SERVICE_NAME_DESCRIPTION + "\nOmit to retrieve details for **all services**.",
+                    schema = @Schema(type = "string", allowableValues = {
+                            "cvesearchService", "svmsyncService", "svmmatchService",
+                            "deleteattachmentService", "svmTrackingFeedbackService",
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                    }))
+            @RequestParam(value = "serviceName", required = false) String serviceName
+    ) throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        if (CommonUtils.isNullEmptyOrWhitespace(serviceName)) {
+            return ResponseEntity.ok(scheduleService.getAllServicesDetails(sw360User));
+        }
+        Map<String, Object> details = scheduleService.getServiceDetails(serviceName, sw360User);
+        return ResponseEntity.ok(Map.of(serviceName, details));
+    }
+
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
@@ -22,6 +22,9 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper.throwIfNotAdmin;
 
 @Service
@@ -29,16 +32,21 @@ import static org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper.th
 public class Sw360ScheduleService {
     private static final Logger log = LogManager.getLogger(Sw360ScheduleService.class);
 
-    private RequestSummary scheduleService(User sw360User, String serviceName) throws TException {
+    public RequestSummary scheduleService(User sw360User, String serviceName) throws TException {
         throwIfNotAdmin(sw360User);
         ThriftClients thriftClients = new ThriftClients();
         return thriftClients.makeScheduleClient().scheduleService(serviceName);
     }
 
-    private RequestStatus unscheduleService(User sw360User, String serviceName) throws TException {
+    public RequestStatus unscheduleService(User sw360User, String serviceName) throws TException {
         throwIfNotAdmin(sw360User);
         ThriftClients thriftClients = new ThriftClients();
         return thriftClients.makeScheduleClient().unscheduleService(serviceName, sw360User);
+    }
+
+    public RequestStatus triggerManualService(User sw360User, String serviceName) throws TException {
+        throwIfNotAdmin(sw360User);
+        return new ThriftClients().makeScheduleClient().triggerManualService(serviceName, sw360User);
     }
 
     public RequestStatus cancelAllServices(User sw360User) throws TException {
@@ -172,5 +180,51 @@ public class Sw360ScheduleService {
             log.error("Error occurred while fetching the status of services", e);
             throw e;
         }
+    }
+
+    public Map<String, Object> getServiceDetails(String serviceName, User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
+        try {
+            var client = new ThriftClients().makeScheduleClient();
+            boolean isScheduled = client.isServiceScheduled(serviceName, sw360User).isAnswerPositive();
+            int offsetSeconds = client.getFirstRunOffset(serviceName);
+            int intervalSeconds = client.getInterval(serviceName);
+            String nextSync = client.getNextSync(serviceName);
+
+            return Map.of(
+                    "isScheduled", isScheduled,
+                    "firstOffsetSeconds", offsetSeconds,
+                    "intervalSeconds", intervalSeconds,
+                    "nextSynchronization", nextSync != null ? nextSync : "N/A"
+            );
+        } catch (TException e) {
+            log.error("Error occurred while fetching details for service '{}':", serviceName, e);
+            throw e;
+        }
+    }
+
+    public Map<String, Map<String, Object>> getAllServicesDetails(User sw360User) throws TException {
+        throwIfNotAdmin(sw360User);
+        List<String> services = List.of(
+                ThriftClients.CVESEARCH_SERVICE,
+                ThriftClients.SVMSYNC_SERVICE,
+                ThriftClients.SVMMATCH_SERVICE,
+                ThriftClients.DELETE_ATTACHMENT_SERVICE,
+                ThriftClients.SVM_TRACKING_FEEDBACK_SERVICE,
+                ThriftClients.SVM_LIST_UPDATE_SERVICE,
+                ThriftClients.SRC_UPLOAD_SERVICE,
+                ThriftClients.IMPORT_DEPARTMENT_SERVICE
+        );
+
+        Map<String, Map<String, Object>> result = new java.util.LinkedHashMap<>();
+        for (String svc : services) {
+            try {
+                result.put(svc, getServiceDetails(svc, sw360User));
+            } catch (TException e) {
+                log.warn("Could not fetch details for service '{}': {}", svc, e.getMessage());
+                result.put(svc, Map.of("error", "Failed to retrieve details"));
+            }
+        }
+        return result;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ScheduleTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ScheduleTest.java
@@ -31,11 +31,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
@@ -53,38 +56,36 @@ public class ScheduleTest extends TestIntegrationBase {
 
     @Before
     public void before() throws TException {
-        // Setup test request summary
         testRequestSummary = new RequestSummary();
         testRequestSummary.setRequestStatus(RequestStatus.SUCCESS);
         testRequestSummary.setMessage("Service scheduled successfully");
 
-        // Setup object mapper
         objectMapper = new ObjectMapper();
 
-        // Setup user mock
         User user = TestHelper.getTestUser();
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
 
-        // Setup schedule service mocks
         given(this.scheduleServiceMock.cancelAllServices(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.scheduleCveSearch(any())).willReturn(testRequestSummary);
-        given(this.scheduleServiceMock.cancelCveSearch(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.deleteAttachmentService(any())).willReturn(testRequestSummary);
-        given(this.scheduleServiceMock.cancelDeleteAttachment(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.cancelAttachmentDeletionLocalFS(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.triggerCveSearch(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.cancelSvmSync(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.cancelSvmReverseMatch(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.scheduleSvmReverseMatch(any())).willReturn(testRequestSummary);
-        given(this.scheduleServiceMock.svmReleaseTrackingFeedback(any())).willReturn(testRequestSummary);
-        given(this.scheduleServiceMock.svmMonitoringListUpdate(any())).willReturn(testRequestSummary);
-        given(this.scheduleServiceMock.triggerSrcUpload(any())).willReturn(testRequestSummary);
-        given(this.scheduleServiceMock.cancelSvmMonitoringListUpdate(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.unscheduleSrcUpload(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.triggerSourceUploadForReleaseComponents(any())).willReturn(RequestStatus.SUCCESS);
+
+        // New unified endpoints
+        given(this.scheduleServiceMock.scheduleService(any(), anyString())).willReturn(testRequestSummary);
+        given(this.scheduleServiceMock.unscheduleService(any(), anyString())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.triggerManualService(any(), anyString())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.isServiceScheduled(anyString(), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.isAnyServiceScheduled(any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.getServiceDetails(anyString(), any()))
+                .willReturn(Map.of("isScheduled", true, "firstOffsetSeconds", 0,
+                        "intervalSeconds", 86400, "nextSynchronization", "2026-05-13T00:00:00"));
+        given(this.scheduleServiceMock.getAllServicesDetails(any()))
+                .willReturn(java.util.Map.of(
+                        "cvesearchService", Map.of("isScheduled", true, "firstOffsetSeconds", 0,
+                                "intervalSeconds", 86400, "nextSynchronization", "2026-05-13T00:00:00"),
+                        "svmsyncService", Map.of("isScheduled", false, "firstOffsetSeconds", 3600,
+                                "intervalSeconds", 86400, "nextSynchronization", "N/A")
+                ));
     }
 
-    // ========== SCHEDULE SERVICE TESTS ==========
+    // ========== UNSCHEDULE ALL SERVICES TEST ==========
 
     @Test
     public void should_cancel_all_schedule_services() throws IOException {
@@ -95,205 +96,145 @@ public class ScheduleTest extends TestIntegrationBase {
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
     }
 
     @Test
-    public void should_schedule_cve_service() throws IOException {
+    public void should_handle_exception_in_cancel_all_services() throws IOException, TException {
+        doThrow(new RuntimeException("Service cancellation failed"))
+                .when(scheduleServiceMock).cancelAllServices(any());
+
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cveService",
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleAllServices",
                         HttpMethod.POST,
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    // ========== NEW UNIFIED ENDPOINT TESTS ==========
+
+    @Test
+    public void should_schedule_service_by_name() throws IOException {
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/scheduleService?serviceName=cvesearchService",
+                        HttpMethod.POST,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain request summary", response.getBody().contains("requestStatus"));
+        assertTrue("Response should contain requestStatus", response.getBody().contains("requestStatus"));
     }
 
     @Test
-    public void should_cancel_schedule_svm_sync() throws IOException {
+    public void should_return_bad_request_when_schedule_service_name_missing() throws IOException {
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleSvmSync",
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/scheduleService",
+                        HttpMethod.POST,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    public void should_unschedule_service_by_name() throws IOException {
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/unscheduleService?serviceName=cvesearchService",
                         HttpMethod.DELETE,
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
+        assertTrue("Response should contain SUCCESS", response.getBody().contains("SUCCESS"));
     }
 
     @Test
-    public void should_schedule_reverse_svm_match() throws IOException {
+    public void should_return_bad_request_when_unschedule_service_name_missing() throws IOException {
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/svmReverseMatch",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain request summary", response.getBody().contains("requestStatus"));
-    }
-
-    @Test
-    public void should_cancel_reverse_match() throws IOException {
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleSvmReverseMatch",
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/unscheduleService",
                         HttpMethod.DELETE,
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
     }
 
     @Test
-    public void should_track_feedback() throws IOException {
+    public void should_trigger_service_by_name() throws IOException {
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/trackingFeedback",
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/triggerService?serviceName=cvesearchService",
                         HttpMethod.POST,
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain request summary", response.getBody().contains("requestStatus"));
+        assertTrue("Response should contain SUCCESS", response.getBody().contains("SUCCESS"));
     }
 
     @Test
-    public void should_svm_list_update() throws IOException {
+    public void should_return_bad_request_when_trigger_service_name_missing() throws IOException {
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/monitoringListUpdate",
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/triggerService",
                         HttpMethod.POST,
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain request summary", response.getBody().contains("requestStatus"));
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
     }
 
     @Test
-    public void should_cancel_monitoring_svm_list() throws IOException {
+    public void should_return_service_details_for_specific_service() throws IOException {
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cancelMonitoringListUpdate",
-                        HttpMethod.DELETE,
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/serviceDetails?serviceName=cvesearchService",
+                        HttpMethod.GET,
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
+        assertTrue("Response should contain service name key", response.getBody().contains("cvesearchService"));
+        assertTrue("Response should contain isScheduled", response.getBody().contains("isScheduled"));
+        assertTrue("Response should contain intervalSeconds", response.getBody().contains("intervalSeconds"));
+        assertTrue("Response should contain firstOffsetSeconds", response.getBody().contains("firstOffsetSeconds"));
+        assertTrue("Response should contain nextSynchronization", response.getBody().contains("nextSynchronization"));
     }
 
     @Test
-    public void should_src_upload() throws IOException {
+    public void should_return_all_service_details_when_no_service_name() throws IOException {
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/srcUpload",
-                        HttpMethod.POST,
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/serviceDetails",
+                        HttpMethod.GET,
                         new HttpEntity<>(null, headers),
                         String.class);
 
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain request summary", response.getBody().contains("requestStatus"));
-    }
-
-    @Test
-    public void should_cancel_src_upload() throws IOException {
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cancelSrcUpload",
-                        HttpMethod.DELETE,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
-    }
-
-    @Test
-    public void should_unschedule_cve_search() throws IOException {
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleCve",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
-    }
-
-    @Test
-    public void should_schedule_service_from_local() throws IOException {
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/deleteAttachment",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain request summary", response.getBody().contains("requestStatus"));
-    }
-
-    @Test
-    public void should_cancel_schedule_attachment() throws IOException {
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unScheduleDeleteAttachment",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
-    }
-
-    @Test
-    public void should_delete_old_attachment_from_local() throws IOException {
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cancelAttachmentDeletion",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
-    }
-
-    @Test
-    public void should_schedule_source_upload() throws IOException {
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/scheduleSourceUploadForReleaseComponents",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
+        assertTrue("Response should contain cvesearchService", response.getBody().contains("cvesearchService"));
+        assertTrue("Response should contain svmsyncService", response.getBody().contains("svmsyncService"));
     }
 
     @Test
@@ -322,17 +263,47 @@ public class ScheduleTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
     }
 
-    // ========== EXCEPTION HANDLING TESTS ==========
+    @Test
+    public void should_return_true_when_any_service_is_scheduled() throws IOException {
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/isAnyServiceScheduled",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue("Response should be true", response.getBody().contains("true"));
+    }
 
     @Test
-    public void should_handle_exception_in_cancel_all_services() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Service cancellation failed"))
-                .when(scheduleServiceMock).cancelAllServices(any());
+    public void should_return_false_when_no_service_is_scheduled() throws IOException, TException {
+        given(this.scheduleServiceMock.isAnyServiceScheduled(any())).willReturn(RequestStatus.FAILURE);
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleAllServices",
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/isAnyServiceScheduled",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue("Response should be false", response.getBody().contains("false"));
+    }
+
+    @Test
+    public void should_handle_exception_in_schedule_service() throws IOException, TException {
+        doThrow(new RuntimeException("Schedule service failed"))
+                .when(scheduleServiceMock).scheduleService(any(), eq("cvesearchService"));
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/schedule/scheduleService?serviceName=cvesearchService",
                         HttpMethod.POST,
                         new HttpEntity<>(null, headers),
                         String.class);
@@ -340,243 +311,4 @@ public class ScheduleTest extends TestIntegrationBase {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
     }
 
-    @Test
-    public void should_handle_exception_in_schedule_cve_service() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("CVE service scheduling failed"))
-                .when(scheduleServiceMock).scheduleCveSearch(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cveService",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_schedule_svm_sync() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("SVM sync scheduling failed"))
-                .when(scheduleServiceMock).svmSync(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/scheduleSvmSync",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_cancel_svm_sync() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("SVM sync cancellation failed"))
-                .when(scheduleServiceMock).cancelSvmSync(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleSvmSync",
-                        HttpMethod.DELETE,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_reverse_svm_match() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Reverse SVM match failed"))
-                .when(scheduleServiceMock).scheduleSvmReverseMatch(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/svmReverseMatch",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_cancel_reverse_match() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Reverse match cancellation failed"))
-                .when(scheduleServiceMock).cancelSvmReverseMatch(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleSvmReverseMatch",
-                        HttpMethod.DELETE,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_track_feedback() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Tracking feedback failed"))
-                .when(scheduleServiceMock).svmReleaseTrackingFeedback(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/trackingFeedback",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_svm_list_update() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("SVM list update failed"))
-                .when(scheduleServiceMock).svmMonitoringListUpdate(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/monitoringListUpdate",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_cancel_monitoring_svm_list() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Monitoring list cancellation failed"))
-                .when(scheduleServiceMock).cancelSvmMonitoringListUpdate(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cancelMonitoringListUpdate",
-                        HttpMethod.DELETE,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_src_upload() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Source upload failed"))
-                .when(scheduleServiceMock).triggerSrcUpload(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/srcUpload",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_cancel_src_upload() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Source upload cancellation failed"))
-                .when(scheduleServiceMock).unscheduleSrcUpload(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cancelSrcUpload",
-                        HttpMethod.DELETE,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_unschedule_cve_search() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("CVE search unscheduling failed"))
-                .when(scheduleServiceMock).cancelCveSearch(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unscheduleCve",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_schedule_service_from_local() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Attachment deletion scheduling failed"))
-                .when(scheduleServiceMock).deleteAttachmentService(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/deleteAttachment",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_cancel_schedule_attachment() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Attachment scheduling cancellation failed"))
-                .when(scheduleServiceMock).cancelDeleteAttachment(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/unScheduleDeleteAttachment",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_delete_old_attachment_from_local() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Attachment deletion from local FS failed"))
-                .when(scheduleServiceMock).cancelAttachmentDeletionLocalFS(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/cancelAttachmentDeletion",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
-    public void should_handle_exception_in_schedule_source_upload() throws IOException, TException {
-        // Mock service to throw exception
-        doThrow(new RuntimeException("Source upload scheduling failed"))
-                .when(scheduleServiceMock).triggerSourceUploadForReleaseComponents(any());
-
-        HttpHeaders headers = getHeaders(port);
-        ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/schedule/scheduleSourceUploadForReleaseComponents",
-                        HttpMethod.POST,
-                        new HttpEntity<>(null, headers),
-                        String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
@@ -12,10 +12,13 @@
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
@@ -32,6 +35,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.util.Map;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ScheduleSpecTest extends TestRestDocsSpecBase {
     @Value("${sw360.test-user-id}")
@@ -42,7 +47,7 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
 
     @MockitoBean
     private Sw360ScheduleService scheduleServiceMock;
-    private RequestSummary requestSummary = new RequestSummary();
+    private RequestSummary requestSummary = new RequestSummary().setRequestStatus(RequestStatus.SUCCESS);
 
     @Before
     public void before() throws TException {
@@ -53,20 +58,23 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
         sw360User.setFullname("John Doe");
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(sw360User);
         given(this.scheduleServiceMock.cancelAllServices(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.scheduleCveSearch(any())).willReturn(requestSummary);
-        given(this.scheduleServiceMock.cancelCveSearch(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.deleteAttachmentService(any())).willReturn(requestSummary);
-        given(this.scheduleServiceMock.cancelDeleteAttachment(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.cancelAttachmentDeletionLocalFS(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.triggerCveSearch(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.cancelSvmSync(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.cancelSvmReverseMatch(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.scheduleSvmReverseMatch(any())).willReturn(requestSummary);
-        given(this.scheduleServiceMock.svmReleaseTrackingFeedback(any())).willReturn(requestSummary);
-        given(this.scheduleServiceMock.svmMonitoringListUpdate(any())).willReturn(requestSummary);
-        given(this.scheduleServiceMock.triggerSrcUpload(any())).willReturn(requestSummary);
-        given(this.scheduleServiceMock.cancelSvmMonitoringListUpdate(any())).willReturn(RequestStatus.SUCCESS);
-        given(this.scheduleServiceMock.unscheduleSrcUpload(any())).willReturn(RequestStatus.SUCCESS);
+
+        // New unified endpoints
+        given(this.scheduleServiceMock.scheduleService(any(), anyString())).willReturn(requestSummary);
+        given(this.scheduleServiceMock.unscheduleService(any(), anyString())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.triggerManualService(any(), anyString())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.isServiceScheduled(anyString(), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.isAnyServiceScheduled(any())).willReturn(RequestStatus.SUCCESS);
+        given(this.scheduleServiceMock.getServiceDetails(anyString(), any()))
+                .willReturn(Map.of("isScheduled", true, "firstOffsetSeconds", 0,
+                        "intervalSeconds", 86400, "nextSynchronization", "2026-05-13T00:00:00"));
+        given(this.scheduleServiceMock.getAllServicesDetails(any()))
+                .willReturn(java.util.Map.of(
+                        "cvesearchService", Map.of("isScheduled", true, "firstOffsetSeconds", 0,
+                                "intervalSeconds", 86400, "nextSynchronization", "2026-05-13T00:00:00"),
+                        "svmsyncService", Map.of("isScheduled", false, "firstOffsetSeconds", 3600,
+                                "intervalSeconds", 86400, "nextSynchronization", "N/A")
+                ));
 
     }
 
@@ -75,135 +83,81 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(post("/api/schedule/unscheduleAllServices")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isOk());
+    }
+
+    // ========== NEW UNIFIED ENDPOINT SPEC TESTS ==========
+
+    @Test
+    public void should_document_schedule_service_by_name() throws Exception {
+        mockMvc.perform(post("/api/schedule/scheduleService")
+                .param("serviceName", "cvesearchService")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
     }
 
     @Test
-    public void should_document_schedule_cve_service() throws Exception {
-        mockMvc.perform(post("/api/schedule/cveService")
+    public void should_document_unschedule_service_by_name() throws Exception {
+        mockMvc.perform(delete("/api/schedule/unscheduleService")
+                .param("serviceName", "cvesearchService")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isOk());
     }
 
     @Test
-    public void should_document_schedule_svm_sync() throws Exception {
-        mockMvc.perform(post("/api/schedule/scheduleSvmSync")
+    public void should_document_trigger_service_by_name() throws Exception {
+        mockMvc.perform(post("/api/schedule/triggerService")
+                .param("serviceName", "cvesearchService")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isOk());
     }
 
     @Test
-    public void should_document_cancel_schedule_svm_sync() throws Exception {
-        mockMvc.perform(delete("/api/schedule/unscheduleSvmSync")
+    public void should_document_get_service_details_for_specific_service() throws Exception {
+        mockMvc.perform(get("/api/schedule/serviceDetails")
+                .param("serviceName", "cvesearchService")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cvesearchService.isScheduled").value(true))
+                .andExpect(jsonPath("$.cvesearchService.firstOffsetSeconds").value(0))
+                .andExpect(jsonPath("$.cvesearchService.intervalSeconds").value(86400))
+                .andExpect(jsonPath("$.cvesearchService.nextSynchronization").value("2026-05-13T00:00:00"));
     }
 
     @Test
-    public void should_document_reverse_svm_match() throws Exception {
-        mockMvc.perform(post("/api/schedule/svmReverseMatch")
+    public void should_document_get_all_service_details() throws Exception {
+        mockMvc.perform(get("/api/schedule/serviceDetails")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cvesearchService").exists())
+                .andExpect(jsonPath("$.svmsyncService").exists())
+                .andExpect(jsonPath("$.cvesearchService.isScheduled").value(true))
+                .andExpect(jsonPath("$.svmsyncService.isScheduled").value(false));
     }
 
     @Test
-    public void should_document_cancel_reverse_match() throws Exception {
-        mockMvc.perform(delete("/api/schedule/unscheduleSvmReverseMatch")
+    public void should_document_is_any_service_scheduled_true() throws Exception {
+        mockMvc.perform(get("/api/schedule/isAnyServiceScheduled")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(true));
     }
 
     @Test
-    public void should_document_track_feedback() throws Exception {
-        mockMvc.perform(post("/api/schedule/trackingFeedback")
+    public void should_document_check_service_status() throws Exception {
+        mockMvc.perform(get("/api/schedule/status")
+                .param("serviceName", "cvesearchService")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_svm_list_update() throws Exception {
-        mockMvc.perform(post("/api/schedule/monitoringListUpdate")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_cancel_monitoring_svm_list() throws Exception {
-        mockMvc.perform(delete("/api/schedule/cancelMonitoringListUpdate")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_src_upload() throws Exception {
-        mockMvc.perform(post("/api/schedule/srcUpload")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_cancel_monitoring_cancel_svm_list() throws Exception {
-        mockMvc.perform(delete("/api/schedule/cancelSrcUpload")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_unschedule_cve_search() throws Exception {
-        mockMvc.perform(post("/api/schedule/unscheduleCve")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_schedule_service_from_local() throws Exception {
-        mockMvc.perform(post("/api/schedule/deleteAttachment")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_schedule_cve_search() throws Exception {
-        mockMvc.perform(post("/api/schedule/cveSearch")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_cancel_schedule_attachment() throws Exception {
-        mockMvc.perform(post("/api/schedule/unScheduleDeleteAttachment")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void should_document_delete_old_attachment_from_local() throws Exception {
-        mockMvc.perform(post("/api/schedule/cancelAttachmentDeletion")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
-    }
-
-    @Test
-    public void schedule_source_upload() throws Exception {
-        mockMvc.perform(post("/api/schedule/scheduleSourceUploadForReleaseComponents")
-                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.serviceName").value("cvesearchService"))
+                .andExpect(jsonPath("$.isScheduled").value(true));
     }
 
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
#### This PR refactors the Scheduler REST APIs and adds support for manually triggering scheduler services.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4147*)
> * Did you add or update any new dependencies that are required for your change?

Issue: https://github.com/eclipse-sw360/sw360/issues/4147


### Changes Made:

**1. API Refactoring — Multiple service-specific endpoints consolidated into 3 generic endpoints:**

| Old Endpoints (removed) | New Endpoint |
|------------------------|--------------|
| `POST /schedule/cveService` | `POST /schedule/scheduleService?serviceName=<name>` |
| `POST /schedule/scheduleSvmSync` | ↑ |
| `POST /schedule/svmReverseMatch` | ↑ |
| `POST /schedule/deleteAttachment` | ↑ |
| `POST /schedule/trackingFeedback` | ↑ |
| `POST /schedule/monitoringListUpdate` | ↑ |
| `POST /schedule/srcUpload` | ↑ |
| `POST /schedule/unscheduleCve` | `DELETE /schedule/unscheduleService?serviceName=<name>` |
| `DELETE /schedule/unscheduleSvmSync` | ↑ |
| `POST /schedule/unScheduleDeleteAttachment` | ↑ |
| `DELETE /schedule/unscheduleSvmReverseMatch` | ↑ |
| *(not available before)* | `POST /schedule/triggerManualService?serviceName=<name>` |

**2. New Manual Trigger API:** `POST /schedule/triggerManualService?serviceName=<name>`  
Allows admins to manually trigger any registered scheduler service on demand without waiting for the scheduled time.

**3. New Status & Info APIs:**

| Endpoint | Description |
|----------|-------------|
| `GET /schedule/serviceDetails` | Returns schedule details (offset, interval, next sync, status) for **all** registered services |
| `GET /schedule/serviceDetails?serviceName=<name>` | Returns schedule details for a **specific** service only |


**4. Backend (`ScheduleHandler.java`):** Added `triggerManualService()` method in Thrift handler with switch-case for all registered services.

**5. Thrift (`schedule.thrift`):** Added `triggerManualService` method signature.


### Suggest Reviewer
> @GMishx 

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

#### Schedule a service
curl -X POST "http://localhost:8080/resource/api/schedule/scheduleService?serviceName=cvesearchService" \
  -H "Authorization: Bearer <token>"

#### Unschedule a service
curl -X DELETE "http://localhost:8080/resource/api/schedule/unscheduleService?serviceName=cvesearchService" \
  -H "Authorization: Bearer <token>"

#### Manually trigger a service immediately
curl -X POST "http://localhost:8080/resource/api/schedule/triggerService?serviceName=cvesearchService" \
  -H "Authorization: Bearer <token>"


#### Get schedule details for all services
curl -X GET "http://localhost:8080/resource/api/schedule/serviceDetails" \
  -H "Authorization: Bearer <token>"

#### Get schedule details for a specific service
curl -X GET "http://localhost:8080/resource/api/schedule/serviceDetails?serviceName=svmsyncService" \
  -H "Authorization: Bearer <token>"
```

**Test all supported `serviceName` values:**
- `cvesearchService`
- `svmsyncService`
- `svmmatchService`
- `deleteattachmentService`
- `svmTrackingFeedbackService`
- `svmListUpdateService`
- `srcAttachmentUploadService`

**Additional tests implemented:**
- Updated `ScheduleTest.java` (integration tests) to reflect refactored endpoints
- Updated `ScheduleSpecTest.java` (REST docs spec tests) to reflect new API

---

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
