### PR TITLE
feat(rest): per-issuer jwk-set-uri override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,12 @@ ENV CLOUDANT_ENABLE_RETRIES="true"
 #
 # Spring controllers
 ENV ENABLE_DISKSPACE="false"
-ENV JWKS_ISSUER_URI="http://localhost:8080/authorization"
-ENV SW360_SECURITY_JWT_TRUSTED_ISSUERS="http://localhost:8080/authorization,http://localhost:8083/realms/sw360"
+# Trusted JWT issuers (Spring relaxed-binding to sw360.security.jwt.issuers[N]).
+# *_ISSUER_URI is required per slot; *_JWK_SET_URI is optional and, when set,
+# skips OpenID Connect discovery and fetches JWKS directly from that URL.
+ENV SW360_SECURITY_JWT_ISSUERS_0_ISSUER_URI="http://localhost:8080/authorization"
+ENV SW360_SECURITY_JWT_ISSUERS_1_ISSUER_URI="http://localhost:8083/realms/sw360"
+#ENV SW360_SECURITY_JWT_ISSUERS_1_JWK_SET_URI="http://localhost:8083/realms/sw360/protocol/openid-connect/certs"
 #
 # Email configs
 ENV EMAIL_PROPERTIES_HOST=""

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -64,16 +64,26 @@ file to tweak SW360 behaviour.
 
 **Spring Controllers**
 * `ENABLE_DISKSPACE`: Enable disk space health check (default: `false`).
-* `SW360_SECURITY_JWT_TRUSTED_ISSUERS`: Comma-separated JWT issuer URLs trusted
-    by the Resource Server (default:
-    `http://localhost:8080/authorization,http://localhost:8083/realms/sw360`).
-    Configure all issuers whose Bearer tokens the REST API should accept, for
-    example the built-in SW360 Authorization Server and Keycloak. Each value
-    must exactly match the token's `iss` claim and must be reachable from the
-    `sw360` container for issuer discovery/JWKS lookup.
-* `JWKS_ISSUER_URI`: Single issuer fallback URI (default:
-    `http://localhost:8080/authorization`). This is used only if
-    `sw360.security.jwt.trusted-issuers` is not generated/configured.
+* `SW360_SECURITY_JWT_ISSUERS_<N>_ISSUER_URI`: Public issuer URL for slot
+    `<N>` (0-based). Validated against the `iss` claim of incoming Bearer
+    tokens, so the value must exactly match the token issuer (scheme, host,
+    port, context path, trailing slash). Configure one slot per trusted
+    identity provider, e.g. the built-in SW360 Authorization Server and a
+    Keycloak realm. Defaults:
+    * `SW360_SECURITY_JWT_ISSUERS_0_ISSUER_URI=http://localhost:8080/authorization`
+    * `SW360_SECURITY_JWT_ISSUERS_1_ISSUER_URI=http://localhost:8083/realms/sw360`
+* `SW360_SECURITY_JWT_ISSUERS_<N>_JWK_SET_URI`: *(Optional)* JWKS endpoint URL
+    for slot `<N>`. When set, the resource server skips OpenID Connect
+    discovery and fetches JWKS directly from this URL. Useful when the
+    identity provider sits behind a reverse proxy with a self-signed or
+    privately-issued certificate; the resource server can reach the JWKS
+    endpoint over a loopback or internal URL while clients keep using the
+    public issuer URL. Leave unset to use discovery against `_ISSUER_URI`.
+
+    Both variables are bound directly to
+    `sw360.security.jwt.issuers[N].{issuer-uri,jwk-set-uri}` via Spring Boot's
+    relaxed environment-variable binding; nothing needs to be templated in
+    `application.yml`.
 
 **Email Configuration**
 * `EMAIL_PROPERTIES_HOST`: SMTP host (empty by default). Let it **empty** to

--- a/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/common/SVMUtils.java
+++ b/backend/vmcomponents/src/main/java/org/eclipse/sw360/vmcomponents/common/SVMUtils.java
@@ -69,7 +69,9 @@ public class SVMUtils {
                 throw new IOException(errorMessage);
             }
             String body = new String(response.getEntity().getContent().readAllBytes());
-            log.debug("Response from Server .... \n{}", body);
+            log.debug("Response from Server .... \n{}{}",
+                    body.substring(0, Math.min(500, body.length())),
+                    body.length() > 500 ? "..." : "");
             return body;
         });
     }

--- a/config/sw360/.env.backend
+++ b/config/sw360/.env.backend
@@ -20,10 +20,16 @@ CLOUDANT_ENABLE_RETRIES=true
 # Spring controllers
 #
 ENABLE_DISKSPACE=false
-# Single issuer fallback used when the trusted issuer list is not configured.
-JWKS_ISSUER_URI=http://localhost:8080/authorization
-# Comma-separated issuer URLs. Values must exactly match JWT `iss` claims.
-SW360_SECURITY_JWT_TRUSTED_ISSUERS=http://localhost:8080/authorization,http://localhost:8083/realms/sw360
+# Trusted JWT issuers. Spring Boot's relaxed env-var binding maps each pair
+# below to sw360.security.jwt.issuers[N].{issuer-uri, jwk-set-uri}.
+# `*_ISSUER_URI` is the public issuer URL (validated against the token's `iss`
+# claim). `*_JWK_SET_URI` is optional: when set, the resource server skips
+# OpenID Connect discovery and fetches JWKS directly from that URL (useful
+# when the identity provider sits behind a reverse proxy with a self-signed
+# or privately-issued certificate). Leave it unset to use discovery.
+SW360_SECURITY_JWT_ISSUERS_0_ISSUER_URI=http://localhost:8080/authorization
+SW360_SECURITY_JWT_ISSUERS_1_ISSUER_URI=http://localhost:8083/realms/sw360
+#SW360_SECURITY_JWT_ISSUERS_1_JWK_SET_URI=http://localhost:8083/realms/sw360/protocol/openid-connect/certs
 
 #
 # Email configs

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018,2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,14 +12,19 @@ package org.eclipse.sw360.rest.resourceserver.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.rest.resourceserver.core.SimpleAuthenticationEntryPoint;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationFilter;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationProvider;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360CustomUserDetailsService;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360UserAuthenticationProvider;
+import org.eclipse.sw360.rest.resourceserver.security.jwt.JwtIssuer;
 import org.eclipse.sw360.rest.resourceserver.security.jwt.Sw360JWTAccessTokenConverter;
 import org.eclipse.sw360.rest.resourceserver.security.jwt.Sw360JwtIssuerProperties;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -35,8 +40,12 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
@@ -44,9 +53,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
 
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -132,37 +141,58 @@ public class ResourceServerConfiguration {
 
     @Bean
     public AuthenticationManagerResolver<HttpServletRequest> jwtAuthenticationManagerResolver() {
-        Set<String> trustedIssuers = trustedIssuers();
+        Map<String, JwtIssuer> trustedIssuers = trustedIssuers();
         ConcurrentMap<String, AuthenticationManager> managers = new ConcurrentHashMap<>();
 
         return new JwtIssuerAuthenticationManagerResolver(issuer -> {
-            if (!trustedIssuers.contains(issuer)) {
+            JwtIssuer entry = trustedIssuers.get(issuer);
+            if (entry == null) {
                 throw new InvalidBearerTokenException("Invalid issuer");
             }
-            return managers.computeIfAbsent(issuer, this::jwtAuthenticationManagerForIssuer);
+            return managers.computeIfAbsent(issuer, key -> jwtAuthenticationManagerForIssuer(entry));
         });
     }
 
-    private AuthenticationManager jwtAuthenticationManagerForIssuer(String issuer) {
-        JwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(issuer);
+    @Contract("_ -> new")
+    private @NonNull AuthenticationManager jwtAuthenticationManagerForIssuer(JwtIssuer issuer) {
+        JwtDecoder jwtDecoder = buildJwtDecoder(issuer);
         JwtAuthenticationProvider jwtAuthenticationProvider = new JwtAuthenticationProvider(jwtDecoder);
         jwtAuthenticationProvider.setJwtAuthenticationConverter(sw360JWTAccessTokenConverter);
         return new ProviderManager(jwtAuthenticationProvider);
     }
 
-    private Set<String> trustedIssuers() {
-        Set<String> issuers = new LinkedHashSet<>();
-        jwtIssuerProperties.getTrustedIssuers().stream()
-                .filter(issuer -> issuer != null && !issuer.isBlank())
-                .map(String::trim)
-                .forEach(issuers::add);
-        if (issuers.isEmpty() && fallbackIssuerUri != null && !fallbackIssuerUri.isBlank()) {
-            issuers.add(fallbackIssuerUri.trim());
+    /**
+     * Build the {@link JwtDecoder} for a trusted issuer.
+     *
+     * <p>When {@link JwtIssuer#getJwkSetUri()} is provided, the decoder is built directly
+     * against the JWKS endpoint and the issuer claim is validated against
+     * {@link JwtIssuer#getIssuerUri()}. This skips OpenID Connect discovery.</p>
+     *
+     * <p>When {@link JwtIssuer#getJwkSetUri()} is absent, the decoder is built via
+     * discovery against {@link JwtIssuer#getIssuerUri()}, which requires the issuer URL
+     * to be reachable and TLS-trusted by the JVM.</p>
+     */
+    private JwtDecoder buildJwtDecoder(@NonNull JwtIssuer issuer) {
+        if (issuer.getJwkSetUri() != null && !issuer.getJwkSetUri().isBlank()) {
+            NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(issuer.getJwkSetUri()).build();
+            OAuth2TokenValidator<Jwt> validator = JwtValidators.createDefaultWithIssuer(issuer.getIssuerUri());
+            decoder.setJwtValidator(validator);
+            return decoder;
+        }
+        return JwtDecoders.fromIssuerLocation(issuer.getIssuerUri());
+    }
+
+    private @NonNull @Unmodifiable Map<String, JwtIssuer> trustedIssuers() {
+        Map<String, JwtIssuer> issuers = new LinkedHashMap<>(jwtIssuerProperties.getEffectiveIssuers());
+        if (issuers.isEmpty() && CommonUtils.isNotNullEmptyOrWhitespace(fallbackIssuerUri)) {
+            JwtIssuer fallback = new JwtIssuer();
+            fallback.setIssuerUri(fallbackIssuerUri.trim());
+            issuers.put(fallback.getIssuerUri(), fallback);
         }
         if (issuers.isEmpty()) {
             throw new IllegalStateException("No trusted JWT issuer configured for the SW360 resource server.");
         }
-        return Set.copyOf(issuers);
+        return Map.copyOf(issuers);
     }
 
     @Bean

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/JwtIssuer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/JwtIssuer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.security.jwt;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Structured trusted-issuer entry for the SW360 resource server.
+ *
+ * <p>When {@link #jwkSetUri} is left {@code null} or blank, the resource server falls
+ * back to OpenID Connect discovery against {@link #issuerUri} (via
+ * {@code JwtDecoders.fromIssuerLocation(...)}). This requires the issuer URL to be
+ * reachable from the resource server and its TLS certificate chain to be trusted by
+ * the JVM truststore.</p>
+ *
+ * <p>When {@link #jwkSetUri} is supplied, discovery is skipped entirely: a
+ * {@code NimbusJwtDecoder} is built directly against the JWKS endpoint, and the issuer
+ * claim is validated against {@link #issuerUri}.</p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class JwtIssuer {
+
+    /**
+     * Public issuer URL exactly as it appears in the JWT {@code iss} claim. This value is
+     * used as the lookup key when validating incoming tokens.
+     */
+    private String issuerUri;
+
+    /**
+     * Optional JWKS endpoint URL. When set, discovery is skipped and the JWKS is fetched
+     * directly from this URL.
+     */
+    private String jwkSetUri;
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JwtIssuerProperties.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JwtIssuerProperties.java
@@ -11,15 +11,49 @@ package org.eclipse.sw360.rest.resourceserver.security.jwt;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * Configuration properties driving multi-issuer JWT validation in the SW360 resource server.
+ *
+ * <p>{@code sw360.security.jwt.issuers}): list of {@link JwtIssuer} entries,
+ * each with an {@code issuer-uri} and an optional {@code jwk-set-uri}. Use
+ * {@code jwk-set-uri} to skip discovery and fetch JWKS directly from a loopback
+ * / internal URL (typical behind a reverse proxy).
+ * </p>
+ */
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "sw360.security.jwt")
 public class Sw360JwtIssuerProperties {
 
-    private List<String> trustedIssuers = new ArrayList<>();
+    private List<JwtIssuer> issuers = new ArrayList<>();
+
+    /**
+     * Resolve the effective issuer set as a map keyed by issuer URI, preserving insertion
+     * order. {@code null} or blank issuer URIs are skipped.
+     */
+    public Map<String, JwtIssuer> getEffectiveIssuers() {
+        Map<String, JwtIssuer> resolved = new LinkedHashMap<>();
+        if (issuers != null) {
+            for (JwtIssuer entry : issuers) {
+                if (entry == null || CommonUtils.isNullEmptyOrWhitespace(entry.getIssuerUri())) {
+                    continue;
+                }
+                JwtIssuer normalized = new JwtIssuer();
+                normalized.setIssuerUri(entry.getIssuerUri().trim());
+                String jwks = entry.getJwkSetUri();
+                // unset JWKS results into auto-discovery
+                normalized.setJwkSetUri(jwks == null || jwks.isBlank() ? null : jwks.trim());
+                resolved.put(normalized.getIssuerUri(), normalized);
+            }
+        }
+        return resolved;
+    }
 }

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 #
-# Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+# Copyright Siemens AG, 2017,2026. Part of the SW360 Portal Project.
 # Copyright Bosch.IO GmbH 2020
 #
 # This program and the accompanying materials are made
@@ -77,16 +77,16 @@ sw360:
   thrift-server-url: ${SW360_THRIFT_SERVER_URL:http://localhost:8080}
   base-url: ${SW360_BASE_URL:http://localhost:8080}
   frontend-url: ${SW360_FRONTEND_URL:http://localhost:3000}
-  test-user-id: admin@sw360.org
-  test-user-password: 12345
   couchdb-url: ${SW360_COUCHDB_URL:http://localhost:5984}
   cors:
     allowed-origin: ${SW360_CORS_ALLOWED_ORIGIN:#{null}}
   security:
     jwt:
-      trusted-issuers:
-        - http://localhost:8080/authorization
-        - http://localhost:8083/realms/sw360
+      # supply jwk-set-uri to skip discovery and fetch JWKS directly
+      issuers:
+        - issuer-uri: http://localhost:8080/authorization
+        - issuer-uri: http://localhost:8083/realms/sw360
+          jwk-set-uri: http://localhost:8083/realms/sw360/protocol/openid-connect/certs
     # Keep enabled for development/testing; set to false in production when
     # all clients authenticate via JWT or API token only.
     http-basic:

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JwtIssuerPropertiesTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JwtIssuerPropertiesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.security.jwt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Sw360JwtIssuerPropertiesTest {
+
+    @Test
+    void shouldReturnEmptyMap_whenNoIssuersConfigured() {
+        Sw360JwtIssuerProperties props = new Sw360JwtIssuerProperties();
+
+        Map<String, JwtIssuer> result = props.getEffectiveIssuers();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldMapStructuredIssuers_andNormalizeJwkSetUri() {
+        Sw360JwtIssuerProperties props = new Sw360JwtIssuerProperties();
+        JwtIssuer first = new JwtIssuer();
+        first.setIssuerUri("https://sw360.example.com/kc/realms/sw360");
+        first.setJwkSetUri("  http://localhost:8083/kc/realms/sw360/protocol/openid-connect/certs  ");
+        JwtIssuer second = new JwtIssuer();
+        second.setIssuerUri("http://localhost:8080/authorization");
+        second.setJwkSetUri("   "); // blank should be normalized to null
+        props.setIssuers(Arrays.asList(first, second));
+
+        Map<String, JwtIssuer> result = props.getEffectiveIssuers();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get("https://sw360.example.com/kc/realms/sw360").getJwkSetUri())
+                .isEqualTo("http://localhost:8083/kc/realms/sw360/protocol/openid-connect/certs");
+        assertThat(result.get("http://localhost:8080/authorization").getJwkSetUri()).isNull();
+    }
+
+    @Test
+    void shouldSkipStructuredEntries_withBlankOrNullIssuerUri() {
+        Sw360JwtIssuerProperties props = new Sw360JwtIssuerProperties();
+        JwtIssuer valid = new JwtIssuer();
+        valid.setIssuerUri("https://sw360.example.com/kc/realms/sw360");
+        JwtIssuer blank = new JwtIssuer();
+        blank.setIssuerUri("   ");
+        JwtIssuer nullIssuer = new JwtIssuer();
+        props.setIssuers(Arrays.asList(valid, blank, nullIssuer, null));
+
+        Map<String, JwtIssuer> result = props.getEffectiveIssuers();
+
+        assertThat(result).hasSize(1).containsKey("https://sw360.example.com/kc/realms/sw360");
+    }
+}

--- a/scripts/docker-config/etc_sw360/rest/application.yml.template
+++ b/scripts/docker-config/etc_sw360/rest/application.yml.template
@@ -50,12 +50,6 @@ spring:
     multipart:
       max-file-size: 500MB
       max-request-size: 600MB
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          # Single issuer fallback used when sw360.security.jwt.trusted-issuers is not configured.
-          issuer-uri: $JWKS_ISSUER_URI
 
 #logging:
 #  level:
@@ -81,9 +75,12 @@ sw360:
     # Production containers should authenticate via JWT or API token.
     http-basic:
       enabled: $SW360_SECURITY_HTTP_BASIC_ENABLED
-    jwt:
-      # Comma-separated Docker env value rendered as a YAML flow sequence.
-      trusted-issuers: [$SW360_SECURITY_JWT_TRUSTED_ISSUERS]
+    # Trusted JWT issuers are bound directly from environment variables using
+    # Spring Boot's relaxed binding rules; nothing needs to be templated here.
+    # For each issuer slot N, set:
+    #   SW360_SECURITY_JWT_ISSUERS_<N>_ISSUER_URI=<public issuer URL>
+    #   SW360_SECURITY_JWT_ISSUERS_<N>_JWK_SET_URI=<optional loopback JWKS URL>
+    # See README_DOCKER.md and Deploy-Configuration-Files.md for the full reference.
 
 blacklist:
   sw360:


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Adds `sw360.security.jwt.issuers[*]` with optional `jwk-set-uri`, which skips OpenID Connect discovery and fetches JWKS directly from a loopback / internal URL. Useful when the identity provider sits behind a reverse proxy with a self-signed certificate. Moves the test-only `sw360.test-user-*` properties out of the main application.yml.

### How To Test?
Setup the system and set the `jwk-set-uri`

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
