### PR TITLE
fix(lucene): remove leading wildcard configuration.

### DIFF
--- a/build-configuration/resources/couchdb.properties
+++ b/build-configuration/resources/couchdb.properties
@@ -21,11 +21,6 @@ couchdb.config = sw360config
 couchdb.vulnerability_management = sw360vm
 lucenesearch.limit = 150
 
-# FIXME: Look for alternatives
-# Warning: Nouveau currently does not support use of leading wildcards.
-# see more: https://wiki.apache.org/lucene-java/LuceneFAQ#What_wildcard_search_support_is_available_from_Lucene.3F
-lucenesearch.leading.wildcard = false
-
 # Use retires from cloudant
 cloudant.enable.retries = true
 # How many retries before failure

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/DatabaseSettings.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/DatabaseSettings.java
@@ -43,7 +43,6 @@ public class DatabaseSettings {
     public static final boolean COUCH_DB_CACHE;
 
     public static final int LUCENE_SEARCH_LIMIT;
-    public static final boolean LUCENE_LEADING_WILDCARD;
 
     public static final boolean CLOUDANT_ENABLE_RETRIES;
     public static final int CLOUDANT_MAX_RETRIES;
@@ -75,8 +74,6 @@ public class DatabaseSettings {
         COUCH_DB_CACHE = Boolean.parseBoolean(props.getProperty("couchdb.cache", "true"));
 
         LUCENE_SEARCH_LIMIT = Integer.parseInt(props.getProperty("lucenesearch.limit", "25"));
-        LUCENE_LEADING_WILDCARD =
-                Boolean.parseBoolean(props.getProperty("lucenesearch.leading.wildcard", "false"));
 
         CLOUDANT_ENABLE_RETRIES = Boolean.parseBoolean(props.getProperty("cloudant.enable.retries", "true"));
         CLOUDANT_MAX_RETRIES = Integer.parseInt(props.getProperty("cloudant.max.retries", "2"));

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -486,7 +486,6 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     }
 
     public static @NotNull String prepareWildcardQuery(@NotNull String query) {
-        String leadingWildcardChar = DatabaseSettings.LUCENE_LEADING_WILDCARD ? "*" : "";
         if (query.startsWith("\"") && query.endsWith("\"")) {
             // Exact phrase search - strip outer quotes first, sanitize, then add quotes back
             String innerText = query.substring(1, query.length() - 1);
@@ -495,7 +494,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             return "\"" + sanitized + "\"";
         } else {
             String wildCardQuery = Arrays.stream(sanitizeQueryInput(query)
-                    .split(" ")).map(q -> leadingWildcardChar + q + "*")
+                    .split(" ")).map(q -> q + "*")
                     .collect(Collectors.joining(" "));
             return "(\"" + wildCardQuery + "\" " + wildCardQuery + ")";
         }

--- a/scripts/docker-config/couchdb.properties.template
+++ b/scripts/docker-config/couchdb.properties.template
@@ -19,10 +19,6 @@ couchdb.config = sw360config
 couchdb.vulnerability_management = sw360vm
 lucenesearch.limit = $COUCHDB_LUCENESEARCH_LIMIT
 
-# Warning: Nouveau currently does not support use of leading wildcards.
-# see more: https://wiki.apache.org/lucene-java/LuceneFAQ#What_wildcard_search_support_is_available_from_Lucene.3F
-lucenesearch.leading.wildcard = false
-
 # Use retires from cloudant
 cloudant.enable.retries = $CLOUDANT_ENABLE_RETRIES
 # How many retries before failure

--- a/scripts/docker-config/docker-entrypoint-keycloak.sh
+++ b/scripts/docker-config/docker-entrypoint-keycloak.sh
@@ -23,7 +23,6 @@ couchdb.change_logs = sw360changelogs\n\
 couchdb.config = sw360config\n\
 couchdb.vulnerability_management = sw360vm\n\
 lucenesearch.limit = %d\n\
-lucenesearch.leading.wildcard = false\n\
 cloudant.enable.retries = %s\n\
 cloudant.max.retries = 2\n\
 cloudant.max.retry.interval = 5\n" \


### PR DESCRIPTION
Description
SW360 previously had a configurable lucenesearch.leading.wildcard property that could enable leading wildcard queries (e.g., *term*). However, CouchDB's Nouveau (Lucene-based search) does not support leading wildcards — they cause query parse errors and search failures.

Despite the property being hardcoded to false, the configuration and code still existed, creating confusion and risk that someone might enable it expecting it to work.

Solution
Removed the lucenesearch.leading.wildcard property and all associated code entirely:

[couchdb.properties](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed property and comment
[couchdb.properties.template](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed property and comment
[docker-entrypoint-keycloak.sh](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed property line
[DatabaseSettings.java](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed LUCENE_LEADING_WILDCARD field and initialization
[NouveauLuceneAwareDatabaseConnector.java](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — simplified [prepareWildcardQuery()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to always use trailing wildcards only (term*)

Queries now unconditionally use trailing wildcards (term*), which Nouveau fully supports.