### PR TITLE
fix(project): show transitive sub-project releases in licenseClearing and attachmentUsage endpoints

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2593,7 +2593,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     private HalResource attachmentUsageReleases(Project sw360Project, List<Map<String, Object>> releases, List<Map<String, Object>> attachmentUsageMap) {
         ObjectMapper oMapper = new ObjectMapper();
-        Map<String, ProjectReleaseRelationship> releaseIdToUsages = sw360Project.getReleaseIdToUsage();
         Map<String, Object> projectMap = oMapper.convertValue(sw360Project, Map.class);
         Map<String, Object> resultMap = new HashMap<>();
         resultMap.put("linkedProjects", projectMap.get("linkedProjects"));
@@ -2613,7 +2612,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
         HalResource halProject = new HalResource<>(resultMap);
 
-        if (releaseIdToUsages != null) {
+        if (sw360Project.getReleaseIdToUsage() != null || (releases != null && !releases.isEmpty())) {
             restControllerHelper.addEmbeddedProjectAttachmentUsage(halProject, releases, attachmentUsageMap);
         }
         return halProject;
@@ -2893,7 +2892,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
     private HalResource<Project> createHalLicenseClearing(Project sw360Project, List<EntityModel<Release>> releases) {
         Project sw360 = new Project();
-        Map<String, ProjectReleaseRelationship> releaseIdToUsage = sw360Project.getReleaseIdToUsage();
         sw360.setReleaseIdToUsage(sw360Project.getReleaseIdToUsage());
         sw360.setLinkedProjects(sw360Project.getLinkedProjects());
         sw360.setId(sw360Project.getId());
@@ -2902,7 +2900,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         sw360.unsetVisbility();
         sw360.unsetSecurityResponsibles();
         HalResource<Project> halProject = new HalResource<>(sw360);
-        if (releaseIdToUsage != null) {
+        if (sw360Project.getReleaseIdToUsage() != null || (releases != null && !releases.isEmpty())) {
             restControllerHelper.addEmbeddedProjectReleases(halProject, releases);
         }
         return halProject;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -1493,4 +1493,85 @@ public class ProjectTest extends TestIntegrationBase {
         assertTrue("Should contain Apache License 2.0", licenseNames.contains("Apache License 2.0"));
         assertTrue("Should contain MIT License", licenseNames.contains("MIT License"));
     }
+
+    // ========== SUB-PROJECT TRANSITIVE RELEASE TESTS ==========
+
+    @Test
+    public void should_get_license_clearing_with_transitive_releases_from_subproject() throws IOException, TException {
+        // Parent project with NO direct releases but a linked sub-project
+        Project parentProject = new Project();
+        parentProject.setId("parentNoReleases");
+        parentProject.setName("Parent Project");
+        parentProject.setVisbility(Visibility.EVERYONE);
+        parentProject.setReleaseIdToUsage(null); // No direct releases
+        Map<String, ProjectProjectRelationship> linkedProjects = new HashMap<>();
+        linkedProjects.put(project1.getId(), new ProjectProjectRelationship(ProjectRelationship.CONTAINED));
+        parentProject.setLinkedProjects(linkedProjects);
+
+        given(this.projectServiceMock.getProjectForUserById(eq("parentNoReleases"), any())).willReturn(parentProject);
+        // Transitive fetch returns releases from sub-project
+        given(this.projectServiceMock.getReleaseIds(eq("parentNoReleases"), any(), eq(true)))
+                .willReturn(new HashSet<>(Arrays.asList(release1.getId(), release2.getId())));
+        given(this.projectServiceMock.getFilteredReleases(any(), any(), any(), any(), any()))
+                .willReturn(Arrays.asList(release1, release2));
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), any())).willReturn(release2);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/parentNoReleases/licenseClearing?transitive=true",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        // Verify that _embedded contains releases even though parent has no direct releaseIdToUsage
+        JsonNode responseJson = new ObjectMapper().readTree(response.getBody());
+        assertTrue("Response should contain _embedded field",
+                responseJson.has("_embedded"));
+        JsonNode embedded = responseJson.get("_embedded");
+        assertTrue("Embedded should contain sw360:release",
+                embedded.has("sw360:release"));
+        assertEquals("Should contain 2 releases from sub-project",
+                2, embedded.get("sw360:release").size());
+    }
+
+    @Test
+    public void should_get_attachment_usage_with_transitive_releases_from_subproject() throws IOException, TException {
+        // Parent project with NO direct releases but a linked sub-project
+        Project parentProject = new Project();
+        parentProject.setId("parentNoReleases2");
+        parentProject.setName("Parent Project 2");
+        parentProject.setVisbility(Visibility.EVERYONE);
+        parentProject.setReleaseIdToUsage(null); // No direct releases
+        Map<String, ProjectProjectRelationship> linkedProjects = new HashMap<>();
+        linkedProjects.put(project1.getId(), new ProjectProjectRelationship(ProjectRelationship.CONTAINED));
+        parentProject.setLinkedProjects(linkedProjects);
+
+        given(this.projectServiceMock.getProjectForUserById(eq("parentNoReleases2"), any())).willReturn(parentProject);
+        given(this.projectServiceMock.getReleaseIds(eq("parentNoReleases2"), any(), eq(true)))
+                .willReturn(new HashSet<>(Arrays.asList(release1.getId())));
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
+        given(this.releaseServiceMock.setComponentDependentFieldsInRelease(any(Release.class), any(User.class))).willReturn(release1);
+        given(this.attachmentServiceMock.getAllAttachmentUsage(eq("parentNoReleases2")))
+                .willReturn(new ArrayList<>());
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/parentNoReleases2/attachmentUsage?transitive=true",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        // Verify that _embedded contains releases even though parent has no direct releaseIdToUsage
+        JsonNode responseJson = new ObjectMapper().readTree(response.getBody());
+        assertTrue("Response should contain _embedded field",
+                responseJson.has("_embedded"));
+        JsonNode embedded = responseJson.get("_embedded");
+        assertTrue("Embedded should contain sw360:release",
+                embedded.has("sw360:release"));
+    }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

Fixes sub-project releases not appearing in "License Clearing" and "Attachment Usage" views when the parent project has no directly linked releases (only sub-projects with linked releases). The UI expand buttons and "Expand All" were broken due to the missing `_embedded["sw360:release"]` field in the API response.

### Suggest Reviewer
@GMishx 

## Root Cause

Both `createHalLicenseClearing` and `attachmentUsageReleases` methods gated the embedding of releases on `releaseIdToUsage != null`. When a project has only sub-projects (no directly linked releases), `getReleaseIdToUsage()` returns `null` — so even though the transitive releases were correctly fetched, they were never added to the response.

## Fix

Changed the condition to check if the `releases` list is non-empty instead of checking `releaseIdToUsage`:

| Endpoint | Before | After |
|----------|--------|-------|
| `/projects/{id}/licenseClearing` | `if (releaseIdToUsage != null)` | `if (releases != null && !releases.isEmpty())` |
| `/projects/{id}/attachmentUsage` | `if (releaseIdToUsages != null)` | `if (releases != null && !releases.isEmpty())` |

This ensures sub-project releases are included in the response when `transitive=true`, enabling the UI to show expand buttons and "Expand All" to work correctly.

## How To Test?

1. Create a project (Parent) with no directly linked releases
2. Create a sub-project with linked releases
3. Link the sub-project to the parent project
4. Call `GET /api/projects/{parentId}/licenseClearing?transitive=true`
5. Verify `_embedded["sw360:release"]` is present in the response with the sub-project's releases
6. Call `GET /api/projects/{parentId}/attachmentUsage?transitive=true`
7. Verify releases from sub-projects are included
8. In the UI, verify expand buttons appear for sub-projects in "License Clearing" and "Attachment Usage" tabs
9. Verify "Expand All" button works correctly


https://github.com/user-attachments/assets/36d9bc33-bda8-44ed-8bed-e415292c0dd1



https://github.com/user-attachments/assets/61584c8f-b6a8-420d-8d03-cf04adb331bf




## Checklist

Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] Integration test added

