### PR TITLE
feat(archival): scaffold service-api and backend archival module

### DIFF
--- a/backend/archival/docs/ARCHIVE_FORMAT.md
+++ b/backend/archival/docs/ARCHIVE_FORMAT.md
@@ -1,0 +1,90 @@
+<!--
+  ~ Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+# SW360 Archive Format (`.tar.gz`)
+
+The archival service produces and consumes a single TAR.GZ bundle per archive
+operation. This document is the contract — both the archive flow (writes) and
+the restore flow (reads) must follow it.
+
+## File name
+
+```
+sw360_archive_<bundleId>.tar.gz
+```
+
+`bundleId` is the same value that appears in `manifest.json` and the
+`ArchivalRecord` registry entry.
+
+## Layout
+
+```
+sw360_archive_<bundleId>.tar.gz
+├── manifest.json                        <- read first by restore preview
+│
+├── projects/
+│   └── <projectId>/
+│       ├── project.json                 <- the Project document
+│       ├── changelogs.json              <- full audit history
+│       ├── obligations.json             <- accepted license obligations
+│       ├── clearing-requests.json
+│       └── attachments/
+│           ├── <attachmentId>.bin       <- raw binary
+│           └── <attachmentId>.meta.json <- filename, mimetype, sha, etc.
+│
+├── components/
+│   └── <componentId>/
+│       ├── component.json
+│       ├── changelogs.json
+│       ├── attachments/
+│       └── releases/
+│           └── <releaseId>/
+│               ├── release.json
+│               ├── changelogs.json
+│               ├── spdx.json            <- if exists
+│               ├── attachments/
+│               └── packages/
+│                   └── <packageId>/
+│                       ├── package.json
+│                       └── changelogs.json
+│
+├── releases/                            <- for standalone-archived releases
+│   └── <releaseId>/
+│       └── (same shape as nested release above)
+│
+└── packages/                            <- for orphan packages only
+    └── <packageId>/
+        ├── package.json
+        ├── changelogs.json
+        └── moderation-requests.json
+
+
+## Notes
+
+1. **`manifest.json` is always at the root** and is the first file written.
+   Restore preview reads only this file.
+2. **Attachments are raw binary** (`<id>.bin`), never base64 inside JSON.
+   They are streamed in directly so multi-GB files do not load into memory.
+   The sibling `<id>.meta.json` carries filename, content type, SHA, uploader,
+   and upload timestamp.
+3. **One folder per entity ID**, even if the bundle has a single entity —
+   the layout stays consistent across bundle sizes.
+4. **Nested vs. standalone** — a Release archived as part of its parent
+   Component lives under `components/<id>/releases/<id>/`. A Release archived
+   on its own lives under `releases/<id>/`. Restore handles both.
+5. **Orphan Packages** (Packages with no live parent Release) live under
+   `packages/<id>/`. Packages with a live parent Release are bundled with that
+   Release.
+
+## Versioning
+
+`manifest.json` carries a `manifestVersion` field. Bump it whenever the layout
+or manifest shape changes in a breaking way; restore reads it first and refuses
+to operate on a manifest version it does not understand.

--- a/backend/archival/pom.xml
+++ b/backend/archival/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.sw360</groupId>
+        <artifactId>backend</artifactId>
+        <version>20.1.0-rc-2</version>
+    </parent>
+
+    <artifactId>backend-archival</artifactId>
+    <packaging>war</packaging>
+    <name>backend-archival</name>
+    <build>
+        <finalName>archival</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <configuration>
+                    <mainClass>org.eclipse.sw360.archival.ArchivalApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <artifact.deploy.dir>${backend.deploy.dir}</artifact.deploy.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>service-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>backend-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalApplication.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+@SpringBootApplication
+public class ArchivalApplication extends SpringBootServletInitializer {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ArchivalApplication.class, args);
+    }
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(ArchivalApplication.class);
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalConstants.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalConstants.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+public final class ArchivalConstants {
+
+    public static final String COUCH_DB_ARCHIVAL = "sw360archives";
+
+    public static final int MANIFEST_VERSION = 1;
+
+    private ArchivalConstants() {}
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.services.archival.ArchivalRecord;
+import org.eclipse.sw360.services.archival.ArchiveRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/archival")
+@PreAuthorize("hasAuthority('ADMIN')")
+public class ArchivalController {
+
+    private final ArchivalHandler handler;
+
+    public ArchivalController(ArchivalHandler handler) {
+        this.handler = handler;
+    }
+
+    @PostMapping("/archive")
+    public ResponseEntity<StreamingResponseBody> archive(@RequestBody ArchiveRequest req,
+                                                         Principal principal) {
+        String userEmail = principal != null ? principal.getName() : "unknown";
+        String filename = "sw360_archive_" + Instant.now().toEpochMilli() + ".tar.gz";
+
+        StreamingResponseBody body = sink -> {
+            try {
+                handler.archive(req, userEmail, sink);
+            } catch (SW360Exception e) {
+                throw new IOException("archive failed: " + e.getMessage(), e);
+            }
+        };
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.parseMediaType("application/gzip"))
+                .body(body);
+    }
+
+    @GetMapping("/records")
+    public List<ArchivalRecord> listRecords() {
+        return handler.getAll();
+    }
+
+    @GetMapping("/records/{id}")
+    public ResponseEntity<ArchivalRecord> getRecord(@PathVariable String id) {
+        ArchivalRecord r = handler.get(id);
+        return r == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(r);
+    }
+
+    @DeleteMapping("/records/{id}")
+    public ResponseEntity<Void> deleteRecord(@PathVariable String id) {
+        return handler.delete(id) ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/health")
+    @PreAuthorize("permitAll()")
+    public Map<String, Object> health() {
+        return Map.of(
+                "status", "UP",
+                "service", "archival",
+                "timestamp", Instant.now().toString()
+        );
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalHandler.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalHandler.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.archival.bundle.ArchiveBuilder;
+import org.eclipse.sw360.archival.bundle.CollectedEntity;
+import org.eclipse.sw360.archival.bundle.EntityProvider;
+import org.eclipse.sw360.archival.bundle.Sw360EntityProvider;
+import org.eclipse.sw360.archival.db.ArchivalDatabaseHandler;
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.services.archival.ArchivalRecord;
+import org.eclipse.sw360.services.archival.ArchivalStatus;
+import org.eclipse.sw360.services.archival.ArchiveManifest;
+import org.eclipse.sw360.services.archival.ArchiveRequest;
+import org.eclipse.sw360.services.archival.ManifestEntry;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class ArchivalHandler {
+
+    private static final String SW360_VERSION = "20.0.0-beta";
+
+    private final ArchivalDatabaseHandler db;
+
+    public ArchivalHandler() throws IOException {
+        this.db = new ArchivalDatabaseHandler(
+                DatabaseSettings.getConfiguredClient(),
+                ArchivalConstants.COUCH_DB_ARCHIVAL);
+    }
+
+    ArchivalHandler(ArchivalDatabaseHandler db) {
+        this.db = db;
+    }
+
+    public ArchiveResult archive(ArchiveRequest req, String userEmail, OutputStream sink)
+            throws SW360Exception, IOException {
+        return archive(req, userEmail, sink,
+                new Sw360EntityProvider(req.isIncludeAttachments(), req.isIncludeChangelogs()));
+    }
+
+    public ArchiveResult archive(ArchiveRequest req,
+                                 String userEmail,
+                                 OutputStream sink,
+                                 EntityProvider provider) throws SW360Exception, IOException {
+        if (req.getEntityIds() == null || req.getEntityIds().isEmpty()) {
+            throw new SW360Exception("archive request has no entity IDs");
+        }
+
+        String bundleId = "bundle-" + UUID.randomUUID();
+        Instant now = Instant.now();
+
+        // Record the archive request as PENDING before processing begins.
+        List<ArchivalRecord> records = new ArrayList<>(req.getEntityIds().size());
+        for (String entityId : req.getEntityIds()) {
+            ArchivalRecord r = new ArchivalRecord();
+            r.setId(UUID.randomUUID().toString());
+            r.setBundleId(bundleId);
+            r.setEntityId(entityId);
+            r.setEntityType(req.getEntityType());
+            r.setStatus(ArchivalStatus.IN_PROGRESS);
+            r.setArchivedBy(userEmail);
+            r.setArchivedAt(now);
+            r.setComment(req.getComment());
+            records.add(db.add(r));
+        }
+
+        // Collect entities (entity doc, changelogs, attachments).
+        List<CollectedEntity> collected = new ArrayList<>(records.size());
+        for (ArchivalRecord r : records) {
+            try {
+                collected.add(provider.collect(r.getEntityType(), r.getEntityId()));
+            } catch (Exception e) {
+                markFailed(r, "collection failed: " + e.getMessage());
+                throw new SW360Exception("entity collection failed for " + r.getEntityId() + ": " + e.getMessage());
+            }
+        }
+
+        // Build and stream the TAR.GZ archive directly to the output sink.
+        ArchiveManifest manifest;
+        try {
+            ArchiveBuilder builder = new ArchiveBuilder(bundleId, userEmail, SW360_VERSION, req.getComment());
+            manifest = builder.writeTo(sink, collected);
+        } catch (IOException e) {
+            for (ArchivalRecord r : records) markFailed(r, "bundling failed: " + e.getMessage());
+            throw e;
+        }
+
+        // Mark the archived entities as ARCHIVED using attachment counts from the manifest.
+        Map<String, ManifestEntry> byId = new HashMap<>();
+        for (ManifestEntry e : manifest.getEntries()) byId.put(e.getEntityId(), e);
+
+        for (ArchivalRecord r : records) {
+            ManifestEntry e = byId.get(r.getEntityId());
+            if (e != null) r.setAttachmentCount(e.getAttachmentCount());
+            r.setStatus(ArchivalStatus.ARCHIVED);
+            db.update(r);
+        }
+
+        return new ArchiveResult(bundleId, manifest, records);
+    }
+
+    public ArchivalRecord get(String id) {
+        return db.get(id);
+    }
+
+    public List<ArchivalRecord> getAll() {
+        return db.getAll();
+    }
+
+    public boolean delete(String id) {
+        return db.delete(id);
+    }
+
+    private void markFailed(ArchivalRecord r, String reason) {
+        r.setStatus(ArchivalStatus.FAILED);
+        r.setComment((r.getComment() == null ? "" : r.getComment() + " | ") + reason);
+        try {
+            db.update(r);
+        } catch (Exception ignore) {
+            // If updating the registry fails, preserve and propagate the original error.
+        }
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchiveResult.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchiveResult.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.services.archival.ArchivalRecord;
+import org.eclipse.sw360.services.archival.ArchiveManifest;
+
+import java.util.List;
+
+/** What ArchivalHandler.archive returns alongside the streamed TAR. */
+public record ArchiveResult(String bundleId,
+                            ArchiveManifest manifest,
+                            List<ArchivalRecord> records) {}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/SecurityConfig.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/SecurityConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Minimal security configuration for the archival module.
+ * JWT/OAuth resource-server support will be added when SW360's authorization server is integrated.
+ */
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/archival/health").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ArchiveBuilder.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ArchiveBuilder.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.eclipse.sw360.archival.ArchivalConstants;
+import org.eclipse.sw360.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.services.archival.ArchiveManifest;
+import org.eclipse.sw360.services.archival.ManifestEntry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Builds the TAR.GZ archive for a set of CollectedEntity instances.
+ * Layout is defined in backend/archival/docs/ARCHIVE_FORMAT.md.
+ */
+public final class ArchiveBuilder {
+
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    private static final int COPY_BUFFER = 64 * 1024;
+
+    private final String bundleId;
+    private final String createdBy;
+    private final String sw360Version;
+    private final String comment;
+
+    public ArchiveBuilder(String bundleId, String createdBy, String sw360Version, String comment) {
+        this.bundleId = bundleId;
+        this.createdBy = createdBy;
+        this.sw360Version = sw360Version;
+        this.comment = comment;
+    }
+
+    public ArchiveManifest writeTo(OutputStream rawOut, List<CollectedEntity> entities) throws IOException {
+        List<ManifestEntry> manifestEntries = new ArrayList<>(entities.size());
+
+        try (GzipCompressorOutputStream gz = new GzipCompressorOutputStream(rawOut);
+             TarArchiveOutputStream tar = new TarArchiveOutputStream(gz)) {
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+
+            for (CollectedEntity entity : entities) {
+                manifestEntries.add(writeEntity(tar, entity));
+            }
+
+            ArchiveManifest manifest = buildManifest(manifestEntries);
+            writeBinaryEntry(tar, "manifest.json", JSON.writeValueAsBytes(manifest));
+
+            tar.finish();
+            return manifest;
+        }
+    }
+
+    private ManifestEntry writeEntity(TarArchiveOutputStream tar, CollectedEntity entity) throws IOException {
+        String folder = folderFor(entity.entityType()) + "/" + entity.entityId() + "/";
+        MessageDigest entityHash = newSha256();
+        long totalAttachmentBytes = 0;
+
+        // documents (project.json, changelogs.json, ...)
+        for (var doc : entity.documents().entrySet()) {
+            byte[] body = doc.getValue();
+            writeBinaryEntry(tar, folder + doc.getKey(), body);
+            entityHash.update(body);
+        }
+
+        // attachments
+        if (entity.attachments() != null) {
+            for (AttachmentSource att : entity.attachments()) {
+                String attId = att.metadata().getAttachmentId();
+                String binPath = folder + "attachments/" + attId + ".bin";
+                String metaPath = folder + "attachments/" + attId + ".meta.json";
+
+                long bytesWritten = streamAttachment(tar, binPath, att, entityHash);
+                totalAttachmentBytes += bytesWritten;
+
+                byte[] metaBytes = JSON.writeValueAsBytes(att.metadata());
+                writeBinaryEntry(tar, metaPath, metaBytes);
+                entityHash.update(metaBytes);
+            }
+        }
+
+        ManifestEntry entry = new ManifestEntry();
+        entry.setEntityId(entity.entityId());
+        entry.setEntityName(entity.entityName());
+        entry.setEntityType(entity.entityType());
+        entry.setEntityVersion(entity.entityVersion());
+        entry.setPath(folder);
+        entry.setAttachmentCount(entity.attachments() == null ? 0 : entity.attachments().size());
+        entry.setAttachmentTotalBytes(totalAttachmentBytes);
+        entry.setChecksum("sha256:" + HexFormat.of().formatHex(entityHash.digest()));
+        return entry;
+    }
+
+    private long streamAttachment(TarArchiveOutputStream tar,
+                                  String path,
+                                  AttachmentSource source,
+                                  MessageDigest entityHash) throws IOException {
+        TarArchiveEntry tarEntry = new TarArchiveEntry(path);
+        tarEntry.setSize(source.sizeBytes());
+        tarEntry.setModTime(System.currentTimeMillis());
+        tar.putArchiveEntry(tarEntry);
+
+        long copied = 0;
+        byte[] buf = new byte[COPY_BUFFER];
+        try (InputStream in = source.open()) {
+            int n;
+            while ((n = in.read(buf)) > 0) {
+                tar.write(buf, 0, n);
+                entityHash.update(buf, 0, n);
+                copied += n;
+            }
+        }
+        tar.closeArchiveEntry();
+
+        if (copied != source.sizeBytes()) {
+            throw new IOException("Attachment " + source.metadata().getAttachmentId()
+                    + " size mismatch: declared " + source.sizeBytes() + " but streamed " + copied);
+        }
+        return copied;
+    }
+
+    private void writeBinaryEntry(TarArchiveOutputStream tar, String path, byte[] body) throws IOException {
+        TarArchiveEntry tarEntry = new TarArchiveEntry(path);
+        tarEntry.setSize(body.length);
+        tarEntry.setModTime(System.currentTimeMillis());
+        tar.putArchiveEntry(tarEntry);
+        tar.write(body);
+        tar.closeArchiveEntry();
+    }
+
+    private ArchiveManifest buildManifest(List<ManifestEntry> entries) {
+        ArchiveManifest m = new ArchiveManifest();
+        m.setBundleId(bundleId);
+        m.setCreatedAt(Instant.now());
+        m.setCreatedBy(createdBy);
+        m.setSw360Version(sw360Version);
+        m.setManifestVersion(ArchivalConstants.MANIFEST_VERSION);
+        m.setComment(comment);
+        m.setEntries(entries);
+        return m;
+    }
+
+    private static String folderFor(ArchivalEntityType t) {
+        return switch (t) {
+            case PROJECT -> "projects";
+            case COMPONENT -> "components";
+            case RELEASE -> "releases";
+            case PACKAGE -> "packages";
+        };
+    }
+
+    private static MessageDigest newSha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/AttachmentSource.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/AttachmentSource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.services.archival.AttachmentMetadata;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/** Streamed handle to one attachment binary
+ *  open() is called when the bundler is ready to copy bytes.
+*/
+
+public interface AttachmentSource {
+
+    AttachmentMetadata metadata();
+
+    long sizeBytes();
+
+    InputStream open() throws IOException;
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ByteArrayAttachmentSource.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ByteArrayAttachmentSource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.services.archival.AttachmentMetadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * AttachmentSource backed by an in-memory byte array.
+ * Suitable for tests and small files; use a streaming source for CouchDB attachments.
+ */
+public final class ByteArrayAttachmentSource implements AttachmentSource {
+
+    private final AttachmentMetadata metadata;
+    private final byte[] body;
+
+    public ByteArrayAttachmentSource(AttachmentMetadata metadata, byte[] body) {
+        this.metadata = metadata;
+        this.body = body;
+        if (metadata.getSizeBytes() != body.length) {
+            metadata.setSizeBytes(body.length);
+        }
+    }
+
+    @Override
+    public AttachmentMetadata metadata() { return metadata; }
+
+    @Override
+    public long sizeBytes() { return body.length; }
+
+    @Override
+    public InputStream open() { return new ByteArrayInputStream(body); }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/CollectedEntity.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/CollectedEntity.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.services.archival.ArchivalEntityType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Everything we need to bundle one entity into the TAR.
+ * documents: filename -> serialised JSON bytes (e.g. project.json, changelogs.json).
+ * attachments: lazy handles streamed in directly without loading into memory.
+ */
+public final class CollectedEntity {
+
+    private final String entityId;
+    private final String entityName;
+    private final String entityVersion;
+    private final ArchivalEntityType entityType;
+    private final Map<String, byte[]> documents;
+    private final List<AttachmentSource> attachments;
+
+    public CollectedEntity(String entityId,
+                           String entityName,
+                           String entityVersion,
+                           ArchivalEntityType entityType,
+                           Map<String, byte[]> documents,
+                           List<AttachmentSource> attachments) {
+        this.entityId = entityId;
+        this.entityName = entityName;
+        this.entityVersion = entityVersion;
+        this.entityType = entityType;
+        this.documents = documents;
+        this.attachments = attachments;
+    }
+
+    public String entityId() { return entityId; }
+    public String entityName() { return entityName; }
+    public String entityVersion() { return entityVersion; }
+    public ArchivalEntityType entityType() { return entityType; }
+    public Map<String, byte[]> documents() { return documents; }
+    public List<AttachmentSource> attachments() { return attachments; }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/EntityProvider.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/EntityProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.services.archival.ArchivalEntityType;
+
+/**
+ * Retrieves an entity and its associated data from the live SW360 databases.
+ * Implementations use the existing Project, Component, Release, and Package
+ * database handlers. Keeping this behind an interface allows the archive
+ * workflow to be tested without requiring a running CouchDB instance.
+ */
+public interface EntityProvider {
+
+    boolean includeAttachments();
+
+    boolean includeChangelogs();
+
+    CollectedEntity collect(ArchivalEntityType type, String entityId) throws Exception;
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/InMemoryEntityProvider.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/InMemoryEntityProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.services.archival.ArchivalEntityType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test implementation that stores CollectedEntity instances in memory.
+ * Allows tests to prepopulate entities by ID without any SW360 or CouchDB dependencies.
+ */
+public final class InMemoryEntityProvider implements EntityProvider {
+
+    private final Map<String, CollectedEntity> byId = new HashMap<>();
+
+    public InMemoryEntityProvider register(CollectedEntity e) {
+        byId.put(key(e.entityType(), e.entityId()), e);
+        return this;
+    }
+
+    @Override
+    public boolean includeAttachments() { return true; }
+
+    @Override
+    public boolean includeChangelogs() { return true; }
+
+    @Override
+    public CollectedEntity collect(ArchivalEntityType type, String entityId) {
+        CollectedEntity hit = byId.get(key(type, entityId));
+        if (hit == null) {
+            throw new IllegalArgumentException("No entity registered for " + type + "/" + entityId);
+        }
+        return hit;
+    }
+
+    private static String key(ArchivalEntityType type, String id) {
+        return type.name() + ":" + id;
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/Sw360EntityProvider.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/Sw360EntityProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.services.archival.ArchivalEntityType;
+
+/**
+ * Production EntityProvider that reads from the live SW360 databases.
+ * Not wired yet — the DB handler integration is still to come.
+ *
+ * Planned wiring:
+ *   PROJECT   -> ProjectDatabaseHandler.getProjectByIdIgnoringVisibility(id)
+ *                + ChangeLogsDatabaseHandler.getChangeLogsByDocumentId(id)
+ *                + ProjectObligationRepository, AttachmentUsageRepository
+ *   COMPONENT -> ComponentDatabaseHandler.getComponent(id, user) (+ all linked Releases)
+ *   RELEASE   -> ComponentDatabaseHandler.getRelease(id, user) (+ SpdxDocument if present)
+ *   PACKAGE   -> PackageDatabaseHandler.getPackageById(id)
+ *
+ * Attachments: walk entity.getAttachments() and build an AttachmentSource for each,
+ * backed by AttachmentConnector.unsafeGetAttachmentStream(...).
+ *
+ * Project entities additionally persist:
+ *   - clearing-requests.json (ProjectVulnerabilityRating etc.)
+ *   - obligations.json
+ *   - attachment-usage.json (so clearing decisions survive a restore)
+ */
+public class Sw360EntityProvider implements EntityProvider {
+
+    private final boolean includeAttachments;
+    private final boolean includeChangelogs;
+
+    public Sw360EntityProvider(boolean includeAttachments, boolean includeChangelogs) {
+        this.includeAttachments = includeAttachments;
+        this.includeChangelogs = includeChangelogs;
+    }
+
+    @Override
+    public boolean includeAttachments() { return includeAttachments; }
+
+    @Override
+    public boolean includeChangelogs() { return includeChangelogs; }
+
+    @Override
+    public CollectedEntity collect(ArchivalEntityType type, String entityId) {
+        throw new UnsupportedOperationException(
+                "Sw360EntityProvider is not wired to the live SW360 databases yet. "
+                        + "Requested " + type + "/" + entityId);
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalDatabaseHandler.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalDatabaseHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.db;
+
+import com.ibm.cloud.cloudant.v1.Cloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.services.archival.ArchivalRecord;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ArchivalDatabaseHandler {
+
+    private final ArchivalRepository repository;
+
+    public ArchivalDatabaseHandler(Cloudant client, String dbName) throws MalformedURLException {
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
+        repository = new ArchivalRepository(db);
+    }
+
+    public ArchivalDatabaseHandler(ArchivalRepository repository) {
+        this.repository = repository;
+    }
+
+    public ArchivalRecord add(ArchivalRecord record) throws SW360Exception {
+        ArchivalRecordDocument doc = ArchivalRecordDocument.fromRecord(record);
+        repository.add(doc);
+        return doc.toRecord();
+    }
+
+    public ArchivalRecord get(String id) {
+        ArchivalRecordDocument doc = repository.get(id);
+        return doc == null ? null : doc.toRecord();
+    }
+
+    public List<ArchivalRecord> getAll() {
+        return repository.getAll().stream()
+                .map(ArchivalRecordDocument::toRecord)
+                .collect(Collectors.toList());
+    }
+
+    public List<ArchivalRecord> getByBundleId(String bundleId) {
+        return repository.getByBundleId(bundleId).stream()
+                .map(ArchivalRecordDocument::toRecord)
+                .collect(Collectors.toList());
+    }
+
+    public boolean delete(String id) {
+        return repository.remove(id);
+    }
+
+    /**
+     * Re-fetches the existing doc to keep its _rev, copies the new field values,
+     * and writes it back. Returns true if the row existed and was updated.
+     */
+    public boolean update(ArchivalRecord record) {
+        ArchivalRecordDocument existing = repository.get(record.getId());
+        if (existing == null) return false;
+
+        existing.setBundleId(record.getBundleId());
+        existing.setEntityId(record.getEntityId());
+        existing.setEntityName(record.getEntityName());
+        existing.setEntityType(record.getEntityType());
+        existing.setStatus(record.getStatus());
+        existing.setArchivedBy(record.getArchivedBy());
+        existing.setArchivedAt(record.getArchivedAt());
+        existing.setRestoredBy(record.getRestoredBy());
+        existing.setRestoredAt(record.getRestoredAt());
+        existing.setAttachmentCount(record.getAttachmentCount());
+        existing.setComment(record.getComment());
+
+        repository.update(existing);
+        return true;
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRecordDocument.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRecordDocument.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.db;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.sw360.services.archival.ArchivalRecord;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivalRecordDocument extends ArchivalRecord {
+
+    public static final String TYPE = "archivalRecord";
+
+    @JsonProperty("_id")
+    private String docId;
+
+    @JsonProperty("_rev")
+    private String revision;
+
+    @JsonProperty("type")
+    private String type = TYPE;
+
+    public String getDocId() { return docId; }
+    public void setDocId(String docId) { this.docId = docId; }
+
+    public String getRevision() { return revision; }
+    public void setRevision(String revision) { this.revision = revision; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public static ArchivalRecordDocument fromRecord(ArchivalRecord r) {
+        ArchivalRecordDocument d = new ArchivalRecordDocument();
+        d.setId(r.getId());
+        d.setDocId(r.getId());
+        d.setBundleId(r.getBundleId());
+        d.setEntityId(r.getEntityId());
+        d.setEntityName(r.getEntityName());
+        d.setEntityType(r.getEntityType());
+        d.setStatus(r.getStatus());
+        d.setArchivedBy(r.getArchivedBy());
+        d.setArchivedAt(r.getArchivedAt());
+        d.setRestoredBy(r.getRestoredBy());
+        d.setRestoredAt(r.getRestoredAt());
+        d.setAttachmentCount(r.getAttachmentCount());
+        d.setComment(r.getComment());
+        return d;
+    }
+
+    public ArchivalRecord toRecord() {
+        ArchivalRecord r = new ArchivalRecord();
+        r.setId(getDocId());
+        r.setBundleId(getBundleId());
+        r.setEntityId(getEntityId());
+        r.setEntityName(getEntityName());
+        r.setEntityType(getEntityType());
+        r.setStatus(getStatus());
+        r.setArchivedBy(getArchivedBy());
+        r.setArchivedAt(getArchivedAt());
+        r.setRestoredBy(getRestoredBy());
+        r.setRestoredAt(getRestoredAt());
+        r.setAttachmentCount(getAttachmentCount());
+        r.setComment(getComment());
+        return r;
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRepository.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRepository.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.db;
+
+import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ArchivalRepository extends DatabaseRepositoryCloudantClient<ArchivalRecordDocument> {
+
+    private static final String ALL =
+            "function(doc) { if (doc.type == '" + ArchivalRecordDocument.TYPE + "') emit(null, doc._id) }";
+
+    private static final String BY_BUNDLE_ID =
+            "function(doc) {" +
+            "  if (doc.type == '" + ArchivalRecordDocument.TYPE + "' && doc.bundleId != null) {" +
+            "    emit(doc.bundleId, doc._id);" +
+            "  }" +
+            "}";
+
+    private static final String BY_ENTITY_TYPE =
+            "function(doc) {" +
+            "  if (doc.type == '" + ArchivalRecordDocument.TYPE + "' && doc.entityType != null) {" +
+            "    emit(doc.entityType, doc._id);" +
+            "  }" +
+            "}";
+
+    public ArchivalRepository(DatabaseConnectorCloudant db) {
+        super(db, ArchivalRecordDocument.class);
+        Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
+        views.put("all", createMapReduce(ALL, null));
+        views.put("byBundleId", createMapReduce(BY_BUNDLE_ID, null));
+        views.put("byEntityType", createMapReduce(BY_ENTITY_TYPE, null));
+        initStandardDesignDocument(views, db);
+    }
+
+    public List<ArchivalRecordDocument> getByBundleId(String bundleId) {
+        Set<String> ids = queryForIdsAsValue("byBundleId", bundleId);
+        return get(ids);
+    }
+
+    public List<ArchivalRecordDocument> getByEntityType(String entityType) {
+        Set<String> ids = queryForIdsAsValue("byEntityType", entityType);
+        return get(ids);
+    }
+}

--- a/backend/archival/src/main/resources/application.yml
+++ b/backend/archival/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+# Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+spring:
+  application:
+    name: sw360-archival
+  jackson:
+    default-property-inclusion: non_null
+
+server:
+  servlet:
+    context-path: /archival
+
+logging:
+  level:
+    org.eclipse.sw360.archival: INFO

--- a/backend/archival/src/test/java/org/eclipse/sw360/archival/ArchivalHandlerTest.java
+++ b/backend/archival/src/test/java/org/eclipse/sw360/archival/ArchivalHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.archival.bundle.ByteArrayAttachmentSource;
+import org.eclipse.sw360.archival.bundle.CollectedEntity;
+import org.eclipse.sw360.archival.bundle.InMemoryEntityProvider;
+import org.eclipse.sw360.archival.db.ArchivalDatabaseHandler;
+import org.eclipse.sw360.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.services.archival.ArchivalRecord;
+import org.eclipse.sw360.services.archival.ArchivalStatus;
+import org.eclipse.sw360.services.archival.ArchiveRequest;
+import org.eclipse.sw360.services.archival.AttachmentMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArchivalHandlerTest {
+
+    @Test
+    void archive_writesOneRecordPerEntity_withSharedBundleIdAndArchivedStatus() throws Exception {
+        FakeDb fakeDb = new FakeDb();
+        ArchivalHandler handler = new ArchivalHandler(fakeDb);
+
+        InMemoryEntityProvider provider = new InMemoryEntityProvider()
+                .register(release("rel-1", "Release One"))
+                .register(release("rel-2", "Release Two"))
+                .register(release("rel-3", "Release Three"));
+
+        ArchiveRequest req = new ArchiveRequest();
+        req.setEntityType(ArchivalEntityType.RELEASE);
+        req.setEntityIds(List.of("rel-1", "rel-2", "rel-3"));
+        req.setComment("Q2 cleanup");
+
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        ArchiveResult result = handler.archive(req, "taanvi@example.com", sink, provider);
+
+        List<ArchivalRecord> records = result.records();
+        assertEquals(3, records.size());
+
+        String bundleId = records.get(0).getBundleId();
+        assertNotNull(bundleId);
+        assertTrue(bundleId.startsWith("bundle-"));
+        assertEquals(bundleId, result.bundleId());
+
+        for (ArchivalRecord r : records) {
+            assertEquals(bundleId, r.getBundleId(), "all records share the bundle id");
+            assertEquals(ArchivalStatus.ARCHIVED, r.getStatus());
+            assertEquals(ArchivalEntityType.RELEASE, r.getEntityType());
+            assertEquals("taanvi@example.com", r.getArchivedBy());
+            assertEquals("Q2 cleanup", r.getComment());
+            assertNotNull(r.getArchivedAt());
+        }
+
+        assertEquals(3, fakeDb.added.size(), "3 rows initially added");
+        assertEquals(3, fakeDb.updated.size(), "3 rows flipped to ARCHIVED");
+        assertTrue(sink.size() > 0, "TAR.GZ bytes were streamed to the sink");
+    }
+
+    private static CollectedEntity release(String id, String name) {
+        AttachmentMetadata meta = new AttachmentMetadata();
+        meta.setAttachmentId("att-" + id);
+        meta.setFilename(id + "-source.zip");
+        meta.setContentType("application/zip");
+
+        Map<String, byte[]> docs = new HashMap<>();
+        docs.put("release.json", ("{\"id\":\"" + id + "\"}").getBytes(StandardCharsets.UTF_8));
+
+        byte[] body = ("fake-bytes-for-" + id).getBytes(StandardCharsets.UTF_8);
+        return new CollectedEntity(id, name, "1.0", ArchivalEntityType.RELEASE, docs,
+                List.of(new ByteArrayAttachmentSource(meta, body)));
+    }
+
+    /** Stand-in for ArchivalDatabaseHandler; the real one needs a Cloudant instance. */
+    static class FakeDb extends ArchivalDatabaseHandler {
+        final List<ArchivalRecord> added = new ArrayList<>();
+        final List<ArchivalRecord> updated = new ArrayList<>();
+        final Map<String, ArchivalRecord> byId = new HashMap<>();
+
+        FakeDb() {
+            super((org.eclipse.sw360.archival.db.ArchivalRepository) null);
+        }
+
+        @Override
+        public ArchivalRecord add(ArchivalRecord r) {
+            added.add(r);
+            byId.put(r.getId(), r);
+            return r;
+        }
+
+        @Override
+        public boolean update(ArchivalRecord r) {
+            if (!byId.containsKey(r.getId())) return false;
+            updated.add(r);
+            byId.put(r.getId(), r);
+            return true;
+        }
+    }
+}

--- a/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/ArchiveBuilderTest.java
+++ b/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/ArchiveBuilderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.eclipse.sw360.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.services.archival.ArchiveManifest;
+import org.eclipse.sw360.services.archival.AttachmentMetadata;
+import org.eclipse.sw360.services.archival.ManifestEntry;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArchiveBuilderTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    void buildsTarGzWithManifestAndAttachments() throws Exception {
+        byte[] sourceZip = "fake-source-zip-bytes".getBytes(StandardCharsets.UTF_8);
+        byte[] sbom = "fake-sbom-bytes".getBytes(StandardCharsets.UTF_8);
+
+        AttachmentMetadata sourceMeta = meta("att-1", "source.zip", "application/zip");
+        AttachmentMetadata sbomMeta = meta("att-2", "sbom.spdx", "text/plain");
+
+        Map<String, byte[]> docs = new LinkedHashMap<>();
+        docs.put("release.json", "{\"name\":\"Apache Commons IO\",\"version\":\"2.11.0\"}".getBytes(StandardCharsets.UTF_8));
+        docs.put("changelogs.json", "[]".getBytes(StandardCharsets.UTF_8));
+
+        CollectedEntity release = new CollectedEntity(
+                "rel-abc-123",
+                "Apache Commons IO",
+                "2.11.0",
+                ArchivalEntityType.RELEASE,
+                docs,
+                List.of(
+                        new ByteArrayAttachmentSource(sourceMeta, sourceZip),
+                        new ByteArrayAttachmentSource(sbomMeta, sbom)));
+
+        ArchiveBuilder builder = new ArchiveBuilder("bundle-1", "taanvi@example.com", "20.0.0-beta", "test bundle");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ArchiveManifest manifest = builder.writeTo(out, List.of(release));
+
+        // Manifest sanity
+        assertEquals("bundle-1", manifest.getBundleId());
+        assertEquals(1, manifest.getManifestVersion());
+        assertEquals(1, manifest.getEntries().size());
+
+        ManifestEntry entry = manifest.getEntries().get(0);
+        assertEquals("rel-abc-123", entry.getEntityId());
+        assertEquals(ArchivalEntityType.RELEASE, entry.getEntityType());
+        assertEquals("releases/rel-abc-123/", entry.getPath());
+        assertEquals(2, entry.getAttachmentCount());
+        assertEquals(sourceZip.length + sbom.length, entry.getAttachmentTotalBytes());
+        assertTrue(entry.getChecksum().startsWith("sha256:"));
+
+        // Round-trip the TAR.GZ and verify the contents
+        Map<String, byte[]> readBack = readArchive(out.toByteArray());
+
+        assertTrue(readBack.containsKey("manifest.json"), "manifest.json present");
+        assertTrue(readBack.containsKey("releases/rel-abc-123/release.json"), "release doc present");
+        assertTrue(readBack.containsKey("releases/rel-abc-123/changelogs.json"), "changelogs present");
+
+        assertArrayEquals(sourceZip, readBack.get("releases/rel-abc-123/attachments/att-1.bin"));
+        assertArrayEquals(sbom, readBack.get("releases/rel-abc-123/attachments/att-2.bin"));
+
+        AttachmentMetadata sourceMetaBack = JSON.readValue(
+                readBack.get("releases/rel-abc-123/attachments/att-1.meta.json"),
+                AttachmentMetadata.class);
+        assertEquals("source.zip", sourceMetaBack.getFilename());
+        assertEquals(sourceZip.length, sourceMetaBack.getSizeBytes());
+
+        // Manifest is JSON-parseable
+        ArchiveManifest manifestBack = JSON.readValue(readBack.get("manifest.json"), ArchiveManifest.class);
+        assertEquals("bundle-1", manifestBack.getBundleId());
+        assertEquals(1, manifestBack.getEntries().size());
+        assertNotNull(manifestBack.getCreatedAt());
+    }
+
+    private static AttachmentMetadata meta(String id, String filename, String contentType) {
+        AttachmentMetadata m = new AttachmentMetadata();
+        m.setAttachmentId(id);
+        m.setFilename(filename);
+        m.setContentType(contentType);
+        return m;
+    }
+
+    private static Map<String, byte[]> readArchive(byte[] tarGz) throws Exception {
+        Map<String, byte[]> out = new HashMap<>();
+        try (TarArchiveInputStream tar = new TarArchiveInputStream(
+                new GzipCompressorInputStream(new ByteArrayInputStream(tarGz)))) {
+            TarArchiveEntry e;
+            while ((e = tar.getNextEntry()) != null) {
+                ByteArrayOutputStream body = new ByteArrayOutputStream();
+                tar.transferTo(body);
+                out.put(e.getName(), body.toByteArray());
+            }
+        }
+        return out;
+    }
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,6 +24,7 @@
 
     <modules>
         <module>common</module>
+        <module>archival</module>
         <module>changelogs</module>
         <module>attachments</module>
         <module>components</module>

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -29,6 +29,7 @@
         <module>importers</module>
         <module>exporters</module>
         <module>nouveau-handler</module>
+        <module>service-api</module>
     </modules>
 
     <build>

--- a/libraries/service-api/pom.xml
+++ b/libraries/service-api/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>libraries</artifactId>
+        <groupId>org.eclipse.sw360</groupId>
+        <version>20.1.0-rc-2</version>
+    </parent>
+
+    <name>service-api</name>
+    <artifactId>service-api</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.annotation.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>org.eclipse.sw360.service-api-${project.version}</finalName>
+    </build>
+</project>

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalEntityType.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalEntityType.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+public enum ArchivalEntityType {
+    PROJECT,
+    COMPONENT,
+    RELEASE,
+    PACKAGE
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalRecord.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalRecord.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivalRecord {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("entityId")
+    private String entityId;
+
+    @JsonProperty("entityName")
+    private String entityName;
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("status")
+    private ArchivalStatus status;
+
+    @JsonProperty("archivedBy")
+    private String archivedBy;
+
+    @JsonProperty("archivedAt")
+    private Instant archivedAt;
+
+    @JsonProperty("restoredBy")
+    private String restoredBy;
+
+    @JsonProperty("restoredAt")
+    private Instant restoredAt;
+
+    @JsonProperty("attachmentCount")
+    private Integer attachmentCount;
+
+    @JsonProperty("comment")
+    private String comment;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getBundleId() { return bundleId; }
+    public void setBundleId(String bundleId) { this.bundleId = bundleId; }
+
+    public String getEntityId() { return entityId; }
+    public void setEntityId(String entityId) { this.entityId = entityId; }
+
+    public String getEntityName() { return entityName; }
+    public void setEntityName(String entityName) { this.entityName = entityName; }
+
+    public ArchivalEntityType getEntityType() { return entityType; }
+    public void setEntityType(ArchivalEntityType entityType) { this.entityType = entityType; }
+
+    public ArchivalStatus getStatus() { return status; }
+    public void setStatus(ArchivalStatus status) { this.status = status; }
+
+    public String getArchivedBy() { return archivedBy; }
+    public void setArchivedBy(String archivedBy) { this.archivedBy = archivedBy; }
+
+    public Instant getArchivedAt() { return archivedAt; }
+    public void setArchivedAt(Instant archivedAt) { this.archivedAt = archivedAt; }
+
+    public String getRestoredBy() { return restoredBy; }
+    public void setRestoredBy(String restoredBy) { this.restoredBy = restoredBy; }
+
+    public Instant getRestoredAt() { return restoredAt; }
+    public void setRestoredAt(Instant restoredAt) { this.restoredAt = restoredAt; }
+
+    public Integer getAttachmentCount() { return attachmentCount; }
+    public void setAttachmentCount(Integer attachmentCount) { this.attachmentCount = attachmentCount; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalStatus.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalStatus.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+public enum ArchivalStatus {
+    PENDING,
+    IN_PROGRESS,
+    ARCHIVED,
+    PARTIALLY_ARCHIVED,
+    RESTORED,
+    FAILED
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalValidationResult.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchivalValidationResult.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivalValidationResult {
+
+    @JsonProperty("entityId")
+    private String entityId;
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("canArchive")
+    private boolean canArchive;
+
+    @JsonProperty("reason")
+    private Reason reason;
+
+    @JsonProperty("details")
+    private String details;
+
+    public enum Reason {
+        OK,
+        ENTITY_NOT_FOUND,
+        REFERENCED_BY_LIVE_PROJECT,
+        REFERENCED_BY_LIVE_RELEASE,
+        OPEN_CLEARING_REQUEST,
+        PERMISSION_DENIED,
+        UNKNOWN
+    }
+
+    public String getEntityId() { return entityId; }
+    public void setEntityId(String entityId) { this.entityId = entityId; }
+
+    public ArchivalEntityType getEntityType() { return entityType; }
+    public void setEntityType(ArchivalEntityType entityType) { this.entityType = entityType; }
+
+    public boolean isCanArchive() { return canArchive; }
+    public void setCanArchive(boolean canArchive) { this.canArchive = canArchive; }
+
+    public Reason getReason() { return reason; }
+    public void setReason(Reason reason) { this.reason = reason; }
+
+    public String getDetails() { return details; }
+    public void setDetails(String details) { this.details = details; }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchiveManifest.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchiveManifest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchiveManifest {
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("createdAt")
+    private Instant createdAt;
+
+    @JsonProperty("createdBy")
+    private String createdBy;
+
+    @JsonProperty("sw360Version")
+    private String sw360Version;
+
+    @JsonProperty("manifestVersion")
+    private int manifestVersion;
+
+    @JsonProperty("comment")
+    private String comment;
+
+    @JsonProperty("entries")
+    private List<ManifestEntry> entries;
+
+    public String getBundleId() { return bundleId; }
+    public void setBundleId(String bundleId) { this.bundleId = bundleId; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public String getCreatedBy() { return createdBy; }
+    public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+
+    public String getSw360Version() { return sw360Version; }
+    public void setSw360Version(String sw360Version) { this.sw360Version = sw360Version; }
+
+    public int getManifestVersion() { return manifestVersion; }
+    public void setManifestVersion(int manifestVersion) { this.manifestVersion = manifestVersion; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+
+    public List<ManifestEntry> getEntries() { return entries; }
+    public void setEntries(List<ManifestEntry> entries) { this.entries = entries; }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchiveRequest.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ArchiveRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchiveRequest {
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("entityIds")
+    private List<String> entityIds;
+
+    @JsonProperty("comment")
+    private String comment;
+
+    @JsonProperty("includeAttachments")
+    private boolean includeAttachments = true;
+
+    @JsonProperty("includeChangelogs")
+    private boolean includeChangelogs = true;
+
+    public ArchivalEntityType getEntityType() { return entityType; }
+    public void setEntityType(ArchivalEntityType entityType) { this.entityType = entityType; }
+
+    public List<String> getEntityIds() { return entityIds; }
+    public void setEntityIds(List<String> entityIds) { this.entityIds = entityIds; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+
+    public boolean isIncludeAttachments() { return includeAttachments; }
+    public void setIncludeAttachments(boolean includeAttachments) { this.includeAttachments = includeAttachments; }
+
+    public boolean isIncludeChangelogs() { return includeChangelogs; }
+    public void setIncludeChangelogs(boolean includeChangelogs) { this.includeChangelogs = includeChangelogs; }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/AttachmentMetadata.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/AttachmentMetadata.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AttachmentMetadata {
+
+    @JsonProperty("attachmentId")
+    private String attachmentId;
+
+    @JsonProperty("filename")
+    private String filename;
+
+    @JsonProperty("contentType")
+    private String contentType;
+
+    @JsonProperty("sizeBytes")
+    private long sizeBytes;
+
+    @JsonProperty("sha1")
+    private String sha1;
+
+    @JsonProperty("attachmentType")
+    private String attachmentType;
+
+    @JsonProperty("uploadedBy")
+    private String uploadedBy;
+
+    @JsonProperty("uploadedAt")
+    private Instant uploadedAt;
+
+    public String getAttachmentId() { return attachmentId; }
+    public void setAttachmentId(String attachmentId) { this.attachmentId = attachmentId; }
+
+    public String getFilename() { return filename; }
+    public void setFilename(String filename) { this.filename = filename; }
+
+    public String getContentType() { return contentType; }
+    public void setContentType(String contentType) { this.contentType = contentType; }
+
+    public long getSizeBytes() { return sizeBytes; }
+    public void setSizeBytes(long sizeBytes) { this.sizeBytes = sizeBytes; }
+
+    public String getSha1() { return sha1; }
+    public void setSha1(String sha1) { this.sha1 = sha1; }
+
+    public String getAttachmentType() { return attachmentType; }
+    public void setAttachmentType(String attachmentType) { this.attachmentType = attachmentType; }
+
+    public String getUploadedBy() { return uploadedBy; }
+    public void setUploadedBy(String uploadedBy) { this.uploadedBy = uploadedBy; }
+
+    public Instant getUploadedAt() { return uploadedAt; }
+    public void setUploadedAt(Instant uploadedAt) { this.uploadedAt = uploadedAt; }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ManifestEntry.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/ManifestEntry.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ManifestEntry {
+
+    @JsonProperty("entityId")
+    private String entityId;
+
+    @JsonProperty("entityName")
+    private String entityName;
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("entityVersion")
+    private String entityVersion;
+
+    @JsonProperty("path")
+    private String path;
+
+    @JsonProperty("attachmentCount")
+    private int attachmentCount;
+
+    @JsonProperty("attachmentTotalBytes")
+    private long attachmentTotalBytes;
+
+    @JsonProperty("checksum")
+    private String checksum;
+
+    public String getEntityId() { return entityId; }
+    public void setEntityId(String entityId) { this.entityId = entityId; }
+
+    public String getEntityName() { return entityName; }
+    public void setEntityName(String entityName) { this.entityName = entityName; }
+
+    public ArchivalEntityType getEntityType() { return entityType; }
+    public void setEntityType(ArchivalEntityType entityType) { this.entityType = entityType; }
+
+    public String getEntityVersion() { return entityVersion; }
+    public void setEntityVersion(String entityVersion) { this.entityVersion = entityVersion; }
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public int getAttachmentCount() { return attachmentCount; }
+    public void setAttachmentCount(int attachmentCount) { this.attachmentCount = attachmentCount; }
+
+    public long getAttachmentTotalBytes() { return attachmentTotalBytes; }
+    public void setAttachmentTotalBytes(long attachmentTotalBytes) { this.attachmentTotalBytes = attachmentTotalBytes; }
+
+    public String getChecksum() { return checksum; }
+    public void setChecksum(String checksum) { this.checksum = checksum; }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/RestorePreview.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/RestorePreview.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RestorePreview {
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("entries")
+    private List<Entry> entries;
+
+    public String getBundleId() { return bundleId; }
+    public void setBundleId(String bundleId) { this.bundleId = bundleId; }
+
+    public List<Entry> getEntries() { return entries; }
+    public void setEntries(List<Entry> entries) { this.entries = entries; }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Entry {
+        @JsonProperty("entityId")
+        private String entityId;
+
+        @JsonProperty("entityName")
+        private String entityName;
+
+        @JsonProperty("entityType")
+        private ArchivalEntityType entityType;
+
+        @JsonProperty("attachmentCount")
+        private Integer attachmentCount;
+
+        @JsonProperty("conflict")
+        private boolean conflict;
+
+        public String getEntityId() { return entityId; }
+        public void setEntityId(String entityId) { this.entityId = entityId; }
+
+        public String getEntityName() { return entityName; }
+        public void setEntityName(String entityName) { this.entityName = entityName; }
+
+        public ArchivalEntityType getEntityType() { return entityType; }
+        public void setEntityType(ArchivalEntityType entityType) { this.entityType = entityType; }
+
+        public Integer getAttachmentCount() { return attachmentCount; }
+        public void setAttachmentCount(Integer attachmentCount) { this.attachmentCount = attachmentCount; }
+
+        public boolean isConflict() { return conflict; }
+        public void setConflict(boolean conflict) { this.conflict = conflict; }
+    }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/RestoreResult.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/services/archival/RestoreResult.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RestoreResult {
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("entries")
+    private List<Entry> entries;
+
+    @JsonProperty("restoredCount")
+    private int restoredCount;
+
+    @JsonProperty("skippedCount")
+    private int skippedCount;
+
+    @JsonProperty("failedCount")
+    private int failedCount;
+
+    public String getBundleId() { return bundleId; }
+    public void setBundleId(String bundleId) { this.bundleId = bundleId; }
+
+    public List<Entry> getEntries() { return entries; }
+    public void setEntries(List<Entry> entries) { this.entries = entries; }
+
+    public int getRestoredCount() { return restoredCount; }
+    public void setRestoredCount(int restoredCount) { this.restoredCount = restoredCount; }
+
+    public int getSkippedCount() { return skippedCount; }
+    public void setSkippedCount(int skippedCount) { this.skippedCount = skippedCount; }
+
+    public int getFailedCount() { return failedCount; }
+    public void setFailedCount(int failedCount) { this.failedCount = failedCount; }
+
+    public enum Outcome { RESTORED, SKIPPED, FAILED }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Entry {
+        @JsonProperty("entityId")
+        private String entityId;
+
+        @JsonProperty("entityType")
+        private ArchivalEntityType entityType;
+
+        @JsonProperty("outcome")
+        private Outcome outcome;
+
+        @JsonProperty("reason")
+        private String reason;
+
+        public String getEntityId() { return entityId; }
+        public void setEntityId(String entityId) { this.entityId = entityId; }
+
+        public ArchivalEntityType getEntityType() { return entityType; }
+        public void setEntityType(ArchivalEntityType entityType) { this.entityType = entityType; }
+
+        public Outcome getOutcome() { return outcome; }
+        public void setOutcome(Outcome outcome) { this.outcome = outcome; }
+
+        public String getReason() { return reason; }
+        public void setReason(String reason) { this.reason = reason; }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces the initial scaffolding for the **Archival & Restore** feature in SW360, providing a safe and reversible alternative to permanently deleting stale Projects, Components, Releases, and Packages.

Following the Spring Boot REST approach used in PR #4216 and the Health and Vendor POCs, this implementation does not introduce any new Thrift services, servlets, or `web.xml` changes. This PR focuses on the core architecture and scaffolding. The TAR.GZ archival pipeline is already functional end-to-end with an in-memory entity provider, while integration with the live SW360 data layer will be added in a follow-up PR.

---

## What's in this PR

### `libraries/service-api` - new shared POJO module
The contract layer between archival service producers and consumers. Plain Java POJOs with Jackson annotations, no Thrift dependency.

| POJO | Purpose |
|---|---|
| `ArchivalRecord` | Lightweight registry row about who archived what, when, in which bundle |
| `ArchivalEntityType` | enum: PROJECT, COMPONENT, RELEASE, PACKAGE |
| `ArchivalStatus` | enum: PENDING, IN_PROGRESS, ARCHIVED, PARTIALLY_ARCHIVED, RESTORED, FAILED |
| `ArchiveRequest` / `ArchiveManifest` / `ManifestEntry` | Archive API contract |
| `AttachmentMetadata` | Shape of the `.meta.json` files written next to attachment binaries |
| `ArchivalValidationResult` | Pre-archive validation contract (used by next PR) |
| `RestorePreview` / `RestoreResult` | Restore API contract (used by future PRs) |

### `backend/archival` - new Spring Boot module
A self-contained Spring Boot WAR.

* **ArchivalApplication** – Entry point for the module, extending `SpringBootServletInitializer` to support deployment within the existing SW360 environment.

* **ArchivalController** – REST controller exposed under `/api/archival`, protected with class-level `@PreAuthorize("hasAuthority('ADMIN')")`.

* **SecurityConfig** – Configures stateless authentication, disables CSRF for REST APIs, keeps `/health` publicly accessible, and requires authentication for all other endpoints.

* **application.yml** – Sets the application context path to `/archival` and configures Jackson for JSON serialization and deserialization.

**REST endpoints**
| Method | Path | Returns |
|---|---|---|
| `POST` | `/api/archival/archive` | Streams a `.tar.gz` to the client (`StreamingResponseBody`, `Content-Disposition: attachment`) |
| `GET` | `/api/archival/records` | All archival records |
| `GET` | `/api/archival/records/{id}` | One record |
| `DELETE` | `/api/archival/records/{id}` | Removes a registry entry (does not touch live data) |
| `GET` | `/api/archival/health` | Liveness check (public) |

**Service layer**
* `ArchivalHandler` - `@Service` implementing the archival workflow: creates `IN_PROGRESS` records, collects entities through `EntityProvider`, generates the TAR.GZ bundle using `ArchiveBuilder`, and marks records as `ARCHIVED` on success. If any step fails, affected records are marked as `FAILED` with the corresponding error reason.
* `ArchiveResult` record - return type encapsulating the generated bundle ID, manifest, and archived records.

**Bundling layer (`bundle/` package)**

* `EntityProvider` - interface for retrieving an entity with its related documents, attachments, and changelogs, keeping bundling independent of the data source.
* `Sw360EntityProvider` - production implementation, currently a stub; integration with existing SW360 database handlers will be added in a follow-up PR.
* `InMemoryEntityProvider` - test implementation for pre-seeding entities by ID.
* `CollectedEntity` - bundled entity containing its ID, type, documents, and attachment references.
* `AttachmentSource` - streaming abstraction for attachment content, preventing large files from being loaded entirely into memory.
* `ByteArrayAttachmentSource` - in-memory implementation used by tests.
* `ArchiveBuilder` - creates the TAR.GZ archive, streams documents and attachments, generates checksums, writes `manifest.json`, and validates attachment sizes.

**Persistence layer (`db/` package)**

* `ArchivalRecordDocument` - CouchDB representation of `ArchivalRecord` with conversion helpers.
* `ArchivalRepository` - repository defining the `all`, `byBundleId`, and `byEntityType` CouchDB views.
* `ArchivalDatabaseHandler` - wrapper exposing CRUD operations through domain objects, backed by the `sw360archives` database.

### `docs/ARCHIVE_FORMAT.md`
Documents the TAR.GZ layout (per-entity folders, attachment binaries as `.bin` + `.meta.json` siblings, `manifest.json` at the root) and the conventions both archive and restore flows must follow.

### Tests (2 unit tests passing)
- `ArchiveBuilderTest` - round-trips a Release with 2 attachments through the bundler, reads the TAR.GZ back from memory, verifies the manifest, JSON documents, and attachment binaries match byte-for-byte.
- `ArchivalHandlerTest` - end-to-end registry pipeline. Archives 3 releases, verifies all rows share a `bundleId`, all end as `ARCHIVED`, registry rows go through IN_PROGRESS → ARCHIVED, and TAR bytes are streamed to the sink.

---

## What is NOT included (next PRs)

- `Sw360EntityProvider.collect(...)` is a stub - wiring to the live SW360 databases via `ProjectDatabaseHandler` / `ComponentDatabaseHandler` / `PackageDatabaseHandler` + `AttachmentConnector`
- Calling existing `removeProjectAndCleanUp` etc. to delete entities after a successful archive
- Pre-archive validation (entity referenced by a live Project, open clearing requests, etc.)
- Restore endpoints - preview, conflict detection, re-insertion
- Resource-server REST client wrapper (`Sw360ArchivalService` via WebClient)
- Async + email delivery for large bundles
- Admin UI

---

## Test plan

- [x] `mvn -pl backend/archival -am test` — 2 tests pass, BUILD SUCCESS
- [x] `mvn -pl backend/archival -am package` — `archival.war` builds
- [x] Round-trip a TAR.GZ in memory and verify manifest + binaries match byte-for-byte
- [ ] Manual deploy + curl against a local Tomcat (next PR, once `Sw360EntityProvider` is wired)