### PR TITLE
build(deps): replace deprecated overwrite param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -910,7 +910,7 @@
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>
           <configuration>
-            <overwrite>true</overwrite>
+            <changeDetection>always</changeDetection>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Replace deprecated `maven-resources-plugin` configuration in the root `pom.xml`.

Issue: N/A

### How To Test?
1. From the `sw360` repository root, run Maven resource processing.
2. Verify the warning below is no longer printed:
   `Parameter 'overwrite' is deprecated: Use changeDetection instead.`
3. Confirm the build still processes resources successfully.

Example command:

```bash
cd /home/z003u7px/development/sw360
mvn -DskipTests process-resources
```

### What Changed?
- Replaced deprecated `maven-resources-plugin` configuration in `pom.xml`
- Changed:
  - from: `<overwrite>true</overwrite>`
  - to: `<changeDetection>always</changeDetection>`
- Preserved the previous behavior because `always` is the documented equivalent of `overwrite=true`

### Dependencies
- No new dependencies were added
- No dependency versions were changed

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] If code is AI-generated, mention the tool and model used (e.g., GitHub Copilot, GPT-4)

AI assistance:
- Drafted with GitHub Copilot