### PR TITLE
feat(licensedb): add LicenseDB config container and HTTP client layer

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -56,6 +56,12 @@ public class SW360ConfigsDatabaseHandler {
             log.error(exception.getMessage());
             loadToConfigsInMemForUi(null);
         }
+        try {
+            loadToConfigsInMemForLicenseDB(repository.getByConfigFor(ConfigFor.LICENSEDB_REST));
+        } catch (IllegalStateException exception) {
+            log.error(exception.getMessage());
+            loadToConfigsInMemForLicenseDB(null);
+        }
     }
 
     private void putInMemory(ConfigFor configFor, Map<String, String> configMap) {
@@ -92,6 +98,16 @@ public class SW360ConfigsDatabaseHandler {
                 .put(INHERIT_ATTACHMENT_USAGES, getOrDefault(configContainer, INHERIT_ATTACHMENT_USAGES, "false"))
             .build();
         putInMemory(ConfigFor.SW360_CONFIGURATION, configMap);
+    }
+
+    private void loadToConfigsInMemForLicenseDB(ConfigContainer configContainer) {
+        ImmutableMap<String, String> configMap = ImmutableMap.<String, String>builder()
+                .put(LICENSEDB_ENABLED, getOrDefault(configContainer, LICENSEDB_ENABLED, "false"))
+                .put(LICENSEDB_BASE_URL, getOrDefault(configContainer, LICENSEDB_BASE_URL, ""))
+                .put(LICENSEDB_USERNAME, getOrDefault(configContainer, LICENSEDB_USERNAME, ""))
+                .put(LICENSEDB_PASSWORD, getOrDefault(configContainer, LICENSEDB_PASSWORD, ""))
+                .build();
+        putInMemory(ConfigFor.LICENSEDB_REST, configMap);
     }
 
     private void loadToConfigsInMemForUi(ConfigContainer configContainer) {
@@ -231,6 +247,14 @@ public class SW360ConfigsDatabaseHandler {
                  PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE
                     -> isValidEnumValue(configValue, UserGroup.class);
 
+            case LICENSEDB_ENABLED
+                    -> isBooleanValue(configValue);
+
+            case LICENSEDB_BASE_URL,
+                 LICENSEDB_USERNAME,
+                 LICENSEDB_PASSWORD
+                    -> configValue != null;
+
             // validate set of strings
             case UI_CLEARING_TEAMS,
                  UI_COMPONENT_CATEGORIES,
@@ -269,6 +293,7 @@ public class SW360ConfigsDatabaseHandler {
         ConfigFor configFor = null;
         Map<String, String> sw360Configs = configsMapInMem.getOrDefault(ConfigFor.SW360_CONFIGURATION, Collections.emptyMap());
         Map<String, String> uiConfigs = configsMapInMem.getOrDefault(ConfigFor.UI_CONFIGURATION, Collections.emptyMap());
+        Map<String, String> licenseDbConfigs = configsMapInMem.getOrDefault(ConfigFor.LICENSEDB_REST, Collections.emptyMap());
 
         // Guess the ConfigFor based on the keys in updatedConfigs
         for (String key : updatedConfigs.keySet()) {
@@ -278,6 +303,10 @@ public class SW360ConfigsDatabaseHandler {
             }
             if (uiConfigs.containsKey(key)) {
                 configFor = ConfigFor.UI_CONFIGURATION;
+                break;
+            }
+            if (licenseDbConfigs.containsKey(key)) {
+                configFor = ConfigFor.LICENSEDB_REST;
                 break;
             }
         }
@@ -324,6 +353,8 @@ public class SW360ConfigsDatabaseHandler {
             loadToConfigsInMemForSw360(configContainer);
         } else if (configFor == ConfigFor.UI_CONFIGURATION) {
             loadToConfigsInMemForUi(configContainer);
+        } else if (configFor == ConfigFor.LICENSEDB_REST) {
+            loadToConfigsInMemForLicenseDB(configContainer);
         } else {
             log.warn("Unknown ConfigFor: {}", configFor);
         }

--- a/backend/licenses-core/pom.xml
+++ b/backend/licenses-core/pom.xml
@@ -33,5 +33,9 @@
             <groupId>org.spdx</groupId>
             <artifactId>tools-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.core5.util.Timeout;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class LicenseDBConnector {
+
+    private static final Logger log = LogManager.getLogger(LicenseDBConnector.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final TypeReference<List<LicenseDBLicenseDTO>> LICENSE_LIST_TYPE =
+            new TypeReference<List<LicenseDBLicenseDTO>>() {};
+    private static final TypeReference<List<LicenseDBObligationDTO>> OBLIGATION_LIST_TYPE =
+            new TypeReference<List<LicenseDBObligationDTO>>() {};
+
+    private static final RequestConfig REQUEST_CONFIG = RequestConfig.custom()
+            .setConnectTimeout(Timeout.ofSeconds(5))
+            .setConnectionRequestTimeout(Timeout.ofSeconds(5))
+            .setResponseTimeout(Timeout.ofSeconds(30))
+            .build();
+
+    private final String baseUrl;
+    private final LicenseDBTokenManager tokenManager;
+
+    public LicenseDBConnector(String baseUrl, LicenseDBTokenManager tokenManager) {
+        this.baseUrl = Objects.requireNonNull(baseUrl, "baseUrl must not be null").replaceAll("/+$", "");
+        this.tokenManager = Objects.requireNonNull(tokenManager, "tokenManager must not be null");
+    }
+
+    public List<LicenseDBLicenseDTO> fetchAllLicenses() throws IOException {
+        List<LicenseDBLicenseDTO> all = doGet(baseUrl + "/api/v1/licenses/export", LICENSE_LIST_TYPE);
+        return all.stream()
+                .filter(LicenseDBLicenseDTO::isActive)
+                .collect(Collectors.toList());
+    }
+
+    public List<LicenseDBObligationDTO> fetchAllObligations() throws IOException {
+        List<LicenseDBObligationDTO> all = doGet(baseUrl + "/api/v1/obligations/export", OBLIGATION_LIST_TYPE);
+        return all.stream()
+                .filter(LicenseDBObligationDTO::isActive)
+                .collect(Collectors.toList());
+    }
+
+    private <T> List<T> doGet(String url, TypeReference<List<T>> typeRef) throws IOException {
+        String token = tokenManager.getValidToken();
+        HttpGet request = new HttpGet(url);
+        request.setHeader("Authorization", "Bearer " + token);
+        request.setHeader("Accept", "application/json");
+
+        try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(REQUEST_CONFIG).build()) {
+            return httpClient.execute(request, response -> {
+                int code = response.getCode();
+                if (code != 200) {
+                    log.error("LicenseDB export failed with HTTP {} for: {}", code, url);
+                    throw new IOException("LicenseDB export returned HTTP: " + code);
+                }
+                try (InputStream content = response.getEntity().getContent()) {
+                    return objectMapper.readValue(content, typeRef);
+                }
+            });
+        }
+    }
+}

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBLicenseDTO.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBLicenseDTO.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LicenseDBLicenseDTO {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("shortname")
+    private String shortname;
+
+    @JsonProperty("fullname")
+    private String fullname;
+
+    @JsonProperty("text")
+    private String text;
+
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("copyleft")
+    private boolean copyleft;
+
+    // LicenseDB API uses mixed case "OSIapproved" not camelCase
+    @JsonProperty("OSIapproved")
+    private boolean osiApproved;
+
+    @JsonProperty("notes")
+    private String notes;
+
+    @JsonProperty("active")
+    private boolean active;
+
+    @JsonProperty("spdx_id")
+    private String spdxId;
+
+    @JsonProperty("obligation_ids")
+    private List<String> obligationIds;
+
+    public List<String> getObligationIds() {
+        return obligationIds != null ? obligationIds : Collections.emptyList();
+    }
+}

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBObligationDTO.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBObligationDTO.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LicenseDBObligationDTO {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("topic")
+    private String topic;
+
+    // possible values: OBLIGATION, RISK, RESTRICTION, RIGHT
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("text")
+    private String text;
+
+    // possible values: GREEN, YELLOW, RED
+    @JsonProperty("classification")
+    private String classification;
+
+    @JsonProperty("comment")
+    private String comment;
+
+    @JsonProperty("active")
+    private boolean active;
+
+    @JsonProperty("category")
+    private String category;
+
+    @JsonProperty("license_ids")
+    private List<String> licenseIds;
+
+    public List<String> getLicenseIds() {
+        return licenseIds != null ? licenseIds : Collections.emptyList();
+    }
+}

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBTokenManager.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBTokenManager.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.Timeout;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+public class LicenseDBTokenManager {
+
+    private static final Logger log = LogManager.getLogger(LicenseDBTokenManager.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final int EXPIRY_BUFFER_SECONDS = 60;
+    private static final RequestConfig REQUEST_CONFIG = RequestConfig.custom()
+            .setConnectTimeout(Timeout.ofSeconds(5))
+            .setConnectionRequestTimeout(Timeout.ofSeconds(5))
+            .setResponseTimeout(Timeout.ofSeconds(30))
+            .build();
+
+    private final String baseUrl;
+    private final String username;
+    private final String password;
+
+    private String cachedToken;
+    private Instant tokenExpiry;
+
+    public LicenseDBTokenManager(String baseUrl, String username, String password) {
+        this.baseUrl = Objects.requireNonNull(baseUrl, "baseUrl must not be null").replaceAll("/+$", "");
+        this.username = Objects.requireNonNull(username, "username must not be null");
+        this.password = Objects.requireNonNull(password, "password must not be null");
+    }
+
+    public synchronized String getValidToken() throws IOException {
+        if (cachedToken == null || isExpired()) {
+            performLogin();
+        }
+        return cachedToken;
+    }
+
+    public synchronized void clearToken() {
+        cachedToken = null;
+        tokenExpiry = null;
+    }
+
+    private void performLogin() throws IOException {
+        String body = objectMapper.createObjectNode()
+                .put("username", username)
+                .put("password", password)
+                .toString();
+
+        HttpPost request = new HttpPost(baseUrl + "/api/v1/login");
+        request.setHeader("Accept", "application/json");
+        request.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+
+        try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(REQUEST_CONFIG).build()) {
+            httpClient.execute(request, response -> {
+                int code = response.getCode();
+                if (code != 200) {
+                    log.error("LicenseDB login failed with HTTP: {}", code);
+                    throw new IOException("LicenseDB login failed with HTTP: " + code);
+                }
+                JsonNode data = objectMapper.readTree(response.getEntity().getContent()).path("data");
+                String token = data.path("access_token").asText(null);
+                if (token == null || token.isEmpty()) {
+                    log.error("LicenseDB login response missing access_token");
+                    throw new IOException("LicenseDB login response missing access_token");
+                }
+                cachedToken = token;
+                tokenExpiry = parseExpiry(data.path("expires_at").asText(null));
+                log.info("LicenseDB token acquired, expires at {}", tokenExpiry);
+                return null;
+            });
+        }
+    }
+
+    private boolean isExpired() {
+        return tokenExpiry == null || Instant.now().isAfter(tokenExpiry.minusSeconds(EXPIRY_BUFFER_SECONDS));
+    }
+
+    private Instant parseExpiry(String expiresAt) {
+        if (expiresAt == null || expiresAt.isEmpty()) {
+            log.warn("LicenseDB token response has no expiry timestamp, defaulting to 1 hour");
+            return Instant.now().plusSeconds(3600);
+        }
+        try {
+            return Instant.parse(expiresAt);
+        } catch (DateTimeParseException e) {
+            log.warn("Cannot parse LicenseDB token expiry '{}', defaulting to 1 hour", expiresAt);
+            return Instant.now().plusSeconds(3600);
+        }
+    }
+}

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -122,6 +122,12 @@ public class SW360ConfigKeys {
     // This property is used to create State of Projects
     public static final String UI_STATE = "ui.state";
 
+    // LicenseDB integration configuration
+    public static final String LICENSEDB_ENABLED = "licensedb.enabled";
+    public static final String LICENSEDB_BASE_URL = "licensedb.base.url";
+    public static final String LICENSEDB_USERNAME = "licensedb.username";
+    public static final String LICENSEDB_PASSWORD = "licensedb.password";
+
     // Configuration keys that should only be visible to ADMIN and SW360_ADMIN users
     public static final Set<String> ADMIN_ONLY_CONFIG_KEYS = Set.of(
             RELEASE_FRIENDLY_URL,
@@ -136,7 +142,10 @@ public class SW360ConfigKeys {
             DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD,
             COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY,
             SVM_NOTIFICATION_URL,
-            VCS_HOSTS
+            VCS_HOSTS,
+            LICENSEDB_BASE_URL,
+            LICENSEDB_USERNAME,
+            LICENSEDB_PASSWORD
     );
 
     // List of all known config keys
@@ -157,7 +166,8 @@ public class SW360ConfigKeys {
             UI_OPERATING_SYSTEMS, UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP,
             UI_PROGRAMMING_LANGUAGES, UI_PROJECT_EXTERNALKEYS, UI_PROJECT_EXTERNALURLS,
             UI_PROJECT_TAG, UI_PROJECT_TYPE, UI_RELEASE_EXTERNALKEYS, UI_SOFTWARE_PLATFORMS, UI_STATE,
-            UI_ENABLE_LINKED_PROJECTS_DISPLAY
+            UI_ENABLE_LINKED_PROJECTS_DISPLAY,
+            LICENSEDB_ENABLED, LICENSEDB_BASE_URL, LICENSEDB_USERNAME, LICENSEDB_PASSWORD
     );
 
     private SW360ConfigKeys() {

--- a/libraries/datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/datahandler/src/main/thrift/sw360.thrift
@@ -139,6 +139,7 @@ enum ConfigFor {
     SW360_CONFIGURATION = 1,
 //    SW360_SCHEDULER = 2,   // Reverted in https://github.com/eclipse-sw360/sw360/pull/3244
     UI_CONFIGURATION = 3,
+    LICENSEDB_REST = 4,
 }
 
 enum ObligationStatus {


### PR DESCRIPTION
## Summary

Adds the LicenseDB integration foundation for SW360.

This wires LicenseDB as a new `LICENSEDB_REST` config container and adds the basic HTTP client layer for talking to LicenseDB's export API.

## Config container

`licensedb.enabled`
`licensedb.base.url`
`licensedb.username`
`licensedb.password`

The integration is disabled by default, credentials are admin-only, and config is exposed through the existing `GET/PATCH /configurations/container/LICENSEDB_REST` API so no new endpoints are needed.

## HTTP client

`LicenseDBTokenManager` handles JWT login and token caching with a 60s expiry buffer.

`LicenseDBLicenseDTO` and `LicenseDBObligationDTO` match the LicenseDB export response.

`LicenseDBConnector` fetches licenses and obligations from `/api/v1/licenses/export` and `/api/v1/obligations/export`, with active-only filtering applied client-side.

No new Maven dependencies.

## Suggested reviewers

@GMishx
@amritkv 
@deo002 
@Farooq-Fateh-Aftab
