### PR TITLE
fix(rest): fetch sub-project attachment usages for LicenseInfo report

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -367,7 +367,16 @@ public class SW360ReportService {
                 projectService.filterAndSortAttachments(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES), true,
                 reportBean.isWithSubProject(), sw360User);
 
-        List<AttachmentUsage> attchmntUsg = attachmentService.getAttachmentUsages(id);
+        List<AttachmentUsage> attchmntUsg = new ArrayList<>(attachmentService.getAttachmentUsages(id));
+        if (reportBean.isWithSubProject()) {
+            mappedProjectLinks.stream()
+                    .map(ProjectLink::getId)
+                    .filter(projectLinkId -> !id.equals(projectLinkId))
+                    .distinct()
+                    .forEach(subProjectId -> wrapTException(() -> {
+                        attchmntUsg.addAll(attachmentService.getAttachmentUsages(subProjectId));
+                    }));
+        }
 
         Map<Source, Set<String>> releaseIdToExcludedLicenses = attchmntUsg.stream()
                 .collect(Collectors.toMap(AttachmentUsage::getOwner,

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -1452,6 +1452,45 @@ public class ProjectTest extends TestIntegrationBase {
     }
 
     @Test
+    public void should_get_license_info_report_with_subproject_releases() throws IOException, TException {
+        // Parent project with NO direct releases but with a linked sub-project
+        Project parentProject = new Project();
+        parentProject.setId("parentProj123");
+        parentProject.setName("Parent No Direct Releases");
+        parentProject.setVersion("1.0");
+        parentProject.setProjectType(ProjectType.CUSTOMER);
+        parentProject.setVisbility(Visibility.EVERYONE);
+
+        // Sub-project that has releases with CLI attachments
+        Project subProject = new Project();
+        subProject.setId("subProj456");
+        subProject.setName("Sub Project With Releases");
+        subProject.setVersion("1.0");
+        Map<String, ProjectReleaseRelationship> subReleaseUsage = new HashMap<>();
+        subReleaseUsage.put(release1.getId(), new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE));
+        subProject.setReleaseIdToUsage(subReleaseUsage);
+
+        // Link sub-project to parent
+        Map<String, ProjectProjectRelationship> linkedProjects = new HashMap<>();
+        linkedProjects.put(subProject.getId(), new ProjectProjectRelationship(ProjectRelationship.CONTAINED));
+        parentProject.setLinkedProjects(linkedProjects);
+
+        given(this.projectServiceMock.getProjectForUserById(eq("parentProj123"), any())).willReturn(parentProject);
+        given(this.sw360ReportServiceMock.getLicenseInfoBuffer(any(), eq("parentProj123"), any()))
+                .willReturn(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<byte[]> response =
+                new TestRestTemplate().exchange(
+                        "http://localhost:" + port + "/api/reports?module=licenseInfo&projectId=parentProj123&generatorClassName=DocxGenerator&variant=DISCLOSURE&withSubProject=true",
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        byte[].class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue("Response body should not be empty", response.getBody().length > 0);
+    }
+
+    @Test
     public void should_get_project_licenses() throws IOException, TException {
         // Setup project with releases
         Map<String, ProjectReleaseRelationship> releaseIdToUsage = new HashMap<>();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.report;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.MainlineState;
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
+import org.eclipse.sw360.datahandler.thrift.attachments.LicenseInfoUsage;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
+import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
+import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
+import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SW360ReportServiceTest {
+
+    @Mock
+    private Sw360ProjectService projectService;
+
+    @Mock
+    private Sw360LicenseService licenseService;
+
+    @Mock
+    private Sw360ComponentService componentService;
+
+    @Mock
+    private Sw360AttachmentService attachmentService;
+
+    @Mock
+    private Sw360LicenseInfoService licenseInfoService;
+
+    @InjectMocks
+    private SW360ReportService sw360ReportService;
+
+    private User testUser;
+    private Project parentProject;
+    private Project subProject;
+
+    @Before
+    public void setUp() {
+        testUser = new User();
+        testUser.setEmail("test@example.com");
+        testUser.setUserGroup(UserGroup.USER);
+
+        parentProject = new Project();
+        parentProject.setId("parentId");
+        parentProject.setName("Parent Project");
+        parentProject.setProjectType(ProjectType.CUSTOMER);
+
+        subProject = new Project();
+        subProject.setId("subId");
+        subProject.setName("Sub Project");
+        Map<String, ProjectReleaseRelationship> subReleases = new HashMap<>();
+        subReleases.put("release1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE));
+        subProject.setReleaseIdToUsage(subReleases);
+
+        Map<String, ProjectProjectRelationship> linkedProjects = new HashMap<>();
+        linkedProjects.put("subId", new ProjectProjectRelationship(ProjectRelationship.CONTAINED));
+        parentProject.setLinkedProjects(linkedProjects);
+    }
+
+    @Test
+    public void should_fetch_attachment_usages_from_subprojects_when_withSubProject_is_true() throws TException {
+        // Given: parent project with no direct releases, sub-project has release with CLI attachment
+        given(projectService.getProjectForUserById(eq("parentId"), any())).willReturn(parentProject);
+
+        // Mock sub-project attachment usage (has a CLI attached to release1)
+        AttachmentUsage subUsage = new AttachmentUsage();
+        subUsage.setOwner(Source.releaseId("release1"));
+        subUsage.setAttachmentContentId("attachContent1");
+        LicenseInfoUsage licInfoUsage = new LicenseInfoUsage();
+        licInfoUsage.setExcludedLicenseIds(Collections.emptySet());
+        licInfoUsage.setIncludeConcludedLicense(false);
+        subUsage.setUsageData(UsageData.licenseInfo(licInfoUsage));
+
+        // Parent has no attachment usages, sub-project has one
+        given(attachmentService.getAttachmentUsages("parentId")).willReturn(Collections.emptyList());
+        given(attachmentService.getAttachmentUsages("subId")).willReturn(List.of(subUsage));
+
+        // Mock createLinkedProjects to return project links with sub-project's releases
+        Attachment cliAttachment = new Attachment();
+        cliAttachment.setAttachmentContentId("attachContent1");
+        cliAttachment.setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_XML);
+        cliAttachment.setFilename("test-cli.xml");
+
+        ReleaseLink releaseLink = new ReleaseLink();
+        releaseLink.setId("release1");
+        releaseLink.setAttachments(List.of(cliAttachment));
+        releaseLink.setReleaseRelationship(ReleaseRelationship.CONTAINED);
+
+        ProjectLink subProjectLink = new ProjectLink();
+        subProjectLink.setId("subId");
+        subProjectLink.setLinkedReleases(List.of(releaseLink));
+
+        ProjectLink parentProjectLink = new ProjectLink();
+        parentProjectLink.setId("parentId");
+        parentProjectLink.setLinkedReleases(Collections.emptyList());
+
+        given(projectService.createLinkedProjects(any(), any(), anyBoolean(), eq(true), any()))
+                .willReturn(List.of(parentProjectLink, subProjectLink));
+
+        // Mock component service for release lookup
+        Release release = new Release();
+        release.setId("release1");
+        release.setName("TestRelease");
+        release.setVersion("1.0");
+        given(componentService.getReleaseById(eq("release1"), any())).willReturn(release);
+
+        // Mock license info parsing
+        given(licenseInfoService.getLicenseInfoForAttachment(any(), any(), eq("attachContent1"), anyBoolean()))
+                .willReturn(Collections.emptyList());
+
+        // Mock final license info file generation
+        LicenseInfoFile licenseInfoFile = new LicenseInfoFile();
+        licenseInfoFile.setGeneratedOutput(ByteBuffer.wrap("test content".getBytes()));
+        given(licenseInfoService.getLicenseInfoFile(any(), any(), any(), any(), any(), any(), any(), anyBoolean()))
+                .willReturn(licenseInfoFile);
+
+        // When
+        SW360ReportBean reportBean = new SW360ReportBean();
+        reportBean.setWithSubProject(true);
+        reportBean.setGeneratorClassName("DocxGenerator");
+        reportBean.setVariant("DISCLOSURE");
+
+        ByteBuffer result = sw360ReportService.getLicenseInfoBuffer(testUser, "parentId", reportBean);
+
+        // Then
+        assertNotNull("Report buffer should not be null", result);
+        assertTrue("Report buffer should have content", result.remaining() > 0);
+
+        // Verify that attachment usages were fetched for BOTH parent and sub-project
+        verify(attachmentService, times(1)).getAttachmentUsages("parentId");
+        verify(attachmentService, times(1)).getAttachmentUsages("subId");
+    }
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

Fixes LicenseInfo report generation returning an empty report ("no releases") when a project has only sub-projects with releases and no directly linked releases. The report now correctly includes releases from sub-projects when `withSubProject=true`.

### Suggest Reviewer
@GMishx

## Root Cause

In `SW360ReportService.getLicenseInfoBuffer()`, `attachmentService.getAttachmentUsages(id)` only fetched attachment usages for the **parent project** ID. When `withSubProject=true`, sub-project attachment usages were never fetched. This meant `usedAttachmentContentIds` didn't contain the sub-project's attachment content IDs, so all sub-project releases were skipped in the filtering loop → empty report.

## Fix

When `withSubProject=true`, iterate over all `ProjectLink` IDs from the mapped project links and also fetch their attachment usages, merging them into the list:

```java
List<AttachmentUsage> attchmntUsg = new ArrayList<>(attachmentService.getAttachmentUsages(id));
if (reportBean.isWithSubProject()) {
    mappedProjectLinks.stream()
            .map(ProjectLink::getId)
            .filter(projectLinkId -> !id.equals(projectLinkId))
            .distinct()
            .forEach(subProjectId -> wrapTException(() -> {
                attchmntUsg.addAll(attachmentService.getAttachmentUsages(subProjectId));
            }));
}
```

## How To Test?

1. Create a parent project with NO directly linked releases
2. Link a sub-project that has releases with CLI (Component License Info) attachments configured in attachment usage
3. Generate LicenseInfo report with `withSubProject=true`:
   `GET /api/reports?module=licenseInfo&projectId={parentId}&generatorClassName=DocxGenerator&variant=DISCLOSURE&withSubProject=true`
4. **Before fix**: Report says "no releases based on your selection"
5. **After fix**: Report includes releases from sub-project with their license information
6. In the UI: Navigate to project → Generate LicenseInfo → check "Include sub-projects" → verify report contains sub-project releases

<img width="1913" height="1075" alt="image" src="https://github.com/user-attachments/assets/ab31d6f2-a493-482a-8223-0fa1f5ba5de3" />

## Checklist

Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] Unit test added (`SW360ReportServiceTest`)
- [x] Integration test added (`ProjectTest`)
