### PR TITLE
fix(rest): handle null project clearing state

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/PermissionUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/PermissionUtils.java
@@ -178,8 +178,11 @@ public class PermissionUtils {
         }
     }
 
-    public static boolean checkEditablePermission(String name, User user, Map<String, Object> reqBodyMap, Project sw360Project) {
-        if (!name.equals(ProjectClearingState.CLOSED.name()) || PermissionUtils.isAdmin(user)) {
+    public static boolean checkEditablePermission(ProjectClearingState state, User user, Map<String, Object> reqBodyMap, Project sw360Project) {
+        if (state == null) {
+            state = ProjectClearingState.OPEN;
+        }
+        if (!ProjectClearingState.CLOSED.equals(state) || PermissionUtils.isAdmin(user)) {
             return true;
         } else {
             if ((reqBodyMap.containsKey("attachments") || reqBodyMap.containsKey("obligationsText")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1950,6 +1950,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             description = "Update a project.",
             tags = {"Projects"}
     )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Project successfully updated"),
+        @ApiResponse(responseCode = "202", description = "Accepted - update request was sent to moderation")
+    })
     @PatchMapping(value = PROJECTS_URL + "/{id}")
     public ResponseEntity<EntityModel<Project>> patchProject(
             @Parameter(description = "Project ID.")
@@ -1960,7 +1964,17 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Project sw360Project = projectService.getProjectForUserById(id, user);
 
-        boolean editPermitted = PermissionUtils.checkEditablePermission(sw360Project.getClearingState().name(), user, reqBodyMap, sw360Project);
+        String comment = (String) reqBodyMap.get("comment");
+        user.setCommentMadeDuringModerationRequest(comment);
+        if (!restControllerHelper.isWriteActionAllowed(sw360Project, user) && comment == null) {
+            throw new BadRequestClientException(RESPONSE_BODY_FOR_MODERATION_REQUEST_WITH_COMMIT.toString());
+        }
+
+        if (sw360Project.getClearingState() == null) {
+            sw360Project.setClearingState(ProjectClearingState.OPEN);
+        }
+
+        boolean editPermitted = PermissionUtils.checkEditablePermission(sw360Project.getClearingState(), user, reqBodyMap, sw360Project);
         if (!editPermitted) {
             log.error("No write permission for project");
             throw new AccessDeniedException("No write permission for project");
@@ -1971,28 +1985,22 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             attachmentService.preserveImmutableAttachmentFields(
                     updateProject.getAttachments(), sw360Project.getAttachments(), user);
         }
-        String comment = (String) reqBodyMap.get("comment");
-        user.setCommentMadeDuringModerationRequest(comment);
-        if (!restControllerHelper.isWriteActionAllowed(sw360Project, user) && comment == null) {
-            throw new BadRequestClientException(RESPONSE_BODY_FOR_MODERATION_REQUEST_WITH_COMMIT.toString());
-        } else {
-            sw360Project = this.restControllerHelper.updateProject(sw360Project, updateProject, reqBodyMap,
-                    mapOfProjectFieldsToRequestBody);
-            if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP
-                    && updateProject.getReleaseIdToUsage() != null) {
-                sw360Project.unsetReleaseRelationNetwork();
-                projectService.syncReleaseRelationNetworkAndReleaseIdToUsage(sw360Project, user);
-            }
-            RequestStatus updateProjectStatus = projectService.updateProject(sw360Project, user);
-            if (updateProjectStatus == RequestStatus.DUPLICATE_ATTACHMENT) {
-                throw new RuntimeException("Duplicate attachment detected while updating project.");
-            }
-            HalResource<Project> userHalResource = createHalProject(sw360Project, user);
-            if (updateProjectStatus == RequestStatus.SENT_TO_MODERATOR) {
-                return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
-            }
-            return new ResponseEntity<>(userHalResource, HttpStatus.OK);
+        sw360Project = this.restControllerHelper.updateProject(sw360Project, updateProject, reqBodyMap,
+                mapOfProjectFieldsToRequestBody);
+        if (SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP
+                && updateProject.getReleaseIdToUsage() != null) {
+            sw360Project.unsetReleaseRelationNetwork();
+            projectService.syncReleaseRelationNetworkAndReleaseIdToUsage(sw360Project, user);
         }
+        RequestStatus updateProjectStatus = projectService.updateProject(sw360Project, user);
+        if (updateProjectStatus == RequestStatus.DUPLICATE_ATTACHMENT) {
+            throw new RuntimeException("Duplicate attachment detected while updating project.");
+        }
+        HalResource<Project> userHalResource = createHalProject(sw360Project, user);
+        if (updateProjectStatus == RequestStatus.SENT_TO_MODERATOR) {
+            return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
+        }
+        return new ResponseEntity<>(userHalResource, HttpStatus.OK);
     }
 
     @Operation(

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -508,6 +508,29 @@ public class ProjectTest extends TestIntegrationBase {
     }
 
     @Test
+    public void should_update_project_when_clearing_state_is_null() throws IOException, TException {
+        // Simulate a legacy / partially-populated project without a clearing state.
+        project1.unsetClearingState();
+        given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
+        given(this.projectServiceMock.updateProject(any(), any())).willReturn(RequestStatus.SUCCESS);
+
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", "Updated Project Name");
+        body.put("description", "Updated project description");
+        body.put("version", "2.0.0");
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/" + project1.getId(),
+                        HttpMethod.PATCH,
+                        new HttpEntity<>(body, headers),
+                        String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
     public void should_link_projects() throws IOException, TException {
         given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
         given(this.projectServiceMock.getProjectForUserById(eq(project2.getId()), any())).willReturn(project2);


### PR DESCRIPTION
## What

This change fixes `PATCH /api/projects/{id}` for projects that have a null `clearingState` (legacy/partially-populated records), and updates OpenAPI documentation for the endpoint responses.

## Changes

- `rest/resource-server/.../ProjectController.java`
  - Add OpenAPI response docs for:
    - `200` Project successfully updated
    - `202` Accepted - update request sent to moderation
  - In `patchProject`:
    - Move moderation comment/write-check logic before update
    - Default `sw360Project.clearingState` to `OPEN` when null
    - Call `PermissionUtils.checkEditablePermission(...)` using `ProjectClearingState`

- `libraries/datahandler/.../PermissionUtils.java`
  - Change `checkEditablePermission` signature from `String` to `ProjectClearingState`
  - Add null fallback to `ProjectClearingState.OPEN`

- `rest/resource-server/.../integration/ProjectTest.java`
  - Add regression test:
    - `should_update_project_when_clearing_state_is_null`

## Why

`patchProject` previously dereferenced `getClearingState().name()` and could fail for projects with missing clearing state data. This change makes the flow null-safe and documents both observed success paths (`200` and `202`).

## How to validate

1. Run project tests for the resource-server module.
2. Verify the new integration test passes.
3. Check generated OpenAPI output for `PATCH /api/projects/{id}` includes both `200` and `202`.