### PR TITLE
Fix/atachments

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -888,7 +888,7 @@ public class RestControllerHelper<T> {
         }
     }
 
-    private void createMissingLicense(String licenseId) throws Exception {
+    public void createMissingLicense(String licenseId) throws Exception {
         License newLicense = new License();
         newLicense.setId(licenseId);
         newLicense.setShortname(licenseId);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -547,7 +547,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             Map<String, String> releaseIdToAcceptedCli = new HashMap<String, String>();
             for (Release rel : releaseData) {
                 String releaseId = rel.getId();
-                for (Attachment attachment : rel.getAttachments()) {
+                for (Attachment attachment : CommonUtils.nullToEmptySet(rel.getAttachments())) {
                     if (CheckStatus.ACCEPTED.equals(attachment.getCheckStatus())) {
                         String attachmentContentId = attachment.getAttachmentContentId();
                         releaseIdToAcceptedCli.put(releaseId, attachmentContentId);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -519,6 +519,22 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return RequestStatus.FAILURE;
     }
 
+    private License tryGetOrCreateLicense(String licenseId, String department,
+            LicenseService.Iface licenseClient) {
+        try {
+            return licenseClient.getByID(licenseId, department);
+        } catch (TException fetchExp) {
+            log.warn("Error fetching license from backend! License Id-{}", licenseId, fetchExp);
+        }
+        try {
+            rch.createMissingLicense(licenseId);
+            return licenseClient.getByID(licenseId, department);
+        } catch (Exception createOrFetchExp) {
+            log.warn("Error creating/fetching missing license! License Id-{}", licenseId, createOrFetchExp);
+            return null;
+        }
+    }
+
     public Map<String, ObligationStatusInfo> getLicenseObligationData(
             Map<String, Set<Release>> licensesFromAttachmentUsage, User user) {
         ThriftClients thriftClients = new ThriftClients();
@@ -545,12 +561,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 limitedRelease.setComponentId(rel.getComponentId());
                 limitedSet.add(limitedRelease);
             }
-            try {
-                lic = licenseClient.getByID(entry.getKey(), user.getDepartment());
-            } catch (TException exp) {
-                log.warn("Error fetching license from backend! License Id-" + entry.getKey(), exp.getMessage());
-                return;
-            }
+            lic = tryGetOrCreateLicense(entry.getKey(), user.getDepartment(), licenseClient);
             if (lic == null || CommonUtils.isNullOrEmptyCollection(lic.getObligations()))
                 return;
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Handle null error when there is no attachment linked to a release when  fetching from projects/{id}/licenseDbObligations endpoint.
> Create a new license if it is not found in the database but detected in the clx report. While not the main issue, it is a nice to have.

### Issue
Request:
```
curl 'http://localhost:8080/resource/api/projects/1308e0f092bc1ff58b96af832c6234ba/licenseDbObligations?page=0&page_entries=10&sort=' \
  -H 'Authorization: Basic xyz'
```
Response:
```
{
  "timestamp" : "2026-06-01T10:55:13.832336484Z",
  "status" : 400,
  "error" : "Bad Request",
  "message" : "Cannot invoke \"java.util.Set.iterator()\" because the return value of \"org.eclipse.sw360.datahandler.thrift.components.Release.getAttachments()\" is null"
}
```

### How To Test?
Attach clx file to a project's release which has sibling releases with zero attachments.
Then hit the /licenseDbObligations endpoint. It should not return an error.

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
