### PR TITLE
feat(component): add config flag to enable/disable nested release linking

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -559,11 +559,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
 
         // Block nested release linking if disabled by configuration
-        if (!SW360Utils.readConfig(IS_NESTED_RELEASE_ENABLED, true)) {
+        if (!SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
             Map<String, ReleaseRelationship> releaseLinks = release.getReleaseIdToRelationship();
-            if (releaseLinks != null && !releaseLinks.isEmpty()) {
-                throw new SW360Exception("Nested release linking is disabled by configuration.")
-                        .setErrorCode(403);
+            if (!CommonUtils.isNullOrEmptyMap(releaseLinks)) {
+                throw new SW360Exception(SW360Constants.PLEASE_ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
             }
         }
 
@@ -1184,18 +1183,16 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         assertNotNull(actual, "Could not find release to update");
 
         // Block nested release linking if disabled by configuration
-        if (!SW360Utils.readConfig(IS_NESTED_RELEASE_ENABLED, true)) {
+        if (!SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
             Map<String, ReleaseRelationship> newLinks = release.getReleaseIdToRelationship();
             Map<String, ReleaseRelationship> existingLinks = actual.getReleaseIdToRelationship();
             boolean hadLinks = existingLinks != null && !existingLinks.isEmpty();
             boolean hasLinks = newLinks != null && !newLinks.isEmpty();
             if (hasLinks && !hadLinks) {
-                throw new SW360Exception("Nested release linking is disabled by configuration.")
-                        .setErrorCode(403);
+                throw new SW360Exception(SW360Constants.PLEASE_ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
             }
             if (hasLinks && !newLinks.equals(existingLinks)) {
-                throw new SW360Exception("Nested release linking is disabled by configuration.")
-                        .setErrorCode(403);
+                throw new SW360Exception(SW360Constants.PLEASE_ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
             }
         }
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -2123,14 +2123,14 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     public boolean checkIfInUse(Set<String> releaseIds) {
-        if (releaseIds != null && releaseIds.size() > 0) {
+        if (!CommonUtils.isNullOrEmptyCollection(releaseIds)) {
             final Set<Component> usingComponents = componentRepository.getUsingComponents(releaseIds);
-            if (usingComponents.size() > 0)
+            if (usingComponents.stream().anyMatch(c -> !c.getReleaseIds().containsAll(releaseIds))) {
                 return true;
+            }
 
             final Set<Project> usingProjects = projectRepository.searchByReleaseId(releaseIds);
-            if (usingProjects.size() > 0)
-                return true;
+            return !CommonUtils.isNullOrEmptyCollection(usingProjects);
         }
         return false;
     }
@@ -2138,11 +2138,11 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     public boolean checkIfInUse(String releaseId) {
 
         final Set<Component> usingComponents = componentRepository.getUsingComponents(releaseId);
-        if (usingComponents.size() > 0)
+        if (!CommonUtils.isNullOrEmptyCollection(usingComponents))
             return true;
 
         final Set<Project> usingProjects = projectRepository.searchByReleaseId(releaseId);
-        return (usingProjects.size() > 0);
+        return !CommonUtils.isNullOrEmptyCollection(usingProjects);
     }
 
     private Component removeReleaseAndCleanUp(Release release, User user) throws SW360Exception {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -558,6 +558,15 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_SOURCE_CODE_URL);
         }
 
+        // Block nested release linking if disabled by configuration
+        if (!SW360Utils.readConfig(IS_NESTED_RELEASE_ENABLED, true)) {
+            Map<String, ReleaseRelationship> releaseLinks = release.getReleaseIdToRelationship();
+            if (releaseLinks != null && !releaseLinks.isEmpty()) {
+                throw new SW360Exception("Nested release linking is disabled by configuration.")
+                        .setErrorCode(403);
+            }
+        }
+
         String componentId = release.getComponentId();
         // Ensure that component exists
         Component component = componentRepository.get(componentId);
@@ -1173,6 +1182,23 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         // Get actual document for members that should no change
         Release actual = releaseRepository.get(release.getId());
         assertNotNull(actual, "Could not find release to update");
+
+        // Block nested release linking if disabled by configuration
+        if (!SW360Utils.readConfig(IS_NESTED_RELEASE_ENABLED, true)) {
+            Map<String, ReleaseRelationship> newLinks = release.getReleaseIdToRelationship();
+            Map<String, ReleaseRelationship> existingLinks = actual.getReleaseIdToRelationship();
+            boolean hadLinks = existingLinks != null && !existingLinks.isEmpty();
+            boolean hasLinks = newLinks != null && !newLinks.isEmpty();
+            if (hasLinks && !hadLinks) {
+                throw new SW360Exception("Nested release linking is disabled by configuration.")
+                        .setErrorCode(403);
+            }
+            if (hasLinks && !newLinks.equals(existingLinks)) {
+                throw new SW360Exception("Nested release linking is disabled by configuration.")
+                        .setErrorCode(403);
+            }
+        }
+
         ensureEccInformationIsSet(actual);
         DatabaseHandlerUtil.saveAttachmentInFileSystem(attachmentConnector, actual.getAttachments(),
                 release.getAttachments(), user.getEmail(), release.getId());

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -83,6 +83,13 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
             "    }" +
             "  }" +
             "}";
+    private static final String COMPONENT_BY_LINKING_RELEASE = "function(doc) {" +
+            "  if (doc.type == 'component') {" +
+            "    for(var i in doc.releaseIds) {" +
+            "      emit(doc.releaseIds[i], doc._id);" +
+            "    }" +
+            "  }" +
+            "}";
     private static final String BY_FOSSOLOGY_ID = "function(doc) {\n" +
             "  if (doc.type == 'release') {\n" +
             "    if (Array.isArray(doc.externalToolProcesses)) {\n" +
@@ -177,6 +184,7 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
         views.put("bycomponenttype", createMapReduce(BY_COMPONENT_TYPE, null));
         views.put("fullbyname", createMapReduce(FULL_BY_NAME, null));
         views.put("byLinkingRelease", createMapReduce(BY_LINKING_RELEASE, null));
+        views.put("componentByLinkingRelease", createMapReduce(COMPONENT_BY_LINKING_RELEASE, null));
         views.put("byFossologyId", createMapReduce(BY_FOSSOLOGY_ID, null));
         views.put("byExternalIds", createMapReduce(BY_EXTERNAL_IDS, null));
         views.put("byDefaultVendorId", createMapReduce(BY_DEFAULT_VENDOR_ID, null));
@@ -280,7 +288,7 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
     }
 
     public Set<Component> getUsingComponents(Set<String> releaseIds) {
-        final Set<String> componentIdsByLinkingRelease = queryForIdsAsValue("byLinkingRelease", releaseIds);
+        final Set<String> componentIdsByLinkingRelease = queryForIdsAsValue("componentByLinkingRelease", releaseIds);
         return new HashSet<>(get(componentIdsByLinkingRelease));
     }
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -75,7 +75,6 @@ public class SW360ConfigsDatabaseHandler {
             .put(AUTO_SET_ECC_STATUS, getOrDefault(configContainer, AUTO_SET_ECC_STATUS, "false"))
             .put(MAIL_REQUEST_FOR_REPORT, getOrDefault(configContainer, MAIL_REQUEST_FOR_REPORT, "false"))
             .put(IS_BULK_RELEASE_DELETING_ENABLED, getOrDefault(configContainer, IS_BULK_RELEASE_DELETING_ENABLED, "false"))
-            .put(IS_NESTED_RELEASE_ENABLED, getOrDefault(configContainer, IS_NESTED_RELEASE_ENABLED, "true"))
             .put(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, getOrDefault(configContainer, DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, "false"))
             .put(IS_FORCE_UPDATE_ENABLED, getOrDefault(configContainer, IS_FORCE_UPDATE_ENABLED, "false"))
             .put(SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE, getOrDefault(configContainer, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE, UserGroup.USER.name()))
@@ -199,7 +198,6 @@ public class SW360ConfigsDatabaseHandler {
                  IS_FORCE_UPDATE_ENABLED,
                  DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD,
                  IS_BULK_RELEASE_DELETING_ENABLED,
-                 IS_NESTED_RELEASE_ENABLED,
                  IS_PACKAGE_PORTLET_ENABLED,
                  INHERIT_ATTACHMENT_USAGES,
                  IS_ADMIN_PRIVATE_ACCESS_ENABLED,

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -75,6 +75,7 @@ public class SW360ConfigsDatabaseHandler {
             .put(AUTO_SET_ECC_STATUS, getOrDefault(configContainer, AUTO_SET_ECC_STATUS, "false"))
             .put(MAIL_REQUEST_FOR_REPORT, getOrDefault(configContainer, MAIL_REQUEST_FOR_REPORT, "false"))
             .put(IS_BULK_RELEASE_DELETING_ENABLED, getOrDefault(configContainer, IS_BULK_RELEASE_DELETING_ENABLED, "false"))
+            .put(IS_NESTED_RELEASE_ENABLED, getOrDefault(configContainer, IS_NESTED_RELEASE_ENABLED, "true"))
             .put(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, getOrDefault(configContainer, DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, "false"))
             .put(IS_FORCE_UPDATE_ENABLED, getOrDefault(configContainer, IS_FORCE_UPDATE_ENABLED, "false"))
             .put(SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE, getOrDefault(configContainer, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE, UserGroup.USER.name()))
@@ -198,6 +199,7 @@ public class SW360ConfigsDatabaseHandler {
                  IS_FORCE_UPDATE_ENABLED,
                  DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD,
                  IS_BULK_RELEASE_DELETING_ENABLED,
+                 IS_NESTED_RELEASE_ENABLED,
                  IS_PACKAGE_PORTLET_ENABLED,
                  INHERIT_ATTACHMENT_USAGES,
                  IS_ADMIN_PRIVATE_ACCESS_ENABLED,

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -19,12 +19,14 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
+import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.SvmConnector;
 import org.eclipse.sw360.datahandler.entitlement.ComponentModerator;
 import org.eclipse.sw360.datahandler.entitlement.ProjectModerator;
 import org.eclipse.sw360.datahandler.entitlement.ReleaseModerator;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.components.*;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
@@ -39,6 +41,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import static org.eclipse.sw360.datahandler.TestUtils.assertTestString;
+import static org.junit.Assume.assumeTrue;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyMap;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.getComponentIds;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.getReleaseIds;
@@ -73,6 +76,7 @@ public class ComponentDatabaseHandlerTest {
     private List<Release> releases;
     private Map<String, Vendor> vendors;
     private ComponentDatabaseHandler handler;
+    private ProjectDatabaseHandler projectHandler;
 
     private int nextReleaseVersion = 0;
 
@@ -153,6 +157,7 @@ public class ComponentDatabaseHandlerTest {
         // Prepare the handler
         handler = new ComponentDatabaseHandler(DatabaseSettingsTest.getConfiguredClient(), dbName, changeLogsDbName, attachmentsDbName, moderator, releaseModerator, projectModerator);
         handler.setSvmConnector(svmConnector);
+        projectHandler = new ProjectDatabaseHandler(DatabaseSettingsTest.getConfiguredClient(), dbName, attachmentsDbName);
     }
 
     @After
@@ -359,6 +364,8 @@ public class ComponentDatabaseHandlerTest {
 
     @Test
     public void testGetLinkedReleases() throws Exception {
+        assumeTrue("Not running since Releases cannot be interlinked",
+                SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
 
         final Map<String, ReleaseRelationship> relations = new HashMap<>();
         relations.put("R1A", ReleaseRelationship.REFERRED);
@@ -420,6 +427,8 @@ public class ComponentDatabaseHandlerTest {
 
     @Test
     public void testGetLinkedReleases2() throws Exception {
+        assumeTrue("Not running since Releases cannot be interlinked",
+                SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
 
         final Map<String, ReleaseRelationship> relations = new HashMap<>();
         relations.put("R1A", ReleaseRelationship.REFERRED);
@@ -537,9 +546,16 @@ public class ComponentDatabaseHandlerTest {
         handler.addRelease(release, user1);
 
         // Make release "DelR" in use by linking it from another release
-        final Release r1A = handler.getRelease("R1A", user1);
-        r1A.setReleaseIdToRelationship(ImmutableMap.of("DelR", ReleaseRelationship.CONTAINED));
-        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            final Release r1A = handler.getRelease("R1A", user1);
+            r1A.setReleaseIdToRelationship(ImmutableMap.of("DelR", ReleaseRelationship.CONTAINED));
+            handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
+        } else {
+            Project project = new Project().setReleaseIdToUsage(
+                    ImmutableMap.of("DelR", new ProjectReleaseRelationship().setReleaseRelation(ReleaseRelationship.CONTAINED))
+            ).setName("Project").setCreatedBy(email1);
+            projectHandler.addProject(project, user1);
+        }
 
         RequestStatus status = handler.deleteComponent("Del", user1);
 
@@ -1056,9 +1072,16 @@ public class ComponentDatabaseHandlerTest {
     @Test
     public void testDontDeleteUsedRelease() throws Exception {
 
-        final Release r1A = handler.getRelease("R1A", user1);
-        r1A.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.CONTAINED));
-        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            final Release r1A = handler.getRelease("R1A", user1);
+            r1A.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.CONTAINED));
+            handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
+        } else {
+            Project project = new Project().setReleaseIdToUsage(
+                    ImmutableMap.of("R2A", new ProjectReleaseRelationship().setReleaseRelation(ReleaseRelationship.CONTAINED))
+            ).setName("Project").setCreatedBy(email1);
+            projectHandler.addProject(project, user1);
+        }
 
         RequestStatus status = handler.deleteRelease("R2A", user1);
         assertEquals(RequestStatus.IN_USE, status);

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -185,8 +185,10 @@ public class ComponentDatabaseHandlerTest {
         component.addToCategories(category);
         final HashMap<String, ReleaseRelationship> releaseLink = new HashMap<>();
 
-        releaseLink.put("R1A", ReleaseRelationship.CONTAINED);
-        releaseLink.put("R2A", ReleaseRelationship.CONTAINED);
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            releaseLink.put("R1A", ReleaseRelationship.CONTAINED);
+            releaseLink.put("R2A", ReleaseRelationship.CONTAINED);
+        }
 
         Release release = new Release().setId("LinkingRelease").setComponentId("Linking").setName("Linking").setVersion("1.0")
                 .setCreatedBy(email1).setVendorId("V1").setReleaseIdToRelationship(releaseLink);
@@ -194,7 +196,12 @@ public class ComponentDatabaseHandlerTest {
         handler.addComponent(component, email1);
         handler.addRelease(release, user1);
 
-        final Set<Component> usingComponents = handler.getUsingComponents("R1A");
+        Set<Component> usingComponents;
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            usingComponents = handler.getUsingComponents("R1A");
+        } else {
+            usingComponents = handler.getUsingComponents(ImmutableSet.of("LinkingRelease"));
+        }
 
         assertTrue(containsInAnyOrder("Linking").matches(getComponentIds(usingComponents)));
     }
@@ -206,8 +213,10 @@ public class ComponentDatabaseHandlerTest {
         component.addToCategories(category);
         final HashMap<String, ReleaseRelationship> releaseLink = new HashMap<>();
 
-        releaseLink.put("R1A", ReleaseRelationship.CONTAINED);
-        releaseLink.put("R2A", ReleaseRelationship.CONTAINED);
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            releaseLink.put("R1A", ReleaseRelationship.CONTAINED);
+            releaseLink.put("R2A", ReleaseRelationship.CONTAINED);
+        }
 
         Release release = new Release().setId("LinkingRelease").setComponentId("Linking").setName("Linking").setVersion("1.0")
                 .setCreatedBy(email1).setVendorId("V1").setReleaseIdToRelationship(releaseLink);
@@ -215,7 +224,12 @@ public class ComponentDatabaseHandlerTest {
         handler.addComponent(component, email1);
         handler.addRelease(release, user1);
 
-        final Set<Component> usingComponents = handler.getUsingComponents(ImmutableSet.of("R1A", "R2A"));
+        Set<Component> usingComponents;
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            usingComponents = handler.getUsingComponents(ImmutableSet.of("R1A", "R2A"));
+        } else {
+            usingComponents = handler.getUsingComponents(ImmutableSet.of("LinkingRelease"));
+        }
 
         assertTrue(containsInAnyOrder("Linking").matches(getComponentIds(usingComponents)));
     }
@@ -1042,9 +1056,16 @@ public class ComponentDatabaseHandlerTest {
 
     @Test
     public void testDontDeleteUsedComponent() throws Exception {
-        final Release r1A = handler.getRelease("R1A", user1);
-        r1A.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.CONTAINED));
-        handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            final Release r1A = handler.getRelease("R1A", user1);
+            r1A.setReleaseIdToRelationship(ImmutableMap.of("R2A", ReleaseRelationship.CONTAINED));
+            handler.updateRelease(r1A, user1, ThriftUtils.IMMUTABLE_OF_RELEASE);
+        } else {
+            Project project = new Project().setReleaseIdToUsage(
+                    ImmutableMap.of("R2A", new ProjectReleaseRelationship().setReleaseRelation(ReleaseRelationship.CONTAINED))
+            ).setName("Project").setCreatedBy(email1);
+            projectHandler.addProject(project, user1);
+        }
 
         RequestStatus status = handler.deleteComponent("C2", user1);
         assertEquals(RequestStatus.IN_USE, status);

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -63,6 +63,9 @@ public class SW360ConfigKeys {
 
     public static final String IS_ADMIN_PRIVATE_ACCESS_ENABLED = "admin.private.project.access.enabled";
 
+    // This property is used to enable/disable the nested release (release-to-release linking) feature
+    public static final String IS_NESTED_RELEASE_ENABLED = "nested.release.enabled";
+
     public static final String SKIP_DOMAINS_FOR_VALID_SOURCE_CODE = "release.sourcecodeurl.skip.domains";
 
     // This property is used to configure the length of generated API tokens
@@ -74,7 +77,7 @@ public class SW360ConfigKeys {
 
     // This property is used to configure the SVM notification URL
     public static final String SVM_NOTIFICATION_URL = "svm.notification.url";
-    
+
     // Properties purely used by UI
     // This property is used to enable/disable linked projects display in the UI
     public static final String UI_ENABLE_LINKED_PROJECTS_DISPLAY = "ui.enable.linked.projects.display";
@@ -145,7 +148,7 @@ public class SW360ConfigKeys {
             USE_LICENSE_INFO_FROM_FILES, MAINLINE_STATE_ENABLED_FOR_USER, IS_STORE_ATTACHMENT_TO_FILE_SYSTEM_ENABLED,
             ATTACHMENT_DELETE_NO_OF_DAYS, ATTACHMENT_STORE_FILE_SYSTEM_LOCATION,
             COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, AUTO_SET_ECC_STATUS, MAIL_REQUEST_FOR_REPORT,
-            IS_BULK_RELEASE_DELETING_ENABLED,
+            IS_BULK_RELEASE_DELETING_ENABLED, IS_NESTED_RELEASE_ENABLED,
             DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, IS_FORCE_UPDATE_ENABLED, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE,
             TOOL_NAME, TOOL_VENDOR, IS_PACKAGE_PORTLET_ENABLED, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, INHERIT_ATTACHMENT_USAGES,
             RELEASE_FRIENDLY_URL, IS_ADMIN_PRIVATE_ACCESS_ENABLED, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, VCS_HOSTS,

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -63,9 +63,6 @@ public class SW360ConfigKeys {
 
     public static final String IS_ADMIN_PRIVATE_ACCESS_ENABLED = "admin.private.project.access.enabled";
 
-    // This property is used to enable/disable the nested release (release-to-release linking) feature
-    public static final String IS_NESTED_RELEASE_ENABLED = "nested.release.enabled";
-
     public static final String SKIP_DOMAINS_FOR_VALID_SOURCE_CODE = "release.sourcecodeurl.skip.domains";
 
     // This property is used to configure the length of generated API tokens
@@ -148,7 +145,7 @@ public class SW360ConfigKeys {
             USE_LICENSE_INFO_FROM_FILES, MAINLINE_STATE_ENABLED_FOR_USER, IS_STORE_ATTACHMENT_TO_FILE_SYSTEM_ENABLED,
             ATTACHMENT_DELETE_NO_OF_DAYS, ATTACHMENT_STORE_FILE_SYSTEM_LOCATION,
             COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, AUTO_SET_ECC_STATUS, MAIL_REQUEST_FOR_REPORT,
-            IS_BULK_RELEASE_DELETING_ENABLED, IS_NESTED_RELEASE_ENABLED,
+            IS_BULK_RELEASE_DELETING_ENABLED,
             DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, IS_FORCE_UPDATE_ENABLED, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE,
             TOOL_NAME, TOOL_VENDOR, IS_PACKAGE_PORTLET_ENABLED, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, INHERIT_ATTACHMENT_USAGES,
             RELEASE_FRIENDLY_URL, IS_ADMIN_PRIVATE_ACCESS_ENABLED, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, VCS_HOSTS,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.release;
 
+import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_NESTED_RELEASE_ENABLED;
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.SPDX_DOCUMENT_ENABLED;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapSW360Exception;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
@@ -1225,6 +1226,10 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             )
             @RequestBody Map<String, ReleaseRelationship> releaseIdToRelationship
     ) throws TException {
+        if (!SW360Utils.readConfig(IS_NESTED_RELEASE_ENABLED, true)) {
+            throw new HttpClientErrorException(HttpStatus.FORBIDDEN,
+                    "Nested release linking is disabled by configuration.");
+        }
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Release sw360Release = releaseService.getReleaseForUserById(id, sw360User);
         if (releaseIdToRelationship.isEmpty()) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -12,9 +12,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.release;
 
-import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_NESTED_RELEASE_ENABLED;
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.SPDX_DOCUMENT_ENABLED;
-import static org.eclipse.sw360.datahandler.common.WrappedException.wrapSW360Exception;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
@@ -87,13 +85,11 @@ import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.eclipse.sw360.rest.resourceserver.core.RestExceptionHandler.ErrorMessage;
 import org.eclipse.sw360.rest.resourceserver.packages.PackageController;
 import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -105,7 +101,6 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.bind.annotation.*;
@@ -1226,9 +1221,8 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             )
             @RequestBody Map<String, ReleaseRelationship> releaseIdToRelationship
     ) throws TException {
-        if (!SW360Utils.readConfig(IS_NESTED_RELEASE_ENABLED, true)) {
-            throw new HttpClientErrorException(HttpStatus.FORBIDDEN,
-                    "Nested release linking is disabled by configuration.");
+        if (!SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
+            throw new SW360Exception(SW360Constants.PLEASE_ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
         }
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Release sw360Release = releaseService.getReleaseForUserById(id, sw360User);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.CycloneDxComponentType;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -87,6 +88,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -685,6 +687,9 @@ public class ReleaseTest extends TestIntegrationBase {
 
     @Test
     public void should_link_releases_to_release() throws IOException, TException {
+        assumeTrue("Not running since Releases cannot be interlinked",
+                SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
+
         given(this.releaseServiceMock.updateRelease(any(), any())).willReturn(RequestStatus.SUCCESS);
 
         HttpHeaders headers = getHeaders(port);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -1453,6 +1453,20 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_reject_link_releases_when_nested_release_disabled() throws Exception {
+        try (MockedStatic<SW360Utils> mockedStatic = mockStatic(SW360Utils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
+            mockedStatic.when(() -> SW360Utils.readConfig(eq("nested.release.enabled"), eq(true))).thenReturn(false);
+
+            mockMvc.perform(post("/api/releases/" + release.getId() + "/releases")
+                    .contentType(MediaTypes.HAL_JSON)
+                    .content(this.objectMapper.writeValueAsString(releaseIdToRelationship1))
+                    .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                    .accept(MediaTypes.HAL_JSON))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Test
     public void should_document_link_packages() throws Exception {
         MockHttpServletRequestBuilder requestBuilder = patch("/api/releases/" + release.getId() + "/link/packages");
         link_unlink_packages(requestBuilder);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -42,6 +43,7 @@ import java.util.UUID;
 
 import com.google.common.collect.Sets;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
@@ -1443,6 +1445,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_document_link_releases_to_release() throws Exception {
+        assumeTrue("Not running since Releases cannot be interlinked",
+                SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
 
         mockMvc.perform(post("/api/releases/" + release.getId() + "/releases")
                 .contentType(MediaTypes.HAL_JSON)
@@ -1454,15 +1458,20 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_reject_link_releases_when_nested_release_disabled() throws Exception {
-        try (MockedStatic<SW360Utils> mockedStatic = mockStatic(SW360Utils.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
-            mockedStatic.when(() -> SW360Utils.readConfig(eq("nested.release.enabled"), eq(true))).thenReturn(false);
-
+        if (!SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) {
             mockMvc.perform(post("/api/releases/" + release.getId() + "/releases")
-                    .contentType(MediaTypes.HAL_JSON)
-                    .content(this.objectMapper.writeValueAsString(releaseIdToRelationship1))
-                    .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
-                    .accept(MediaTypes.HAL_JSON))
-                    .andExpect(status().isForbidden());
+                            .contentType(MediaTypes.HAL_JSON)
+                            .content(this.objectMapper.writeValueAsString(releaseIdToRelationship1))
+                            .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                            .accept(MediaTypes.HAL_JSON))
+                    .andExpect(status().isInternalServerError());
+        } else {
+            mockMvc.perform(post("/api/releases/" + release.getId() + "/releases")
+                            .contentType(MediaTypes.HAL_JSON)
+                            .content(this.objectMapper.writeValueAsString(releaseIdToRelationship1))
+                            .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                            .accept(MediaTypes.HAL_JSON))
+                    .andExpect(status().isCreated());
         }
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

Add a DB-stored configuration flag (`nested.release.enabled`) to enable or disable the nested release (release-to-release linking) feature. Some organizations use nested releases to model sub-component dependencies, while others consider it a process violation. This change allows admins to control the behavior via configuration.


## Changes

- **`SW360ConfigKeys.java`** — Added `IS_NESTED_RELEASE_ENABLED` constant (`nested.release.enabled`)
- **`SW360ConfigsDatabaseHandler.java`** — Registered the key with default `true` and added boolean validation
- **`ReleaseController.java`** — Guarded `POST /api/releases/{id}/releases` endpoint; returns HTTP 403 when disabled
- **`ComponentDatabaseHandler.java`** — Defense-in-depth checks in `addRelease()` and `updateRelease()` to reject nested release links when disabled
- **`ReleaseSpecTest.java`** — Added test verifying the endpoint returns 403 when configuration is disabled

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Default value: `true` | Backward compatible — existing deployments keep the feature active |
| Enforcement at REST + backend layers | REST gives immediate feedback; backend protects against imports/SBOM paths |
| Config category: `SW360_CONFIGURATION` | Affects backend behavior, not purely UI |
| Existing links tolerated when disabled | Only blocks adding/modifying links, does not remove existing data |

## How to Use

Admins can disable nested release linking via the configurations API:

```http
PUT /api/configurations
Content-Type: application/json

{
  "nested.release.enabled": "false"
}
```

## Suggest Reviewer

@GMishx 

## How To Test?

1. **Default behavior (enabled):** `POST /api/releases/{id}/releases` works as before
2. **Disabled behavior:**
   - Set `nested.release.enabled` to `false` via `PUT /api/configurations`
   - Attempt `POST /api/releases/{id}/releases` → expect HTTP 403
   - Attempt creating a release with `releaseIdToRelationship` set → expect rejection
3. **Run tests:** `mvn test -pl rest/resource-server -Dtest="ReleaseSpecTest#should_reject_link_releases_when_nested_release_disabled"`

## Checklist

Must:
- [x] New configuration key registered and validated
- [x] Test added for the new behavior



