### PR TITLE
fix(Configuration): Combine multiple mail configuration to single and added  mail send for license info download

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -73,8 +73,7 @@ public class SW360ConfigsDatabaseHandler {
             .put(IS_STORE_ATTACHMENT_TO_FILE_SYSTEM_ENABLED, getOrDefault(configContainer, IS_STORE_ATTACHMENT_TO_FILE_SYSTEM_ENABLED, "false"))
             .put(ATTACHMENT_DELETE_NO_OF_DAYS, getOrDefault(configContainer, ATTACHMENT_DELETE_NO_OF_DAYS, String.valueOf(SW360Constants.DEFAULT_ATTACHMENT_DELETE_NO_DAY)))
             .put(AUTO_SET_ECC_STATUS, getOrDefault(configContainer, AUTO_SET_ECC_STATUS, "false"))
-            .put(MAIL_REQUEST_FOR_PROJECT_REPORT, getOrDefault(configContainer, MAIL_REQUEST_FOR_PROJECT_REPORT, "false"))
-            .put(MAIL_REQUEST_FOR_COMPONENT_REPORT, getOrDefault(configContainer, MAIL_REQUEST_FOR_COMPONENT_REPORT, "false"))
+            .put(MAIL_REQUEST_FOR_REPORT, getOrDefault(configContainer, MAIL_REQUEST_FOR_REPORT, "false"))
             .put(IS_BULK_RELEASE_DELETING_ENABLED, getOrDefault(configContainer, IS_BULK_RELEASE_DELETING_ENABLED, "false"))
             .put(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, getOrDefault(configContainer, DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, "false"))
             .put(IS_FORCE_UPDATE_ENABLED, getOrDefault(configContainer, IS_FORCE_UPDATE_ENABLED, "false"))
@@ -195,8 +194,7 @@ public class SW360ConfigsDatabaseHandler {
                  MAINLINE_STATE_ENABLED_FOR_USER,
                  IS_STORE_ATTACHMENT_TO_FILE_SYSTEM_ENABLED,
                  AUTO_SET_ECC_STATUS,
-                 MAIL_REQUEST_FOR_PROJECT_REPORT,
-                 MAIL_REQUEST_FOR_COMPONENT_REPORT,
+                 MAIL_REQUEST_FOR_REPORT,
                  IS_FORCE_UPDATE_ENABLED,
                  DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD,
                  IS_BULK_RELEASE_DELETING_ENABLED,

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -35,10 +35,8 @@ public class SW360ConfigKeys {
     // Enable auto set ECC status
     public static final String AUTO_SET_ECC_STATUS = "auto.set.ecc.status";
 
-    // This property is used to enable mail request for projects report
-    public static final String MAIL_REQUEST_FOR_PROJECT_REPORT = "send.project.spreadsheet.export.to.mail.enabled";
-    // This property is used to enable mail request for components report
-    public static final String MAIL_REQUEST_FOR_COMPONENT_REPORT = "send.component.spreadsheet.export.to.mail.enabled";
+    // This property is used to enable mail request for spreadsheet export (projects and components)
+    public static final String MAIL_REQUEST_FOR_REPORT = "send.export.to.mail.enabled";
     // This property is used to enable the bulk release deleting feature
     public static final String IS_BULK_RELEASE_DELETING_ENABLED = "bulk.release.deleting.enabled";
     // This property is used to disable the ISR generation in fossology process
@@ -146,8 +144,8 @@ public class SW360ConfigKeys {
             SPDX_DOCUMENT_ENABLED, IS_COMPONENT_VISIBILITY_RESTRICTION_ENABLED,
             USE_LICENSE_INFO_FROM_FILES, MAINLINE_STATE_ENABLED_FOR_USER, IS_STORE_ATTACHMENT_TO_FILE_SYSTEM_ENABLED,
             ATTACHMENT_DELETE_NO_OF_DAYS, ATTACHMENT_STORE_FILE_SYSTEM_LOCATION,
-            COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, AUTO_SET_ECC_STATUS, MAIL_REQUEST_FOR_PROJECT_REPORT,
-            MAIL_REQUEST_FOR_COMPONENT_REPORT, IS_BULK_RELEASE_DELETING_ENABLED,
+            COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, AUTO_SET_ECC_STATUS, MAIL_REQUEST_FOR_REPORT,
+            IS_BULK_RELEASE_DELETING_ENABLED,
             DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, IS_FORCE_UPDATE_ENABLED, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE,
             TOOL_NAME, TOOL_VENDOR, IS_PACKAGE_PORTLET_ENABLED, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, INHERIT_ATTACHMENT_USAGES,
             RELEASE_FRIENDLY_URL, IS_ADMIN_PRIVATE_ACCESS_ENABLED, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, VCS_HOSTS,

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -166,6 +166,9 @@ public class SW360Constants {
             AttachmentType.COMPONENT_LICENSE_INFO_COMBINED, AttachmentType.INITIAL_SCAN_REPORT);
     public static final Collection<AttachmentType> SOURCE_CODE_ATTACHMENT_TYPES = Arrays.asList(AttachmentType.SOURCE, AttachmentType.SOURCE_SELF);
     public static final String CONTENT_TYPE_OPENXML_SPREADSHEET = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    public static final String CONTENT_TYPE_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    public static final String CONTENT_TYPE_XHTML = "application/xhtml+xml";
+    public static final String CONTENT_TYPE_TEXT = "text/plain";
     public static final String CONTENT_TYPE_XML = "application/xml";
     public static final String CONTENT_TYPE_JSON = "application/json";
     public static final String CONTENT_TYPE_CSV = "text/csv";

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseInfoExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseInfoExporter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Siemens AG, 2024. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.exporter;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+/**
+ * Handles saving and downloading license info reports (docx / xhtml / text)
+ * to/from the local file system,
+ *
+ * <p>File layout: {@code /tmp/<userEmail>/file/<timestamp>_<uuid>}
+ * The <em>relative</em> path {@code <userEmail>/file/<filename>} is used as the
+ * download token,</p>
+ */
+public class LicenseInfoExporter {
+
+    private static final Logger log = LogManager.getLogger(LicenseInfoExporter.class);
+
+    private static final String TMP_EXPORTEDFILES = "/tmp/";
+    private static final String SLASH = "/";
+
+    /**
+     * Saves the generated license-info report buffer to a temp file and
+     * returns the relative path (token) for later download.
+     *
+     * @param buffer the report content
+     * @param user   the requesting user (email used as directory name)
+     * @return relative path used as download token, e.g.
+     *         {@code user@example.com/file/2024-01-01_<uuid>}
+     * @throws IOException on any file-system error
+     */
+    public String saveReportToFile(ByteBuffer buffer, User user) throws IOException {
+        String token = UUID.randomUUID().toString();
+        String filePath = TMP_EXPORTEDFILES + user.getEmail() + SLASH + "file" + SLASH;
+        File dir = new File(filePath);
+        if (!dir.mkdirs() && !dir.exists()) {
+            log.error("Failed to create export directory: {}", dir.getAbsolutePath());
+            throw new IOException("Failed to create export directory: " + dir.getAbsolutePath());
+        }
+        File file = new File(dir.getPath() + SLASH + SW360Utils.getCreatedOn() + "_" + token);
+        if (!file.createNewFile()) {
+            log.error("Failed to create export file: {}", file.getAbsolutePath());
+            throw new IOException("Failed to create export file: " + file.getAbsolutePath());
+        }
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(buffer.array());
+        }
+        return user.getEmail() + SLASH + "file" + SLASH + file.getName();
+    }
+
+    /**
+     * Reads the license-info report identified by {@code token} and returns its content.
+     *
+     * @param token the relative path returned by {@link #saveReportToFile}
+     * @return the file content as a {@link ByteBuffer}
+     * @throws FileNotFoundException if the file does not exist or the token is invalid
+     * @throws IOException           on any other file-system error
+     */
+    public ByteBuffer downloadReport(String token) throws IOException {
+        File file = new File(TMP_EXPORTEDFILES + token);
+        String canonicalPath = file.getCanonicalPath();
+        String allowedDir = new File(TMP_EXPORTEDFILES).getCanonicalPath();
+        if (!canonicalPath.startsWith(allowedDir + File.separator)) {
+            log.error("Path traversal attempt detected. Token: {}", token);
+            throw new FileNotFoundException("Invalid file token: " + token);
+        }
+        if (!file.exists() || !file.isFile()) {
+            throw new FileNotFoundException("License info report file not found for token: " + token);
+        }
+        try (InputStream fis = new FileInputStream(file)) {
+            byte[] data = IOUtils.toByteArray(fis);
+            return ByteBuffer.wrap(data);
+        }
+    }
+}
+

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -6,8 +6,7 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.rest.resourceserver.report;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.MAIL_REQUEST_FOR_COMPONENT_REPORT;
-import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.MAIL_REQUEST_FOR_PROJECT_REPORT;
+import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.MAIL_REQUEST_FOR_REPORT;
 import static org.eclipse.sw360.datahandler.common.SW360Constants.CONTENT_TYPE_OPENXML_SPREADSHEET;
 import static org.eclipse.sw360.datahandler.common.SW360Constants.JSON_FILE_EXTENSION;
 import static org.eclipse.sw360.datahandler.common.SW360Constants.XML_FILE_EXTENSION;
@@ -259,7 +258,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             String baseUrl, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
-            if (SW360Utils.readConfig(MAIL_REQUEST_FOR_PROJECT_REPORT, false)) {
+            if (SW360Utils.readConfig(MAIL_REQUEST_FOR_REPORT, false)) {
                 sw360ReportService.getUploadedProjectPath(sw360User, reportBean.isWithLinkedReleases(), baseUrl, projectId);
                 JsonObject responseJson = new JsonObject();
                 responseJson.addProperty("response", "The downloaded report link will be send to the end user.");
@@ -283,7 +282,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, String baseUrl, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
-            if (SW360Utils.readConfig(MAIL_REQUEST_FOR_COMPONENT_REPORT, false)) {
+            if (SW360Utils.readConfig(MAIL_REQUEST_FOR_REPORT, false)) {
                 sw360ReportService.getUploadedComponentPath(sw360User, reportBean.isWithLinkedReleases(), baseUrl);
                 JsonObject responseJson = new JsonObject();
                 responseJson.addProperty("response", "Component report download link will get send to the end user.");
@@ -324,7 +323,15 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, String projectId, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
-            downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+            if (SW360Utils.readConfig(MAIL_REQUEST_FOR_REPORT, false)) {
+                sw360ReportService.getUploadedLicenseInfoPath(sw360User, reportBean.isWithSubProject(),
+                        null, projectId, reportBean);
+                JsonObject responseJson = new JsonObject();
+                responseJson.addProperty("response", "The license info report link will be sent to the end user.");
+                response.getWriter().write(responseJson.toString());
+            } else {
+                downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+            }
         } catch (ResourceNotFoundException e) {
             throw e;
         } catch (AccessDeniedException e) {
@@ -453,6 +460,25 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     }
 
     private void setContentTypeForFormat(HttpServletResponse response, String format) {
+        setContentTypeForDownload(response, format, null);
+    }
+
+    private void setContentTypeForDownload(HttpServletResponse response, String format, String generatorClassName) {
+        if (generatorClassName != null) {
+            switch (generatorClassName) {
+                case "DocxGenerator":
+                    response.setContentType(SW360Constants.CONTENT_TYPE_DOCX);
+                    return;
+                case "XhtmlGenerator":
+                    response.setContentType(SW360Constants.CONTENT_TYPE_XHTML);
+                    return;
+                case "TextGenerator":
+                    response.setContentType(SW360Constants.CONTENT_TYPE_TEXT);
+                    return;
+                default:
+                    break;
+            }
+        }
         String fmt = (format == null) ? "xlsx" : format.trim().toLowerCase();
         switch (fmt) {
             case "csv":
@@ -485,12 +511,18 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     public void downloadExcel(
             HttpServletRequest request,
             HttpServletResponse response,
-            @Parameter(description = "Module name.", schema = @Schema(allowableValues = {SW360Constants.PROJECTS, SW360Constants.COMPONENTS, SW360Constants.LICENSES}))
+            @Parameter(description = "Module name.", schema = @Schema(allowableValues = {SW360Constants.PROJECTS, SW360Constants.COMPONENTS, SW360Constants.LICENSES, LICENSE_INFO}))
             @RequestParam(value = "module", required = true) String module,
             @Parameter(description = "Token to download report.")
             @RequestParam(value = "token", required = true) String token,
             @Parameter(description = "Extended by releases.")
-            @RequestParam(value = "extendedByReleases", required = false, defaultValue = "false") boolean extendedByReleases
+            @RequestParam(value = "extendedByReleases", required = false, defaultValue = "false") boolean extendedByReleases,
+            @Parameter(description = "Output generator class name. Required for module [" + LICENSE_INFO + "]",
+                    schema = @Schema(type = "string", allowableValues = {"DocxGenerator", "XhtmlGenerator", "TextGenerator"}))
+            @RequestParam(value = "generatorClassName", required = false) String generatorClassName,
+            @Parameter(description = "Variant of the license info report. Required for module [" + LICENSE_INFO + "]",
+                    schema = @Schema(implementation = OutputFormatVariant.class))
+            @RequestParam(value = "variant", required = false) String variant
     ) throws SW360Exception {
         final User user = restControllerHelper.getSw360UserFromAuthentication();
         try {
@@ -508,13 +540,24 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                     buffer = sw360ReportService.getLicenseReportStreamFromURl(token);
                     fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
                     break;
+                case LICENSE_INFO:
+                    buffer = sw360ReportService.getLicenseInfoReportStreamFromUrl(token);
+                    String projectId = request.getParameter("projectId");
+                    if (projectId != null) {
+                        fileName = sw360ReportService.getGenericLicInfoFileName(user, projectId,
+                                generatorClassName, variant);
+                    }
+                    setContentTypeForDownload(response, null, generatorClassName);
+                    break;
                 default:
                     break;
             }
             if (null == buffer) {
                 throw new TException("No data available for the user " + user.getEmail());
             }
-            response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
+            if (!LICENSE_INFO.equals(module)) {
+                response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
+            }
             setContentDisposition(response, fileName);
             copyDataStreamToResponse(response, buffer);
         } catch (ResourceNotFoundException e) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -6,81 +6,74 @@ package org.eclipse.sw360.rest.resourceserver.report;
 
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
+import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.REPORT_FILENAME_MAPPING;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.*;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
 import org.eclipse.sw360.datahandler.thrift.attachments.SourcePackageUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
-import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
-import org.eclipse.sw360.datahandler.thrift.projects.Project;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
-import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.eclipse.sw360.exporter.ReleaseExporter;
-import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
-import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.stereotype.Service;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-
-import lombok.RequiredArgsConstructor;
-
-import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.REPORT_FILENAME_MAPPING;
-
-import org.eclipse.sw360.exporter.CSVExport;
-import org.eclipse.sw360.exporter.JsonExport;
-import org.eclipse.sw360.exporter.ProjectExporter;
-import org.eclipse.sw360.exporter.XmlExport;
-
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
-import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatInfo;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.datahandler.couchdb.AttachmentStreamConnector;
+import org.eclipse.sw360.exporter.CSVExport;
+import org.eclipse.sw360.exporter.JsonExport;
+import org.eclipse.sw360.exporter.LicenseInfoExporter;
+import org.eclipse.sw360.exporter.ProjectExporter;
+import org.eclipse.sw360.exporter.ReleaseExporter;
+import org.eclipse.sw360.exporter.XmlExport;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
 import com.google.common.base.Strings;
-
 import lombok.NonNull;
-
-import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
-
-import org.eclipse.sw360.datahandler.couchdb.AttachmentStreamConnector;
-
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -106,6 +99,7 @@ public class SW360ReportService {
 
     private static final Logger log = LogManager.getLogger(SW360ReportService.class);
     private static final Set<String> SUPPORTED_FORMATS = Set.of("xlsx", "csv", "json", "xml");
+    private final LicenseInfoExporter licenseInfoExporter = new LicenseInfoExporter();
     ThriftClients thriftClients = new ThriftClients();
     ProjectService.Iface projectclient = thriftClients.makeProjectClient();
     ComponentService.Iface componentclient = thriftClients.makeComponentClient();
@@ -260,6 +254,55 @@ public class SW360ReportService {
             case "xlsx":
             default:
                 return "xlsx";
+        }
+    }
+
+    public void getUploadedLicenseInfoPath(User user, boolean withSubProject, String base, String projectId,
+                                           SW360ReportBean reportBean) throws TException {
+        if (projectId != null && !validateProject(projectId, user)) {
+            throw new SW360Exception("No project record found for the project Id : " + projectId);
+        }
+        Runnable asyncRunnable = () -> wrapTException(() -> {
+            try {
+                String licenseInfoPath = generateLicenseInfoReport(user, projectId, reportBean);
+                String downloadUrl = frontendUrl + "/reports/download?module=licenseInfo"
+                        + "&withSubProject=" + withSubProject
+                        + "&projectId=" + projectId
+                        + "&generatorClassName=" + URLEncoder.encode(
+                                reportBean.getGeneratorClassName() != null ? reportBean.getGeneratorClassName() : "",
+                                StandardCharsets.UTF_8)
+                        + "&variant=" + URLEncoder.encode(
+                                reportBean.getVariant() != null ? reportBean.getVariant() : "",
+                                StandardCharsets.UTF_8)
+                        + "&token=" + URLEncoder.encode(licenseInfoPath, StandardCharsets.UTF_8);
+                URL emailURL = new URI(downloadUrl).toURL();
+                log.debug("License info report download link for user {}: {}", user.getEmail(), emailURL);
+                if (!CommonUtils.isNullEmptyOrWhitespace(licenseInfoPath)) {
+                    sendExportSpreadsheetSuccessMail(emailURL.toString(), user.getEmail());
+                }
+            } catch (ResourceNotFoundException exp) {
+                throw exp;
+            } catch (AccessDeniedException exp) {
+                throw exp;
+            } catch (Exception exp) {
+                throw new TException(exp.getMessage());
+            }
+        });
+        Thread asyncThread = new Thread(asyncRunnable);
+        asyncThread.start();
+    }
+
+    private String generateLicenseInfoReport(User user, String projectId, SW360ReportBean reportBean)
+            throws TException, IOException {
+        ByteBuffer buffer = getLicenseInfoBuffer(user, projectId, reportBean);
+        return licenseInfoExporter.saveReportToFile(buffer, user);
+    }
+
+    public ByteBuffer getLicenseInfoReportStreamFromUrl(String token) throws TException {
+        try {
+            return licenseInfoExporter.downloadReport(token);
+        } catch (Exception e) {
+            throw new TException("Failed to read license info report: " + e.getMessage(), e);
         }
     }
 

--- a/scripts/migrations/064_migrate_unified_mail_export_config_key.py
+++ b/scripts/migrations/064_migrate_unified_mail_export_config_key.py
@@ -1,0 +1,198 @@
+#!/usr/bin/python
+# -----------------------------------------------------------------------------
+# Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This is a manual database migration script. It is assumed that a
+# dedicated framework for automatic migration will be written in the
+# future. When that happens, this script should be refactored to conform
+# to the framework's prerequisites to be run by the framework. For
+# example, server address and db name should be parameterized, the code
+# reorganized into a single class or function, etc.
+#
+# This script migrates the two separate mail export configuration keys:
+#   send.project.spreadsheet.export.to.mail.enabled
+#   send.component.spreadsheet.export.to.mail.enabled
+# into a single unified key:
+#   send.export.to.mail.enabled
+# in the SW360_CONFIGURATION document stored in CouchDB.
+#
+# Document structure (actual):
+#   {
+#     "_id": "...",
+#     "configFor": "SW360_CONFIGURATION",
+#     "configKeyToValues": {
+#       "send.project.spreadsheet.export.to.mail.enabled": ["false"],
+#       "send.component.spreadsheet.export.to.mail.enabled": ["false"],
+#       ...
+#     }
+#   }
+# -----------------------------------------------------------------------------
+
+import couchdb
+import getpass
+import json
+import time
+import sys
+from datetime import datetime
+
+# ---------------------------------------
+# constants
+# ---------------------------------------
+
+DRY_RUN = False
+DBNAME = 'sw360config'
+
+OLD_KEY_PROJECT   = "send.project.spreadsheet.export.to.mail.enabled"
+OLD_KEY_COMPONENT = "send.component.spreadsheet.export.to.mail.enabled"
+NEW_KEY           = "send.export.to.mail.enabled"
+
+# The document is identified by the configFor field, not a type field
+CONFIG_FOR_VALUE  = "SW360_CONFIGURATION"
+# Field name in the document that holds the configuration key-value pairs
+CONFIG_FIELD      = "configKeyToValues"
+
+# ---------------------------------------
+# database connection
+# ---------------------------------------
+
+print("--- CouchDB Connection Setup ---")
+couchdb_host = input("Enter CouchDB host [default: http://localhost:5984]: ").strip() or "http://localhost:5984"
+print(f"  Host     : {couchdb_host}")
+
+couchdb_user = input("Enter CouchDB username: ").strip()
+print(f"  Username : {couchdb_user}")
+
+couchdb_pass = getpass.getpass("Enter CouchDB password: ")
+print("  Password : ****")
+print("--------------------------------")
+
+scheme, rest = couchdb_host.rstrip("/").split("://", 1)
+COUCHSERVER = f"{scheme}://{couchdb_user}:{couchdb_pass}@{rest}/"
+
+try:
+    couch = couchdb.Server(COUCHSERVER)
+    db = couch[DBNAME]
+except Exception as e:
+    print(f"Error connecting to CouchDB: {e}")
+    sys.exit(1)
+
+# ---------------------------------------
+# functions
+# ---------------------------------------
+
+def create_log_entry(doc_id, status, error=None):
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "docId": doc_id,
+        "status": status,
+        "error": str(error) if error else None,
+    }
+
+
+def migrate_mail_export_config_key():
+    log = {
+        "migrationDate": datetime.now().isoformat(),
+        "dryRun": DRY_RUN,
+        "statistics": {
+            "totalProcessed": 0,
+            "successCount": 0,
+            "errorCount": 0,
+            "skippedCount": 0
+        },
+        "entries": []
+    }
+
+    try:
+        print('Fetching SW360 configuration documents...')
+
+        # Query by configFor field (actual document structure uses configFor, not type)
+        query = {
+            "selector": {
+                "configFor": {"$eq": CONFIG_FOR_VALUE}
+            },
+            "limit": 99999
+        }
+        config_docs = list(db.find(query))
+        total_docs = len(config_docs)
+        print(f'Found {total_docs} configuration document(s) to process')
+
+        for doc in config_docs:
+            doc_id = doc.get('_id', 'unknown')
+            try:
+                # Values are stored in configKeyToValues, not configMap
+                config_map = doc.get(CONFIG_FIELD, {})
+
+                project_val   = config_map.get(OLD_KEY_PROJECT)   # list or None
+                component_val = config_map.get(OLD_KEY_COMPONENT) # list or None
+
+                # Skip if neither old key is present
+                if project_val is None and component_val is None:
+                    print(f'Skipping document {doc_id}: old keys not present')
+                    log["statistics"]["skippedCount"] += 1
+                    log["entries"].append(create_log_entry(doc_id, "SKIPPED"))
+                    continue
+
+                # Values are arrays (e.g. ["false"]); use the first non-None list as the new value
+                new_val = project_val if project_val is not None else component_val
+
+                # Ensure the value is stored as a list (preserve array structure)
+                if not isinstance(new_val, list):
+                    new_val = [new_val]
+
+                print(f'Processing document: {doc_id}')
+                print(f'  [SET]    \'{NEW_KEY}\' = {new_val}')
+
+                # Write new unified key (as array, matching the existing document format)
+                config_map[NEW_KEY] = new_val
+
+                # Remove old keys
+                for old_key in (OLD_KEY_PROJECT, OLD_KEY_COMPONENT):
+                    if old_key in config_map:
+                        del config_map[old_key]
+                        print(f'  [REMOVE] \'{old_key}\'')
+
+                doc[CONFIG_FIELD] = config_map
+
+                if not DRY_RUN:
+                    db.save(doc)
+
+                log["statistics"]["successCount"] += 1
+                log["entries"].append(create_log_entry(doc_id, "SUCCESS"))
+
+            except Exception as e:
+                log["statistics"]["errorCount"] += 1
+                print(f"Error processing document {doc_id}: {str(e)}")
+                log["entries"].append(create_log_entry(doc_id, "ERROR", e))
+
+            log["statistics"]["totalProcessed"] += 1
+
+    except Exception as e:
+        print(f"Fatal error during migration: {str(e)}")
+        log["fatalError"] = str(e)
+    finally:
+        try:
+            with open('migrate_unified_mail_export_config_key.log', 'w') as log_file:
+                json.dump(log, log_file, indent=2)
+        except Exception as e:
+            print(f"Error writing log file: {str(e)}")
+
+        print('\n------------------------------------------')
+        print(f"\nMigration Summary:")
+        print(f"Total processed      : {log['statistics']['totalProcessed']}")
+        print(f"Successfully updated : {log['statistics']['successCount']}")
+        print(f"Skipped              : {log['statistics']['skippedCount']}")
+        print(f"Errors               : {log['statistics']['errorCount']}")
+        print(f"DryRun               : {DRY_RUN}")
+        print('\n------------------------------------------')
+
+
+if __name__ == "__main__":
+    start_time = time.time()
+    migrate_mail_export_config_key()
+    print(f'\nMigration completed in {time.time() - start_time:.2f}s')

--- a/scripts/migrations/064_migrate_unified_mail_export_config_key.py
+++ b/scripts/migrations/064_migrate_unified_mail_export_config_key.py
@@ -7,45 +7,48 @@
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-#
-# This is a manual database migration script. It is assumed that a
-# dedicated framework for automatic migration will be written in the
-# future. When that happens, this script should be refactored to conform
-# to the framework's prerequisites to be run by the framework. For
-# example, server address and db name should be parameterized, the code
-# reorganized into a single class or function, etc.
-#
-# This script migrates the two separate mail export configuration keys:
-#   send.project.spreadsheet.export.to.mail.enabled
-#   send.component.spreadsheet.export.to.mail.enabled
-# into a single unified key:
-#   send.export.to.mail.enabled
-# in the SW360_CONFIGURATION document stored in CouchDB.
-#
-# Document structure (actual):
-#   {
-#     "_id": "...",
-#     "configFor": "SW360_CONFIGURATION",
-#     "configKeyToValues": {
-#       "send.project.spreadsheet.export.to.mail.enabled": ["false"],
-#       "send.component.spreadsheet.export.to.mail.enabled": ["false"],
-#       ...
-#     }
-#   }
+
+"""
+ This is a manual database migration script. It is assumed that a
+ dedicated framework for automatic migration will be written in the
+ future. When that happens, this script should be refactored to conform
+ to the framework's prerequisites to be run by the framework. For
+ example, server address and db name should be parameterized, the code
+ reorganized into a single class or function, etc.
+
+ This script migrates the two separate mail export configuration keys:
+   send.project.spreadsheet.export.to.mail.enabled
+   send.component.spreadsheet.export.to.mail.enabled
+ into a single unified key:
+   send.export.to.mail.enabled
+ in the SW360_CONFIGURATION document stored in CouchDB.
+
+ Document structure (actual):
+   {
+     "_id": "...",
+     "configFor": "SW360_CONFIGURATION",
+     "configKeyToValues": {
+       "send.project.spreadsheet.export.to.mail.enabled": ["false"],
+       "send.component.spreadsheet.export.to.mail.enabled": ["false"],
+       ...
+     }
+   }
+"""
 # -----------------------------------------------------------------------------
 
-import couchdb
-import getpass
 import json
 import time
 import sys
 from datetime import datetime
+
+import couchdb
 
 # ---------------------------------------
 # constants
 # ---------------------------------------
 
 DRY_RUN = False
+COUCHSERVER = "http://username:pwd@localhost:5984/"
 DBNAME = 'sw360config'
 
 OLD_KEY_PROJECT   = "send.project.spreadsheet.export.to.mail.enabled"
@@ -60,20 +63,6 @@ CONFIG_FIELD      = "configKeyToValues"
 # ---------------------------------------
 # database connection
 # ---------------------------------------
-
-print("--- CouchDB Connection Setup ---")
-couchdb_host = input("Enter CouchDB host [default: http://localhost:5984]: ").strip() or "http://localhost:5984"
-print(f"  Host     : {couchdb_host}")
-
-couchdb_user = input("Enter CouchDB username: ").strip()
-print(f"  Username : {couchdb_user}")
-
-couchdb_pass = getpass.getpass("Enter CouchDB password: ")
-print("  Password : ****")
-print("--------------------------------")
-
-scheme, rest = couchdb_host.rstrip("/").split("://", 1)
-COUCHSERVER = f"{scheme}://{couchdb_user}:{couchdb_pass}@{rest}/"
 
 try:
     couch = couchdb.Server(COUCHSERVER)
@@ -183,7 +172,7 @@ def migrate_mail_export_config_key():
             print(f"Error writing log file: {str(e)}")
 
         print('\n------------------------------------------')
-        print(f"\nMigration Summary:")
+        print('\nMigration Summary:')
         print(f"Total processed      : {log['statistics']['totalProcessed']}")
         print(f"Successfully updated : {log['statistics']['successCount']}")
         print(f"Skipped              : {log['statistics']['skippedCount']}")


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4222*)
> * Did you add or update any new dependencies that are required for your change?

Closes https://github.com/eclipse-sw360/sw360/issues/4222

This PR consolidates two separate mail-notification configuration keys for spreadsheet export
into a single unified key, and extends the mail-send flow to also cover **License Info** report
downloads.

### Frontend PR:
https://github.com/eclipse-sw360/sw360-frontend/pull/1746

### What changed and why

| Area | Change |
|------|--------|
| **`SW360ConfigKeys`** | Removed `MAIL_REQUEST_FOR_PROJECT_REPORT` and `MAIL_REQUEST_FOR_COMPONENT_REPORT`; replaced with a single `MAIL_REQUEST_FOR_REPORT = "send.export.to.mail.enabled"` |
| **`SW360ConfigsDatabaseHandler`** | Updated references to use the new unified config key |
| **`SW360Constants`** | Added `CONTENT_TYPE_DOCX`, `CONTENT_TYPE_XHTML`, `CONTENT_TYPE_TEXT` content-type constants (previously inline strings or local controller constants) |
| **`LicenseInfoExporter`** (new) | New exporter class in `libraries/exporters` that saves license info report bytes (docx / xhtml / text) to `/tmp` using the same path convention as `ExcelExporter#makeExcelExportForProject`, and returns an `InputStream` for download. `/tmp` cleanup is left to the OS |
| **`SW360ReportController`** | Added `getLicensesInfoReports` mail-send branch calling `sw360ReportService.getUploadedLicenseInfoPath`; merged `setContentTypeForLicenseInfoFormat` into `setContentTypeForFormat` (renamed `setContentTypeForDownload`); extracted content-type literals to `SW360Constants` |
| **`064_migrate_unified_mail_export_config_key.py`** (new) | One-time CouchDB migration script that renames the two old keys to the new unified key in the `SW360_CONFIGURATION` document |



### Suggest Reviewer
> @GMishx 

### How To Test?

1. **Run the migration** against your CouchDB instance (adjust credentials as needed):
   ```bash
   cd scripts/migrations
   python3 064_migrate_unified_mail_export_config_key.py
   ```
   Verify the log file `migrate_unified_mail_export_config_key.log` shows `"successCount": 1`
   and that the CouchDB `sw360config` document now contains only `send.export.to.mail.enabled`.


2. **Test Project / Component report mail flow**:
   - Enable the config key `send.export.to.mail.enabled = true` in SW360 admin settings.
   - Trigger a project spreadsheet export via `GET /api/reports?module=projects&projectId=<id>`.
   - Trigger a component spreadsheet export via `GET /api/reports?module=components`.
   - Confirm an email with the download link is sent for both.

3. **Test License Info report mail flow** (new):
   - With `send.export.to.mail.enabled = true`, call:
     ```
     GET /api/reports?module=licenseInfo&projectId=<id>&generatorClassName=DocxGenerator&variant=REPORT&withSubProject=false
     ```
   - Confirm an email with the download link is sent.
   - Download the report using the token from the email:
     ```
     GET /api/reports/download?module=licenseInfo&token=<token>&generatorClassName=DocxGenerator&variant=REPORT
     ```
   - Verify the correct `Content-Type` header is returned (`application/vnd.openxmlformats-officedocument.wordprocessingml.document` for Docx, `application/xhtml+xml` for Xhtml, `text/plain` for Text).

4. **Test with mail disabled** (`send.export.to.mail.enabled = false`):
   - All three modules (projects, components, licenseInfo) should stream the report directly in the HTTP response as before.


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
