### PR TITLE
feat(release): making release state editable.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -218,6 +218,17 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     private void autosetReleaseClearingState(Release releaseAfter, Release releaseBefore) {
+        // If the clearing state was manually set to UNDER_CLEARING from an allowed
+        // source state (NEW_CLEARING or REPORT_AVAILABLE), preserve the manual override
+        // and skip the automatic recalculation based on attachments.
+        ClearingState stateBefore = releaseBefore.getClearingState();
+        ClearingState stateAfter = releaseAfter.getClearingState();
+        if (stateAfter == ClearingState.UNDER_CLEARING
+                && stateBefore != ClearingState.UNDER_CLEARING
+                && (stateBefore == ClearingState.NEW_CLEARING || stateBefore == ClearingState.REPORT_AVAILABLE)) {
+            return;
+        }
+
         Optional<Attachment> oldBestCR = getBestClearingReport(releaseBefore);
         Optional<Attachment> newBestCR = getBestClearingReport(releaseAfter);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -68,6 +68,7 @@ import org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.Doc
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxdocument.SPDXDocument;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformation;
 import org.eclipse.sw360.datahandler.thrift.components.BulkOperationNode;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
@@ -564,7 +565,24 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         Release updateRelease = setBackwardCompatibleFieldsInRelease(reqBodyMap);
         attachmentService.preserveImmutableAttachmentFields(
                 updateRelease.getAttachments(), sw360Release.getAttachments(), user);
-        updateRelease.setClearingState(sw360Release.getClearingState());
+
+        // Apply the same clearing state edit rules as the frontend:
+        // Only clearing admin/expert can change clearing state, and only to
+        // UNDER_CLEARING from NEW_CLEARING or REPORT_AVAILABLE.
+        // If conditions are not met, silently preserve existing state and proceed with other field updates.
+        if (updateRelease.isSetClearingState()
+                && updateRelease.getClearingState() == ClearingState.UNDER_CLEARING
+                && PermissionUtils.isUserAtLeastClearingAdminOrExpert(user)) {
+            ClearingState currentState = sw360Release.getClearingState();
+            if (currentState == ClearingState.NEW_CLEARING || currentState == ClearingState.REPORT_AVAILABLE) {
+                updateRelease.setClearingState(ClearingState.UNDER_CLEARING);
+            } else {
+                updateRelease.setClearingState(sw360Release.getClearingState());
+            }
+        } else {
+            updateRelease.setClearingState(sw360Release.getClearingState());
+        }
+
         sw360Release = this.restControllerHelper.updateRelease(sw360Release, updateRelease);
         releaseService.setComponentNameAsReleaseName(sw360Release, user);
         RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, user);


### PR DESCRIPTION
Description
This PR makes the Release Clearing State editable for privileged users and adds a FOSSology warning dialog.

Changes:

- Only Clearing Experts/Admin and Admins are allowed to change the Clearing State.
- Clearing State can only be changed from New and Report Available to Under Clearing.
- The automated Clearing State change still works (with CLI uploads, CLI approval, CLI rejection).
- There is a Changelog entry for the state change.
- If Clearing State is Under Clearing, clicking on Send to FOSSology button shows a warning.