### PR TITLE
fix(test): Migrated integration tests from JUnit4 to JUnit6

### DIFF
--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ApiRootAuthorizationRegressionTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ApiRootAuthorizationRegressionTest.java
@@ -15,9 +15,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthority;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -40,7 +39,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -52,11 +50,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringRunner.class)
 @Import(ApiRootAuthorizationRegressionTest.ApiRootAuthorizationTestConfig.class)
 public class ApiRootAuthorizationRegressionTest extends TestIntegrationBase {
 
@@ -66,7 +63,7 @@ public class ApiRootAuthorizationRegressionTest extends TestIntegrationBase {
     @Value("${local.server.port}")
     private int port;
 
-    @Before
+    @BeforeEach
     public void setUpReadOnlyUser() {
         User readOnlyUser = new User();
         readOnlyUser.setEmail(READ_ONLY_EMAIL);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/AttachmentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/AttachmentTest.java
@@ -14,14 +14,11 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
-import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.*;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -40,12 +37,6 @@ public class AttachmentTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360AttachmentService attachmentServiceMock;
-
-    @MockitoBean
-    private Sw360ReleaseService releaseServiceMock;
 
     private final String shaInvalid = "56789";
     private final String attachmentId = "test-attachment-123";

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/AttachmentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/AttachmentTest.java
@@ -16,15 +16,12 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.*;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -32,13 +29,13 @@ import org.springframework.util.MultiValueMap;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class AttachmentTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -53,7 +50,7 @@ public class AttachmentTest extends TestIntegrationBase {
     private final String shaInvalid = "56789";
     private final String attachmentId = "test-attachment-123";
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
 
         given(this.attachmentServiceMock.getAttachmentsBySha1(eq(TestHelper.attachmentShaUsedMultipleTimes))).willReturn(TestHelper.getDummyAttachmentInfoListForTest());
@@ -112,11 +109,11 @@ public class AttachmentTest extends TestIntegrationBase {
         // Verify the response contains attachment data at root level
         // The response structure has attachment fields directly, not nested under "attachment"
         String responseBody = response.getBody();
-        Assert.assertNotNull(responseBody);
-        assertTrue("Response should contain attachmentContentId", responseBody.contains("attachmentContentId"));
-        assertTrue("Response should contain filename", responseBody.contains("filename"));
-        assertTrue("Response should contain _links", responseBody.contains("_links"));
-        assertTrue("Response should contain _embedded", responseBody.contains("_embedded"));
+        assertNotNull(responseBody);
+        assertTrue(responseBody.contains("attachmentContentId"), "Response should contain attachmentContentId");
+        assertTrue(responseBody.contains("filename"), "Response should contain filename");
+        assertTrue(responseBody.contains("_links"), "Response should contain _links");
+        assertTrue(responseBody.contains("_embedded"), "Response should contain _embedded");
     }
 
     @Test
@@ -148,10 +145,10 @@ public class AttachmentTest extends TestIntegrationBase {
 
         // Verify the response contains attachment data
         String responseBody = response.getBody();
-        Assert.assertNotNull(responseBody);
-        assertTrue("Response should contain attachments", responseBody.contains("attachments"));
-        assertTrue("Response should contain attachmentContentId", responseBody.contains("attachmentContentId"));
-        assertTrue("Response should contain filename", responseBody.contains("filename"));
+        assertNotNull(responseBody);
+        assertTrue(responseBody.contains("attachments"), "Response should contain attachments");
+        assertTrue(responseBody.contains("attachmentContentId"), "Response should contain attachmentContentId");
+        assertTrue(responseBody.contains("filename"), "Response should contain filename");
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/CacheAdminTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/CacheAdminTest.java
@@ -18,9 +18,8 @@ import org.eclipse.sw360.rest.resourceserver.cache.ApiResponseCacheManager;
 import org.eclipse.sw360.rest.resourceserver.cache.CacheState;
 import org.eclipse.sw360.rest.resourceserver.cache.CacheStatistics;
 import org.eclipse.sw360.rest.resourceserver.cache.CachedEndpoint;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
@@ -29,20 +28,18 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
-@RunWith(SpringRunner.class)
 public class CacheAdminTest extends TestIntegrationBase {
 
     @LocalServerPort
@@ -53,7 +50,7 @@ public class CacheAdminTest extends TestIntegrationBase {
 
     private List<CacheStatistics> testStats;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         User user = TestHelper.getTestUser();
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/CacheAdminTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/CacheAdminTest.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.cache.ApiResponseCacheManager;
 import org.eclipse.sw360.rest.resourceserver.cache.CacheState;
 import org.eclipse.sw360.rest.resourceserver.cache.CacheStatistics;
 import org.eclipse.sw360.rest.resourceserver.cache.CachedEndpoint;
@@ -27,7 +26,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,9 +42,6 @@ public class CacheAdminTest extends TestIntegrationBase {
 
     @LocalServerPort
     private int port;
-
-    @MockitoBean
-    private ApiResponseCacheManager cacheManagerMock;
 
     private List<CacheStatistics> testStats;
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ChangeLogTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ChangeLogTest.java
@@ -20,7 +20,6 @@ import org.eclipse.sw360.datahandler.thrift.changelogs.Operation;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ReferenceDocData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.eclipse.sw360.rest.resourceserver.changelog.Sw360ChangeLogService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +29,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,9 +48,6 @@ public class ChangeLogTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360ChangeLogService changeLogServiceMock;
 
     private User adminUser;
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ChangeLogTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ChangeLogTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,19 +21,16 @@ import org.eclipse.sw360.datahandler.thrift.changelogs.ReferenceDocData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.changelog.Sw360ChangeLogService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,13 +40,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class ChangeLogTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -59,7 +56,7 @@ public class ChangeLogTest extends TestIntegrationBase {
 
     private User adminUser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         adminUser = new User();
         adminUser.setEmail("admin@sw360.org");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,9 +23,8 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.clearingrequest.Sw360ClearingRequestService;
 import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -34,21 +34,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class ClearingRequestTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -66,7 +64,7 @@ public class ClearingRequestTest extends TestIntegrationBase {
     private User adminUser;
     private ClearingRequest cr;
 
-    @Before
+    @BeforeEach
     public void setUp() throws TException {
         adminUser = new User();
         adminUser.setEmail("admin@sw360.org");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
@@ -20,9 +20,6 @@ import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.eclipse.sw360.rest.resourceserver.clearingrequest.Sw360ClearingRequestService;
-import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
-import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,7 +30,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -51,15 +47,6 @@ public class ClearingRequestTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360ClearingRequestService clearingServiceMock;
-
-    @MockitoBean
-    private Sw360ProjectService projectServiceMock;
-
-    @MockitoBean
-    private Sw360ModerationRequestService moderationServiceMock;
 
     private User adminUser;
     private ClearingRequest cr;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -31,9 +31,8 @@ import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -48,7 +47,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -69,17 +67,17 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 
-@RunWith(SpringRunner.class)
+
 public class ComponentTest extends TestIntegrationBase {
     private static final Logger log = LogManager.getLogger(ComponentTest.class);
 
@@ -100,7 +98,7 @@ public class ComponentTest extends TestIntegrationBase {
 
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         List<Component> componentList = new ArrayList<>();
         component = new Component();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -27,10 +27,7 @@ import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
-import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -45,8 +42,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -83,15 +78,6 @@ public class ComponentTest extends TestIntegrationBase {
 
     @LocalServerPort
     private int port;
-
-    @MockitoSpyBean
-    private Sw360ComponentService componentServiceMock;
-
-    @MockitoBean
-    private Sw360AttachmentService attachmentServiceMock;
-
-    @MockitoBean
-    private SW360ReportService sw360ReportServiceMock;
 
     private Component component;
     private final String componentId = "123456789";

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,9 +18,8 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.configuration.SW360ConfigurationsService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
@@ -29,17 +29,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.InvalidPropertiesFormatException;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,7 +46,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
-@RunWith(SpringRunner.class)
 public class ConfigurationsTest extends TestIntegrationBase {
 
     @LocalServerPort
@@ -57,7 +55,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
     private Map<String, String> testConfigsFromDb;
     private Map<String, String> allTestConfigs;
 
-    @Before
+    @BeforeEach
     public void before() throws TException, InvalidPropertiesFormatException {
         // Setup test configuration data
         testConfigsFromProperties = new HashMap<>();
@@ -105,14 +103,10 @@ public class ConfigurationsTest extends TestIntegrationBase {
 
         // Verify response structure
         String responseBody = response.getBody();
-        assertTrue("Response should contain flexible project configuration",
-                responseBody.contains("enable.flexible.project.release.relationship"));
-        assertTrue("Response should contain SVM component ID",
-                responseBody.contains("svm.component.id"));
-        assertTrue("Response should contain SPDX document configuration",
-                responseBody.contains("spdx.document.enabled"));
-        assertTrue("Response should contain SW360 tool name",
-                responseBody.contains("sw360.tool.name"));
+        assertTrue(responseBody.contains("enable.flexible.project.release.relationship"), "Response should contain flexible project configuration");
+        assertTrue(responseBody.contains("svm.component.id"), "Response should contain SVM component ID");
+        assertTrue(responseBody.contains("spdx.document.enabled"), "Response should contain SPDX document configuration");
+        assertTrue(responseBody.contains("sw360.tool.name"), "Response should contain SW360 tool name");
     }
 
     @Test
@@ -129,12 +123,9 @@ public class ConfigurationsTest extends TestIntegrationBase {
 
         // Verify only changeable configurations (from DB) are returned
         String responseBody = response.getBody();
-        assertTrue("Response should contain SPDX document configuration",
-                responseBody.contains("spdx.document.enabled"));
-        assertTrue("Response should contain SW360 tool name",
-                responseBody.contains("sw360.tool.name"));
-        assertFalse("Response should not contain properties configurations",
-                responseBody.contains("enable.flexible.project.release.relationship"));
+        assertTrue(responseBody.contains("spdx.document.enabled"), "Response should contain SPDX document configuration");
+        assertTrue(responseBody.contains("sw360.tool.name"), "Response should contain SW360 tool name");
+        assertFalse(responseBody.contains("enable.flexible.project.release.relationship"), "Response should not contain properties configurations");
     }
 
     @Test
@@ -151,12 +142,9 @@ public class ConfigurationsTest extends TestIntegrationBase {
 
         // Verify only non-changeable configurations (from properties) are returned
         String responseBody = response.getBody();
-        assertTrue("Response should contain flexible project configuration",
-                responseBody.contains("enable.flexible.project.release.relationship"));
-        assertTrue("Response should contain SVM component ID",
-                responseBody.contains("svm.component.id"));
-        assertFalse("Response should not contain DB configurations",
-                responseBody.contains("spdx.document.enabled"));
+        assertTrue(responseBody.contains("enable.flexible.project.release.relationship"), "Response should contain flexible project configuration");
+        assertTrue(responseBody.contains("svm.component.id"), "Response should contain SVM component ID");
+        assertFalse(responseBody.contains("spdx.document.enabled"), "Response should not contain DB configurations");
     }
 
     // ========== UPDATE CONFIGURATIONS TESTS ==========
@@ -183,8 +171,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain success message",
-                responseBody.contains("Configurations are updated successfully"));
+        assertTrue(responseBody.contains("Configurations are updated successfully"), "Response should contain success message");
     }
 
     @Test
@@ -209,8 +196,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain unauthorized message",
-                responseBody.contains("Unauthorized") || responseBody.contains("unauthorized"));
+        assertTrue(responseBody.contains("Unauthorized") || responseBody.contains("unauthorized"), "Response should contain unauthorized message");
     }
 
     @Test
@@ -236,8 +222,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain invalid input message",
-                responseBody.contains("Invalid configurations") || responseBody.contains("unable to find DB container"));
+        assertTrue(responseBody.contains("Invalid configurations") || responseBody.contains("unable to find DB container"), "Response should contain invalid input message");
     }
 
     @Test
@@ -263,8 +248,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain in-use message",
-                responseBody.contains("being updated by another administrator"));
+        assertTrue(responseBody.contains("being updated by another administrator"), "Response should contain in-use message");
     }
 
     // ========== CONTAINER-SPECIFIC CONFIGURATIONS TESTS ==========
@@ -282,10 +266,8 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain container configurations",
-                responseBody.contains("spdx.document.enabled"));
-        assertTrue("Response should contain SW360 tool name",
-                responseBody.contains("sw360.tool.name"));
+        assertTrue(responseBody.contains("spdx.document.enabled"), "Response should contain container configurations");
+        assertTrue(responseBody.contains("sw360.tool.name"), "Response should contain SW360 tool name");
     }
 
     @Test
@@ -301,10 +283,8 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain container configurations",
-                responseBody.contains("spdx.document.enabled"));
-        assertTrue("Response should contain SW360 tool name",
-                responseBody.contains("sw360.tool.name"));
+        assertTrue(responseBody.contains("spdx.document.enabled"), "Response should contain container configurations");
+        assertTrue(responseBody.contains("sw360.tool.name"), "Response should contain SW360 tool name");
     }
 
     @Test
@@ -327,8 +307,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain success message",
-                responseBody.contains("Configurations are updated successfully"));
+        assertTrue(responseBody.contains("Configurations are updated successfully"), "Response should contain success message");
     }
 
     @Test
@@ -364,8 +343,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
                         any());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain success message",
-                responseBody.contains("Configurations are updated successfully"));
+        assertTrue(responseBody.contains("Configurations are updated successfully"), "Response should contain success message");
     }
 
     @Test
@@ -388,8 +366,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain success message",
-                responseBody.contains("Configurations are updated successfully"));
+        assertTrue(responseBody.contains("Configurations are updated successfully"), "Response should contain success message");
     }
 
     @Test
@@ -414,8 +391,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain unauthorized message",
-                responseBody.contains("Unauthorized") || responseBody.contains("unauthorized"));
+        assertTrue(responseBody.contains("Unauthorized") || responseBody.contains("unauthorized"), "Response should contain unauthorized message");
     }
 
     // ========== EXCEPTION COVERAGE TESTS ==========
@@ -437,8 +413,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Response should contain error information");
     }
 
     @Test
@@ -465,8 +440,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Response should contain error information");
     }
 
     @Test
@@ -486,8 +460,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Response should contain error information");
     }
 
     @Test
@@ -514,8 +487,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Response should contain error information");
     }
 
     @Test
@@ -543,8 +515,7 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain InvalidPropertiesFormatException message",
-                responseBody.contains("Invalid configuration format"));
+        assertTrue(responseBody.contains("Invalid configuration format"), "Response should contain InvalidPropertiesFormatException message");
     }
 
     @Test
@@ -572,7 +543,6 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain InvalidPropertiesFormatException message",
-                responseBody.contains("Invalid container configuration format"));
+        assertTrue(responseBody.contains("Invalid container configuration format"), "Response should contain InvalidPropertiesFormatException message");
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
@@ -17,7 +17,6 @@ import org.eclipse.sw360.datahandler.thrift.ConfigFor;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.configuration.SW360ConfigurationsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -28,7 +27,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DatabaseSanitationTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DatabaseSanitationTest.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.eclipse.sw360.rest.resourceserver.databasesanitation.Sw360DatabaseSanitationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,7 +26,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -43,9 +41,6 @@ public class DatabaseSanitationTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360DatabaseSanitationService sanitationServiceMock;
 
     private User adminUser;
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DatabaseSanitationTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DatabaseSanitationTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,9 +17,8 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.databasesanitation.Sw360DatabaseSanitationService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -28,19 +28,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class DatabaseSanitationTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -51,7 +49,7 @@ public class DatabaseSanitationTest extends TestIntegrationBase {
 
     private User adminUser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         adminUser = new User();
         adminUser.setEmail("admin@sw360.org");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DepartmentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DepartmentTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,9 +19,8 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.department.Sw360DepartmentService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -30,7 +30,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,15 +37,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class DepartmentTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -57,7 +55,7 @@ public class DepartmentTest extends TestIntegrationBase {
 
     private User adminUser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         adminUser = new User();
         adminUser.setEmail("admin@sw360.org");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DepartmentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/DepartmentTest.java
@@ -18,7 +18,6 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.eclipse.sw360.rest.resourceserver.department.Sw360DepartmentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,7 +28,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,9 +47,6 @@ public class DepartmentTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360DepartmentService departmentServiceMock;
 
     private User adminUser;
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/EccTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/EccTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2025 Pranay Heda pranayheda24@gmail.com
- * Part of the SW360 Portal Project.
+ * Copyright 2025 Pranay Heda pranayheda24@gmail.com. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,9 +19,8 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -33,20 +32,19 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringRunner.class)
 public class EccTest extends TestIntegrationBase {
 
     @LocalServerPort
@@ -59,7 +57,7 @@ public class EccTest extends TestIntegrationBase {
     private Release release1;
     private Release release2;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         releaseList = new ArrayList<>();
 
@@ -217,8 +215,8 @@ public class EccTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain eccInformation", response.getBody().contains("eccInformation"));
-        assertTrue("Untouched assessorContactPerson should survive", response.getBody().contains("john.doe@example.com"));
+        assertTrue(response.getBody().contains("eccInformation"), "Response should contain eccInformation");
+        assertTrue(response.getBody().contains("john.doe@example.com"), "Untouched assessorContactPerson should survive");
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/EccTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/EccTest.java
@@ -18,7 +18,6 @@ import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -31,7 +30,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 
 import java.util.ArrayList;
@@ -49,9 +47,6 @@ public class EccTest extends TestIntegrationBase {
 
     @LocalServerPort
     private int port;
-
-    @MockitoBean
-    private Sw360ReleaseService releaseServiceMock;
 
     private List<Release> releaseList;
     private Release release1;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/HealthTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/HealthTest.java
@@ -23,7 +23,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 
@@ -35,9 +34,6 @@ public class HealthTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private SW360RestHealthIndicator restHealthIndicatorMock;
 
     @BeforeEach
     public void before() throws TException {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/HealthTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/HealthTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra 2025.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +13,8 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.rest.resourceserver.SW360RestHealthIndicator;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -24,15 +24,13 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class HealthTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -41,7 +39,7 @@ public class HealthTest extends TestIntegrationBase {
     @MockitoBean
     private SW360RestHealthIndicator restHealthIndicatorMock;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         // Setup default healthy state
         SW360RestHealthIndicator.RestState restState = new SW360RestHealthIndicator.RestState();
@@ -67,15 +65,16 @@ public class HealthTest extends TestIntegrationBase {
 
         // Verify the response contains health data
         String responseBody = response.getBody();
-        assertTrue("Response should contain status", responseBody.contains("status"));
-        assertTrue("Response should contain components", responseBody.contains("components"));
-        assertTrue("Response should contain diskSpace", responseBody.contains("diskSpace"));
-        assertTrue("Response should contain ping", responseBody.contains("ping"));
-        assertTrue("Response should contain total", responseBody.contains("total"));
-        assertTrue("Response should contain free", responseBody.contains("free"));
-        assertTrue("Response should contain threshold", responseBody.contains("threshold"));
-        assertTrue("Response should contain path", responseBody.contains("path"));
-        assertTrue("Response should contain exists", responseBody.contains("exists"));
+        assert responseBody != null;
+        assertTrue(responseBody.contains("status"), "Response should contain status");
+        assertTrue(responseBody.contains("components"), "Response should contain components");
+        assertTrue(responseBody.contains("diskSpace"), "Response should contain diskSpace");
+        assertTrue(responseBody.contains("ping"), "Response should contain ping");
+        assertTrue(responseBody.contains("total"), "Response should contain total");
+        assertTrue(responseBody.contains("free"), "Response should contain free");
+        assertTrue(responseBody.contains("threshold"), "Response should contain threshold");
+        assertTrue(responseBody.contains("path"), "Response should contain path");
+        assertTrue(responseBody.contains("exists"), "Response should contain exists");
     }
 
     @Test
@@ -103,15 +102,16 @@ public class HealthTest extends TestIntegrationBase {
 
         // Verify the response contains health data
         String responseBody = response.getBody();
-        assertTrue("Response should contain status", responseBody.contains("status"));
-        assertTrue("Response should contain components", responseBody.contains("components"));
-        assertTrue("Response should contain diskSpace", responseBody.contains("diskSpace"));
-        assertTrue("Response should contain ping", responseBody.contains("ping"));
-        assertTrue("Response should contain total", responseBody.contains("total"));
-        assertTrue("Response should contain free", responseBody.contains("free"));
-        assertTrue("Response should contain threshold", responseBody.contains("threshold"));
-        assertTrue("Response should contain path", responseBody.contains("path"));
-        assertTrue("Response should contain exists", responseBody.contains("exists"));
+        assert responseBody != null;
+        assertTrue(responseBody.contains("status"), "Response should contain status");
+        assertTrue(responseBody.contains("components"), "Response should contain components");
+        assertTrue(responseBody.contains("diskSpace"), "Response should contain diskSpace");
+        assertTrue(responseBody.contains("ping"), "Response should contain ping");
+        assertTrue(responseBody.contains("total"), "Response should contain total");
+        assertTrue(responseBody.contains("free"), "Response should contain free");
+        assertTrue(responseBody.contains("threshold"), "Response should contain threshold");
+        assertTrue(responseBody.contains("path"), "Response should contain path");
+        assertTrue(responseBody.contains("exists"), "Response should contain exists");
     }
 
     @Test
@@ -127,7 +127,8 @@ public class HealthTest extends TestIntegrationBase {
 
         // Verify the response contains health data
         String responseBody = response.getBody();
-        assertTrue("Response should contain status", responseBody.contains("status"));
-        assertTrue("Response should contain components", responseBody.contains("components"));
+        assert responseBody != null;
+        assertTrue(responseBody.contains("status"), "Response should contain status");
+        assertTrue(responseBody.contains("components"), "Response should contain components");
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ImportExportTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ImportExportTest.java
@@ -19,7 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.importexport.Sw360ImportExportService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +30,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -51,9 +49,6 @@ public class ImportExportTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360ImportExportService importExportServiceMock;
 
     @BeforeEach
     public void before() throws TException, ServletException, IOException {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ImportExportTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ImportExportTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,10 +20,8 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.importexport.Sw360ImportExportService;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.core.io.ByteArrayResource;
@@ -33,23 +32,21 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.util.Objects;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringRunner.class)
 public class ImportExportTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -58,7 +55,7 @@ public class ImportExportTest extends TestIntegrationBase {
     @MockitoBean
     private Sw360ImportExportService importExportServiceMock;
 
-    @Before
+    @BeforeEach
     public void before() throws TException, ServletException, IOException {
         // Setup successful responses with detailed data
         RequestSummary successSummary = new RequestSummary();
@@ -154,14 +151,13 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers indicate file download
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertTrue("Should be CSV content",
-                Objects.requireNonNull(responseHeaders.getFirst("Content-Disposition")).contains("test.csv"));
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertTrue(Objects.requireNonNull(responseHeaders.getFirst("Content-Disposition")).contains("test.csv"), "Should be CSV content");
 
         // Verify response body contains CSV data
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("test,csv,data"));
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("test,csv,data"), "Response should contain CSV data");
     }
 
     @Test
@@ -177,22 +173,20 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertNotNull("Should have Content-Type header", responseHeaders.getFirst("Content-Type"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertNotNull(responseHeaders.getFirst("Content-Type"), "Should have Content-Type header");
 
         // Verify response body
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("attachment,template,data"));
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("attachment,template,data"), "Response should contain CSV data");
 
         // Verify specific header values
         String contentDisposition = responseHeaders.getFirst("Content-Disposition");
         assertNotNull(contentDisposition);
-        assertTrue("Content-Disposition should indicate attachment",
-                contentDisposition.contains("attachment"));
-        assertTrue("Content-Disposition should specify filename",
-                contentDisposition.contains("attachment_template.csv"));
+        assertTrue(contentDisposition.contains("attachment"), "Content-Disposition should indicate attachment");
+        assertTrue(contentDisposition.contains("attachment_template.csv"), "Content-Disposition should specify filename");
     }
 
     @Test
@@ -208,22 +202,20 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertNotNull("Should have Content-Type header", responseHeaders.getFirst("Content-Type"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertNotNull(responseHeaders.getFirst("Content-Type"), "Should have Content-Type header");
 
         // Verify response body
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("attachment,info,data"));
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("attachment,info,data"), "Response should contain CSV data");
 
         // Verify specific header values
         String contentDisposition = responseHeaders.getFirst("Content-Disposition");
         assertNotNull(contentDisposition);
-        assertTrue("Content-Disposition should indicate attachment",
-                contentDisposition.contains("attachment"));
-        assertTrue("Content-Disposition should specify filename",
-                contentDisposition.contains("attachment_info.csv"));
+        assertTrue(contentDisposition.contains("attachment"), "Content-Disposition should indicate attachment");
+        assertTrue(contentDisposition.contains("attachment_info.csv"), "Content-Disposition should specify filename");
     }
 
     @Test
@@ -239,22 +231,20 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertNotNull("Should have Content-Type header", responseHeaders.getFirst("Content-Type"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertNotNull(responseHeaders.getFirst("Content-Type"), "Should have Content-Type header");
 
         // Verify response body
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("release,sample,data"));
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("release,sample,data"), "Response should contain CSV data");
 
         // Verify specific header values
         String contentDisposition = responseHeaders.getFirst("Content-Disposition");
         assertNotNull(contentDisposition);
-        assertTrue("Content-Disposition should indicate attachment",
-                contentDisposition.contains("attachment"));
-        assertTrue("Content-Disposition should specify filename",
-                contentDisposition.contains("release_sample.csv"));
+        assertTrue(contentDisposition.contains("attachment"), "Content-Disposition should indicate attachment");
+        assertTrue(contentDisposition.contains("release_sample.csv"), "Content-Disposition should specify filename");
     }
 
     @Test
@@ -270,22 +260,20 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertNotNull("Should have Content-Type header", responseHeaders.getFirst("Content-Type"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertNotNull(responseHeaders.getFirst("Content-Type"), "Should have Content-Type header");
 
         // Verify response body
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("release,link,data"));
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("release,link,data"), "Response should contain CSV data");
 
         // Verify specific header values
         String contentDisposition = responseHeaders.getFirst("Content-Disposition");
         assertNotNull(contentDisposition);
-        assertTrue("Content-Disposition should indicate attachment",
-                contentDisposition.contains("attachment"));
-        assertTrue("Content-Disposition should specify filename",
-                contentDisposition.contains("release_link.csv"));
+        assertTrue(contentDisposition.contains("attachment"), "Content-Disposition should indicate attachment");
+        assertTrue(contentDisposition.contains("release_link.csv"), "Content-Disposition should specify filename");
     }
 
     @Test
@@ -301,22 +289,20 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertNotNull("Should have Content-Type header", responseHeaders.getFirst("Content-Type"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertNotNull(responseHeaders.getFirst("Content-Type"), "Should have Content-Type header");
 
         // Verify response body
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("component,details,data"));
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("component,details,data"), "Response should contain CSV data");
 
         // Verify specific header values
         String contentDisposition = responseHeaders.getFirst("Content-Disposition");
         assertNotNull(contentDisposition);
-        assertTrue("Content-Disposition should indicate attachment",
-                contentDisposition.contains("attachment"));
-        assertTrue("Content-Disposition should specify filename",
-                contentDisposition.contains("component_details.csv"));
+        assertTrue(contentDisposition.contains("attachment"), "Content-Disposition should indicate attachment");
+        assertTrue(contentDisposition.contains("component_details.csv"), "Content-Disposition should specify filename");
     }
 
     @Test
@@ -332,22 +318,20 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertNotNull("Should have Content-Type header", responseHeaders.getFirst("Content-Type"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertNotNull(responseHeaders.getFirst("Content-Type"), "Should have Content-Type header");
 
         // Verify response body
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("users,data,export"));
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("users,data,export"), "Response should contain CSV data");
 
         // Verify specific header values
         String contentDisposition = responseHeaders.getFirst("Content-Disposition");
         assertNotNull(contentDisposition);
-        assertTrue("Content-Disposition should indicate attachment",
-                contentDisposition.contains("attachment"));
-        assertTrue("Content-Disposition should specify filename",
-                contentDisposition.contains("users.csv"));
+        assertTrue(contentDisposition.contains("attachment"), "Content-Disposition should indicate attachment");
+        assertTrue(contentDisposition.contains("users.csv"), "Content-Disposition should specify filename");
     }
 
     @Test
@@ -376,7 +360,7 @@ public class ImportExportTest extends TestIntegrationBase {
                         RequestSummary.class);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Assert.assertNotNull(response.getBody());
+        assertNotNull(response.getBody());
         assertEquals(RequestStatus.SUCCESS, response.getBody().getRequestStatus());
     }
 
@@ -406,7 +390,7 @@ public class ImportExportTest extends TestIntegrationBase {
                         RequestSummary.class);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Assert.assertNotNull(response.getBody());
+        assertNotNull(response.getBody());
         assertEquals(RequestStatus.SUCCESS, response.getBody().getRequestStatus());
     }
 
@@ -436,7 +420,7 @@ public class ImportExportTest extends TestIntegrationBase {
                         RequestSummary.class);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Assert.assertNotNull(response.getBody());
+        assertNotNull(response.getBody());
         assertEquals(RequestStatus.SUCCESS, response.getBody().getRequestStatus());
     }
 
@@ -526,20 +510,19 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Comprehensive response verification
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Assert.assertNotNull(response.getBody());
+        assertNotNull(response.getBody());
 
         RequestSummary responseBody = response.getBody();
         assertEquals(RequestStatus.SUCCESS, responseBody.getRequestStatus());
-        assertEquals("Operation completed successfully", responseBody.getMessage());
+        assertEquals(responseBody.getMessage(), "Operation completed successfully");
         assertEquals(5, responseBody.getTotalElements());
         assertEquals(5, responseBody.getTotalAffectedElements());
 
         // Verify the response structure is complete
-        assertEquals("Response should indicate success", RequestStatus.SUCCESS, responseBody.getRequestStatus());
-        assertTrue("Response should have a meaningful message",
-                responseBody.getMessage() != null && !responseBody.getMessage().isEmpty());
-        assertTrue("Total elements should be positive", responseBody.getTotalElements() > 0);
-        assertTrue("Affected elements should be positive", responseBody.getTotalAffectedElements() > 0);
+        assertEquals(RequestStatus.SUCCESS, responseBody.getRequestStatus(), "Response should indicate success");
+        assertTrue(responseBody.getMessage() != null && !responseBody.getMessage().isEmpty(), "Response should have a meaningful message");
+        assertTrue(responseBody.getTotalElements() > 0, "Total elements should be positive");
+        assertTrue(responseBody.getTotalAffectedElements() > 0, "Affected elements should be positive");
     }
 
     @Test
@@ -555,23 +538,21 @@ public class ImportExportTest extends TestIntegrationBase {
 
         // Verify response headers
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertNotNull("Should have Content-Type header", responseHeaders.getFirst("Content-Type"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertNotNull(responseHeaders.getFirst("Content-Type"), "Should have Content-Type header");
 
         // Verify response body
         String responseBody = response.getBody();
-        assertNotNull("Response body should not be null", responseBody);
-        assertTrue("Response should contain CSV data", responseBody.contains("test,csv,data"));
-        assertTrue("Response should not be empty", !responseBody.isEmpty());
+        assertNotNull(responseBody, "Response body should not be null");
+        assertTrue(responseBody.contains("test,csv,data"), "Response should contain CSV data");
+        assertTrue(!responseBody.isEmpty(), "Response should not be empty");
 
         // Verify specific header values
         String contentDisposition = responseHeaders.getFirst("Content-Disposition");
         assertNotNull(contentDisposition);
-        assertTrue("Content-Disposition should indicate attachment",
-                contentDisposition.contains("attachment"));
-        assertTrue("Content-Disposition should specify filename",
-                contentDisposition.contains("filename"));
+        assertTrue(contentDisposition.contains("attachment"), "Content-Disposition should indicate attachment");
+        assertTrue(contentDisposition.contains("filename"), "Content-Disposition should specify filename");
     }
 
     @Test
@@ -603,35 +584,33 @@ public class ImportExportTest extends TestIntegrationBase {
                         RequestSummary.class);
 
         // Comprehensive response assertions
-        assertEquals("HTTP status should be OK", HttpStatus.OK, response.getStatusCode());
-        Assert.assertNotNull("Response body should not be null", response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode(), "HTTP status should be OK");
+        assertNotNull(response.getBody(), "Response body should not be null");
 
         RequestSummary responseBody = response.getBody();
 
         // Verify RequestStatus
-        assertEquals("Request status should be SUCCESS", RequestStatus.SUCCESS, responseBody.getRequestStatus());
-        assertEquals("Request status should indicate success", RequestStatus.SUCCESS, responseBody.getRequestStatus());
+        assertEquals(RequestStatus.SUCCESS, responseBody.getRequestStatus(), "Request status should be SUCCESS");
+        assertEquals(RequestStatus.SUCCESS, responseBody.getRequestStatus(), "Request status should indicate success");
 
         // Verify message content
-        assertEquals("Message should match expected", "Operation completed successfully", responseBody.getMessage());
-        assertNotNull("Message should not be null", responseBody.getMessage());
-        assertFalse("Message should not be empty", responseBody.getMessage().isEmpty());
-        assertTrue("Message should contain 'completed'", responseBody.getMessage().contains("completed"));
+        assertEquals(responseBody.getMessage(), "Operation completed successfully");
+        assertNotNull(responseBody.getMessage(), "Message should not be null");
+        assertFalse(responseBody.getMessage().isEmpty(), "Message should not be empty");
+        assertTrue(responseBody.getMessage().contains("completed"), "Message should contain 'completed'");
 
         // Verify element counts
-        assertEquals("Total elements should be 5", 5, responseBody.getTotalElements());
-        assertEquals("Affected elements should be 5", 5, responseBody.getTotalAffectedElements());
-        assertTrue("Total elements should be positive", responseBody.getTotalElements() > 0);
-        assertTrue("Affected elements should be positive", responseBody.getTotalAffectedElements() > 0);
-        assertTrue("Affected elements should not exceed total elements",
-                responseBody.getTotalAffectedElements() <= responseBody.getTotalElements());
+        assertEquals(5, responseBody.getTotalElements(), "Total elements should be 5");
+        assertEquals(5, responseBody.getTotalAffectedElements(), "Affected elements should be 5");
+        assertTrue(responseBody.getTotalElements() > 0, "Total elements should be positive");
+        assertTrue(responseBody.getTotalAffectedElements() > 0, "Affected elements should be positive");
+        assertTrue(responseBody.getTotalAffectedElements() <= responseBody.getTotalElements(), "Affected elements should not exceed total elements");
 
         // Verify response structure integrity
-        assertTrue("Response should be complete",
-                responseBody.isSetRequestStatus() &&
-                        responseBody.isSetMessage() &&
-                        responseBody.isSetTotalElements() &&
-                        responseBody.isSetTotalAffectedElements());
+        assertTrue(responseBody.isSetRequestStatus() &&
+                responseBody.isSetMessage() &&
+                responseBody.isSetTotalElements() &&
+                responseBody.isSetTotalAffectedElements(), "Response should be complete");
     }
 
     @Test
@@ -651,17 +630,15 @@ public class ImportExportTest extends TestIntegrationBase {
                         String.class);
 
         // Verify error response
-        assertEquals("HTTP status should be BAD_REQUEST",
-                HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(), "HTTP status should be BAD_REQUEST");
 
         // Verify error response body
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertFalse("Error response should not be empty", responseBody.isEmpty());
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertFalse(responseBody.isEmpty(), "Error response should not be empty");
 
         // Verify error response structure (JSON error response)
-        assertTrue("Error response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message") || responseBody.contains("status"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message") || responseBody.contains("status"), "Error response should contain error information");
     }
 
 
@@ -684,9 +661,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain IO exception message",
-                responseBody.contains("Error downloading component template"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading component template"), "Error response should contain IO exception message");
     }
 
     @Test
@@ -706,9 +682,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain IO exception message",
-                responseBody.contains("Error downloading attachment sample"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading attachment sample"), "Error response should contain IO exception message");
     }
 
     @Test
@@ -728,9 +703,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain IO exception message",
-                responseBody.contains("Error downloading attachment info"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading attachment info"), "Error response should contain IO exception message");
     }
 
     @Test
@@ -750,9 +724,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain TException message",
-                responseBody.contains("Error downloading release sample"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading release sample"), "Error response should contain TException message");
     }
 
     @Test
@@ -772,9 +745,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain IO exception message",
-                responseBody.contains("Error downloading release sample"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading release sample"), "Error response should contain IO exception message");
     }
 
     @Test
@@ -794,9 +766,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain TException message",
-                responseBody.contains("Error downloading release link"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading release link"), "Error response should contain TException message");
     }
 
     @Test
@@ -816,9 +787,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain IO exception message",
-                responseBody.contains("Error downloading release link"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading release link"), "Error response should contain IO exception message");
     }
 
     @Test
@@ -838,9 +808,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain TException message",
-                responseBody.contains("Error downloading component"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading component"), "Error response should contain TException message");
     }
 
     @Test
@@ -860,9 +829,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain IO exception message",
-                responseBody.contains("Error downloading component"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error downloading component"), "Error response should contain IO exception message");
     }
 
     @Test
@@ -882,9 +850,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain TException message",
-                responseBody.contains("Error download users"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error download users"), "Error response should contain TException message");
     }
 
     @Test
@@ -904,9 +871,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain IO exception message",
-                responseBody.contains("Error download users"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("Error download users"), "Error response should contain IO exception message");
     }
 
     @Test
@@ -941,9 +907,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain exception information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Error response should contain exception information");
     }
 
     @Test
@@ -978,9 +943,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain exception information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Error response should contain exception information");
     }
 
     @Test
@@ -1015,9 +979,8 @@ public class ImportExportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 
         String responseBody = response.getBody();
-        assertNotNull("Error response body should not be null", responseBody);
-        assertTrue("Error response should contain exception information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertNotNull(responseBody, "Error response body should not be null");
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Error response should contain exception information");
     }
 
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/LicenseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/LicenseTest.java
@@ -22,8 +22,6 @@ import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
-import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,7 +33,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -64,12 +61,6 @@ public class LicenseTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360LicenseService licenseServiceMock;
-
-    @MockitoBean
-    private SW360ReportService sw360ReportServiceMock;
 
     private License license1, license2, license3;
     private Obligation obligation1, obligation2;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/LicenseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/LicenseTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,9 +24,8 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.core.io.ByteArrayResource;
@@ -36,7 +36,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -51,9 +50,9 @@ import java.util.Map;
 import java.util.Collections;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -61,7 +60,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringRunner.class)
 public class LicenseTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -78,7 +76,7 @@ public class LicenseTest extends TestIntegrationBase {
     private RequestSummary testRequestSummary;
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() throws TException, IOException {
         // Setup test request summary
         testRequestSummary = new RequestSummary();
@@ -190,12 +188,12 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded licenses", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:licenses", responseBody.contains("sw360:licenses"));
-        assertTrue("Response should contain pagination info", responseBody.contains("page"));
-        assertTrue("Response should contain totalElements", responseBody.contains("totalElements"));
-        assertTrue("Response should contain Apache license", responseBody.contains("Apache License 2.0"));
-        assertTrue("Response should contain MIT license", responseBody.contains("The MIT License (MIT)"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded licenses");
+        assertTrue(responseBody.contains("sw360:licenses"), "Response should contain sw360:licenses");
+        assertTrue(responseBody.contains("page"), "Response should contain pagination info");
+        assertTrue(responseBody.contains("totalElements"), "Response should contain totalElements");
+        assertTrue(responseBody.contains("Apache License 2.0"), "Response should contain Apache license");
+        assertTrue(responseBody.contains("The MIT License (MIT)"), "Response should contain MIT license");
     }
 
     @Test
@@ -211,15 +209,15 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain license fullName", responseBody.contains("fullName"));
-        assertTrue("Response should contain license shortName", responseBody.contains("shortName"));
-        assertTrue("Response should contain Apache License 2.0", responseBody.contains("Apache License 2.0"));
-        assertTrue("Response should contain Apache 2.0", responseBody.contains("Apache 2.0"));
-        assertTrue("Response should contain externalIds", responseBody.contains("externalIds"));
-        assertTrue("Response should contain SPDX identifier", responseBody.contains("SPDX"));
-        assertTrue("Response should contain external license link", responseBody.contains("externalLicenseLink"));
-        assertTrue("Response should contain note", responseBody.contains("note"));
-        assertTrue("Response should contain License's Note", responseBody.contains("License's Note"));
+        assertTrue(responseBody.contains("fullName"), "Response should contain license fullName");
+        assertTrue(responseBody.contains("shortName"), "Response should contain license shortName");
+        assertTrue(responseBody.contains("Apache License 2.0"), "Response should contain Apache License 2.0");
+        assertTrue(responseBody.contains("Apache 2.0"), "Response should contain Apache 2.0");
+        assertTrue(responseBody.contains("externalIds"), "Response should contain externalIds");
+        assertTrue(responseBody.contains("SPDX"), "Response should contain SPDX identifier");
+        assertTrue(responseBody.contains("externalLicenseLink"), "Response should contain external license link");
+        assertTrue(responseBody.contains("note"), "Response should contain note");
+        assertTrue(responseBody.contains("License's Note"), "Response should contain License's Note");
     }
 
     @Test
@@ -243,14 +241,14 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain created license fullName", responseBody.contains("fullName"));
-        assertTrue("Response should contain created license shortName", responseBody.contains("shortName"));
-        assertTrue("Response should contain Apache 3.0", responseBody.contains("Apache 3.0"));
-        assertTrue("Response should contain Apache License 3.0", responseBody.contains("Apache License 3.0"));
-        assertTrue("Response should contain checked field", responseBody.contains("checked"));
-        assertTrue("Response should contain OSIApproved field", responseBody.contains("OSIApproved"));
-        assertTrue("Response should contain FSFLibre field", responseBody.contains("FSFLibre"));
-        assertTrue("Response should contain _links", responseBody.contains("_links"));
+        assertTrue(responseBody.contains("fullName"), "Response should contain created license fullName");
+        assertTrue(responseBody.contains("shortName"), "Response should contain created license shortName");
+        assertTrue(responseBody.contains("Apache 3.0"), "Response should contain Apache 3.0");
+        assertTrue(responseBody.contains("Apache License 3.0"), "Response should contain Apache License 3.0");
+        assertTrue(responseBody.contains("checked"), "Response should contain checked field");
+        assertTrue(responseBody.contains("OSIApproved"), "Response should contain OSIApproved field");
+        assertTrue(responseBody.contains("FSFLibre"), "Response should contain FSFLibre field");
+        assertTrue(responseBody.contains("_links"), "Response should contain _links");
     }
 
     @Test
@@ -272,7 +270,7 @@ public class LicenseTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain updated license data", response.getBody().contains("fullName"));
+        assertTrue(response.getBody().contains("fullName"), "Response should contain updated license data");
     }
 
     @Test
@@ -314,11 +312,11 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded license types", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:licenseTypes", responseBody.contains("sw360:licenseTypes"));
-        assertTrue("Response should contain Public domain license type", responseBody.contains("Public domain"));
-        assertTrue("Response should contain Proprietary license type", responseBody.contains("Proprietary license"));
-        assertTrue("Response should contain _links", responseBody.contains("_links"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded license types");
+        assertTrue(responseBody.contains("sw360:licenseTypes"), "Response should contain sw360:licenseTypes");
+        assertTrue(responseBody.contains("Public domain"), "Response should contain Public domain license type");
+        assertTrue(responseBody.contains("Proprietary license"), "Response should contain Proprietary license type");
+        assertTrue(responseBody.contains("_links"), "Response should contain _links");
     }
 
     @Test
@@ -334,8 +332,8 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain SUCCESS status", responseBody.contains("SUCCESS"));
-        assertTrue("Response should be a valid response", responseBody.equals("SUCCESS") || responseBody.contains("SUCCESS"));
+        assertTrue(responseBody.contains("SUCCESS"), "Response should contain SUCCESS status");
+        assertTrue("SUCCESS".equals(responseBody) || responseBody.contains("SUCCESS"), "Response should be a valid response");
     }
 
     @Test
@@ -349,7 +347,7 @@ public class LicenseTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
+        assertTrue(response.getBody().contains("SUCCESS"), "Response should contain SUCCESS status");
     }
 
     // ========== OBLIGATION TESTS ==========
@@ -367,13 +365,13 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded obligations", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:obligations", responseBody.contains("sw360:obligations"));
-        assertTrue("Response should contain Obligation 1", responseBody.contains("Obligation 1"));
-        assertTrue("Response should contain Obligation 2", responseBody.contains("Obligation 2"));
-        assertTrue("Response should contain obligation titles", responseBody.contains("title"));
-        assertTrue("Response should contain obligation types", responseBody.contains("obligationType"));
-        assertTrue("Response should contain _links", responseBody.contains("_links"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded obligations");
+        assertTrue(responseBody.contains("sw360:obligations"), "Response should contain sw360:obligations");
+        assertTrue(responseBody.contains("Obligation 1"), "Response should contain Obligation 1");
+        assertTrue(responseBody.contains("Obligation 2"), "Response should contain Obligation 2");
+        assertTrue(responseBody.contains("title"), "Response should contain obligation titles");
+        assertTrue(responseBody.contains("obligationType"), "Response should contain obligation types");
+        assertTrue(responseBody.contains("_links"), "Response should contain _links");
     }
 
     @Test
@@ -421,11 +419,11 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain request status", responseBody.contains("requestStatus"));
-        assertTrue("Response should contain SUCCESS status", responseBody.contains("SUCCESS"));
-        assertTrue("Response should contain OSADL import message", responseBody.contains("licensesSuccess"));
-        assertTrue("Response should contain total elements", responseBody.contains("totalElements"));
-        assertTrue("Response should contain total affected elements", responseBody.contains("totalAffectedElements"));
+        assertTrue(responseBody.contains("requestStatus"), "Response should contain request status");
+        assertTrue(responseBody.contains("SUCCESS"), "Response should contain SUCCESS status");
+        assertTrue(responseBody.contains("licensesSuccess"), "Response should contain OSADL import message");
+        assertTrue(responseBody.contains("totalElements"), "Response should contain total elements");
+        assertTrue(responseBody.contains("totalAffectedElements"), "Response should contain total affected elements");
     }
 
 
@@ -456,9 +454,8 @@ public class LicenseTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should indicate successful upload",
-                responseBody.contains("SUCCESS") || responseBody.contains("success") ||
-                        responseBody.contains("uploaded") || responseBody.isEmpty());
+        assertTrue(responseBody.contains("SUCCESS") || responseBody.contains("success") ||
+                responseBody.contains("uploaded") || responseBody.isEmpty(), "Response should indicate successful upload");
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
@@ -19,10 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.moderation.DocumentType;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
-import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,7 +29,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -48,23 +43,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
 
 public class ModerationRequestTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360ModerationRequestService moderationServiceMock;
-
-    @MockitoBean
-    private Sw360ProjectService projectServiceMock;
-
-    @MockitoBean
-    private Sw360ReleaseService releaseServiceMock;
-
-    @MockitoBean
-    private Sw360ComponentService componentServiceMock;
 
     private User adminUser;
     private ModerationRequest openMr;
@@ -91,7 +75,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         // Stubs for embedding calls in controller when fetching by ID
         given(projectServiceMock.getProjectForUserById(anyString(), any())).willReturn(new org.eclipse.sw360.datahandler.thrift.projects.Project());
         given(releaseServiceMock.getReleaseForUserById(anyString(), any())).willReturn(new org.eclipse.sw360.datahandler.thrift.components.Release());
-        given(componentServiceMock.getComponentForUserById(anyString(), any())).willReturn(new org.eclipse.sw360.datahandler.thrift.components.Component());
+        willReturn(new org.eclipse.sw360.datahandler.thrift.components.Component()).given(componentServiceMock).getComponentForUserById(anyString(), any());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,9 +23,8 @@ import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRe
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -34,7 +34,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -42,14 +41,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class ModerationRequestTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -70,7 +69,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
     private User adminUser;
     private ModerationRequest openMr;
 
-    @Before
+    @BeforeEach
     public void setUp() throws TException {
         adminUser = new User();
         adminUser.setEmail("admin@sw360.org");
@@ -109,6 +108,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("MR-1"));
         assertTrue(response.getBody().contains("requestingUser"));
     }
@@ -133,6 +133,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("APPROVED"));
     }
 
@@ -156,6 +157,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("REJECTED"));
     }
 
@@ -178,6 +180,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("PENDING"));
     }
 
@@ -200,6 +203,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("INPROGRESS"));
     }
 
@@ -223,6 +227,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("INPROGRESS"));
     }
 
@@ -263,6 +268,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("deleted"));
     }
 
@@ -283,6 +289,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("permission"));
     }
 
@@ -306,6 +313,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("Some requests were deleted"));
     }
 
@@ -345,6 +353,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assert response.getBody() != null;
         assertTrue(response.getBody().contains("invalid"));
     }
 
@@ -493,7 +502,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         );
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertTrue(response.getBody() != null);
+        assertNotNull(response.getBody());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
@@ -19,7 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +29,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -51,9 +49,6 @@ public class ObligationTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360ObligationService obligationServiceMock;
 
     private Obligation obligation1, obligation2;
     private List<Obligation> obligationList;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ObligationTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,9 +20,8 @@ import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -31,7 +31,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -39,16 +38,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringRunner.class)
 public class ObligationTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -61,7 +59,7 @@ public class ObligationTest extends TestIntegrationBase {
     private List<Obligation> obligationList;
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         // Setup test user
         User user = TestHelper.getTestUser();
@@ -132,12 +130,12 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded obligations", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:obligations", responseBody.contains("sw360:obligations"));
-        assertTrue("Response should contain pagination info", responseBody.contains("page"));
-        assertTrue("Response should contain totalElements", responseBody.contains("totalElements"));
-        assertTrue("Response should contain Obligation 1", responseBody.contains("Obligation 1"));
-        assertTrue("Response should contain Obligation 2", responseBody.contains("Obligation 2"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded obligations");
+        assertTrue(responseBody.contains("sw360:obligations"), "Response should contain sw360:obligations");
+        assertTrue(responseBody.contains("page"), "Response should contain pagination info");
+        assertTrue(responseBody.contains("totalElements"), "Response should contain totalElements");
+        assertTrue(responseBody.contains("Obligation 1"), "Response should contain Obligation 1");
+        assertTrue(responseBody.contains("Obligation 2"), "Response should contain Obligation 2");
     }
 
     @Test
@@ -153,9 +151,9 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded obligations", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:obligations", responseBody.contains("sw360:obligations"));
-        assertTrue("Response should contain LICENSE_OBLIGATION", responseBody.contains("LICENSE_OBLIGATION"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded obligations");
+        assertTrue(responseBody.contains("sw360:obligations"), "Response should contain sw360:obligations");
+        assertTrue(responseBody.contains("LICENSE_OBLIGATION"), "Response should contain LICENSE_OBLIGATION");
     }
 
     @Test
@@ -171,14 +169,14 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain obligation title", responseBody.contains("title"));
-        assertTrue("Response should contain obligation text", responseBody.contains("text"));
-        assertTrue("Response should contain obligation level", responseBody.contains("obligationLevel"));
-        assertTrue("Response should contain obligation type", responseBody.contains("obligationType"));
-        assertTrue("Response should contain Obligation 1", responseBody.contains("Obligation 1"));
-        assertTrue("Response should contain License Obligation", responseBody.contains("License Obligation"));
-        assertTrue("Response should contain LICENSE_OBLIGATION", responseBody.contains("LICENSE_OBLIGATION"));
-        assertTrue("Response should contain PERMISSION", responseBody.contains("PERMISSION"));
+        assertTrue(responseBody.contains("title"), "Response should contain obligation title");
+        assertTrue(responseBody.contains("text"), "Response should contain obligation text");
+        assertTrue(responseBody.contains("obligationLevel"), "Response should contain obligation level");
+        assertTrue(responseBody.contains("obligationType"), "Response should contain obligation type");
+        assertTrue(responseBody.contains("Obligation 1"), "Response should contain Obligation 1");
+        assertTrue(responseBody.contains("License Obligation"), "Response should contain License Obligation");
+        assertTrue(responseBody.contains("LICENSE_OBLIGATION"), "Response should contain LICENSE_OBLIGATION");
+        assertTrue(responseBody.contains("PERMISSION"), "Response should contain PERMISSION");
     }
 
     @Test
@@ -204,14 +202,14 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain obligation title", responseBody.contains("title"));
-        assertTrue("Response should contain obligation text", responseBody.contains("text"));
-        assertTrue("Response should contain obligation level", responseBody.contains("obligationLevel"));
-        assertTrue("Response should contain obligation type", responseBody.contains("obligationType"));
-        assertTrue("Response should contain Test Obligation", responseBody.contains("Test Obligation"));
-        assertTrue("Response should contain This is the text of my Test Obligation", responseBody.contains("This is the text of my Test Obligation"));
-        assertTrue("Response should contain LICENSE_OBLIGATION", responseBody.contains("LICENSE_OBLIGATION"));
-        assertTrue("Response should contain PERMISSION", responseBody.contains("PERMISSION"));
+        assertTrue(responseBody.contains("title"), "Response should contain obligation title");
+        assertTrue(responseBody.contains("text"), "Response should contain obligation text");
+        assertTrue(responseBody.contains("obligationLevel"), "Response should contain obligation level");
+        assertTrue(responseBody.contains("obligationType"), "Response should contain obligation type");
+        assertTrue(responseBody.contains("Test Obligation"), "Response should contain Test Obligation");
+        assertTrue(responseBody.contains("This is the text of my Test Obligation"), "Response should contain This is the text of my Test Obligation");
+        assertTrue(responseBody.contains("LICENSE_OBLIGATION"), "Response should contain LICENSE_OBLIGATION");
+        assertTrue(responseBody.contains("PERMISSION"), "Response should contain PERMISSION");
     }
 
     @Test
@@ -237,8 +235,8 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain success message", responseBody.contains("has been updated successfully"));
-        assertTrue("Response should contain obligation ID", responseBody.contains(obligation1.getId()));
+        assertTrue(responseBody.contains("has been updated successfully"), "Response should contain success message");
+        assertTrue(responseBody.contains(obligation1.getId()), "Response should contain obligation ID");
     }
 
     @Test
@@ -254,10 +252,10 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain resourceId", responseBody.contains("resourceId"));
-        assertTrue("Response should contain status", responseBody.contains("status"));
-        assertTrue("Response should contain obligation IDs", responseBody.contains(obligation1.getId()));
-        assertTrue("Response should contain obligation IDs", responseBody.contains(obligation2.getId()));
+        assertTrue(responseBody.contains("resourceId"), "Response should contain resourceId");
+        assertTrue(responseBody.contains("status"), "Response should contain status");
+        assertTrue(responseBody.contains(obligation1.getId()), "Response should contain obligation IDs");
+        assertTrue(responseBody.contains(obligation2.getId()), "Response should contain obligation IDs");
     }
 
     // ========== ERROR HANDLING TESTS ==========
@@ -416,8 +414,7 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain server error status for unexpected failure",
-                responseBody.contains("500"));
+        assertTrue(responseBody.contains("500"), "Response should contain server error status for unexpected failure");
     }
 
     @Test
@@ -436,6 +433,6 @@ public class ObligationTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain not found status", responseBody.contains("404"));
+        assertTrue(responseBody.contains("404"), "Response should contain not found status");
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/PackageTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/PackageTest.java
@@ -19,8 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.packages.PackageManager;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
-import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +29,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,13 +52,6 @@ public class PackageTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private SW360PackageService packageServiceMock;
-
-    @MockitoBean
-    private Sw360ReleaseService releaseServiceMock;
-
 
     private Package package1, package2, package3;
     private Set<String> licenseIds;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/PackageTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/PackageTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,9 +21,8 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
@@ -32,7 +32,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,9 +41,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -52,7 +51,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
 public class PackageTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -69,7 +67,7 @@ public class PackageTest extends TestIntegrationBase {
     private Set<String> licenseIds;
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         // Setup object mapper
         objectMapper = new ObjectMapper();
@@ -184,12 +182,12 @@ public class PackageTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded packages", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:packages", responseBody.contains("sw360:packages"));
-        assertTrue("Response should contain pagination info", responseBody.contains("page"));
-        assertTrue("Response should contain totalElements", responseBody.contains("totalElements"));
-        assertTrue("Response should contain angular-sanitize package", responseBody.contains("angular-sanitize"));
-        assertTrue("Response should contain applicationinsights-web package", responseBody.contains("applicationinsights-web"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded packages");
+        assertTrue(responseBody.contains("sw360:packages"), "Response should contain sw360:packages");
+        assertTrue(responseBody.contains("page"), "Response should contain pagination info");
+        assertTrue(responseBody.contains("totalElements"), "Response should contain totalElements");
+        assertTrue(responseBody.contains("angular-sanitize"), "Response should contain angular-sanitize package");
+        assertTrue(responseBody.contains("applicationinsights-web"), "Response should contain applicationinsights-web package");
     }
 
     @Test
@@ -205,19 +203,19 @@ public class PackageTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded packages", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:packages", responseBody.contains("sw360:packages"));
-        assertTrue("Response should contain package IDs", responseBody.contains("id"));
-        assertTrue("Response should contain package names", responseBody.contains("name"));
-        assertTrue("Response should contain package versions", responseBody.contains("version"));
-        assertTrue("Response should contain package types", responseBody.contains("packageType"));
-        assertTrue("Response should contain created dates", responseBody.contains("createdOn"));
-        assertTrue("Response should contain package managers", responseBody.contains("packageManager"));
-        assertTrue("Response should contain PURLs", responseBody.contains("purl"));
-        assertTrue("Response should contain VCS URLs", responseBody.contains("vcs"));
-        assertTrue("Response should contain homepage URLs", responseBody.contains("homepageUrl"));
-        assertTrue("Response should contain license IDs", responseBody.contains("licenseIds"));
-        assertTrue("Response should contain descriptions", responseBody.contains("description"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded packages");
+        assertTrue(responseBody.contains("sw360:packages"), "Response should contain sw360:packages");
+        assertTrue(responseBody.contains("id"), "Response should contain package IDs");
+        assertTrue(responseBody.contains("name"), "Response should contain package names");
+        assertTrue(responseBody.contains("version"), "Response should contain package versions");
+        assertTrue(responseBody.contains("packageType"), "Response should contain package types");
+        assertTrue(responseBody.contains("createdOn"), "Response should contain created dates");
+        assertTrue(responseBody.contains("packageManager"), "Response should contain package managers");
+        assertTrue(responseBody.contains("purl"), "Response should contain PURLs");
+        assertTrue(responseBody.contains("vcs"), "Response should contain VCS URLs");
+        assertTrue(responseBody.contains("homepageUrl"), "Response should contain homepage URLs");
+        assertTrue(responseBody.contains("licenseIds"), "Response should contain license IDs");
+        assertTrue(responseBody.contains("description"), "Response should contain descriptions");
     }
 
     @Test
@@ -233,20 +231,20 @@ public class PackageTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain package ID", responseBody.contains("id"));
-        assertTrue("Response should contain package name", responseBody.contains("name"));
-        assertTrue("Response should contain package version", responseBody.contains("version"));
-        assertTrue("Response should contain package type", responseBody.contains("packageType"));
-        assertTrue("Response should contain created date", responseBody.contains("createdOn"));
-        assertTrue("Response should contain package manager", responseBody.contains("packageManager"));
-        assertTrue("Response should contain PURL", responseBody.contains("purl"));
-        assertTrue("Response should contain VCS URL", responseBody.contains("vcs"));
-        assertTrue("Response should contain homepage URL", responseBody.contains("homepageUrl"));
-        assertTrue("Response should contain license IDs", responseBody.contains("licenseIds"));
-        assertTrue("Response should contain release ID", responseBody.contains("releaseId"));
-        assertTrue("Response should contain description", responseBody.contains("description"));
-        assertTrue("Response should contain angular-sanitize", responseBody.contains("angular-sanitize"));
-        assertTrue("Response should contain 1.8.2", responseBody.contains("1.8.2"));
+        assertTrue(responseBody.contains("id"), "Response should contain package ID");
+        assertTrue(responseBody.contains("name"), "Response should contain package name");
+        assertTrue(responseBody.contains("version"), "Response should contain package version");
+        assertTrue(responseBody.contains("packageType"), "Response should contain package type");
+        assertTrue(responseBody.contains("createdOn"), "Response should contain created date");
+        assertTrue(responseBody.contains("packageManager"), "Response should contain package manager");
+        assertTrue(responseBody.contains("purl"), "Response should contain PURL");
+        assertTrue(responseBody.contains("vcs"), "Response should contain VCS URL");
+        assertTrue(responseBody.contains("homepageUrl"), "Response should contain homepage URL");
+        assertTrue(responseBody.contains("licenseIds"), "Response should contain license IDs");
+        assertTrue(responseBody.contains("releaseId"), "Response should contain release ID");
+        assertTrue(responseBody.contains("description"), "Response should contain description");
+        assertTrue(responseBody.contains("angular-sanitize"), "Response should contain angular-sanitize");
+        assertTrue(responseBody.contains("1.8.2"), "Response should contain 1.8.2");
     }
 
     @Test
@@ -277,20 +275,20 @@ public class PackageTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain package ID", responseBody.contains("id"));
-        assertTrue("Response should contain package name", responseBody.contains("name"));
-        assertTrue("Response should contain package version", responseBody.contains("version"));
-        assertTrue("Response should contain package type", responseBody.contains("packageType"));
-        assertTrue("Response should contain created date", responseBody.contains("createdOn"));
-        assertTrue("Response should contain package manager", responseBody.contains("packageManager"));
-        assertTrue("Response should contain PURL", responseBody.contains("purl"));
-        assertTrue("Response should contain VCS URL", responseBody.contains("vcs"));
-        assertTrue("Response should contain homepage URL", responseBody.contains("homepageUrl"));
-        assertTrue("Response should contain license IDs", responseBody.contains("licenseIds"));
-        assertTrue("Response should contain release ID", responseBody.contains("releaseId"));
-        assertTrue("Response should contain description", responseBody.contains("description"));
-        assertTrue("Response should contain _links", responseBody.contains("_links"));
-        assertTrue("Response should contain _embedded", responseBody.contains("_embedded"));
+        assertTrue(responseBody.contains("id"), "Response should contain package ID");
+        assertTrue(responseBody.contains("name"), "Response should contain package name");
+        assertTrue(responseBody.contains("version"), "Response should contain package version");
+        assertTrue(responseBody.contains("packageType"), "Response should contain package type");
+        assertTrue(responseBody.contains("createdOn"), "Response should contain created date");
+        assertTrue(responseBody.contains("packageManager"), "Response should contain package manager");
+        assertTrue(responseBody.contains("purl"), "Response should contain PURL");
+        assertTrue(responseBody.contains("vcs"), "Response should contain VCS URL");
+        assertTrue(responseBody.contains("homepageUrl"), "Response should contain homepage URL");
+        assertTrue(responseBody.contains("licenseIds"), "Response should contain license IDs");
+        assertTrue(responseBody.contains("releaseId"), "Response should contain release ID");
+        assertTrue(responseBody.contains("description"), "Response should contain description");
+        assertTrue(responseBody.contains("_links"), "Response should contain _links");
+        assertTrue(responseBody.contains("_embedded"), "Response should contain _embedded");
     }
 
     @Test
@@ -314,20 +312,20 @@ public class PackageTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain package ID", responseBody.contains("id"));
-        assertTrue("Response should contain package name", responseBody.contains("name"));
-        assertTrue("Response should contain package version", responseBody.contains("version"));
-        assertTrue("Response should contain package type", responseBody.contains("packageType"));
-        assertTrue("Response should contain created date", responseBody.contains("createdOn"));
-        assertTrue("Response should contain package manager", responseBody.contains("packageManager"));
-        assertTrue("Response should contain PURL", responseBody.contains("purl"));
-        assertTrue("Response should contain VCS URL", responseBody.contains("vcs"));
-        assertTrue("Response should contain updated homepage URL", responseBody.contains("https://angularJS.org"));
-        assertTrue("Response should contain updated description", responseBody.contains("Updated Description"));
-        assertTrue("Response should contain license IDs", responseBody.contains("licenseIds"));
-        assertTrue("Response should contain release ID", responseBody.contains("releaseId"));
-        assertTrue("Response should contain _links", responseBody.contains("_links"));
-        assertTrue("Response should contain _embedded", responseBody.contains("_embedded"));
+        assertTrue(responseBody.contains("id"), "Response should contain package ID");
+        assertTrue(responseBody.contains("name"), "Response should contain package name");
+        assertTrue(responseBody.contains("version"), "Response should contain package version");
+        assertTrue(responseBody.contains("packageType"), "Response should contain package type");
+        assertTrue(responseBody.contains("createdOn"), "Response should contain created date");
+        assertTrue(responseBody.contains("packageManager"), "Response should contain package manager");
+        assertTrue(responseBody.contains("purl"), "Response should contain PURL");
+        assertTrue(responseBody.contains("vcs"), "Response should contain VCS URL");
+        assertTrue(responseBody.contains("https://angularJS.org"), "Response should contain updated homepage URL");
+        assertTrue(responseBody.contains("Updated Description"), "Response should contain updated description");
+        assertTrue(responseBody.contains("licenseIds"), "Response should contain license IDs");
+        assertTrue(responseBody.contains("releaseId"), "Response should contain release ID");
+        assertTrue(responseBody.contains("_links"), "Response should contain _links");
+        assertTrue(responseBody.contains("_embedded"), "Response should contain _embedded");
     }
 
     @Test
@@ -357,9 +355,9 @@ public class PackageTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded packages", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:packages", responseBody.contains("sw360:packages"));
-        assertTrue("Response should contain pagination info", responseBody.contains("page"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded packages");
+        assertTrue(responseBody.contains("sw360:packages"), "Response should contain sw360:packages");
+        assertTrue(responseBody.contains("page"), "Response should contain pagination info");
     }
 
     @Test
@@ -375,9 +373,9 @@ public class PackageTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain embedded packages", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:packages", responseBody.contains("sw360:packages"));
-        assertTrue("Response should contain angular-sanitize", responseBody.contains("angular-sanitize"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain embedded packages");
+        assertTrue(responseBody.contains("sw360:packages"), "Response should contain sw360:packages");
+        assertTrue(responseBody.contains("angular-sanitize"), "Response should contain angular-sanitize");
     }
 
     // ========== EXCEPTION HANDLING TESTS ==========

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -55,9 +55,8 @@ import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.core.io.ByteArrayResource;
@@ -71,7 +70,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -86,16 +84,15 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class ProjectTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -136,7 +133,7 @@ public class ProjectTest extends TestIntegrationBase {
     private User testUser;
     private final Set<Project> projectList = new HashSet<>();
 
-    @Before
+    @BeforeEach
     public void before() throws TException, IOException {
         setupTestUser();
         setupTestProjects();
@@ -1510,7 +1507,8 @@ public class ProjectTest extends TestIntegrationBase {
                         new HttpEntity<>(null, headers),
                         byte[].class);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertTrue("Response body should not be empty", response.getBody().length > 0);
+        assert response.getBody() != null;
+        assertTrue(response.getBody().length > 0, "Response body should not be empty");
     }
 
     @Test
@@ -1548,12 +1546,12 @@ public class ProjectTest extends TestIntegrationBase {
         Set<String> licenseNames = new HashSet<>();
         for (int i = 0; i < licenses.size(); i++) {
             JsonNode license = licenses.get(i);
-            assertTrue("License should have 'fullName' field", license.has("fullName"));
-            assertTrue("License should have 'checked' field", license.has("checked"));
+            assertTrue(license.has("fullName"), "License should have 'fullName' field");
+            assertTrue(license.has("checked"), "License should have 'checked' field");
             licenseNames.add(license.get("fullName").textValue());
         }
-        assertTrue("Should contain Apache License 2.0", licenseNames.contains("Apache License 2.0"));
-        assertTrue("Should contain MIT License", licenseNames.contains("MIT License"));
+        assertTrue(licenseNames.contains("Apache License 2.0"), "Should contain Apache License 2.0");
+        assertTrue(licenseNames.contains("MIT License"), "Should contain MIT License");
     }
 
     // ========== SUB-PROJECT TRANSITIVE RELEASE TESTS ==========
@@ -1590,13 +1588,10 @@ public class ProjectTest extends TestIntegrationBase {
 
         // Verify that _embedded contains releases even though parent has no direct releaseIdToUsage
         JsonNode responseJson = new ObjectMapper().readTree(response.getBody());
-        assertTrue("Response should contain _embedded field",
-                responseJson.has("_embedded"));
+        assertTrue(responseJson.has("_embedded"), "Response should contain _embedded field");
         JsonNode embedded = responseJson.get("_embedded");
-        assertTrue("Embedded should contain sw360:release",
-                embedded.has("sw360:release"));
-        assertEquals("Should contain 2 releases from sub-project",
-                2, embedded.get("sw360:release").size());
+        assertTrue(embedded.has("sw360:release"), "Embedded should contain sw360:release");
+        assertEquals(2, embedded.get("sw360:release").size(), "Should contain 2 releases from sub-project");
     }
 
     @Test
@@ -1630,10 +1625,8 @@ public class ProjectTest extends TestIntegrationBase {
 
         // Verify that _embedded contains releases even though parent has no direct releaseIdToUsage
         JsonNode responseJson = new ObjectMapper().readTree(response.getBody());
-        assertTrue("Response should contain _embedded field",
-                responseJson.has("_embedded"));
+        assertTrue(responseJson.has("_embedded"), "Response should contain _embedded field");
         JsonNode embedded = responseJson.get("_embedded");
-        assertTrue("Embedded should contain sw360:release",
-                embedded.has("sw360:release"));
+        assertTrue(embedded.has("sw360:release"), "Embedded should contain sw360:release");
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -46,14 +46,6 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
-import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
-import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
-import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
-import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
-import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,7 +61,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -97,30 +88,6 @@ public class ProjectTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360ProjectService projectServiceMock;
-
-    @MockitoBean
-    private Sw360ReleaseService releaseServiceMock;
-
-    @MockitoBean
-    private Sw360AttachmentService attachmentServiceMock;
-
-    @MockitoBean
-    private Sw360LicenseInfoService licenseInfoMockService;
-
-    @MockitoBean
-    private SW360PackageService packageServiceMock;
-
-    @MockitoBean
-    private SW360ReportService sw360ReportServiceMock;
-
-    @MockitoBean
-    private Sw360VulnerabilityService vulnerabilityServiceMock;
-
-    @MockitoBean
-    private Sw360LicenseService sw360LicenseServiceMock;
 
     // Test data
     private Project project1;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright Bosch Software Innovations GmbH, 2018.
  * Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,14 +37,7 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
-import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
-import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
-import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
-import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
-import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
-import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
-import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -56,7 +50,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.core.io.ByteArrayResource;
@@ -98,34 +91,6 @@ public class ReleaseTest extends TestIntegrationBase {
     @Value("${local.server.port}")
     @SuppressWarnings("unused")
     private int port;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private Sw360ReleaseService releaseServiceMock;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private Sw360LicenseService licenseServiceMock;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private Sw360AttachmentService attachmentServiceMock;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private SW360PackageService packageServiceMock;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private Sw360VulnerabilityService vulnerabilityServiceMock;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private Sw360VendorService sw360VendorService;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private Sw360LicenseInfoService licenseInfoMockService;
 
     private Release release;
     public static String attachmentShaInvalid = "999";

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -44,9 +44,8 @@ import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.hateoas.CollectionModel;
@@ -58,7 +57,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.core.io.ByteArrayResource;
@@ -84,18 +82,17 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class ReleaseTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -133,7 +130,7 @@ public class ReleaseTest extends TestIntegrationBase {
     private Release release;
     public static String attachmentShaInvalid = "999";
 
-    @Before
+    @BeforeEach
     public void before() throws TException, IOException {
         List<EntityModel<Attachment>> attachmentResources = new ArrayList<>();
         Attachment attachment = new Attachment("1231231254", "spring-core-4.3.4.RELEASE.jar");
@@ -687,9 +684,7 @@ public class ReleaseTest extends TestIntegrationBase {
 
     @Test
     public void should_link_releases_to_release() throws IOException, TException {
-        assumeTrue("Not running since Releases cannot be interlinked",
-                SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
-
+        assumeTrue(SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP, "Not running since Releases cannot be interlinked");
         given(this.releaseServiceMock.updateRelease(any(), any())).willReturn(RequestStatus.SUCCESS);
 
         HttpHeaders headers = getHeaders(port);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReportTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReportTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +13,8 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
@@ -23,18 +23,16 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(SpringRunner.class)
 public class ReportTest extends TestIntegrationBase {
 
     @LocalServerPort
@@ -43,7 +41,7 @@ public class ReportTest extends TestIntegrationBase {
     @MockitoBean
     private SW360ReportService sw360ReportServiceMock;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org"))
                 .willReturn(TestHelper.getTestUser());
@@ -78,14 +76,11 @@ public class ReportTest extends TestIntegrationBase {
         String contentDisposition = response.getHeaders().getFirst("Content-Disposition");
         assertNotNull("Content-Disposition header should be present", contentDisposition);
         // ASCII fallback should have non-ASCII replaced with underscore
-        assertTrue("Should contain ASCII fallback filename",
-                contentDisposition.contains("filename=\"LicenseInfo-Gridscale X_ Protection-1.2.1-2026-05-16_16_09_30.docx\""));
+        assertTrue(contentDisposition.contains("filename=\"LicenseInfo-Gridscale X_ Protection-1.2.1-2026-05-16_16_09_30.docx\""), "Should contain ASCII fallback filename");
         // RFC 5987 encoded filename should be present
-        assertTrue("Should contain RFC 5987 filename*",
-                contentDisposition.contains("filename*=UTF-8''"));
+        assertTrue(contentDisposition.contains("filename*=UTF-8''"), "Should contain RFC 5987 filename*");
         // Should contain URL-encoded trademark symbol
-        assertTrue("Should contain encoded TM symbol",
-                contentDisposition.contains("%E2%84%A2"));
+        assertTrue(contentDisposition.contains("%E2%84%A2"), "Should contain encoded TM symbol");
     }
 
     @Test
@@ -113,10 +108,8 @@ public class ReportTest extends TestIntegrationBase {
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
         String contentDisposition = response.getHeaders().getFirst("Content-Disposition");
-        assertNotNull("Content-Disposition header should be present", contentDisposition);
-        assertTrue("Should contain the original filename",
-                contentDisposition.contains("filename=\"LicenseInfo-SimpleProject-1.0-2026-05-16.docx\""));
-        assertTrue("Should contain RFC 5987 filename*",
-                contentDisposition.contains("filename*=UTF-8''"));
+        assertNotNull(contentDisposition, "Content-Disposition header should be present");
+        assertTrue(contentDisposition.contains("filename=\"LicenseInfo-SimpleProject-1.0-2026-05-16.docx\""), "Should contain the original filename");
+        assertTrue(contentDisposition.contains("filename*=UTF-8''"), "Should contain RFC 5987 filename*");
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReportTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReportTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.sw360.rest.resourceserver.integration;
 
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -22,7 +21,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.nio.ByteBuffer;
 
@@ -37,9 +35,6 @@ public class ReportTest extends TestIntegrationBase {
 
     @LocalServerPort
     private int port;
-
-    @MockitoBean
-    private SW360ReportService sw360ReportServiceMock;
 
     @BeforeEach
     public void before() throws Exception {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ScheduleTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ScheduleTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,9 +18,8 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.schedule.Sw360ScheduleService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
@@ -28,21 +28,19 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringRunner.class)
 public class ScheduleTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -54,7 +52,7 @@ public class ScheduleTest extends TestIntegrationBase {
     private RequestSummary testRequestSummary;
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         testRequestSummary = new RequestSummary();
         testRequestSummary.setRequestStatus(RequestStatus.SUCCESS);
@@ -98,7 +96,7 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS status", response.getBody().contains("SUCCESS"));
+        assertTrue(response.getBody().contains("SUCCESS"), "Response should contain SUCCESS status");
     }
 
     @Test
@@ -130,7 +128,7 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain requestStatus", response.getBody().contains("requestStatus"));
+        assertTrue(response.getBody().contains("requestStatus"), "Response should contain requestStatus");
     }
 
     @Test
@@ -158,7 +156,7 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS", response.getBody().contains("SUCCESS"));
+        assertTrue(response.getBody().contains("SUCCESS"), "Response should contain SUCCESS");
     }
 
     @Test
@@ -186,7 +184,7 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain SUCCESS", response.getBody().contains("SUCCESS"));
+        assertTrue(response.getBody().contains("SUCCESS"), "Response should contain SUCCESS");
     }
 
     @Test
@@ -214,11 +212,11 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain service name key", response.getBody().contains("cvesearchService"));
-        assertTrue("Response should contain isScheduled", response.getBody().contains("isScheduled"));
-        assertTrue("Response should contain intervalSeconds", response.getBody().contains("intervalSeconds"));
-        assertTrue("Response should contain firstOffsetSeconds", response.getBody().contains("firstOffsetSeconds"));
-        assertTrue("Response should contain nextSynchronization", response.getBody().contains("nextSynchronization"));
+        assertTrue(response.getBody().contains("cvesearchService"), "Response should contain service name key");
+        assertTrue(response.getBody().contains("isScheduled"), "Response should contain isScheduled");
+        assertTrue(response.getBody().contains("intervalSeconds"), "Response should contain intervalSeconds");
+        assertTrue(response.getBody().contains("firstOffsetSeconds"), "Response should contain firstOffsetSeconds");
+        assertTrue(response.getBody().contains("nextSynchronization"), "Response should contain nextSynchronization");
     }
 
     @Test
@@ -233,8 +231,8 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain cvesearchService", response.getBody().contains("cvesearchService"));
-        assertTrue("Response should contain svmsyncService", response.getBody().contains("svmsyncService"));
+        assertTrue(response.getBody().contains("cvesearchService"), "Response should contain cvesearchService");
+        assertTrue(response.getBody().contains("svmsyncService"), "Response should contain svmsyncService");
     }
 
     @Test
@@ -275,7 +273,7 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should be true", response.getBody().contains("true"));
+        assertTrue(response.getBody().contains("true"), "Response should be true");
     }
 
     @Test
@@ -292,7 +290,7 @@ public class ScheduleTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should be false", response.getBody().contains("false"));
+        assertTrue(response.getBody().contains("false"), "Response should be false");
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ScheduleTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ScheduleTest.java
@@ -17,7 +17,6 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.schedule.Sw360ScheduleService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,7 +26,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.Map;
@@ -45,9 +43,6 @@ public class ScheduleTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360ScheduleService scheduleServiceMock;
 
     private RequestSummary testRequestSummary;
     private ObjectMapper objectMapper;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/SearchTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/SearchTest.java
@@ -14,7 +14,6 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.search.Sw360SearchService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -24,7 +23,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,9 +38,6 @@ public class SearchTest extends TestIntegrationBase {
 
     @LocalServerPort
     private int port;
-
-    @MockitoBean
-    private Sw360SearchService searchServiceMock;
 
     private List<SearchResult> searchResults;
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/SearchTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/SearchTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2025 Pranay Heda pranayheda24@gmail.com
- * Part of the SW360 Portal Project.
+ * Copyright 2025 Pranay Heda pranayheda24@gmail.com. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,9 +15,8 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.search.Sw360SearchService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
@@ -26,19 +25,17 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringRunner.class)
 public class SearchTest extends TestIntegrationBase {
 
     @LocalServerPort
@@ -49,7 +46,7 @@ public class SearchTest extends TestIntegrationBase {
 
     private List<SearchResult> searchResults;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         searchResults = new ArrayList<>();
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
@@ -13,11 +13,32 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.rest.resourceserver.SW360RestHealthIndicator;
 import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
+import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.cache.ApiResponseCacheManager;
+import org.eclipse.sw360.rest.resourceserver.changelog.Sw360ChangeLogService;
+import org.eclipse.sw360.rest.resourceserver.clearingrequest.Sw360ClearingRequestService;
+import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
 import org.eclipse.sw360.rest.resourceserver.configuration.SW360ConfigurationsService;
+import org.eclipse.sw360.rest.resourceserver.databasesanitation.Sw360DatabaseSanitationService;
+import org.eclipse.sw360.rest.resourceserver.department.Sw360DepartmentService;
+import org.eclipse.sw360.rest.resourceserver.importexport.Sw360ImportExportService;
+import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
+import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
+import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
+import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
+import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
+import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
+import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
+import org.eclipse.sw360.rest.resourceserver.report.SW360ReportService;
+import org.eclipse.sw360.rest.resourceserver.schedule.Sw360ScheduleService;
+import org.eclipse.sw360.rest.resourceserver.search.Sw360SearchService;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360CustomUserDetailsService;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthority;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
+import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
+import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +49,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,7 +62,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @SpringBootTest(classes = Sw360ResourceServer.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ContextConfiguration
 abstract public class TestIntegrationBase {
 
     private static final String AUTH_BASIC = "Basic ";
@@ -57,6 +78,71 @@ abstract public class TestIntegrationBase {
     @MockitoBean
     protected SW360ConfigurationsService sw360ConfigurationsServiceMock;
 
+    @MockitoBean
+    protected Sw360AttachmentService attachmentServiceMock;
+
+    @MockitoBean
+    protected Sw360ReleaseService releaseServiceMock;
+
+    @MockitoBean
+    protected ApiResponseCacheManager cacheManagerMock;
+
+    @MockitoBean
+    protected Sw360ChangeLogService changeLogServiceMock;
+
+    @MockitoBean
+    protected Sw360ClearingRequestService clearingServiceMock;
+
+    @MockitoBean
+    protected Sw360ProjectService projectServiceMock;
+
+    @MockitoBean
+    protected Sw360ModerationRequestService moderationServiceMock;
+
+    @MockitoSpyBean
+    protected Sw360ComponentService componentServiceMock;
+
+    @MockitoBean
+    protected SW360ReportService sw360ReportServiceMock;
+
+    @MockitoBean
+    protected Sw360DatabaseSanitationService sanitationServiceMock;
+
+    @MockitoBean
+    protected Sw360DepartmentService departmentServiceMock;
+
+    @MockitoBean
+    protected SW360RestHealthIndicator restHealthIndicatorMock;
+
+    @MockitoBean
+    protected Sw360ImportExportService importExportServiceMock;
+
+    @MockitoBean
+    protected Sw360LicenseService licenseServiceMock;
+
+    @MockitoBean
+    protected Sw360ObligationService obligationServiceMock;
+
+    @MockitoBean
+    protected SW360PackageService packageServiceMock;
+
+    @MockitoBean
+    protected Sw360LicenseInfoService licenseInfoMockService;
+
+    @MockitoBean
+    protected Sw360VulnerabilityService vulnerabilityServiceMock;
+
+    @MockitoBean
+    protected Sw360LicenseService sw360LicenseServiceMock;
+
+    @MockitoBean
+    protected Sw360VendorService sw360VendorService;
+
+    @MockitoBean
+    protected Sw360ScheduleService scheduleServiceMock;
+
+    @MockitoBean
+    protected Sw360SearchService searchServiceMock;
 
 
     @BeforeEach

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/TestIntegrationBase.java
@@ -18,7 +18,7 @@ import org.eclipse.sw360.rest.resourceserver.configuration.SW360ConfigurationsSe
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360CustomUserDetailsService;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthority;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -59,7 +59,7 @@ abstract public class TestIntegrationBase {
 
 
 
-    @Before
+    @BeforeEach
     public void setupMockerUser(){
         when(sw360CustomUserDetailsService.loadUserByUsername("admin@sw360.org")).thenReturn(new org.springframework.security.core.userdetails.User("admin@sw360.org", encoder.encode("12345"), List.of(new SimpleGrantedAuthority(Sw360GrantedAuthority.ADMIN.getAuthority()))));
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.sw360.rest.resourceserver.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -33,9 +33,8 @@ import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -44,9 +43,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 public class UserTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -57,7 +54,7 @@ public class UserTest extends TestIntegrationBase {
     private List<RestApiToken> restApiTokens;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         userList = new ArrayList<>();
         restApiTokens = new ArrayList<>();
@@ -156,13 +153,13 @@ public class UserTest extends TestIntegrationBase {
         assertFalse(body.get("deactivated").booleanValue());
 
         // Verify complex nested objects exist
-        assertTrue("Should have secondaryDepartmentsAndRoles", body.has("secondaryDepartmentsAndRoles"));
-        assertTrue("Should have formerEmailAddresses", body.has("formerEmailAddresses"));
-        assertTrue("Should have notificationPreferences", body.has("notificationPreferences"));
+        assertTrue(body.has("secondaryDepartmentsAndRoles"), "Should have secondaryDepartmentsAndRoles");
+        assertTrue(body.has("formerEmailAddresses"), "Should have formerEmailAddresses");
+        assertTrue(body.has("notificationPreferences"), "Should have notificationPreferences");
 
         // Verify the self link contains the user ID
         JsonNode selfLink = body.get("_links").get("self").get("href");
-        assertTrue("Self link should contain user ID", selfLink.textValue().contains(user.getId()));
+        assertTrue(selfLink.textValue().contains(user.getId()), "Self link should contain user ID");
     }
 
 
@@ -184,9 +181,9 @@ public class UserTest extends TestIntegrationBase {
         assertFalse(body.get("deactivated").booleanValue());
 
         // Verify complex nested objects exist
-        assertTrue("Should have secondaryDepartmentsAndRoles", body.has("secondaryDepartmentsAndRoles"));
-        assertTrue("Should have formerEmailAddresses", body.has("formerEmailAddresses"));
-        assertTrue("Should have notificationPreferences", body.has("notificationPreferences"));
+        assertTrue(body.has("secondaryDepartmentsAndRoles"), "Should have secondaryDepartmentsAndRoles");
+        assertTrue(body.has("formerEmailAddresses"), "Should have formerEmailAddresses");
+        assertTrue(body.has("notificationPreferences"), "Should have notificationPreferences");
     }
 
     @Test
@@ -207,9 +204,9 @@ public class UserTest extends TestIntegrationBase {
         assertFalse(body.get("deactivated").booleanValue());
 
         // Verify complex nested objects exist
-        assertTrue("Should have secondaryDepartmentsAndRoles", body.has("secondaryDepartmentsAndRoles"));
-        assertTrue("Should have formerEmailAddresses", body.has("formerEmailAddresses"));
-        assertTrue("Should have notificationPreferences", body.has("notificationPreferences"));
+        assertTrue(body.has("secondaryDepartmentsAndRoles"), "Should have secondaryDepartmentsAndRoles");
+        assertTrue(body.has("formerEmailAddresses"), "Should have formerEmailAddresses");
+        assertTrue(body.has("notificationPreferences"), "Should have notificationPreferences");
     }
 
     @Test
@@ -262,8 +259,8 @@ public class UserTest extends TestIntegrationBase {
         assertEquals("FTest", body.get("givenName").textValue());
         assertEquals("lTest", body.get("lastName").textValue());
         assertFalse(body.get("deactivated").booleanValue());
-        assertTrue("Should have wantsMailNotification field", body.has("wantsMailNotification"));
-        assertTrue("Should have _links section", body.has("_links"));
+        assertTrue(body.has("wantsMailNotification"), "Should have wantsMailNotification field");
+        assertTrue(body.has("_links"), "Should have _links section");
     }
 
     @Test
@@ -365,12 +362,10 @@ public class UserTest extends TestIntegrationBase {
 
         // Verify the token length matches the DB configured value
         String responseBody = response.getBody();
-        assertFalse("Response body should not be null or empty",
-                responseBody == null || responseBody.isEmpty());
+        assertFalse(responseBody == null || responseBody.isEmpty(), "Response body should not be null or empty");
 
         String generatedToken = objectMapper.readValue(responseBody, String.class);
-        assertEquals("Token length should match DB configured value of " + dbConfiguredTokenLength,
-                dbConfiguredTokenLength, generatedToken.length());
+        assertEquals(dbConfiguredTokenLength, generatedToken.length(), "Token length should match DB configured value of " + dbConfiguredTokenLength);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VendorTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VendorTest.java
@@ -1,5 +1,6 @@
 /*
 * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+* Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -19,9 +20,8 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
@@ -31,21 +31,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 
-@RunWith(SpringRunner.class)
 public class VendorTest extends TestIntegrationBase {
 
     @LocalServerPort
@@ -58,7 +56,7 @@ public class VendorTest extends TestIntegrationBase {
     private Vendor testVendor2;
     private Set<Release> testReleases;
 
-    @Before
+    @BeforeEach
     public void before() throws TException, ResourceClassNotFoundException {
         // Setup test vendor data
         testVendor = new Vendor();
@@ -133,10 +131,10 @@ public class VendorTest extends TestIntegrationBase {
 
         // Verify response structure
         String responseBody = response.getBody();
-        assertTrue("Response should contain vendors", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:vendors", responseBody.contains("sw360:vendors"));
-        assertTrue("Response should contain Google vendor", responseBody.contains("Google Inc."));
-        assertTrue("Response should contain Pivotal vendor", responseBody.contains("Pivotal Software"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain vendors");
+        assertTrue(responseBody.contains("sw360:vendors"), "Response should contain sw360:vendors");
+        assertTrue(responseBody.contains("Google Inc."), "Response should contain Google vendor");
+        assertTrue(responseBody.contains("Pivotal Software"), "Response should contain Pivotal vendor");
     }
 
     @Test
@@ -153,9 +151,9 @@ public class VendorTest extends TestIntegrationBase {
 
         // Verify pagination structure
         String responseBody = response.getBody();
-        assertTrue("Response should contain page information", responseBody.contains("page"));
-        assertTrue("Response should contain totalElements", responseBody.contains("totalElements"));
-        assertTrue("Response should contain totalPages", responseBody.contains("totalPages"));
+        assertTrue(responseBody.contains("page"), "Response should contain page information");
+        assertTrue(responseBody.contains("totalElements"), "Response should contain totalElements");
+        assertTrue(responseBody.contains("totalPages"), "Response should contain totalPages");
     }
 
     @Test
@@ -180,7 +178,7 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain Google vendor", responseBody.contains("Google Inc."));
+        assertTrue(responseBody.contains("Google Inc."), "Response should contain Google vendor");
     }
 
     // ========== GET SINGLE VENDOR TESTS ==========
@@ -199,10 +197,10 @@ public class VendorTest extends TestIntegrationBase {
 
         // Verify vendor details
         String responseBody = response.getBody();
-        assertTrue("Response should contain vendor fullname", responseBody.contains("Google Inc."));
-        assertTrue("Response should contain vendor shortname", responseBody.contains("Google"));
-        assertTrue("Response should contain vendor URL", responseBody.contains("https://google.com"));
-        assertTrue("Response should contain self link", responseBody.contains("_links"));
+        assertTrue(responseBody.contains("Google Inc."), "Response should contain vendor fullname");
+        assertTrue(responseBody.contains("Google"), "Response should contain vendor shortname");
+        assertTrue(responseBody.contains("https://google.com"), "Response should contain vendor URL");
+        assertTrue(responseBody.contains("_links"), "Response should contain self link");
     }
 
     @Test
@@ -239,10 +237,10 @@ public class VendorTest extends TestIntegrationBase {
 
         // Verify releases structure
         String responseBody = response.getBody();
-        assertTrue("Response should contain releases", responseBody.contains("_embedded"));
-        assertTrue("Response should contain sw360:releases", responseBody.contains("sw360:releases"));
-        assertTrue("Response should contain Release_1", responseBody.contains("Release_1"));
-        assertTrue("Response should contain Release_2", responseBody.contains("Release_2"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain releases");
+        assertTrue(responseBody.contains("sw360:releases"), "Response should contain sw360:releases");
+        assertTrue(responseBody.contains("Release_1"), "Response should contain Release_1");
+        assertTrue(responseBody.contains("Release_2"), "Response should contain Release_2");
     }
 
     @Test
@@ -286,9 +284,9 @@ public class VendorTest extends TestIntegrationBase {
 
         // Verify created vendor
         String responseBody = response.getBody();
-        assertTrue("Response should contain Apache vendor", responseBody.contains("Apache Software Foundation"));
-        assertTrue("Response should contain self link", responseBody.contains("_links"));
-        assertNotNull("Response should contain location header", response.getHeaders().getLocation());
+        assertTrue(responseBody.contains("Apache Software Foundation"), "Response should contain Apache vendor");
+        assertTrue(responseBody.contains("_links"), "Response should contain self link");
+        assertNotNull(response.getHeaders().getLocation(), "Response should contain location header");
     }
 
     @Test
@@ -338,7 +336,7 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain success message", responseBody.contains("Vendor updated successfully"));
+        assertTrue(responseBody.contains("Vendor updated successfully"), "Response should contain success message");
     }
 
     @Test
@@ -365,7 +363,7 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain duplicate error message", responseBody.contains("already exists"));
+        assertTrue(responseBody.contains("already exists"), "Response should contain duplicate error message");
     }
 
     @Test
@@ -388,7 +386,7 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error message", responseBody.contains("cannot be null"));
+        assertTrue(responseBody.contains("cannot be null"), "Response should contain error message");
     }
 
     // ========== DELETE VENDOR TESTS ==========
@@ -406,8 +404,8 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain success message", responseBody.contains("deleted successfully"));
-        assertTrue("Response should contain vendor name", responseBody.contains("Google Inc."));
+        assertTrue(responseBody.contains("deleted successfully"), "Response should contain success message");
+        assertTrue(responseBody.contains("Google Inc."), "Response should contain vendor name");
     }
 
     @Test
@@ -440,12 +438,10 @@ public class VendorTest extends TestIntegrationBase {
 
         // Verify response headers for file download
         HttpHeaders responseHeaders = response.getHeaders();
-        assertNotNull("Response headers should not be null", responseHeaders);
-        assertNotNull("Should have Content-Disposition header", responseHeaders.getFirst("Content-Disposition"));
-        assertTrue("Should indicate file download",
-                Objects.requireNonNull(responseHeaders.getFirst("Content-Disposition")).contains("attachment"));
-        assertTrue("Should specify Excel filename",
-                Objects.requireNonNull(responseHeaders.getFirst("Content-Disposition")).contains(".xlsx"));
+        assertNotNull(responseHeaders, "Response headers should not be null");
+        assertNotNull(responseHeaders.getFirst("Content-Disposition"), "Should have Content-Disposition header");
+        assertTrue(Objects.requireNonNull(responseHeaders.getFirst("Content-Disposition")).contains("attachment"), "Should indicate file download");
+        assertTrue(Objects.requireNonNull(responseHeaders.getFirst("Content-Disposition")).contains(".xlsx"), "Should specify Excel filename");
     }
 
     // ========== MERGE VENDOR TESTS ==========
@@ -473,7 +469,7 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain SUCCESS status", responseBody.contains("SUCCESS"));
+        assertTrue(responseBody.contains("SUCCESS"), "Response should contain SUCCESS status");
     }
 
     @Test
@@ -514,8 +510,7 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Response should contain error information");
     }
 
     @Test
@@ -535,8 +530,7 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Response should contain error information");
     }
 
     @Test
@@ -563,7 +557,6 @@ public class VendorTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error information",
-                responseBody.contains("error") || responseBody.contains("message"));
+        assertTrue(responseBody.contains("error") || responseBody.contains("message"), "Response should contain error information");
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VendorTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VendorTest.java
@@ -19,7 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -30,7 +29,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -48,9 +46,6 @@ public class VendorTest extends TestIntegrationBase {
 
     @LocalServerPort
     private int port;
-
-    @MockitoBean
-    private Sw360VendorService vendorServiceMock;
 
     private Vendor testVendor;
     private Vendor testVendor2;
@@ -100,19 +95,19 @@ public class VendorTest extends TestIntegrationBase {
         pageData.setDisplayStart(0);
         pageData.setSortColumnNumber(0);
         Map<PaginationData, List<Vendor>> paginatedVendors = Map.of(pageData, vendorList);
-        given(this.vendorServiceMock.getVendors(any())).willReturn(paginatedVendors);
-        given(this.vendorServiceMock.getVendorById(eq(testVendor.getId()))).willReturn(testVendor);
-        given(this.vendorServiceMock.getVendorById(eq(testVendor2.getId()))).willReturn(testVendor2);
-        given(this.vendorServiceMock.getAllReleaseList(eq(testVendor.getId()))).willReturn(testReleases);
-        given(this.vendorServiceMock.deleteVendorByid(any(), any())).willReturn(RequestStatus.SUCCESS);
-        given(this.vendorServiceMock.vendorUpdate(any(), any(), any())).willReturn(RequestStatus.SUCCESS);
-        given(this.vendorServiceMock.mergeVendors(any(), any(), any(), any())).willReturn(RequestStatus.SUCCESS);
-        given(this.vendorServiceMock.exportExcel()).willReturn(ByteBuffer.allocate(10000));
+        given(this.sw360VendorService.getVendors(any())).willReturn(paginatedVendors);
+        given(this.sw360VendorService.getVendorById(eq(testVendor.getId()))).willReturn(testVendor);
+        given(this.sw360VendorService.getVendorById(eq(testVendor2.getId()))).willReturn(testVendor2);
+        given(this.sw360VendorService.getAllReleaseList(eq(testVendor.getId()))).willReturn(testReleases);
+        given(this.sw360VendorService.deleteVendorByid(any(), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.sw360VendorService.vendorUpdate(any(), any(), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.sw360VendorService.mergeVendors(any(), any(), any(), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.sw360VendorService.exportExcel()).willReturn(ByteBuffer.allocate(10000));
 
         // Setup create vendor mock
         Vendor createdVendor = new Vendor("Apache", "Apache Software Foundation", "https://www.apache.org/");
         createdVendor.setId("987567468");
-        given(this.vendorServiceMock.createVendor(any())).willReturn(createdVendor);
+        given(this.sw360VendorService.createVendor(any())).willReturn(createdVendor);
     }
 
     // ========== GET VENDORS TESTS ==========
@@ -165,7 +160,7 @@ public class VendorTest extends TestIntegrationBase {
         pageData.setDisplayStart(0);
         pageData.setSortColumnNumber(0);
         Map<PaginationData, List<Vendor>> paginatedVendors = Map.of(pageData, Collections.singletonList(testVendor));
-        given(this.vendorServiceMock.searchVendors(eq("Google"), any())).willReturn(paginatedVendors);
+        given(this.sw360VendorService.searchVendors(eq("Google"), any())).willReturn(paginatedVendors);
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
@@ -206,7 +201,7 @@ public class VendorTest extends TestIntegrationBase {
     @Test
     public void should_return_400_for_nonexistent_vendor() throws IOException {
         // Mock vendor not found - the controller doesn't check for null, it just returns the result
-        given(this.vendorServiceMock.getVendorById("nonexistent")).willReturn(null);
+        given(this.sw360VendorService.getVendorById("nonexistent")).willReturn(null);
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
@@ -246,7 +241,7 @@ public class VendorTest extends TestIntegrationBase {
     @Test
     public void should_return_404_for_vendor_releases_when_vendor_not_found() throws IOException {
         // Mock vendor not found
-        given(this.vendorServiceMock.getVendorById("nonexistent")).willReturn(null);
+        given(this.sw360VendorService.getVendorById("nonexistent")).willReturn(null);
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
@@ -342,7 +337,7 @@ public class VendorTest extends TestIntegrationBase {
     @Test
     public void should_fail_update_vendor_with_duplicate_name() throws IOException {
         // Mock duplicate vendor scenario
-        given(this.vendorServiceMock.vendorUpdate(any(), any(), any())).willReturn(RequestStatus.DUPLICATE);
+        given(this.sw360VendorService.vendorUpdate(any(), any(), any())).willReturn(RequestStatus.DUPLICATE);
 
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -411,7 +406,7 @@ public class VendorTest extends TestIntegrationBase {
     @Test
     public void should_fail_delete_nonexistent_vendor() throws IOException {
         // Mock vendor not found
-        given(this.vendorServiceMock.getVendorById("nonexistent")).willReturn(null);
+        given(this.sw360VendorService.getVendorById("nonexistent")).willReturn(null);
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
@@ -496,7 +491,7 @@ public class VendorTest extends TestIntegrationBase {
     @Test
     public void should_handle_exception_in_get_vendor_releases() throws IOException, TException {
         // Mock TException in getAllReleaseList
-        doThrow(new TException("Test TException")).when(vendorServiceMock)
+        doThrow(new TException("Test TException")).when(sw360VendorService)
                 .getAllReleaseList(any());
 
         HttpHeaders headers = getHeaders(port);
@@ -516,7 +511,7 @@ public class VendorTest extends TestIntegrationBase {
     @Test
     public void should_handle_exception_in_export_vendors() throws IOException, TException {
         // Mock exception in exportExcel
-        doThrow(new TException("Test TException")).when(vendorServiceMock)
+        doThrow(new TException("Test TException")).when(sw360VendorService)
                 .exportExcel();
 
         HttpHeaders headers = getHeaders(port);
@@ -536,7 +531,7 @@ public class VendorTest extends TestIntegrationBase {
     @Test
     public void should_handle_exception_in_merge_vendors() throws IOException, TException, ResourceClassNotFoundException {
         // Mock TException in mergeVendors
-        doThrow(new TException("Test TException")).when(vendorServiceMock)
+        doThrow(new TException("Test TException")).when(sw360VendorService)
                 .mergeVendors(any(), any(), any(), any());
 
         HttpHeaders headers = getHeaders(port);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
@@ -21,8 +21,6 @@ import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
-import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
-import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +32,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,12 +58,6 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
     private int port;
-
-    @MockitoBean
-    private Sw360VulnerabilityService vulnerabilityServiceMock;
-
-    @MockitoBean
-    private Sw360ReleaseService releaseServiceMock;
 
     private Vulnerability testVulnerability;
     private VulnerabilityApiDTO testVulnerabilityDTO;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/VulnerabilityTest.java
@@ -1,5 +1,6 @@
 /*
 * Copyright Rohit Borra, 2025. Part of the SW360 GSOC Project.
+* Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -23,9 +24,8 @@ import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +35,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,21 +44,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService.VulnerabilityOperation;
 
-@RunWith(SpringRunner.class)
 public class VulnerabilityTest extends TestIntegrationBase {
 
     @Value("${local.server.port}")
@@ -76,7 +73,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
     private ReleaseVulnerabilityRelation testReleaseVulnerabilityRelation;
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() throws TException {
         // Setup test vulnerability
         testVulnerability = new Vulnerability();
@@ -160,8 +157,8 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain vulnerabilities", responseBody.contains("_embedded"));
-        assertTrue("Response should contain vulnerability data", responseBody.contains("CVE-2023-1234"));
+        assertTrue(responseBody.contains("_embedded"), "Response should contain vulnerabilities");
+        assertTrue(responseBody.contains("CVE-2023-1234"), "Response should contain vulnerability data");
     }
 
     @Test
@@ -177,8 +174,8 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain pagination info", responseBody.contains("page"));
-        assertTrue("Response should contain vulnerability data", responseBody.contains("CVE-2023-1234"));
+        assertTrue(responseBody.contains("page"), "Response should contain pagination info");
+        assertTrue(responseBody.contains("CVE-2023-1234"), "Response should contain vulnerability data");
     }
 
     @Test
@@ -205,7 +202,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain search results", responseBody.contains("CVE-2023-1234"));
+        assertTrue(responseBody.contains("CVE-2023-1234"), "Response should contain search results");
     }
 
     // ========== GET SINGLE VULNERABILITY TESTS ==========
@@ -223,9 +220,9 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain vulnerability title", responseBody.contains("Test Vulnerability"));
-        assertTrue("Response should contain external ID", responseBody.contains("CVE-2023-1234"));
-        assertTrue("Response should contain priority", responseBody.contains("high"));
+        assertTrue(responseBody.contains("Test Vulnerability"), "Response should contain vulnerability title");
+        assertTrue(responseBody.contains("CVE-2023-1234"), "Response should contain external ID");
+        assertTrue(responseBody.contains("high"), "Response should contain priority");
     }
 
     @Test
@@ -277,8 +274,8 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain created vulnerability data", responseBody.contains("CVE-2023-5678"));
-        assertTrue("Response should contain title", responseBody.contains("New Test Vulnerability"));
+        assertTrue(responseBody.contains("CVE-2023-5678"), "Response should contain created vulnerability data");
+        assertTrue(responseBody.contains("New Test Vulnerability"), "Response should contain title");
     }
 
     @Test
@@ -302,7 +299,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error about external ID", responseBody.contains("External Id should not be null or empty"));
+        assertTrue(responseBody.contains("External Id should not be null or empty"), "Response should contain error about external ID");
     }
 
     @Test
@@ -330,7 +327,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain conflict error", responseBody.contains("Conflict Vulnerability with same external id"));
+        assertTrue(responseBody.contains("Conflict Vulnerability with same external id"), "Response should contain conflict error");
     }
 
     // ========== UPDATE VULNERABILITY TESTS ==========
@@ -358,8 +355,8 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain updated vulnerability data", responseBody.contains("CVE-2023-1234"));
-        assertTrue("Response should contain updated title", responseBody.contains("Updated Test Vulnerability"));
+        assertTrue(responseBody.contains("CVE-2023-1234"), "Response should contain updated vulnerability data");
+        assertTrue(responseBody.contains("Updated Test Vulnerability"), "Response should contain updated title");
     }
 
     @Test
@@ -383,7 +380,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain error about external ID mismatch", responseBody.contains("External Id is not correct"));
+        assertTrue(responseBody.contains("External Id is not correct"), "Response should contain error about external ID mismatch");
     }
 
     @Test
@@ -421,8 +418,8 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain deletion status", responseBody.contains("resourceId"));
-        assertTrue("Response should contain status", responseBody.contains("status"));
+        assertTrue(responseBody.contains("resourceId"), "Response should contain deletion status");
+        assertTrue(responseBody.contains("status"), "Response should contain status");
     }
 
     @Test
@@ -508,9 +505,9 @@ public class VulnerabilityTest extends TestIntegrationBase {
         assertNotNull(response.getBody());
 
         String responseBody = response.getBody();
-        assertTrue("Response should contain vulnerability tracking status", responseBody.contains("vulnerabilityTrackingStatus"));
-        assertTrue("Response should contain pagination info", responseBody.contains("page"));
-        assertTrue("Response should contain totalElements", responseBody.contains("totalElements"));
+        assertTrue(responseBody.contains("vulnerabilityTrackingStatus"), "Response should contain vulnerability tracking status");
+        assertTrue(responseBody.contains("page"), "Response should contain pagination info");
+        assertTrue(responseBody.contains("totalElements"), "Response should contain totalElements");
     }
 
     // ========== EXCEPTION COVERAGE TESTS ==========
@@ -675,7 +672,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.MULTI_STATUS, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain OK status", response.getBody().contains("\"status\" : 200"));
+        assertTrue(response.getBody().contains("\"status\" : 200"), "Response should contain OK status");
     }
 
     @Test
@@ -702,7 +699,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.MULTI_STATUS, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain FORBIDDEN status", response.getBody().contains("\"status\" : 403"));
+        assertTrue(response.getBody().contains("\"status\" : 403"), "Response should contain FORBIDDEN status");
     }
 
     @Test
@@ -735,8 +732,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain relation already exists message",
-                response.getBody().contains("Vulnerability Release Relation already exists"));
+        assertTrue(response.getBody().contains("Vulnerability Release Relation already exists"), "Response should contain relation already exists message");
     }
 
     @Test
@@ -766,7 +762,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.MULTI_STATUS, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain BAD_REQUEST status", response.getBody().contains("\"status\" : 400"));
+        assertTrue(response.getBody().contains("\"status\" : 400"), "Response should contain BAD_REQUEST status");
     }
 
     @Test
@@ -796,7 +792,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.MULTI_STATUS, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain BAD_REQUEST status", response.getBody().contains("\"status\" : 400"));
+        assertTrue(response.getBody().contains("\"status\" : 400"), "Response should contain BAD_REQUEST status");
     }
 
     @Test
@@ -826,7 +822,7 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.MULTI_STATUS, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain FORBIDDEN status", response.getBody().contains("\"status\" : 403"));
+        assertTrue(response.getBody().contains("\"status\" : 403"), "Response should contain FORBIDDEN status");
     }
 
     @Test
@@ -856,6 +852,6 @@ public class VulnerabilityTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.MULTI_STATUS, response.getStatusCode());
         assertNotNull(response.getBody());
-        assertTrue("Response should contain INTERNAL_SERVER_ERROR status", response.getBody().contains("\"status\" : 500"));
+        assertTrue(response.getBody().contains("\"status\" : 500"), "Response should contain INTERNAL_SERVER_ERROR status");
     }
 }


### PR DESCRIPTION
# [Migration of integration test cases from `JUnit 4` to `JUnit 6`](https://docs.junit.org/6.1.0/migrating-from-junit4.html)

This PR upgrades our integration test suite from `JUnit 4` to `JUnit 6 (Jupiter)`. Beyond simply bumping framework versions, this PR refactors our integration test base classes to aggressively optimize Spring Boot's application context caching.

## Required Changes & Engineering Analogies

### 1. Eradication of `@RunWith(SpringJUnit4ClassRunner.class)` 
`JUnit 4`, every single test class had to explicitly declare how it was supposed to be executed via the runner. In `JUnit 6`, the execution model shifted to an Extensibility framework. Because our `TestIntegrationBase` uses `@SpringBootTest` (which is meta-annotated with `@ExtendWith(SpringExtension.class)`), it acts as a master blueprint. Child classes now automatically inherit this execution blueprint. Redundant declarations create unnecessary noise and have been removed.

### 2. Removal of legacy `@ContextConfiguration`
`@SpringBootTest(classes = Sw360ResourceServer.class)` already acts as an explicit, high-fidelity GPS coordinate telling Spring exactly how to boot the application. Leaving an empty `@ContextConfiguration` alongside it was like handing the framework a blank physical map "just in case." It was a legacy artifact from pre-Spring Boot days and is safely removed to clean up our base configuration.

### 3. Hoisting `@MockitoBean` to `TestIntegrationBase`
Migrated all specific `@MockitoBean` declarations from individual child test classes (like `ProjectTest`) into the unified `TestIntegrationBase`. The Spring `TestContext` framework caches the application context to speed up tests, using the class's configuration signature as the cache key. Previously, because each child class defined its own specific `@MockitoBeans`, Spring saw dozens of unique signatures. This forced it to tear down and rebuild the entire SW360 application context for nearly every test suite (a massive cache miss). By hoisting all mocks to the base class, we create a single, unified configuration signature. Like a database connection pool, the context is spun up exactly once at the start of the suite and reused instantly across all tests.
Moreover Spring's `MockitoTestExecutionListener` handles resetting these shared mock instances automatically after every test method, guaranteeing zero state-bleed or cross-test pollution.

## Impact
 - **Performance:** Drastic reduction in total test suite execution time due to 100% Application Context cache hit rates

 - **Maintainability:** Child test classes are strictly focused on test logic, entirely free of framework lifecycle boilerplate

 - **Modernization:** Fully aligned with JUnit 6 / Jupiter standards, unblocking future tooling upgrades

## Checklist
  - [x] Removed `@RunWith` from all integration test subclasses
  - [x] Removed empty `@ContextConfiguration` from base classes
  - [x] Consolidated all `@MockitoBean` dependencies into `TestIntegrationBase`
  - [x] Verified local test suite execution passes cleanly without state bleed
  - [x] As of now, the `integration` tests under `rest` is upgraded form `Junit 4` to `JUnit 6` 
  
## AI Disclosure
  - [x] This documentation was generated with the help of AI (Gemini 3.1 Pro - Extended Thinking)