### PR TITLE
fix(obligations): add functionality to update obligations of all levels

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -817,15 +817,30 @@ public class SW360Utils {
     public static Map<String, ObligationStatusInfo> getProjectComponentOrganisationLicenseObligationToDisplay(
             Map<String, ObligationStatusInfo> obligationStatusMap, List<Obligation> obligations,
             ObligationLevel oblLevel, boolean addFromDB) {
+        return getProjectComponentOrganisationLicenseObligationToDisplay(obligationStatusMap, obligations,
+                EnumSet.of(oblLevel), addFromDB);
+    }
+
+    public static Map<String, ObligationStatusInfo> getProjectComponentOrganisationLicenseObligationToDisplay(
+            Map<String, ObligationStatusInfo> obligationStatusMap, List<Obligation> obligations, boolean addFromDB) {
+        return getProjectComponentOrganisationLicenseObligationToDisplay(obligationStatusMap, obligations,
+                EnumSet.of(ObligationLevel.PROJECT_OBLIGATION, ObligationLevel.COMPONENT_OBLIGATION,
+                        ObligationLevel.ORGANISATION_OBLIGATION),
+                addFromDB);
+    }
+
+    private static Map<String, ObligationStatusInfo> getProjectComponentOrganisationLicenseObligationToDisplay(
+            Map<String, ObligationStatusInfo> obligationStatusMap, List<Obligation> obligations,
+            Set<ObligationLevel> obligationLevels, boolean addFromDB) {
         Map<String, ObligationStatusInfo> obligationAlreadyPresent = obligationStatusMap.entrySet().stream()
                 .filter(Objects::nonNull).filter(e -> Objects.nonNull(e.getValue()))
                 .filter(e -> Objects.nonNull(e.getValue().getObligationLevel()))
-                .filter(e -> e.getValue().getObligationLevel().equals(oblLevel)).collect(Collectors.toMap(
+                .filter(e -> obligationLevels.contains(e.getValue().getObligationLevel())).collect(Collectors.toMap(
                         e -> e.getKey(), e -> e.getValue(), (oldValue, newValue) -> oldValue));
         obligationAlreadyPresent.entrySet().stream().forEach(e -> obligationStatusMap.remove(e.getKey()));
 
         Map<String, ObligationStatusInfo> mapOfObligations = obligations.stream().filter(Objects::nonNull)
-                .filter(o -> Objects.nonNull(o.getObligationLevel()) && oblLevel.equals(o.getObligationLevel()))
+                .filter(o -> Objects.nonNull(o.getObligationLevel()) && obligationLevels.contains(o.getObligationLevel()))
                 .filter(o -> addFromDB || obligationAlreadyPresent
                         .containsKey(CommonUtils.nullToEmptyString(o.getTitle()).replaceAll("\r\n", " ")))
                 .collect(Collectors.toMap(
@@ -835,7 +850,7 @@ public class SW360Utils {
                                 return obligationAlreadyPresent.remove(key);
                             } else {
                                 return new ObligationStatusInfo().setComment(o.getComments())
-                                        .setObligationLevel(oblLevel).setObligationType(o.getObligationType())
+                                        .setObligationLevel(o.getObligationLevel()).setObligationType(o.getObligationType())
                                         .setReleaseIdToAcceptedCLI(new HashMap<>()).setText(o.getText());
                             }
                         }, (oldValue, newValue) -> oldValue));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3979,8 +3979,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "Obligation Level",
                     schema = @Schema(allowableValues = {"project", "organization", "component", "all"}))
             @RequestParam(value = "obligationLevel", required = true) String oblLevel
-    ) throws TException {
-
+    ) {
         Map<String, ObligationStatusInfo> obligationStatusMap = new HashMap<>();
         try {
             final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -3989,8 +3988,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 Map<String, ObligationStatusInfo> filteredMap = requestBodyObligationStatusInfo.entrySet()
                         .stream()
                         .filter(entry -> entry.getValue() != null &&
-                                entry.getValue().getObligationLevel() != null &&
-                                !entry.getValue().getObligationLevel().toString().trim().isEmpty())
+                                entry.getValue().getObligationLevel() != null)
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
                 Map<String, ObligationStatusInfo> licenseObligationStatusMap = filteredMap.entrySet()
@@ -4029,7 +4027,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
             throw new DataIntegrityViolationException("Cannot update "+oblLevel+" Obligation");
         } catch (Exception e) {
-            log.error("Error updating {0} obligations: ", oblLevel ,e);
+            log.error("Error updating {0} obligations: {}", oblLevel ,e);
             throw new DataIntegrityViolationException("Failed to update "+oblLevel+"  Obligation: " + e.getMessage());
         }
     }
@@ -4096,7 +4094,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     ObligationStatusInfo statusInfo = requestBodyObligationStatusInfo.get(entry);
                     return statusInfo.getObligationLevel() == null;
                 })
-                .distinct()
                 .collect(Collectors.toSet())
                 .stream()
                 .allMatch(obligationStatusMap::containsKey);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3977,7 +3977,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "Map of obligation status info")
             @RequestBody Map<String, ObligationStatusInfo> requestBodyObligationStatusInfo ,
             @Parameter(description = "Obligation Level",
-                    schema = @Schema(allowableValues = {"project", "organization", "component"}))
+                    schema = @Schema(allowableValues = {"project", "organization", "component", "all"}))
             @RequestParam(value = "obligationLevel", required = true) String oblLevel
     ) throws TException {
 
@@ -3985,8 +3985,36 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         try {
             final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             restControllerHelper.throwIfSecurityUser(sw360User);
+            if ("all".equals(oblLevel)) {
+                Map<String, ObligationStatusInfo> filteredMap = requestBodyObligationStatusInfo.entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue() != null &&
+                                entry.getValue().getObligationLevel() != null &&
+                                !entry.getValue().getObligationLevel().toString().trim().isEmpty())
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-            obligationStatusMap = processObligations(id, sw360User, requestBodyObligationStatusInfo, oblLevel);
+                Map<String, ObligationStatusInfo> licenseObligationStatusMap = filteredMap.entrySet()
+                        .stream()
+                        .filter(entry -> ObligationLevel.LICENSE_OBLIGATION.equals(entry.getValue().getObligationLevel()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                Map<String, ObligationStatusInfo> otherObligationStatusMap = filteredMap.entrySet()
+                        .stream()
+                        .filter(entry -> !ObligationLevel.LICENSE_OBLIGATION.equals(entry.getValue().getObligationLevel()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                licenseObligationStatusMap = processLicenseObligations(id, sw360User, licenseObligationStatusMap);
+                otherObligationStatusMap = processObligations(id, sw360User, otherObligationStatusMap);
+
+                if (!CommonUtils.isNullOrEmptyMap(licenseObligationStatusMap)) {
+                    obligationStatusMap.putAll(licenseObligationStatusMap);
+                }
+                if (!CommonUtils.isNullOrEmptyMap(otherObligationStatusMap)) {
+                    obligationStatusMap.putAll(otherObligationStatusMap);
+                }
+            } else {
+                obligationStatusMap = processObligations(id, sw360User, requestBodyObligationStatusInfo, oblLevel);
+            }
             Map<String, ObligationStatusInfo> updatedObligationStatusMap = projectService
                     .compareObligationStatusMap(sw360User, obligationStatusMap, requestBodyObligationStatusInfo);
             Project sw360Project = projectService.getProjectForUserById(id, sw360User);
@@ -4044,6 +4072,42 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         return obligationStatusMap;
     }
 
+    private Map<String, ObligationStatusInfo> processObligations(
+            String projectId,
+            User sw360User,
+            Map<String, ObligationStatusInfo> requestBodyObligationStatusInfo) throws TException {
+        Project sw360Project = projectService.getProjectForUserById(projectId, sw360User);
+        if (hasLinkedObligations(sw360Project)) {
+            return processExistingObligations(sw360Project, sw360User, requestBodyObligationStatusInfo);
+        }
+        return updateProjectObligations(sw360Project, sw360User, new HashMap<>());
+    }
+
+    private Map<String, ObligationStatusInfo> processExistingObligations(
+            Project sw360Project,
+            User sw360User,
+            Map<String, ObligationStatusInfo> requestBodyObligationStatusInfo) throws TException {
+        ObligationList obligationList = projectService.getObligationData(sw360Project.getLinkedObligationId(), sw360User);
+        Map<String, ObligationStatusInfo> obligationStatusMap = CommonUtils.nullToEmptyMap(obligationList.getLinkedObligationStatus());
+
+        boolean allObligationsPresent = requestBodyObligationStatusInfo.keySet()
+                .stream()
+                .filter(entry -> {
+                    ObligationStatusInfo statusInfo = requestBodyObligationStatusInfo.get(entry);
+                    return statusInfo.getObligationLevel() == null;
+                })
+                .distinct()
+                .collect(Collectors.toSet())
+                .stream()
+                .allMatch(obligationStatusMap::containsKey);
+
+        if (!allObligationsPresent) {
+            return updateProjectObligations(sw360Project, sw360User, obligationStatusMap);
+        }
+
+        return obligationStatusMap;
+    }
+
     private Map<String, ObligationStatusInfo> updateProjectObligations(
             Project sw360Project,
             User sw360User,
@@ -4052,6 +4116,18 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
           Map<String, ObligationStatusInfo> updatedObligationStatusMap = projectService.setObligationsFromAdminSection(
                 sw360User, existingObligationStatusMap, sw360Project, oblLevel);
+
+        projectService.addLinkedObligations(sw360Project, sw360User, updatedObligationStatusMap);
+        return updatedObligationStatusMap;
+    }
+
+    private Map<String, ObligationStatusInfo> updateProjectObligations(
+            Project sw360Project,
+            User sw360User,
+            Map<String, ObligationStatusInfo> existingObligationStatusMap) throws TException {
+
+        Map<String, ObligationStatusInfo> updatedObligationStatusMap = projectService.setObligationsFromAdminSection(
+                sw360User, existingObligationStatusMap, sw360Project);
 
         projectService.addLinkedObligations(sw360Project, sw360User, updatedObligationStatusMap);
         return updatedObligationStatusMap;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -755,6 +755,17 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         } return updatedObligationStatusMap;
     }
 
+    public Map<String, ObligationStatusInfo> setObligationsFromAdminSection(User user, Map<String, ObligationStatusInfo> obligationStatusMap,
+                                                                            Project project) throws TException {
+        List<Obligation> obligations = SW360Utils.getObligations();
+        Map<String, ObligationStatusInfo> updatedObligationStatusMap = Maps.newHashMap();
+        ThriftClients thriftClients = new ThriftClients();
+        ComponentService.Iface componentClient = thriftClients.makeComponentClient();
+        updatedObligationStatusMap = SW360Utils.getProjectComponentOrganisationLicenseObligationToDisplay(
+                obligationStatusMap, obligations, true);
+        return updatedObligationStatusMap;
+    }
+
     public Map<String, ObligationStatusInfo> setLicenseInfoWithObligations(
             Map<String, ObligationStatusInfo> obligationStatusMap, Map<String, String> releaseIdToAcceptedCLI,
             List<Release> releases, User user) {


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Closes #4155
Added an option ```all``` for the parameter ```obligationLevel``` in the endpoint ```/{id}/updateObligation. The payload now must compulsarily have the option ```obligationLevel``` for it to be updated.

Issue: 4155

### How To Test?
Create a curl request updating obligations of more than one levels:
```
curl -X 'PATCH' \
  'http://localhost:8080/resource/api/projects/1308e0f092bc1ff58b96af832c6234ba/updateObligation?obligationLevel=project' \
  -H 'accept: application/vnd.hal+json' \
  -H 'Authorization: Basicxyz' \
  -H 'Content-Type: application/json' \
  -d '{
    "abc":{"status":"ESCALATED", "obligationLevel": "LICENSE_OBLIGATION"},
    "Org Obli1": {
      "status": "ESCALATED",
      "obligationLevel": "ORGANISATION_OBLIGATION"
    }
}'
```

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
