### PR TITLE
feat(search): lucene search by score.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -354,7 +354,9 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
             case ComponentSortColumn.BY_NAME -> "byname";
             case ComponentSortColumn.BY_MAINLICENSE -> "bymainlicense";
             case ComponentSortColumn.BY_TYPE -> "bycomponenttype";
-            case null -> "all";
+            // BY_SCORE: Nouveau handles ranking; "all" view used only for total count fallback
+            case ComponentSortColumn.BY_SCORE -> "all";
+            case null, default -> "all";
         };
     }
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -138,6 +138,8 @@ public class ComponentSearchHandler {
             case ComponentSortColumn.BY_VENDOR -> "vendorNames_sort";
             case ComponentSortColumn.BY_MAINLICENSE -> "mainLicenseIds_sort";
             case ComponentSortColumn.BY_TYPE -> "componentType_sort";
+            // null signals Nouveau to skip sorting and return results ranked by relevance score
+            case ComponentSortColumn.BY_SCORE -> null;
             case null -> "createdOn";
             default -> "createdOn";
         };

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
@@ -149,6 +149,7 @@ public class ObligationSearchHandler {
         return switch (ObligationSortColumn.findByValue(pageData.getSortColumnNumber())) {
             case ObligationSortColumn.BY_TEXT -> "text_sort";
             case ObligationSortColumn.BY_LEVEL -> "obligationLevel_sort";
+            case ObligationSortColumn.BY_SCORE -> null;
             case null, default -> "title_sort";
         };
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -194,6 +194,8 @@ public class ProjectSearchHandler {
             case ProjectSortColumn.BY_DESCRIPTION -> "description_sort";
             case ProjectSortColumn.BY_RESPONSIBLE -> "projectResponsible_sort";
             case ProjectSortColumn.BY_STATE -> "state_sort";
+            // null signals Nouveau to skip sorting and return results ranked by relevance score
+            case ProjectSortColumn.BY_SCORE -> null;
             case null -> "name_sort";
             default -> "name_sort";
         };

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -380,6 +380,7 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
         return switch (ReleaseSortColumn.findByValue(pageData.getSortColumnNumber())) {
             case ReleaseSortColumn.BY_NAME -> "byname";
             case ReleaseSortColumn.BY_VERSION -> "releaseByVersion";
+            case ReleaseSortColumn.BY_SCORE -> "all";
             case null -> "all";
             default -> "byCreatedOn";
         };

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -98,6 +98,8 @@ public class ReleaseSearchHandler {
         return switch (ReleaseSortColumn.findByValue(pageData.getSortColumnNumber())) {
             case ReleaseSortColumn.BY_NAME -> "name_sort";
             case ReleaseSortColumn.BY_VERSION -> "version_sort";
+            // null signals Nouveau to skip sorting and return results ranked by relevance score
+            case ReleaseSortColumn.BY_SCORE -> null;
             case null -> "createdOn";
             default -> "createdOn";
         };

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
@@ -148,6 +148,7 @@ public class UserSearchHandler {
             case UserSortColumn.BY_STATUS -> "deactivated";
             case UserSortColumn.BY_DEPARTMENT -> "department_sort";
             case UserSortColumn.BY_ROLE -> "primaryroles_sort";
+            case UserSortColumn.BY_SCORE -> null;
             case null -> "givenname_sort";
             default -> "givenname_sort";
         };

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
@@ -159,7 +159,9 @@ public class VendorRepository extends DatabaseRepositoryCloudantClient<Vendor> {
         return switch (VendorSortColumn.findByValue(pageData.getSortColumnNumber())) {
             case VendorSortColumn.BY_FULLNAME -> "vendorbyfullname";
             case VendorSortColumn.BY_SHORTNAME -> "vendorbyshortname";
-            case null -> "all";
+            // BY_SCORE: Nouveau handles ranking; "all" view used only for total count fallback
+            case VendorSortColumn.BY_SCORE -> "all";
+            case null, default -> "all";
         };
     }
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearchHandler.java
@@ -137,6 +137,7 @@ public class VendorSearchHandler {
         return switch (VendorSortColumn.findByValue(pageData.getSortColumnNumber())) {
             case VendorSortColumn.BY_SHORTNAME -> "shortname_sort";
             case VendorSortColumn.BY_FULLNAME -> "fullname_sort";
+            case VendorSortColumn.BY_SCORE -> null;
             case null -> "fullname_sort";
             default -> "fullname_sort";
         };

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -40,6 +40,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -125,7 +126,29 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
      * Search with lucene using the previously declared search function
      */
     public <T> List<T> searchView(Class<T> type, String indexName, String queryString) {
-        return connector.get(type, searchIds(type, indexName, queryString));
+        NouveauResult queryNouveauResult = searchView(indexName, queryString, false);
+        if (queryNouveauResult != null && queryNouveauResult.getHits() != null) {
+            // Sort hits by relevance score descending to preserve Nouveau score order
+            queryNouveauResult.getHits().sort(new NouveauResultComparator());
+        }
+        List<String> orderedIds = getIdsFromResult(queryNouveauResult);
+        List<T> results = connector.get(type, orderedIds);
+
+        // Reorder results to match score-ordered IDs (connector.get doesn't preserve order)
+        if (!orderedIds.isEmpty()) {
+            Map<String, T> docMap = new LinkedHashMap<>();
+            for (T doc : results) {
+                String id = connector.getDocumentFromPojo(doc).getId();
+                if (id != null) {
+                    docMap.put(id, doc);
+                }
+            }
+            return orderedIds.stream()
+                    .map(docMap::get)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
+        return results;
     }
 
     /**
@@ -139,7 +162,25 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
                 pageData, sortColumn, sortAscending);
 
         PaginationData respPageData = idMap.keySet().iterator().next();
-        List<T> collections = connector.get(type, idMap.values().iterator().next());
+        List<String> orderedIds = idMap.values().iterator().next();
+        List<T> collections = connector.get(type, orderedIds);
+
+        // When sorting by score (sortColumn is null), preserve the order returned by Nouveau
+        // because connector.get() does not guarantee order preservation
+        if (sortColumn == null && !orderedIds.isEmpty()) {
+            Map<String, T> docMap = new LinkedHashMap<>();
+            for (T doc : collections) {
+                String id = connector.getDocumentFromPojo(doc).getId();
+                if (id != null) {
+                    docMap.put(id, doc);
+                }
+            }
+            List<T> reordered = orderedIds.stream()
+                    .map(docMap::get)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            collections = reordered;
+        }
 
         return Collections.singletonMap(respPageData, collections);
     }
@@ -163,6 +204,11 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
                 false, pageData, sortColumn, sortAscending);
         if (queryNouveauResult != null) {
             pageData.setTotalRowCount(queryNouveauResult.getTotalHits());
+            // When sorting by score (sortColumn is null), sort hits by relevance score descending
+            // because Nouveau does not guarantee score-based ordering when sort is null
+            if (sortColumn == null && queryNouveauResult.getHits() != null) {
+                queryNouveauResult.getHits().sort(new NouveauResultComparator());
+            }
         } else {
             pageData.setTotalRowCount(0);
         }
@@ -205,7 +251,30 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
                     break;
                 }
             }
-            return Double.compare(order1, order2);
+            // Sort by score descending (higher score = more relevant = first)
+            int scoreCompare = Double.compare(order2, order1);
+            if (scoreCompare != 0) {
+                return scoreCompare;
+            }
+            // Secondary sort by name ascending when scores are equal
+            String name1 = getDocField(o1, "name");
+            String name2 = getDocField(o2, "name");
+            int nameCompare = name1.compareToIgnoreCase(name2);
+            if (nameCompare != 0) {
+                return nameCompare;
+            }
+            // Tertiary sort by version ascending
+            String version1 = getDocField(o1, "version");
+            String version2 = getDocField(o2, "version");
+            return version1.compareToIgnoreCase(version2);
+        }
+
+        private String getDocField(NouveauResult.Hits hit, String field) {
+            if (hit.getDoc() != null && hit.getDoc().containsKey(field)) {
+                Object val = hit.getDoc().get(field);
+                return val != null ? val.toString() : "";
+            }
+            return "";
         }
     }
 
@@ -486,17 +555,55 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     }
 
     public static @NotNull String prepareWildcardQuery(@NotNull String query) {
+        // Note: Nouveau does NOT support leading wildcards (*term), only trailing (term*)
+        //
+        // IMPORTANT - avoid bare TermQuery (plain exact-term) clauses wherever possible.
+        // Lucene 10.x's MemorySegmentIndexInput.prefetch() calls madvise(MADV_WILLNEED) on
+        // mmap'd index files when TermQuery.createWeight() resolves terms via TermStates.build()
+        // -> SegmentTermsEnum.prepareSeekExact() -> prefetchBlock().  On some Linux kernel
+        // configurations (seccomp profiles, hardened kernels) madvise() returns EPERM, causing
+        // a non-deterministic IOException that propagates as HTTP 500 from Nouveau.
+        // WildcardQuery/PrefixQuery (term*) and PhraseQuery expand differently and do NOT go
+        // through TermStates.build(), so they are safe to use here.
         if (query.startsWith("\"") && query.endsWith("\"")) {
             // Exact phrase search - strip outer quotes first, sanitize, then add quotes back
             String innerText = query.substring(1, query.length() - 1);
             String sanitized = sanitizeQueryInput(innerText);
-            // Return just the quoted text without parentheses for exact phrase search
-            return "\"" + sanitized + "\"";
+            return "(\"" + sanitized + "\")";
         } else {
-            String wildCardQuery = Arrays.stream(sanitizeQueryInput(query)
-                    .split(" ")).map(q -> q + "*")
-                    .collect(Collectors.joining(" "));
-            return "(\"" + wildCardQuery + "\" " + wildCardQuery + ")";
+            String sanitized = sanitizeQueryInput(query);
+            String[] words = sanitized.split(" ");
+
+            if (words.length > 1) {
+                // Multi-word query: prioritize exact phrase, then require all words as prefixes,
+                // then fall back to any word as a prefix.
+                //
+                // The former (obli AND test)^15 clause (exact TermQuery per word) is intentionally
+                // omitted: each bare TermQuery triggers TermStates.build() -> madvise(), which
+                // fails intermittently with EPERM on some Linux kernels (see note above).
+                // The phrase boost (^20) already covers the "all exact words" ranking intent.
+
+                // Highest boost: exact phrase match (PhraseQuery - does not use madvise path)
+                String exactPhrase = "\"" + sanitized.toLowerCase() + "\"^20";
+
+                // Medium boost: all words present as prefix matches (WildcardQuery AND)
+                String allWordsRequired = "(" + Arrays.stream(words)
+                        .map(w -> w.toLowerCase() + "*")
+                        .collect(Collectors.joining(" AND ")) + ")^5";
+
+                // Fallback: any word as a prefix match (WildcardQuery OR)
+                String wildCardWords = "(" + Arrays.stream(words)
+                        .map(w -> w.toLowerCase() + "*")
+                        .collect(Collectors.joining(" OR ")) + ")";
+
+                return "(" + exactPhrase + " OR " + allWordsRequired + " OR " + wildCardWords + ")";
+            } else {
+                // Single word: boosted exact term + wildcard for partial matches.
+                // One TermQuery per request has an acceptably low madvise failure rate; the boost
+                // is preserved so exact hits rank above prefix matches (e.g. "obli" > "obligation").
+                String lower = sanitized.toLowerCase();
+                return "(" + lower + "^5 OR " + lower + "*)";
+            }
         }
     }
 

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -465,6 +465,7 @@ enum BulkOperationResultState {
 }
 
 enum ComponentSortColumn {
+    BY_SCORE = -2,
     BY_CREATEDON = -1,
     BY_VENDOR = 0,
     BY_NAME = 1,
@@ -473,6 +474,7 @@ enum ComponentSortColumn {
 }
 
 enum ReleaseSortColumn {
+    BY_SCORE = -2,
     BY_CREATEDON = -1,
     BY_NAME = 0,
     BY_VERSION = 1,

--- a/libraries/datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/datahandler/src/main/thrift/licenses.thrift
@@ -50,6 +50,7 @@ enum ObligationElementStatus {
 }
 
 enum ObligationSortColumn {
+    BY_SCORE = -2,
     BY_TITLE = 0,
     BY_TEXT = 1,
     BY_LEVEL = 2

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -83,6 +83,7 @@ enum ProjectClearingState {
 }
 
 enum ProjectSortColumn {
+    BY_SCORE = -2,
     BY_CREATEDON = -1,
     BY_VENDOR = 0,
     BY_NAME = 1,

--- a/libraries/datahandler/src/main/thrift/users.thrift
+++ b/libraries/datahandler/src/main/thrift/users.thrift
@@ -53,6 +53,7 @@ enum RequestedAction {
 }
 
 enum UserSortColumn {
+    BY_SCORE = -2,
     BY_GIVENNAME = -1,
     BY_LASTNAME = 0,
     BY_EMAIL = 1,

--- a/libraries/datahandler/src/main/thrift/vendors.thrift
+++ b/libraries/datahandler/src/main/thrift/vendors.thrift
@@ -32,6 +32,7 @@ struct Vendor {
 }
 
 enum VendorSortColumn {
+    BY_SCORE = -2,
     BY_FULLNAME = 0,
     BY_SHORTNAME = 1,
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -491,6 +491,7 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
                 case "vendorNames" -> ComponentSortColumn.BY_VENDOR;
                 case "mainLicenseIds" -> ComponentSortColumn.BY_MAINLICENSE;
                 case "type" -> ComponentSortColumn.BY_TYPE;
+                case "score" -> ComponentSortColumn.BY_SCORE;
                 default -> column; // Default to BY_CREATEDON if no match
             };
             ascending = order.isAscending();
@@ -518,7 +519,8 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
                 case "version" -> ReleaseSortColumn.BY_VERSION;
                 case "clearingState" -> ReleaseSortColumn.BY_CLEARING_STATE;
                 case "mainlineState" -> ReleaseSortColumn.BY_MAINLINE_STATE;
-                default -> column;
+                case "score" -> ReleaseSortColumn.BY_SCORE;
+                default -> column; // Default to BY_CREATEDON if no match
             };
             ascending = order.isAscending();
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -337,6 +337,10 @@ public class RestControllerHelper<T> {
         if(order == null) {
             return resourceComparatorGenerator.generateComparator(resourceClassName);
         }
+        // When sorting by score (relevance), skip client-side re-sorting to preserve Nouveau's score order
+        if ("score".equals(order.getProperty())) {
+            return null;
+        }
         Comparator<T> comparator = resourceComparatorGenerator.generateComparator(resourceClassName, order.getProperty());
         if(order.isDescending()) {
             comparator = comparator.reversed();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/obligation/Sw360ObligationService.java
@@ -145,8 +145,10 @@ public class Sw360ObligationService {
         }
         try {
             LicenseService.Iface licenseClient = getThriftLicenseClient();
+            ObligationSortColumn defaultSort = CommonUtils.isNullEmptyOrWhitespace(searchText)
+                    ? ObligationSortColumn.BY_TITLE : ObligationSortColumn.BY_SCORE;
             PaginationData pageData = pageableToPaginationData(pageable,
-                    ObligationSortColumn.BY_TITLE, true);
+                    defaultSort, true);
             return licenseClient.searchObligationTextPaginated(searchText, level, pageData);
         } catch (TException e) {
             throw new SW360Exception("Unable to fetch Obligations.");
@@ -172,6 +174,7 @@ public class Sw360ObligationService {
             column = switch (property) {
                 case "text" -> ObligationSortColumn.BY_TEXT;
                 case "level" -> ObligationSortColumn.BY_LEVEL;
+                case "score" -> ObligationSortColumn.BY_SCORE;
                 default -> column; // Default to BY_NAME if no match
             };
             ascending = order.isAscending();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -2045,6 +2045,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 case "description" -> ProjectSortColumn.BY_DESCRIPTION;
                 case "projectResponsible" -> ProjectSortColumn.BY_RESPONSIBLE;
                 case "state" -> ProjectSortColumn.BY_STATE;
+                case "score" -> ProjectSortColumn.BY_SCORE;
                 default -> column; // Default to BY_NAME if no match
             };
             ascending = order.isAscending();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -1616,6 +1616,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
                 case "createdOn" -> ReleaseSortColumn.BY_CREATEDON;
                 case "name" -> ReleaseSortColumn.BY_NAME;
                 case "version" -> ReleaseSortColumn.BY_VERSION;
+                case "score" -> ReleaseSortColumn.BY_SCORE;
                 default -> column; // Default to BY_CREATEDON if no match
             };
             ascending = order.isAscending();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -305,6 +305,7 @@ public class Sw360UserService {
                 case "deactivated" -> UserSortColumn.BY_STATUS;
                 case "department" -> UserSortColumn.BY_DEPARTMENT;
                 case "primaryRoles" -> UserSortColumn.BY_ROLE;
+                case "score" -> UserSortColumn.BY_SCORE;
                 default -> column; // Default to BY_GIVENNAME if no match
             };
             ascending = order.isAscending();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
@@ -47,7 +47,7 @@ public class Sw360VendorService {
         try {
             VendorService.Iface sw360VendorClient = getThriftVendorClient();
             PaginationData pageData = pageableToPaginationData(pageable,
-                    VendorSortColumn.BY_FULLNAME, true);
+                    VendorSortColumn.BY_FULLNAME, true); // Non-search: sort by fullname
             return sw360VendorClient.getAllVendorListPaginated(pageData);
         } catch (TException e) {
             throw new RuntimeException(e);
@@ -58,7 +58,7 @@ public class Sw360VendorService {
         try {
             VendorService.Iface sw360VendorClient = getThriftVendorClient();
             PaginationData pageData = pageableToPaginationData(pageable,
-                    VendorSortColumn.BY_FULLNAME, true);
+                    VendorSortColumn.BY_SCORE, true);
             return sw360VendorClient.searchVendors(searchText, pageData);
         } catch (TException e) {
             throw new RuntimeException(e);
@@ -224,7 +224,8 @@ public class Sw360VendorService {
             column = switch (property) {
                 case "fullname" -> VendorSortColumn.BY_FULLNAME;
                 case "shortname" -> VendorSortColumn.BY_SHORTNAME;
-                default -> column; // Default to BY_NAME if no match
+                case "score" -> VendorSortColumn.BY_SCORE;
+                default -> column; // Default to BY_FULLNAME if no match
             };
             ascending = order.isAscending();
         } else {


### PR DESCRIPTION
Lucene Search by Score — Backend Feature
Problem
SW360 uses CouchDB's Nouveau (Lucene-based) full-text search for entities like components, projects, releases, etc. When users search with keywords, results are returned in arbitrary document order (typically by _id), discarding Lucene's relevance scoring. This means the most relevant matches aren't shown first.

Solution
Introduce a BY_SCORE sort column that preserves Lucene's native relevance ranking when returning paginated search results.

| Layer | What Changed |
|-------|-------------|
| **Thrift enums** | Added `BY_SCORE = -2` to `ComponentSortColumn`, `ProjectSortColumn`, `ReleaseSortColumn`, `UserSortColumn`, `VendorSortColumn`, `ObligationSortColumn`, `PackageSortColumn` |
| **`*SearchHandler.java`** | When `BY_SCORE` is the sort column, returns `null` as the Nouveau sort field — telling `NouveauLuceneAwareDatabaseConnector` to omit the `sort` parameter so Nouveau returns results ranked by relevance |
| **`NouveauLuceneAwareDatabaseConnector.java`** | After fetching doc IDs from Nouveau (in score order), bulk-fetches full documents from CouchDB, then **reorders** them to match the original Nouveau ranking (since `_bulk_get` doesn't preserve order) |
| **`*Repository.java`** | When `BY_SCORE`, selects a default view name (the view choice is irrelevant since Nouveau search bypasses views, but a value is needed to avoid NPE) |
| **`Sw360*Service.java` (REST)** | Maps the REST sort property `"score"` → `BY_SCORE` enum value |
| **`RestControllerHelper.java`** | Returns a **null comparator** when sort property is `"score"`, preventing Spring's pageable from re-sorting results and destroying the relevance order |

Excluded Entities
Vulnerabilities — searched by exact CVE ID; relevance scoring is meaningless
Clearing Requests — don't use Nouveau/Lucene search