### PR TITLE
feat(vmprocessor): optimize db connection

### DIFF
--- a/.github/instructions/sw360_backend.instructions.md
+++ b/.github/instructions/sw360_backend.instructions.md
@@ -106,12 +106,29 @@ mvn test -pl backend/components
 # Install pre-commit hooks (Spotless formatting)
 pip install pre-commit && pre-commit install
 
-# Format code manually
+# Auto-format only files changed vs origin/main (the project default scope)
 mvn spotless:apply
 
-# Check formatting
+# Check formatting on changed files
 mvn spotless:check
+
+# One-off: audit the entire repo (disable the ratchet) — use sparingly,
+# typically only for centralized cleanups.
+mvn spotless:check -Dspotless.ratchetFrom=
 ```
+
+> **Spotless scope (`ratchetFrom`)**: Spotless is configured in the parent
+> `pom.xml` to inspect only files that differ from `${spotless.ratchetFrom}`
+> (default `origin/main`). This lets the project adopt formatting hygiene
+> incrementally without a one-shot reformat of the entire legacy codebase.
+> Override the property on the command line to scope checks differently
+> (e.g. `-Dspotless.ratchetFrom=HEAD~1` for "the last commit only", or an
+> empty value to disable ratcheting and check everything).
+>
+> **Enforced rules** (intentionally minimal): tabs are converted to 4
+> spaces, trailing whitespace is trimmed, and every Java file ends with a
+> newline. No formatter overhaul (Eclipse/Google) is applied — the existing
+> code style is preserved.
 
 ### Thrift Generation
 ```bash

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandler.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/handler/SVMSyncHandler.java
@@ -62,7 +62,7 @@ public class SVMSyncHandler<T extends TBase> {
     private static final Map<Class<?>, Boolean> processedFlags = new ConcurrentHashMap<>();
 
     public  SVMSyncHandler(Class<T> type) throws MalformedURLException, SW360Exception {
-        this(type, null);
+        this(type, VMProcessHandler.sharedDb());
     }
 
     private SVMSyncHandler(Class<T> type, VMDatabaseHandler dbHandler) throws MalformedURLException, SW360Exception {

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/process/VMProcessHandler.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/process/VMProcessHandler.java
@@ -16,15 +16,19 @@ import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.vmcomponents.common.SVMConstants;
+import org.eclipse.sw360.vmcomponents.db.VMDatabaseHandler;
 import org.eclipse.sw360.vmcomponents.handler.SVMSyncHandler;
 
 import javax.annotation.Nonnull;
 import java.net.MalformedURLException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.log4j.Logger.getLogger;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
@@ -38,12 +42,56 @@ import static org.eclipse.sw360.datahandler.common.SW360Assert.assertTrue;
 public class VMProcessHandler {
     private static final Logger log = getLogger(VMProcessHandler.class);
 
+    /**
+     * JVM-singleton {@link VMDatabaseHandler}. Repositories underneath are
+     * stateless wrappers around the JVM-singleton {@code Cloudant} client
+     * (see {@code DatabaseSettings#CLIENT}); the IBM Cloudant SDK uses OkHttp
+     * which performs its own thread-safe connection pooling, so all SVM worker
+     * threads can safely share a single handler instance. Lazy-initialised so
+     * that a misconfigured CouchDB at boot doesn't blow up the entire backend.
+     */
+    private static volatile VMDatabaseHandler SHARED_DB;
+
     private static final ThreadPoolExecutor executor = new ThreadPoolExecutor(
             SVMConstants.PROCESSING_CORE_POOL_SIZE,
             SVMConstants.PROCESSING_MAX_POOL_SIZE,
             SVMConstants.PROCESSING_KEEP_ALIVE_SECONDS,
             TimeUnit.SECONDS,
-            new PriorityBlockingQueue<>());
+            new PriorityBlockingQueue<>(),
+            namedThreadFactory());
+
+    /**
+     * Names worker threads {@code sw360-vmprocessor-N} so they are identifiable
+     * in {@code jstack}, IDE debug output, {@code top -H}, and Log4j2 {@code %t}
+     * patterns.
+     */
+    private static ThreadFactory namedThreadFactory() {
+        return new ThreadFactory() {
+            private final AtomicInteger counter = new AtomicInteger(1);
+            private final ThreadFactory defaults = Executors.defaultThreadFactory();
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = defaults.newThread(r);
+                t.setName("sw360-vmprocessor-" + counter.getAndIncrement());
+                return t;
+            }
+        };
+    }
+
+    public static VMDatabaseHandler sharedDb() throws MalformedURLException {
+        VMDatabaseHandler local = SHARED_DB;
+        if (local == null) {
+            synchronized (VMProcessHandler.class) {
+                local = SHARED_DB;
+                if (local == null) {
+                    local = new VMDatabaseHandler();
+                    SHARED_DB = local;
+                }
+            }
+        }
+        return local;
+    }
 
     /**
      * it is very important to use ConcurrentHashMap to be threadsafe

--- a/backend/vmcomponents/src/test/java/org/eclipse/sw360/vmcomponents/process/VMProcessHandlerThreadFactoryTest.java
+++ b/backend/vmcomponents/src/test/java/org/eclipse/sw360/vmcomponents/process/VMProcessHandlerThreadFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.vmcomponents.process;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ThreadFactory;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that {@link VMProcessHandler}'s worker threads are named with the
+ * {@code sw360-vmprocessor-} prefix so they are identifiable in stack traces,
+ * profilers, and Log4j2 thread-name patterns.
+ */
+public class VMProcessHandlerThreadFactoryTest {
+
+    @Test
+    public void namedThreadFactoryAssignsSw360VmprocessorPrefix() throws Exception {
+        Method m = VMProcessHandler.class.getDeclaredMethod("namedThreadFactory");
+        m.setAccessible(true);
+        ThreadFactory factory = (ThreadFactory) m.invoke(null);
+
+        Thread t1 = factory.newThread(() -> { /* no-op */ });
+        Thread t2 = factory.newThread(() -> { /* no-op */ });
+
+        assertNotNull(t1);
+        assertNotNull(t2);
+        assertTrue("Expected sw360-vmprocessor-* prefix but was: " + t1.getName(),
+                t1.getName().startsWith("sw360-vmprocessor-"));
+        assertTrue("Expected sw360-vmprocessor-* prefix but was: " + t2.getName(),
+                t2.getName().startsWith("sw360-vmprocessor-"));
+        assertNotEquals("Counter should produce distinct names",
+                t1.getName(), t2.getName());
+    }
+}

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -56,12 +57,51 @@ public class DatabaseRepositoryCloudantClient<T> {
     private static final char HIGH_VALUE_UNICODE_CHARACTER = '\uFFF0';
     private static final Gson GSON = new Gson();
 
+    /**
+     * JVM-/classloader-scoped guard to avoid re-PUTting design documents and
+     * (re-)creating Mango indexes on every repository construction. Design
+     * documents and index definitions only change when code changes.
+     *
+     * Keys:
+     *  - INITIALISED_DDOCS:    "<dbName>::<designDocId>"
+     *  - INITIALISED_INDEXES:  "<dbName>::<designDocId>::<indexName>"
+     */
+    private static final Set<String> INITIALISED_DDOCS = ConcurrentHashMap.newKeySet();
+    private static final Set<String> INITIALISED_INDEXES = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Test-only hook to forget all design-document and index initialisations
+     * for the given database. Required because the tests delete and recreate
+     * databases between test methods within the same JVM; without this the
+     * JVM-wide cache would incorrectly believe the (now-deleted) database
+     * still has its design docs and indexes installed.
+     *
+     * <p>Production code never calls this. Test helpers
+     * (e.g. {@code TestUtils.deleteDatabase} / {@code TestUtils.createDatabase})
+     * call it after destroying or recreating a database.
+     *
+     * @param dbName the CouchDB/Cloudant database name to forget
+     */
+    public static void forgetInitialisedDesignArtifacts(String dbName) {
+        if (dbName == null || dbName.isEmpty()) {
+            return;
+        }
+        String prefix = dbName + "::";
+        INITIALISED_DDOCS.removeIf(k -> k.startsWith(prefix));
+        INITIALISED_INDEXES.removeIf(k -> k.startsWith(prefix));
+    }
+
     private final Class<T> type;
     private DatabaseConnectorCloudant connector;
 
     public void initStandardDesignDocument(Map<String, DesignDocumentViewsMapReduce> views,
                                            @NotNull DatabaseConnectorCloudant db) {
         String ddocId = type.getSimpleName();
+        String key = db.getDbName() + "::" + ddocId;
+        if (!INITIALISED_DDOCS.add(key)) {
+            // Already initialised in this JVM/classloader; skip
+            return;
+        }
         DesignDocument newDdoc = new DesignDocument.Builder()
                 .views(views)
                 .build();
@@ -79,6 +119,9 @@ public class DatabaseRepositoryCloudantClient<T> {
 
     public void createIndex(String ddocId, String indexName, String[] fields,
                             DatabaseConnectorCloudant db) {
+        if (!INITIALISED_INDEXES.add(db.getDbName() + "::" + ddocId + "::" + indexName)) {
+            return;
+        }
         IndexDefinition.Builder indexDefinitionBuilder = new IndexDefinition.Builder();
         for (String fieldName : fields) {
             IndexField field = new IndexField.Builder()
@@ -103,6 +146,9 @@ public class DatabaseRepositoryCloudantClient<T> {
             String ddocId, String indexName, String type, String @NotNull [] fields,
             DatabaseConnectorCloudant db
     ) {
+        if (!INITIALISED_INDEXES.add(db.getDbName() + "::" + ddocId + "::" + indexName)) {
+            return;
+        }
         IndexDefinition.Builder indexDefinitionBuilder = new IndexDefinition.
                 Builder();
         for (String fieldName : fields) {

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Ordering;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseInstanceCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseInstanceTrackerCloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
 import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
@@ -131,6 +132,10 @@ public class TestUtils {
         if (instance.checkIfDbExists(dbName))
             instance.deleteDatabase(dbName);
 
+        // Forget the JVM-wide design-doc/index init cache for this database;
+        // recreating it below would otherwise skip the design-doc PUT.
+        DatabaseRepositoryCloudantClient.forgetInitialisedDesignArtifacts(dbName);
+
         // Giving 500ms Delay between Deleting and Creating test Db
         try {
             Thread.sleep(500);
@@ -147,6 +152,10 @@ public class TestUtils {
             instance.deleteDatabase(dbName);
         }
         instance.createDB(dbName);
+
+        // Newly-created DB has no design docs/indexes; clear the cache so
+        // the first repository constructed against it actually installs them.
+        DatabaseRepositoryCloudantClient.forgetInitialisedDesignArtifacts(dbName);
 
         DatabaseInstanceTrackerCloudant.destroy();
     }

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClientTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClientTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.cloudantclient;
+
+import com.ibm.cloud.cloudant.v1.model.DesignDocument;
+import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
+import com.ibm.cloud.cloudant.v1.model.IndexDefinition;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link DatabaseRepositoryCloudantClient} performs design-document
+ * and index initialisation only once per (database, design-doc) pair within the
+ * current JVM/classloader.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DatabaseRepositoryCloudantClientTest {
+
+    @Mock
+    private DatabaseConnectorCloudant dbA;
+
+    @Mock
+    private DatabaseConnectorCloudant dbB;
+
+    @Before
+    public void resetCaches() throws Exception {
+        // Clear the JVM-wide guard between tests so test order doesn't matter.
+        clearStaticSet("INITIALISED_DDOCS");
+        clearStaticSet("INITIALISED_INDEXES");
+    }
+
+    private static void clearStaticSet(String fieldName) throws Exception {
+        Field f = DatabaseRepositoryCloudantClient.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        ((Set<?>) f.get(null)).clear();
+    }
+
+    private <T> DatabaseRepositoryCloudantClient<T> repoFor(
+            DatabaseConnectorCloudant connector, Class<T> type) {
+        return new DatabaseRepositoryCloudantClient<>(connector, type);
+    }
+
+    private Map<String, DesignDocumentViewsMapReduce> emptyViews() {
+        return Collections.emptyMap();
+    }
+
+    @Test
+    public void initStandardDesignDocument_isExecutedOnceForSameTypeAndDb() {
+        when(dbA.getDbName()).thenReturn("sw360db");
+
+        DatabaseRepositoryCloudantClient<Component> repo = repoFor(dbA, Component.class);
+
+        repo.initStandardDesignDocument(emptyViews(), dbA);
+        repo.initStandardDesignDocument(emptyViews(), dbA);
+        repo.initStandardDesignDocument(emptyViews(), dbA);
+
+        verify(dbA, times(1)).putDesignDocument(any(DesignDocument.class), eq("Component"));
+    }
+
+    @Test
+    public void initStandardDesignDocument_runsForEachDistinctType() {
+        when(dbA.getDbName()).thenReturn("sw360db");
+
+        repoFor(dbA, Component.class).initStandardDesignDocument(emptyViews(), dbA);
+        repoFor(dbA, Project.class).initStandardDesignDocument(emptyViews(), dbA);
+
+        verify(dbA, times(1)).putDesignDocument(any(DesignDocument.class), eq("Component"));
+        verify(dbA, times(1)).putDesignDocument(any(DesignDocument.class), eq("Project"));
+    }
+
+    @Test
+    public void initStandardDesignDocument_runsOncePerDatabaseForSameType() {
+        when(dbA.getDbName()).thenReturn("sw360db");
+        when(dbB.getDbName()).thenReturn("sw360attachments");
+
+        DatabaseRepositoryCloudantClient<Component> repoA = repoFor(dbA, Component.class);
+        DatabaseRepositoryCloudantClient<Component> repoB = repoFor(dbB, Component.class);
+
+        repoA.initStandardDesignDocument(emptyViews(), dbA);
+        repoA.initStandardDesignDocument(emptyViews(), dbA);
+        repoB.initStandardDesignDocument(emptyViews(), dbB);
+        repoB.initStandardDesignDocument(emptyViews(), dbB);
+
+        verify(dbA, times(1)).putDesignDocument(any(DesignDocument.class), eq("Component"));
+        verify(dbB, times(1)).putDesignDocument(any(DesignDocument.class), eq("Component"));
+    }
+
+    @Test
+    public void createIndex_isExecutedOnceForSameTriple() {
+        when(dbA.getDbName()).thenReturn("sw360db");
+
+        DatabaseRepositoryCloudantClient<Component> repo = repoFor(dbA, Component.class);
+
+        repo.createIndex("compIdx", "byName", new String[]{"name"}, dbA);
+        repo.createIndex("compIdx", "byName", new String[]{"name"}, dbA);
+
+        verify(dbA, times(1)).createIndex(
+                any(IndexDefinition.class), eq("compIdx"), eq("byName"), eq("json"));
+    }
+
+    @Test
+    public void createIndex_runsForDistinctIndexNamesOnSameDdoc() {
+        when(dbA.getDbName()).thenReturn("sw360db");
+
+        DatabaseRepositoryCloudantClient<Component> repo = repoFor(dbA, Component.class);
+
+        repo.createIndex("compIdx", "byName", new String[]{"name"}, dbA);
+        repo.createIndex("compIdx", "byVendor", new String[]{"vendor"}, dbA);
+
+        verify(dbA, times(1)).createIndex(
+                any(IndexDefinition.class), eq("compIdx"), eq("byName"), eq("json"));
+        verify(dbA, times(1)).createIndex(
+                any(IndexDefinition.class), eq("compIdx"), eq("byVendor"), eq("json"));
+    }
+
+    @Test
+    public void createPartialTypeIndex_isExecutedOnceForSameTriple() {
+        when(dbA.getDbName()).thenReturn("sw360db");
+
+        DatabaseRepositoryCloudantClient<Component> repo = repoFor(dbA, Component.class);
+
+        repo.createPartialTypeIndex("compIdx", "byNameTyped", "component",
+                new String[]{"name"}, dbA);
+        repo.createPartialTypeIndex("compIdx", "byNameTyped", "component",
+                new String[]{"name"}, dbA);
+
+        verify(dbA, times(1)).createIndex(
+                any(IndexDefinition.class), eq("compIdx"), eq("byNameTyped"), eq("json"));
+    }
+
+    @Test
+    public void designDocAndIndexCachesAreIndependent() {
+        when(dbA.getDbName()).thenReturn("sw360db");
+
+        DatabaseRepositoryCloudantClient<Component> repo = repoFor(dbA, Component.class);
+
+        // Same ddocId reused for both APIs; design-doc init should not block index init.
+        repo.initStandardDesignDocument(emptyViews(), dbA);
+        repo.createIndex("Component", "byName", new String[]{"name"}, dbA);
+
+        verify(dbA, times(1)).putDesignDocument(any(DesignDocument.class), eq("Component"));
+        verify(dbA, times(1)).createIndex(
+                any(IndexDefinition.class), eq("Component"), eq("byName"), eq("json"));
+        verify(dbA, never()).createIndex(any(IndexDefinition.class), eq("Component"),
+                eq("nonexistent"), anyString());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <poi.version>5.5.1</poi.version>
     <project-lombok.version>1.18.46</project-lombok.version>
     <slf4j.version>2.0.18</slf4j.version>
-    <spotless.version>2.29.0</spotless.version>
+    <spotless.version>2.46.1</spotless.version>
     <spring-boot.version>4.0.6</spring-boot.version>
     <spring-restdocs.version>4.0.0</spring-restdocs.version>
     <spring-security-oauth2-authorization-server.version>7.0.5</spring-security-oauth2-authorization-server.version>
@@ -180,6 +180,16 @@
     <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
     <velocity-tools-generic.version>3.1</velocity-tools-generic.version>
     <saxon-dom.version>8.7</saxon-dom.version>
+
+    <!--
+      Tip used by the spotless-maven-plugin to limit checks/auto-formatting
+      to files that differ from this git revision. Defaults to `origin/main`
+      so an unmodified working tree on the default branch reports clean.
+      Override on the command line, e.g. `-Dspotless.ratchetFrom=HEAD~1` or
+      `-Dspotless.ratchetFrom=` (empty) to disable ratcheting and check the
+      whole repo.
+    -->
+    <spotless.ratchetFrom>origin/main</spotless.ratchetFrom>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -1041,6 +1051,40 @@
         <version>${maven-scm-plugin.version}</version>
         <configuration>
           <tag>${project.artifactId}-${project.version}</tag>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!--
+          Spotless enforces minimal, mechanical Java formatting rules. It is
+          configured with `ratchetFrom` so that only files that changed relative
+          to `${spotless.ratchetFrom}` (default `origin/main`) are inspected,
+          which lets us adopt formatting hygiene incrementally without a
+          one-shot reformat of the entire legacy codebase.
+
+          Usage:
+            mvn spotless:check    # verify changed files (used in pre-commit/CI)
+            mvn spotless:apply    # auto-fix changed files
+
+          Disable ratcheting (e.g. for full-repo audits):
+            mvn spotless:check -Dspotless.ratchetFrom=
+        -->
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <ratchetFrom>${spotless.ratchetFrom}</ratchetFrom>
+          <java>
+            <includes>
+              <include>src/main/java/**/*.java</include>
+              <include>src/test/java/**/*.java</include>
+            </includes>
+            <indent>
+              <spaces>true</spaces>
+              <spacesPerTab>4</spacesPerTab>
+            </indent>
+            <trimTrailingWhitespace/>
+            <endWithNewline/>
+          </java>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Use singleton format for creating the CouchDB design documents and Indexes only once. This gives performance boost for VMProcess which creates 100s of CouchDB connector, wasting time checking the not changed documents.

This change also pools the CouchDB Connections for VMProcessors.

Also, add spotless as a plugin to pom.xml with ratchetFrom mechanism against main branch since we are adopting it and don't want to fix the entire repo at once.

### Suggest Reviewer
@rudra-superrr @bibhuti230185

### How To Test?
1. Change a design document in CouchDB.
2. Start the backend.
3. The CouchDB design document should be updated.
4. Setup SVM sync, check the connection pool info.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR