### PR TITLE
fix(project): guard empty release IDs in project count

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1462,6 +1462,9 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
      * @throws TException
      */
     public int countProjectsByReleaseIds(Set<String> releaseIds) {
+        if (CommonUtils.isNullOrEmptyCollection(releaseIds)) {
+            return 0;
+        }
         try {
             ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
             return sw360ProjectClient.getCountByReleaseIds(releaseIds);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Siemens AG, 2026.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.project;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class Sw360ProjectServiceTest {
+
+    private Sw360ProjectService projectService;
+
+    @Before
+    public void setUp() {
+        projectService = spy(new Sw360ProjectService(mock(RestControllerHelper.class)));
+    }
+
+    @Test
+    public void should_return_zero_and_skip_Thrift_when_release_ids_are_empty()
+            throws TException {
+        Set<String> emptyReleaseIds = Collections.emptySet();
+
+        int result = projectService.countProjectsByReleaseIds(emptyReleaseIds);
+
+        assertEquals("Expected 0 for empty release-id set", 0, result);
+        verify(projectService, never()).getThriftProjectClient();
+    }
+
+    @Test
+    public void should_return_zero_and_skip_Thrift_when_release_ids_are_null()
+            throws TException {
+        Set<String> nullReleaseIds = null;
+
+        int result = projectService.countProjectsByReleaseIds(nullReleaseIds);
+
+        assertEquals("Expected 0 for null release-id set", 0, result);
+        verify(projectService, never()).getThriftProjectClient();
+    }
+
+    @Test
+    public void should_verify_CommonUtils_identifies_null_and_empty_collections() {
+        assertTrue("Empty set should be identified as empty",
+                CommonUtils.isNullOrEmptyCollection(Collections.emptySet()));
+
+        assertTrue("Null collection should be identified as empty",
+                CommonUtils.isNullOrEmptyCollection(null));
+
+        Set<String> nonEmpty = new HashSet<>();
+        nonEmpty.add("item");
+        assertFalse("Non-empty set should not be identified as empty",
+                CommonUtils.isNullOrEmptyCollection(nonEmpty));
+    }
+
+    @Test
+    public void should_not_trigger_guard_for_valid_non_empty_release_ids() {
+        Set<String> releaseIds = new HashSet<>();
+        releaseIds.add("release1");
+        releaseIds.add("release2");
+
+        boolean isEmptyOrNull = CommonUtils.isNullOrEmptyCollection(releaseIds);
+
+        assertFalse("Non-empty release IDs should NOT trigger guard", isEmptyOrNull);
+    }
+
+    @Test
+    public void should_attempt_Thrift_call_for_non_empty_release_ids() throws TException {
+        Set<String> releaseIds = new HashSet<>();
+        releaseIds.add("release1");
+
+        org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface projectClient = mock(org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface.class);
+        org.mockito.Mockito.doReturn(projectClient).when(projectService).getThriftProjectClient();
+        org.mockito.Mockito.when(projectClient.getCountByReleaseIds(releaseIds)).thenReturn(2);
+
+        int result = projectService.countProjectsByReleaseIds(releaseIds);
+
+        assertEquals("Expected count from Thrift client for non-empty input", 2, result);
+        verify(projectService, times(1)).getThriftProjectClient();
+        verify(projectClient, times(1)).getCountByReleaseIds(releaseIds);
+    }
+
+    @Test
+    public void should_return_zero_for_multiple_release_ids_when_Thrift_fails() throws TException {
+        Set<String> releaseIds = new HashSet<>();
+        releaseIds.add("release1");
+        releaseIds.add("release2");
+        releaseIds.add("release3");
+
+        org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface projectClient = mock(org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface.class);
+        org.mockito.Mockito.doReturn(projectClient).when(projectService).getThriftProjectClient();
+        org.mockito.Mockito.when(projectClient.getCountByReleaseIds(releaseIds)).thenThrow(new TException("forced failure for test"));
+
+        int result = projectService.countProjectsByReleaseIds(releaseIds);
+
+        assertEquals("Expected 0 when Thrift call fails", 0, result);
+        verify(projectService, times(1)).getThriftProjectClient();
+        verify(projectClient, times(1)).getCountByReleaseIds(releaseIds);
+    }
+
+    @Test
+    public void should_delegate_getProjectsByReleaseIds() throws TException {
+        Set<String> releaseIds = new HashSet<>();
+        releaseIds.add("release1");
+        org.eclipse.sw360.datahandler.thrift.users.User user =
+                new org.eclipse.sw360.datahandler.thrift.users.User().setEmail("test@sw360.org");
+        Set<org.eclipse.sw360.datahandler.thrift.projects.Project> expected = new HashSet<>();
+        expected.add(new org.eclipse.sw360.datahandler.thrift.projects.Project().setId("project1"));
+
+        org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface projectClient = mock(org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface.class);
+        org.mockito.Mockito.doReturn(projectClient).when(projectService).getThriftProjectClient();
+        org.mockito.Mockito.when(projectClient.searchByReleaseIds(releaseIds, user)).thenReturn(expected);
+
+        Set<org.eclipse.sw360.datahandler.thrift.projects.Project> result =
+                projectService.getProjectsByReleaseIds(releaseIds, user);
+
+        assertEquals(1, result.size());
+        verify(projectClient, times(1)).searchByReleaseIds(releaseIds, user);
+    }
+
+    @Test
+    public void should_delegate_getProjectsByRelease() throws TException {
+        String releaseId = "release1";
+        org.eclipse.sw360.datahandler.thrift.users.User user =
+                new org.eclipse.sw360.datahandler.thrift.users.User().setEmail("test@sw360.org");
+        Set<org.eclipse.sw360.datahandler.thrift.projects.Project> expected = new HashSet<>();
+        expected.add(new org.eclipse.sw360.datahandler.thrift.projects.Project().setId("project1"));
+
+        org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface projectClient = mock(org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface.class);
+        org.mockito.Mockito.doReturn(projectClient).when(projectService).getThriftProjectClient();
+        org.mockito.Mockito.when(projectClient.searchByReleaseId(releaseId, user)).thenReturn(expected);
+
+        Set<org.eclipse.sw360.datahandler.thrift.projects.Project> result =
+                projectService.getProjectsByRelease(releaseId, user);
+
+        assertEquals(1, result.size());
+        verify(projectClient, times(1)).searchByReleaseId(releaseId, user);
+    }
+
+}


### PR DESCRIPTION
## Summary
Fixes project update flow when release-id input is empty/null by guarding `countProjectsByReleaseIds(...)` in REST service before Thrift backend call.

### Changes:
- Guard added in `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java`
  - return `0` when `releaseIds` is null/empty
- Unit tests added in `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java`
  - empty/null short-circuit
  - non-empty Thrift path
  - Thrift-failure fallback to `0`
  - delegation checks for release-id search methods

### Suggest Reviewer
@GMishx 

### How To Test?

Run unit tests:
```bash
mvn test -pl rest/resource-server -Dtest=Sw360ProjectServiceTest
```

Manual verification:
1. Create a project without direct releases.
2. Update that project.
3. Confirm no `SW360Exception(why:Invalid empty input!)` occurs.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR



