### PR TITLE
fix: Use release index for component release pagination count

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -357,7 +357,7 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
                 .useIndex(Collections.singletonList(indexName));
 
         List<Release> releases = getConnector().getQueryResultPaginated(
-                qb, Release.class, pageData, sortSelector);
+                qb, Release.class, pageData, sortSelector, indexName, true);
 
         return Collections.singletonMap(pageData, releases);
     }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -735,16 +735,35 @@ public class DatabaseConnectorCloudant {
             PostFindOptions.Builder qb, Class<T> type, PaginationData pageData,
             Map<String, String> sortSelector
     ) {
+        return getQueryResultPaginated(qb, type, pageData, sortSelector, "PaginationIdx");
+    }
+
+    public <T> List<T> getQueryResultPaginated(
+            PostFindOptions.Builder qb, Class<T> type, PaginationData pageData,
+            Map<String, String> sortSelector, String countIndexName
+    ) {
+        return getQueryResultPaginated(qb, type, pageData, sortSelector, countIndexName, false);
+    }
+
+    public <T> List<T> getQueryResultPaginated(
+            PostFindOptions.Builder qb, Class<T> type, PaginationData pageData,
+            Map<String, String> sortSelector, String countIndexName, boolean sortCountQuery
+    ) {
         final int rowsPerPage = pageData.getRowsPerPage();
         final int skip = pageData.getDisplayStart();
 
         long rowQueryLimit = Math.max(rowsPerPage, LUCENE_SEARCH_LIMIT);
 
-        PostFindOptions countQuery = qb.build().newBuilder()
-                .fields(Collections.singletonList("_id"))
-                .limit(rowQueryLimit)
-                .useIndex(Collections.singletonList("PaginationIdx"))
-                .build();
+        PostFindOptions.Builder countQueryBuilder = qb.build().newBuilder()
+            .fields(Collections.singletonList("_id"))
+            .limit(rowQueryLimit)
+            .useIndex(Collections.singletonList(countIndexName));
+
+        if (sortCountQuery) {
+            countQueryBuilder.addSort(sortSelector);
+        }
+
+        PostFindOptions countQuery = countQueryBuilder.build();
 
         try {
             FindResult result = this.instance.getClient().postFind(countQuery).execute().getResult();


### PR DESCRIPTION
Fixes slow loading of the Component Portal Release Overview tab by using the component release index for the pagination count query.
