### PR TITLE
fix(report): Encode Content-Disposition filename and reduce debug log verbosity

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -263,7 +263,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 selectedData.add(stringResult);
             }
         }
-        log.debug("Resulting string: {}", selectedData);
+        log.trace("Resulting string: {}", selectedData);
         return selectedData;
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -14,7 +14,9 @@ import static org.eclipse.sw360.datahandler.common.SW360Constants.XML_FILE_EXTEN
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 
@@ -40,7 +42,8 @@ import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
+import org.eclipse.sw360.rest.resourceserver.core
+        .BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
@@ -401,7 +404,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             if (null == buff) {
                 throw new TException("No data available for the user " + user.getEmail());
             }
-            response.setHeader(CONTENT_DISPOSITION, String.format(ATTACHMENT_FILENAME_S, fileName));
+            setContentDisposition(response, fileName);
             copyDataStreamToResponse(response, buff);
         } catch (ResourceNotFoundException e) {
             throw e;
@@ -435,6 +438,18 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
 
     private void copyDataStreamToResponse(HttpServletResponse response, ByteBuffer buffer) throws IOException {
         FileCopyUtils.copy(buffer.array(), response.getOutputStream());
+    }
+
+    private void setContentDisposition(HttpServletResponse response, String fileName) {
+        if (fileName == null || fileName.isEmpty()) {
+            response.setHeader(CONTENT_DISPOSITION, "attachment");
+            return;
+        }
+        String asciiName = fileName.replaceAll("[^\\x20-\\x7E]", "_");
+        String encodedName = URLEncoder.encode(fileName, StandardCharsets.UTF_8)
+                .replace("+", "%20");
+        response.setHeader(CONTENT_DISPOSITION,
+                "attachment; filename=\"" + asciiName + "\"; filename*=UTF-8''" + encodedName);
     }
 
     private void setContentTypeForFormat(HttpServletResponse response, String format) {
@@ -500,7 +515,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                 throw new TException("No data available for the user " + user.getEmail());
             }
             response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
-            response.setHeader(CONTENT_DISPOSITION, String.format(ATTACHMENT_FILENAME_S, fileName));
+            setContentDisposition(response, fileName);
             copyDataStreamToResponse(response, buffer);
         } catch (ResourceNotFoundException e) {
             throw e;
@@ -531,7 +546,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             if (SW360Constants.XML_FILE_EXTENSION.equalsIgnoreCase(reportBean.getBomType())) {
                 response.setContentType(SW360Constants.CONTENT_TYPE_XML);
             }
-            response.setHeader(CONTENT_DISPOSITION, String.format(ATTACHMENT_FILENAME_S, fileName));
+            setContentDisposition(response, fileName);
             copyDataStreamToResponse(response, ByteBuffer.wrap(buff.getBytes()));
         }
         catch (AccessDeniedException e) {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReportTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReportTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.integration;
+
+import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(SpringRunner.class)
+public class ReportTest extends TestIntegrationBase {
+
+    @LocalServerPort
+    private int port;
+
+    @MockitoBean
+    private SW360ReportService sw360ReportServiceMock;
+
+    @Before
+    public void before() throws Exception {
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org"))
+                .willReturn(TestHelper.getTestUser());
+
+        ByteBuffer dummyBuffer = ByteBuffer.wrap("dummy content".getBytes());
+
+        given(sw360ReportServiceMock.getLicenseInfoBuffer(any(), eq("project123"), any()))
+                .willReturn(dummyBuffer);
+
+        // Return a filename with non-ASCII characters (™ symbol)
+        given(sw360ReportServiceMock.getGenericLicInfoFileName(any(), eq("project123"), any(), any()))
+                .willReturn("LicenseInfo-Gridscale X\u2122 Protection-1.2.1-2026-05-16_16_09_30.docx");
+    }
+
+    @Test
+    public void should_return_report_with_valid_content_disposition_for_unicode_project_name() throws Exception {
+        HttpHeaders headers = getHeaders(port);
+        String url = "http://localhost:" + port + "/api/reports"
+                + "?module=licenseInfo"
+                + "&projectId=project123"
+                + "&generatorClassName=DocxGenerator"
+                + "&variant=REPORT";
+
+        ResponseEntity<byte[]> response = new TestRestTemplate().exchange(
+                url,
+                HttpMethod.GET,
+                new HttpEntity<>(null, headers),
+                byte[].class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        String contentDisposition = response.getHeaders().getFirst("Content-Disposition");
+        assertNotNull("Content-Disposition header should be present", contentDisposition);
+        // ASCII fallback should have non-ASCII replaced with underscore
+        assertTrue("Should contain ASCII fallback filename",
+                contentDisposition.contains("filename=\"LicenseInfo-Gridscale X_ Protection-1.2.1-2026-05-16_16_09_30.docx\""));
+        // RFC 5987 encoded filename should be present
+        assertTrue("Should contain RFC 5987 filename*",
+                contentDisposition.contains("filename*=UTF-8''"));
+        // Should contain URL-encoded trademark symbol
+        assertTrue("Should contain encoded TM symbol",
+                contentDisposition.contains("%E2%84%A2"));
+    }
+
+    @Test
+    public void should_return_report_with_ascii_only_project_name() throws Exception {
+        given(sw360ReportServiceMock.getGenericLicInfoFileName(any(), eq("projectAscii"), any(), any()))
+                .willReturn("LicenseInfo-SimpleProject-1.0-2026-05-16.docx");
+
+        ByteBuffer dummyBuffer = ByteBuffer.wrap("dummy content".getBytes());
+        given(sw360ReportServiceMock.getLicenseInfoBuffer(any(), eq("projectAscii"), any()))
+                .willReturn(dummyBuffer);
+
+        HttpHeaders headers = getHeaders(port);
+        String url = "http://localhost:" + port + "/api/reports"
+                + "?module=licenseInfo"
+                + "&projectId=projectAscii"
+                + "&generatorClassName=DocxGenerator"
+                + "&variant=REPORT";
+
+        ResponseEntity<byte[]> response = new TestRestTemplate().exchange(
+                url,
+                HttpMethod.GET,
+                new HttpEntity<>(null, headers),
+                byte[].class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        String contentDisposition = response.getHeaders().getFirst("Content-Disposition");
+        assertNotNull("Content-Disposition header should be present", contentDisposition);
+        assertTrue("Should contain the original filename",
+                contentDisposition.contains("filename=\"LicenseInfo-SimpleProject-1.0-2026-05-16.docx\""));
+        assertTrue("Should contain RFC 5987 filename*",
+                contentDisposition.contains("filename*=UTF-8''"));
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportControllerContentDispositionTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportControllerContentDispositionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.report;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SW360ReportControllerContentDispositionTest {
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private RestControllerHelper restControllerHelper;
+
+    @Mock
+    private SW360ReportService sw360ReportService;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private SW360ReportController controller;
+
+    private Method setContentDispositionMethod;
+
+    @Before
+    public void setUp() throws Exception {
+        setContentDispositionMethod = SW360ReportController.class
+                .getDeclaredMethod("setContentDisposition", HttpServletResponse.class, String.class);
+        setContentDispositionMethod.setAccessible(true);
+    }
+
+    @Test
+    public void shouldHandleAsciiFilenameWithoutEncoding() throws Exception {
+        String fileName = "LicenseInfo-ProjectA-1.0-2026-05-16.docx";
+
+        setContentDispositionMethod.invoke(controller, response, fileName);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(eq("Content-Disposition"), captor.capture());
+
+        String header = captor.getValue();
+        assertThat(header).contains("filename=\"" + fileName + "\"");
+        assertThat(header).contains("filename*=UTF-8''");
+    }
+
+    @Test
+    public void shouldReplaceNonAsciiInFallbackFilename() throws Exception {
+        String fileName = "LicenseInfo-Gridscale X\u2122 Protection-1.0.docx";
+
+        setContentDispositionMethod.invoke(controller, response, fileName);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(eq("Content-Disposition"), captor.capture());
+
+        String header = captor.getValue();
+        assertThat(header).contains("filename=\"LicenseInfo-Gridscale X_ Protection-1.0.docx\"");
+        assertThat(header).contains("filename*=UTF-8''");
+        assertThat(header).contains("%E2%84%A2");
+    }
+
+    @Test
+    public void shouldEncodeSpacesAsPercent20() throws Exception {
+        String fileName = "License Info Report.docx";
+
+        setContentDispositionMethod.invoke(controller, response, fileName);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(eq("Content-Disposition"), captor.capture());
+
+        String header = captor.getValue();
+        String filenameStar = header.substring(header.indexOf("filename*=UTF-8''") + "filename*=UTF-8''".length());
+        assertThat(filenameStar).doesNotContain("+");
+        assertThat(filenameStar).contains("%20");
+    }
+
+    @Test
+    public void shouldHandleUmlautsInFilename() throws Exception {
+        String fileName = "LicenseInfo-Pr\u00fcfbericht-\u00fcber-1.0.docx";
+
+        setContentDispositionMethod.invoke(controller, response, fileName);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(eq("Content-Disposition"), captor.capture());
+
+        String header = captor.getValue();
+        assertThat(header).contains("filename=\"LicenseInfo-Pr_fbericht-_ber-1.0.docx\"");
+        assertThat(header).contains("%C3%BC");
+    }
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

Fixes two issues when generating license-info reports for projects with non-ASCII characters (™, ü, ñ, etc.) in their name:

1. **Content-Disposition header rejected by Tomcat** — The raw Unicode filename caused an `UnmappableCharacterException`, Tomcat silently removed the header, and the browser fell back to a generic filename (`LicenseInfo-2026-05-16.zip`) losing the intended `.docx` extension.
2. **Debug log pollution** — `Sw360ProjectService:266` logged the full attachment-usage key string (hundreds of KB) at DEBUG level on every request.

### Suggest Reviewer
@GMishx 

## Changes

| File | Change |
|------|--------|
| `SW360ReportController.java` | Added `setContentDisposition()` helper using RFC 5987 dual-filename encoding. Replaced all 3 header-setting sites. |
| `Sw360ProjectService.java` | Changed `log.debug("Resulting string: ...")` → `log.trace(...)` |
| `SW360ReportControllerContentDispositionTest.java` | Unit test for encoding logic (ASCII, ™, spaces, umlauts) |
| `ReportTest.java` | Integration test verifying Content-Disposition header via `TestRestTemplate` |

### RFC 5987 Encoding

```
Content-Disposition: attachment; filename="LicenseInfo-Gridscale X_ Protection-1.2.1.docx"; filename*=UTF-8''LicenseInfo-Gridscale%20X%E2%84%A2%20Protection-1.2.1.docx
```

- `filename` — ASCII-safe fallback (non-ASCII replaced with `_`) that Tomcat can serialize
- `filename*` — Full Unicode name that modern browsers prefer for display/save

## How To Test?

1. Create a project with name containing special characters (e.g. `Gridscale X™ Protection Data Manager`)
2. Generate a license-info report (DOCX format) via `/api/reports?module=licenseInfo&projectId=...&generatorClassName=DocxGenerator&variant=REPORT`
3. Verify:
   - Downloaded file has correct Unicode name with `.docx` extension
   - No `WARNING` in Tomcat catalina log about invalid `Content-Disposition`
   - DEBUG logs do not contain the full attachment key dump


https://github.com/user-attachments/assets/722fbaf0-accc-4bc7-b09d-72c140bd0fae


## Checklist

Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] Signed-off-by present in commit
- [x] Unit tests added
- [x] Integration test added
- [x] Pre-commit hooks pass (formatting, conventional commit)

