### PR TITLE
fix(project): make luceneSearch default true

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -284,8 +284,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "additionalData", required = false) String additionalData,
             @Parameter(description = "Filter by attachment author email (createdBy field of attachments)")
             @RequestParam(value = "attachmentAuthor", required = false) String attachmentAuthor,
-            @Parameter(description = "List project by lucene search")
-            @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
+            @Parameter(description = "List project by lucene search, default true")
+            @RequestParam(value = "luceneSearch", required = false, defaultValue = "true") boolean luceneSearch,
             HttpServletRequest request
     ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -331,7 +331,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             List<Project> sw360Projects, Map<PaginationData, List<Project>> paginatedProjects
     ) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException {
         PaginationResult<Project> paginationResult;
-        if (paginatedProjects != null) {
+        if (!CommonUtils.isNullOrEmptyMap(paginatedProjects)) {
             sw360Projects.addAll(paginatedProjects.values().iterator().next());
             int totalCount = Math.toIntExact(paginatedProjects.keySet().stream()
                     .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -608,7 +608,7 @@ public class ProjectTest extends TestIntegrationBase {
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?type=CUSTOMER",
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?luceneSearch=false&type=CUSTOMER",
                         HttpMethod.GET,
                         new HttpEntity<>(null, headers),
                         String.class);
@@ -617,7 +617,7 @@ public class ProjectTest extends TestIntegrationBase {
     }
 
     @Test
-    public void should_get_projects_by_name() throws IOException, TException {
+    public void should_get_projects_by_name_without_lucene() throws IOException, TException {
         given(this.projectServiceMock.searchAccessibleProjectByExactValues(any(), any(), any())).willReturn(
                 Collections.singletonMap(
                         new PaginationData().setRowsPerPage(1).setDisplayStart(0).setTotalRowCount(1),
@@ -627,7 +627,7 @@ public class ProjectTest extends TestIntegrationBase {
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?name=Alpha",
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?luceneSearch=false&name=Alpha",
                         HttpMethod.GET,
                         new HttpEntity<>(null, headers),
                         String.class);
@@ -664,7 +664,7 @@ public class ProjectTest extends TestIntegrationBase {
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?group=" + project1.getBusinessUnit().replace(" ", "%20"),
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?luceneSearch=false&group=" + project1.getBusinessUnit().replace(" ", "%20"),
                         HttpMethod.GET,
                         new HttpEntity<>(null, headers),
                         String.class);
@@ -703,7 +703,7 @@ public class ProjectTest extends TestIntegrationBase {
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
-                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?tag=test-tag",
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects?luceneSearch=false&tag=test-tag",
                         HttpMethod.GET,
                         new HttpEntity<>(null, headers),
                         String.class);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Revert the default behavior of `/projects` endpoint to treat `luceneSearch` by default as `true`.

### How To Test?
Make API call to `/projects?name=<name>` and the results should come from lucene search.