### PR TITLE
feat(rest): add attachmentAuthor filter parameter to GET /projects 

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -740,6 +740,11 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {
                 if (Project._Fields.ADDITIONAL_DATA.getFieldName().equals(entry.getKey())) {
                     andConditions.add(all(entry.getKey(), entry.getValue().stream().toList()));
+                } else if (SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY.equals(entry.getKey())) {
+                    String value = entry.getValue().stream().findFirst().orElse("");
+                    if (!value.isEmpty()) {
+                        andConditions.add(elemMatch("attachments", eq("createdBy", value)));
+                    }
                 } else if (EMPTY_SEARCH_FIELDS.contains(entry.getKey())
                         && entry.getValue().contains(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN)) {
                     andConditions.add(buildEmptyProjectFieldRestriction(entry.getKey(), entry.getValue()));

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -93,6 +93,13 @@ public class ProjectSearchHandler {
                 "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
                 "      index('double', 'createdOn', Number(formattedDt), {'store': true});"+
                 "    }" +
+                "    if(doc.attachments && doc.attachments.length > 0) {" +
+                "      for(var i in doc.attachments) {" +
+                "        if(doc.attachments[i].createdBy) {" +
+                "          index('text', 'attachmentCreatedBy', doc.attachments[i].createdBy, {'store': true});" +
+                "        }" +
+                "      }" +
+                "    }" +
                 "}")
                     .setFieldAnalyzer(
                             Map.of("version", "keyword")

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -61,6 +61,7 @@ public class SW360Constants {
     public static final String RELEASE_IDS = "releaseIds";
     public static final String PACKAGE_IDS = "packageIds";
     public static final String PROJECT_SEARCH_EMPTY_TOKEN = "__EMPTY__";
+    public static final String PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY = "attachmentCreatedBy";
 
     // Proper values of the "type" member to deserialize to CouchDB
     public static final String TYPE_OBLIGATION = "obligation";

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -21,6 +21,7 @@ import org.apache.thrift.TFieldIdEnum;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationOptions;
@@ -1769,7 +1770,8 @@ public class RestControllerHelper<T> {
      */
     public static Map<String, Set<String>> getFilterMapForProject(
             String tag, String projectType, String group, String version, String projectResponsible,
-            ProjectState projectState, ProjectClearingState projectClearingState, String additionalData
+            ProjectState projectState, ProjectClearingState projectClearingState, String additionalData,
+            String attachmentAuthor
     ) {
         Map<String, Set<String>> filterMap = new HashMap<>();
         if (CommonUtils.isNotNullEmptyOrWhitespace(tag)) {
@@ -1795,6 +1797,9 @@ public class RestControllerHelper<T> {
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(additionalData)) {
             filterMap.put(Project._Fields.ADDITIONAL_DATA.getFieldName(), CommonUtils.splitToSet(additionalData));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(attachmentAuthor)) {
+            filterMap.put(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY, Collections.singleton(attachmentAuthor));
         }
         return filterMap;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -282,6 +282,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "clearingStatus", required = false) ProjectClearingState projectClearingState,
             @Parameter(description = "The additionalData of the project")
             @RequestParam(value = "additionalData", required = false) String additionalData,
+            @Parameter(description = "Filter by attachment author email (createdBy field of attachments)")
+            @RequestParam(value = "attachmentAuthor", required = false) String attachmentAuthor,
             @Parameter(description = "List project by lucene search")
             @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
             HttpServletRequest request
@@ -291,7 +293,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Map<PaginationData, List<Project>> paginatedProjects = null;
 
         Map<String, Set<String>> filterMap = RestControllerHelper.getFilterMapForProject(
-                tag, projectType, group, version, projectResponsible, projectState, projectClearingState, additionalData);
+                tag, projectType, group, version, projectResponsible, projectState, projectClearingState, additionalData, attachmentAuthor);
         if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
             Set<String> values = Collections.singleton(name);
             filterMap.put(Project._Fields.NAME.getFieldName(), values);
@@ -303,6 +305,12 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                         .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
                         .collect(Collectors.toSet());
                 filterMap.put(Project._Fields.NAME.getFieldName(), values);
+            }
+            if (filterMap.containsKey(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY)) {
+                Set<String> values = filterMap.get(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY).stream()
+                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
+                        .collect(Collectors.toSet());
+                filterMap.put(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY, values);
             }
 
             paginatedProjects = projectService.refineSearch(filterMap, sw360User, pageable);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -169,7 +169,7 @@ public class SW360ReportService {
             filterMap = RestControllerHelper.getFilterMapForProject(
                     reportBean.getTag(), reportBean.getType(), reportBean.getGroup(), reportBean.getVersion(),
                     reportBean.getProjectResponsible(), reportBean.getProjectState(), reportBean.getProjectClearingState(),
-                    reportBean.getAdditionalData()
+                    reportBean.getAdditionalData(), null
             );
             if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getName())) {
                 filterMap.put(Project._Fields.NAME.getFieldName(), CommonUtils.splitToSet(reportBean.getName()));


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Add backend support for filtering projects by attachment author via the new `attachmentAuthor` query parameter on `GET /projects`.

Front end PR https://github.com/eclipse-sw360/sw360-frontend/pull/1717

### What changed 

- Added `attachmentAuthor` request param handling in
  `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java`
- Extended project filter-map creation to include attachment author key in
  `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java`
- Added filter key constant in
  `libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java`
- Implemented Mango query restriction for attachments using `$elemMatch` on
  `attachments.createdBy` in
  `backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java`
- Extended project Lucene indexing/search support for attachment author in
  `backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java`
- Updated call-site compatibility in
  `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java`

### Behavior

- `GET /projects?attachmentAuthor=user@example.com`
  returns projects having at least one attachment with matching `createdBy`
- Works with other existing filters, sorting, and pagination
- Supports `luceneSearch=true` (wildcard/fuzzy-style matching) and
  `luceneSearch=false` (exact-style filtering path)
- Works with `allDetails=true` (embedded attachment data still returned)

### Dependencies

- No new dependencies added.

### Suggest Reviewer

@GMishx , @amritkv 

### How To Test?

1. Call:
   `GET /projects?attachmentAuthor=<email>&allDetails=true`
   and verify only matching projects are returned.
2. Combine with existing filters (for example `state`, `type`, `group`) and
   verify intersection behavior.
3. Verify pagination and sorting still work with `attachmentAuthor`.
4. Verify both:
   - `luceneSearch=true`
   - `luceneSearch=false`
5. (Important operational note) After deploying index-related changes, use a
   fresh redeploy/reindex state to avoid stale index artifacts.

### Checklist

Must:
- [x] All related issues are referenced in commit messages and in PR
- [ ] If code is AI-generated, mention the tool and model used (e.g., GitHub Copilot, GPT-4)