### PR TITLE
Add sync engine to import licenses and obligations from LicenseDB

### DIFF
--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.sw360.licenses.db;
 
+import com.ibm.cloud.cloudant.v1.model.Document;
 import com.ibm.cloud.cloudant.v1.model.DocumentResult;
 import org.apache.commons.io.IOUtils;
 import org.apache.thrift.TException;
@@ -32,9 +33,15 @@ import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.changelogs.Operation;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
+import org.eclipse.sw360.licenses.tools.LicenseDBConnector;
+import org.eclipse.sw360.licenses.tools.LicenseDBDataMapper;
+import org.eclipse.sw360.licenses.tools.LicenseDBLicenseDTO;
+import org.eclipse.sw360.licenses.tools.LicenseDBObligationDTO;
+import org.eclipse.sw360.licenses.tools.LicenseDBTokenManager;
+import org.eclipse.sw360.licenses.tools.OSADLObligationConnector;
 import org.eclipse.sw360.licenses.tools.SpdxConnector;
 import org.eclipse.sw360.exporter.LicenseExporter;
-import org.eclipse.sw360.licenses.tools.OSADLObligationConnector;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -101,6 +108,7 @@ public class LicenseDatabaseHandler {
     private static boolean IMPORT_STATUS = false;
     private static long IMPORT_TIME = 0;
     private static final long TIME_OUT = 1800000; // 30 minutes: 30 * 60 * 1000;
+    private static final String LICENSEDB_SYNC_STATE_DOC_ID = "licensedb-sync-state";
     private String obligationText;
     private final Logger log = LogManager.getLogger(LicenseDatabaseHandler.class);
 
@@ -1144,6 +1152,311 @@ public class LicenseDatabaseHandler {
         });
 
         return overallProcessingFlux.block();
+    }
+
+    public RequestSummary importAllLicenseDBLicenses(User user) {
+        RequestSummary requestSummary = new RequestSummary().setTotalAffectedElements(0).setMessage("");
+        Timestamp ts = Timestamp.from(Instant.now());
+        long currentTime = ts.getTime();
+        if (IMPORT_STATUS && ((IMPORT_TIME + TIME_OUT) > currentTime)) {
+            return requestSummary.setRequestStatus(RequestStatus.PROCESSING);
+        }
+
+        IMPORT_STATUS = true;
+        IMPORT_TIME = currentTime;
+
+        try {
+            String enabled = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_ENABLED);
+            if (!"true".equals(enabled)) {
+                log.info("LicenseDB integration is disabled. Skipping sync.");
+                return requestSummary.setRequestStatus(RequestStatus.FAILURE)
+                        .setMessage("LicenseDB integration is disabled.");
+            }
+            String baseUrl = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_BASE_URL);
+            String username = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_USERNAME);
+            String password = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_PASSWORD);
+
+            if (isNullOrEmpty(baseUrl) || isNullOrEmpty(username) || isNullOrEmpty(password)) {
+                log.error("LicenseDB configuration is incomplete (missing baseUrl, username, or password).");
+                return requestSummary.setRequestStatus(RequestStatus.FAILURE)
+                        .setMessage("LicenseDB configuration is incomplete.");
+            }
+
+            LicenseDBConnector connector = createLicenseDBConnector(baseUrl, username, password);
+
+            // Fetch obligations first because license records reference them by UUID
+            List<LicenseDBObligationDTO> obligationDTOs;
+            List<LicenseDBLicenseDTO> licenseDTOs;
+            try {
+                obligationDTOs = connector.fetchAllObligations();
+                licenseDTOs = connector.fetchAllLicenses();
+            } catch (IOException e) {
+                String msg = "LicenseDB sync failed (connection error): " + e.getMessage();
+                log.error(msg, e);
+                return requestSummary.setRequestStatus(RequestStatus.FAILURE).setMessage(msg);
+            }
+            log.info("LicenseDB sync: fetched {} active obligations and {} active licenses",
+                    obligationDTOs.size(), licenseDTOs.size());
+
+            return processLicenseDBSync(obligationDTOs, licenseDTOs, requestSummary);
+
+        } catch (SW360Exception e) {
+            String msg = "LicenseDB sync failed: " + e.getMessage();
+            log.error(msg, e);
+            return requestSummary.setRequestStatus(RequestStatus.FAILURE).setMessage(msg);
+        } finally {
+            IMPORT_STATUS = false;
+        }
+    }
+
+    private LicenseDBConnector createLicenseDBConnector(String baseUrl, String username, String password) {
+        LicenseDBTokenManager tokenManager = new LicenseDBTokenManager(baseUrl, username, password);
+        return new LicenseDBConnector(baseUrl, tokenManager);
+    }
+
+    private RequestSummary processLicenseDBSync(List<LicenseDBObligationDTO> obligationDTOs,
+            List<LicenseDBLicenseDTO> licenseDTOs, RequestSummary requestSummary) throws SW360Exception {
+        final List<Obligation> allSw360Obligations = obligRepository.getAll();
+        final List<License> allSw360Licenses = licenseRepository.getAll();
+
+        Map<String, Obligation> obligationsByLicenseDbId = new HashMap<>();
+        Set<String> allLicenseDbTrackedSw360ObIds = new HashSet<>();
+        for (Obligation oblig : allSw360Obligations) {
+            if (oblig.getExternalIds() != null
+                    && oblig.getExternalIds().containsKey(LicenseDBDataMapper.EXTERNAL_ID_LICENSEDB_OB)) {
+                String licenseDbObId = oblig.getExternalIds().get(LicenseDBDataMapper.EXTERNAL_ID_LICENSEDB_OB);
+                obligationsByLicenseDbId.put(licenseDbObId, oblig);
+                allLicenseDbTrackedSw360ObIds.add(oblig.getId());
+            }
+        }
+
+        Map<String, License> licensesByLicenseDbId = new HashMap<>();
+        Map<String, License> licensesByShortname = new HashMap<>();
+        for (License license : allSw360Licenses) {
+            if (license.getExternalIds() != null
+                    && license.getExternalIds().containsKey(LicenseDBDataMapper.EXTERNAL_ID_LICENSEDB)) {
+                licensesByLicenseDbId.put(
+                        license.getExternalIds().get(LicenseDBDataMapper.EXTERNAL_ID_LICENSEDB), license);
+            }
+            if (license.getId() != null) {
+                licensesByShortname.put(license.getId(), license);
+            }
+        }
+
+        Map<String, String> licenseDbObIdToSw360ObId = new HashMap<>();
+        int obligationsCreated = 0;
+        int obligationsUpdated = 0;
+
+        for (LicenseDBObligationDTO dto : obligationDTOs) {
+            if (isNullOrEmpty(dto.getId())) {
+                log.warn("Skipping LicenseDB obligation with missing LicenseDB ID");
+                continue;
+            }
+            if (isNullOrEmpty(dto.getText())) {
+                log.warn("Skipping LicenseDB obligation '{}' with empty text", dto.getId());
+                continue;
+            }
+            if (isNullOrEmpty(dto.getTopic())) {
+                log.warn("Skipping LicenseDB obligation '{}' with null topic", dto.getId());
+                continue;
+            }
+
+            String licenseDbObId = dto.getId();
+            Obligation existing = obligationsByLicenseDbId.get(licenseDbObId);
+
+            if (existing != null) {
+                existing.setText(dto.getText());
+                existing.setTitle(dto.getTopic());
+                existing.setComments(dto.getComment());
+                existing.setObligationType(LicenseDBDataMapper.mapObligationType(dto.getType()));
+                try {
+                    prepareTodo(existing);
+                } catch (SW360Exception e) {
+                    log.warn("Skipping update for LicenseDB obligation '{}': {}", dto.getId(), e.getMessage());
+                    continue;
+                }
+                obligRepository.update(existing);
+                licenseDbObIdToSw360ObId.put(licenseDbObId, existing.getId());
+                allLicenseDbTrackedSw360ObIds.add(existing.getId());
+                obligationsUpdated++;
+            } else {
+                Obligation newObligation = LicenseDBDataMapper.toObligation(dto);
+                try {
+                    prepareTodo(newObligation);
+                } catch (SW360Exception e) {
+                    log.warn("Skipping LicenseDB obligation '{}': {}", dto.getId(), e.getMessage());
+                    continue;
+                }
+                obligRepository.add(newObligation);
+                licenseDbObIdToSw360ObId.put(licenseDbObId, newObligation.getId());
+                obligationsByLicenseDbId.put(licenseDbObId, newObligation);
+                allLicenseDbTrackedSw360ObIds.add(newObligation.getId());
+                obligationsCreated++;
+            }
+        }
+
+        int licensesCreated = 0;
+        int licensesUpdated = 0;
+
+        for (LicenseDBLicenseDTO dto : licenseDTOs) {
+            if (isNullOrEmpty(dto.getId())) {
+                log.warn("Skipping LicenseDB license '{}' with missing LicenseDB ID", dto.getShortname());
+                continue;
+            }
+            if (isNullOrEmpty(dto.getShortname())) {
+                log.warn("Skipping LicenseDB license '{}' with empty shortname", dto.getId());
+                continue;
+            }
+
+            Set<String> newLicenseDbObSw360Ids = new HashSet<>();
+            for (String obUuid : dto.getObligationIds()) {
+                String sw360ObId = licenseDbObIdToSw360ObId.get(obUuid);
+                if (sw360ObId != null) {
+                    newLicenseDbObSw360Ids.add(sw360ObId);
+                }
+            }
+
+            License existing = licensesByLicenseDbId.get(dto.getId());
+            if (existing == null) {
+                // Try matching by shortname for licenses that have not been linked to LicenseDB before
+                existing = licensesByShortname.get(dto.getShortname());
+            }
+
+            if (existing != null) {
+                Set<String> oldObligationIds = existing.getObligationDatabaseIds() != null
+                        ? new HashSet<>(existing.getObligationDatabaseIds())
+                        : new HashSet<>();
+                applyLicenseDBUpdate(existing, dto, newLicenseDbObSw360Ids, allLicenseDbTrackedSw360ObIds);
+                try {
+                    prepareLicense(existing);
+                } catch (SW360Exception e) {
+                    log.warn("Skipping update for license '{}': {}", dto.getShortname(), e.getMessage());
+                    continue;
+                }
+                syncLicenseObligationList(existing, oldObligationIds);
+                licenseRepository.update(existing);
+                licensesByLicenseDbId.put(dto.getId(), existing);
+                licensesUpdated++;
+            } else {
+                License newLicense = LicenseDBDataMapper.toLicense(dto);
+                newLicense.setObligationDatabaseIds(new HashSet<>(newLicenseDbObSw360Ids));
+                try {
+                    prepareLicense(newLicense);
+                } catch (SW360Exception e) {
+                    log.warn("Skipping new license '{}': {}", dto.getShortname(), e.getMessage());
+                    continue;
+                }
+                syncLicenseObligationList(newLicense, Collections.emptySet());
+                licenseRepository.add(newLicense);
+                licensesByLicenseDbId.put(dto.getId(), newLicense);
+                licensesByShortname.put(newLicense.getId(), newLicense);
+                licensesCreated++;
+            }
+        }
+
+        int total = licenseDTOs.size();
+        int affected = licensesCreated + licensesUpdated;
+        String message = String.format(
+                "{\"licensesCreated\":%d,\"licensesUpdated\":%d,\"obligationsCreated\":%d,\"obligationsUpdated\":%d}",
+                licensesCreated, licensesUpdated, obligationsCreated, obligationsUpdated);
+        log.info("LicenseDB sync complete: {}", message);
+        updateLastSyncTimestamp();
+        return requestSummary.setTotalElements(total).setTotalAffectedElements(affected)
+                .setMessage(message).setRequestStatus(RequestStatus.SUCCESS);
+    }
+
+    private void applyLicenseDBUpdate(License existing, LicenseDBLicenseDTO dto,
+            Set<String> newLicenseDbObSw360Ids, Set<String> allLicenseDbTrackedSw360ObIds) {
+        Map<String, String> externalIds = existing.getExternalIds() != null
+                ? new HashMap<>(existing.getExternalIds())
+                : new HashMap<>();
+        externalIds.put(LicenseDBDataMapper.EXTERNAL_ID_LICENSEDB, dto.getId());
+        if (!isNullOrEmpty(dto.getSpdxId())) {
+            externalIds.put("SPDX-License-Identifier", dto.getSpdxId());
+        }
+        existing.setExternalIds(externalIds);
+
+        if (!isNullOrEmpty(dto.getFullname())) {
+            existing.setFullname(dto.getFullname());
+        }
+        existing.setText(dto.getText());
+        existing.setExternalLicenseLink(dto.getUrl());
+        existing.setNote(dto.getNotes());
+        existing.setOSIApproved(dto.isOsiApproved() ? Quadratic.YES : Quadratic.NA);
+        // Do not overwrite checked, FSFLibre or whitelist as these fields are managed only in SW360
+
+        // Keep obligations added directly in SW360 and only replace the ones that came from LicenseDB
+        Set<String> existingObIds = existing.getObligationDatabaseIds() != null
+                ? existing.getObligationDatabaseIds()
+                : Collections.emptySet();
+        Set<String> sw360NativeObIds = existingObIds.stream()
+                .filter(id -> !allLicenseDbTrackedSw360ObIds.contains(id))
+                .collect(Collectors.toSet());
+        Set<String> mergedObligations = new HashSet<>(sw360NativeObIds);
+        mergedObligations.addAll(newLicenseDbObSw360Ids);
+        existing.setObligationDatabaseIds(mergedObligations);
+    }
+
+    private void syncLicenseObligationList(License license, Set<String> oldObligationIds) {
+        Set<String> newObligationIds = license.getObligationDatabaseIds() != null
+                ? license.getObligationDatabaseIds()
+                : Collections.emptySet();
+        if (newObligationIds.equals(oldObligationIds)) {
+            return;
+        }
+        LicenseObligationList obligationList = new LicenseObligationList();
+        Map<String, Obligation> obligations = new HashMap<>();
+        getObligationsByIds(newObligationIds).forEach(o -> obligations.put(o.getTitle(), o));
+        obligationList.setLinkedObligations(obligations);
+        obligationList.setLicenseId(license.getId());
+        if (!isNullOrEmpty(license.getObligationListId())) {
+            try {
+                LicenseObligationList base = obligationListRepository.get(license.getObligationListId());
+                obligationList.setId(base.getId());
+                obligationList.setRevision(base.getRevision());
+                obligationListRepository.update(obligationList);
+            } catch (Exception e) {
+                log.warn("Could not update obligation list for license '{}': {}", license.getId(), e.getMessage());
+            }
+        } else if (!newObligationIds.isEmpty()) {
+            try {
+                obligationListRepository.add(obligationList);
+                license.setObligationListId(obligationList.getId());
+            } catch (SW360Exception e) {
+                log.warn("Could not create obligation list for license '{}': {}", license.getId(), e.getMessage());
+            }
+        }
+    }
+
+    private void updateLastSyncTimestamp() {
+        try {
+            String now = Instant.now().toString();
+            Document existing = null;
+            try {
+                existing = db.getDocument(LICENSEDB_SYNC_STATE_DOC_ID);
+            } catch (SW360Exception e) {
+                // The sync state document does not exist yet so create a new one
+            }
+            if (existing != null) {
+                Map<String, Object> props = existing.getProperties() != null
+                        ? new HashMap<>(existing.getProperties())
+                        : new HashMap<>();
+                props.put("lastSyncTimestamp", now);
+                existing.setProperties(props);
+                db.update(existing);
+            } else {
+                Document doc = new Document();
+                doc.setId(LICENSEDB_SYNC_STATE_DOC_ID);
+                Map<String, Object> props = new HashMap<>();
+                props.put("type", "licensedb-sync-state");
+                props.put("lastSyncTimestamp", now);
+                doc.setProperties(props);
+                db.add(doc);
+            }
+            log.info("LicenseDB sync state updated: lastSyncTimestamp={}", now);
+        } catch (Exception e) {
+            log.warn("Failed to update LicenseDB sync state: {}", e.getMessage());
+        }
     }
 
     private Mono<Void> processAndPersistObligationReactive(User user, License sw360License, OSADLObligationConnector osadlConnector, Obligation oblig, String licenseId, ConcurrentHashMap<String, String> licensesMissing, ConcurrentHashMap<String, String> licensesSuccess, Map<String, Obligation> sw360ObligationsMap) {

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBDataMapper.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBDataMapper.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import org.eclipse.sw360.datahandler.thrift.Quadratic;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class LicenseDBDataMapper {
+
+    public static final String EXTERNAL_ID_LICENSEDB = "licensedb-id";
+    public static final String EXTERNAL_ID_LICENSEDB_OB = "licensedb-ob-id";
+
+    private LicenseDBDataMapper() {
+    }
+
+    public static Obligation toObligation(LicenseDBObligationDTO dto) {
+        return new Obligation()
+                .setText(dto.getText())
+                .setTitle(dto.getTopic())
+                .setComments(dto.getComment())
+                .setObligationLevel(ObligationLevel.LICENSE_OBLIGATION)
+                .setObligationType(mapObligationType(dto.getType()))
+                .setExternalIds(Collections.singletonMap(EXTERNAL_ID_LICENSEDB_OB, dto.getId()))
+                .setWhitelist(new HashSet<>());
+    }
+
+    public static License toLicense(LicenseDBLicenseDTO dto) {
+        Map<String, String> externalIds = new HashMap<>();
+        externalIds.put(EXTERNAL_ID_LICENSEDB, dto.getId());
+        if (dto.getSpdxId() != null && !dto.getSpdxId().isEmpty()) {
+            externalIds.put("SPDX-License-Identifier", dto.getSpdxId());
+        }
+
+        String fullname = (dto.getFullname() != null && !dto.getFullname().isEmpty())
+                ? dto.getFullname()
+                : dto.getShortname();
+
+        return new License()
+                .setId(dto.getShortname())
+                .setShortname(dto.getShortname())
+                .setFullname(fullname)
+                .setText(dto.getText())
+                .setExternalLicenseLink(dto.getUrl())
+                .setNote(dto.getNotes())
+                .setOSIApproved(dto.isOsiApproved() ? Quadratic.YES : Quadratic.NA)
+                .setExternalIds(externalIds)
+                .setChecked(false)
+                .setObligationDatabaseIds(new HashSet<>());
+    }
+
+    public static ObligationType mapObligationType(String type) {
+        if (type == null) return ObligationType.OBLIGATION;
+        return switch (type.toUpperCase()) {
+            case "RISK" -> ObligationType.RISK;
+            case "RESTRICTION" -> ObligationType.RESTRICTION;
+            case "RIGHT" -> ObligationType.PERMISSION;
+            default -> ObligationType.OBLIGATION;
+        };
+    }
+}

--- a/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -343,6 +343,14 @@ public class LicenseHandler implements LicenseService.Iface {
     }
 
     @Override
+    public RequestSummary importAllLicenseDBLicenses(User user) throws TException {
+        if (user != null && !PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user)) {
+            return new RequestSummary().setRequestStatus(RequestStatus.FAILURE);
+        }
+        return handler.importAllLicenseDBLicenses(user);
+    }
+
+    @Override
     public RequestStatus deleteObligations(String id, User user) throws TException {
         assertId(id);
         assertUser(user);

--- a/backend/schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
+++ b/backend/schedule/src/main/java/org/eclipse/sw360/schedule/service/ScheduleHandler.java
@@ -87,6 +87,9 @@ public class ScheduleHandler implements ScheduleService.Iface {
             case ThriftClients.SRC_UPLOAD_SERVICE:
                 successSync = wrapSupplierException(() -> ThriftClients.makeComponentClient().uploadSourceCodeAttachmentToReleases(), serviceName);
                 break;
+            case ThriftClients.LICENSEDB_SYNC_SERVICE:
+                successSync = wrapSupplierException(() -> ThriftClients.makeLicenseClient().importAllLicenseDBLicenses(null).getRequestStatus(), serviceName);
+                break;
             default:
                 log.error("Could not schedule service: " + serviceName + ". Reason: service is not registered in ThriftClients.");
         }
@@ -131,6 +134,8 @@ public class ScheduleHandler implements ScheduleService.Iface {
                         ThriftClients.makeUserClient().importDepartmentSchedule();
                 case ThriftClients.SRC_UPLOAD_SERVICE ->
                         ThriftClients.makeComponentClient().uploadSourceCodeAttachmentToReleases();
+                case ThriftClients.LICENSEDB_SYNC_SERVICE ->
+                        ThriftClients.makeLicenseClient().importAllLicenseDBLicenses(user).getRequestStatus();
                 default -> {
                     log.error("Could not trigger service: {}. Reason: service is not registered.", serviceName);
                     yield RequestStatus.FAILURE;

--- a/backend/schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleConstants.java
+++ b/backend/schedule/src/main/java/org/eclipse/sw360/schedule/timer/ScheduleConstants.java
@@ -64,6 +64,10 @@ public class ScheduleConstants {
     public static final String DEPARTMENT_OFFSET_DEFAULT  = "0" ; // default 00:00 am, in seconds
     public static final String DEPARTMENT_INTERVAL_PROPERTY_NAME = "schedule.department.interval.seconds";
     public static final String DEPARTMENT_INTERVAL_DEFAULT  = (24*60*60) + "" ; // default 24h, in seconds
+    public static final String LICENSEDB_SYNC_OFFSET_PROPERTY_NAME = "schedule.licensedbsync.firstOffset.seconds";
+    public static final String LICENSEDB_SYNC_INTERVAL_PROPERTY_NAME = "schedule.licensedbsync.interval.seconds";
+    public static final String LICENSEDB_SYNC_OFFSET_DEFAULT = (1*60*60) + "" ; // default 01:00 am, in seconds
+    public static final String LICENSEDB_SYNC_INTERVAL_DEFAULT = (24*60*60) + "" ; // default 24h, in seconds
 
     // scheduler properties
     public static final ConcurrentHashMap<String, Integer> SYNC_FIRST_RUN_OFFSET_SEC = new ConcurrentHashMap<>();
@@ -82,6 +86,7 @@ public class ScheduleConstants {
         loadScheduledServiceProperties(props, ThriftClients.SRC_UPLOAD_SERVICE, SRC_UPLOAD_SERVICE_OFFSET_PROPERTY_NAME, SRC_UPLOAD_SERVICE_OFFSET_DEFAULT, SRC_UPLOAD_SERVICE_INTERVAL_PROPERTY_NAME, SRC_UPLOAD_SERVICE_INTERVAL_DEFAULT);
         loadScheduledServiceProperties(props, ThriftClients.DELETE_ATTACHMENT_SERVICE, DELETE_ATTACHMENT_OFFSET_PROPERTY_NAME, DELETE_ATTACHMENT_OFFSET_DEFAULT, DELETE_ATTACHMENT_INTERVAL_PROPERTY_NAME, DELETE_ATTACHMENT_INTERVAL_DEFAULT);
         loadScheduledServiceProperties(props, ThriftClients.IMPORT_DEPARTMENT_SERVICE, DEPARTMENT_OFFSET_PROPERTY_NAME, DEPARTMENT_OFFSET_DEFAULT, DEPARTMENT_INTERVAL_PROPERTY_NAME, DEPARTMENT_INTERVAL_DEFAULT);
+        loadScheduledServiceProperties(props, ThriftClients.LICENSEDB_SYNC_SERVICE, LICENSEDB_SYNC_OFFSET_PROPERTY_NAME, LICENSEDB_SYNC_OFFSET_DEFAULT, LICENSEDB_SYNC_INTERVAL_PROPERTY_NAME, LICENSEDB_SYNC_INTERVAL_DEFAULT);
 
         String autostartServicesString = props.getProperty(AUTOSTART_PROPERTY_NAME, "").trim();
         autostartServices = java.util.Arrays.stream(autostartServicesString.split(","))

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftClients.java
@@ -151,6 +151,7 @@ public class ThriftClients {
     public static final String DELETE_ATTACHMENT_SERVICE = "deleteattachmentService";
     public static final String IMPORT_DEPARTMENT_SERVICE = "importdepartmentService";
     public static final String SRC_UPLOAD_SERVICE = "srcAttachmentUploadService";
+    public static final String LICENSEDB_SYNC_SERVICE = "licensedbsyncService";
 
 
     static {

--- a/libraries/datahandler/src/main/resources/sw360.properties
+++ b/libraries/datahandler/src/main/resources/sw360.properties
@@ -79,3 +79,12 @@
 #rest.cache.releases-without-alldetails.ttl.seconds=86400
 #rest.cache.releases-without-alldetails.max.stale.seconds=300
 #rest.cache.releases-without-alldetails.per.role.caching=true
+
+# ***************************************
+# LicenseDB Sync Scheduler Properties
+# ***************************************
+
+## First run offset after startup, in seconds (default: 1h)
+#schedule.licensedbsync.firstOffset.seconds=3600
+## Interval between sync runs, in seconds (default: 24h)
+#schedule.licensedbsync.interval.seconds=86400

--- a/libraries/datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/datahandler/src/main/thrift/licenses.thrift
@@ -314,6 +314,9 @@ service LicenseService {
     RequestSummary importAllSpdxLicenses(1: User user);
 
     RequestSummary importAllOSADLLicenses(1: User user);
+
+    RequestSummary importAllLicenseDBLicenses(1: User user);
+
     /**
      * delete obligation from database if user has permissions
      **/

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -588,6 +588,24 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     }
 
     @Operation(
+            summary = "Trigger LicenseDB sync.",
+            description = "Synchronise licenses and obligations from LicenseDB into SW360.",
+            tags = {"Licenses"}
+    )
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "LicenseDB sync completed successfully."),
+            @ApiResponse(responseCode = "500", description = "LicenseDB sync failed.")
+    })
+    @PostMapping(value = LICENSES_URL + "/import/LicenseDB")
+    public ResponseEntity<RequestSummary> importLicenseDB() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary requestSummary = licenseService.importLicenseDBInformation(sw360User);
+        HttpStatus status = requestSummary.getRequestStatus() == RequestStatus.SUCCESS ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR;
+        return new ResponseEntity<>(requestSummary, status);
+    }
+
+    @Operation(
             summary = "Create license type.",
             description = "Create license type.",
             tags = {"Licenses"}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -322,6 +322,15 @@ public class Sw360LicenseService {
         }
     }
 
+    public RequestSummary importLicenseDBInformation(User sw360User) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+            return sw360LicenseClient.importAllLicenseDBLicenses(sw360User);
+        } else {
+            throw new BadRequestClientException("Unable to import LicenseDB licenses. User is not admin");
+        }
+    }
+
     public RequestStatus addLicenseType(User sw360User, String licenseType, HttpServletRequest request) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
         if (StringUtils.isNotEmpty(licenseType)) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/ScheduleAdminController.java
@@ -61,6 +61,7 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
             - `svmListUpdateService` – SVM monitoring list update
             - `srcAttachmentUploadService` – Source attachment upload
             - `importDepartmentService` – Import department schedule
+            - `licensedbsyncService` – LicenseDB license and obligation sync
             """;
 
     @NonNull
@@ -182,7 +183,8 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                     schema = @Schema(type = "string", allowableValues = {
                             "cvesearchService", "svmsyncService", "svmmatchService",
                             "deleteattachmentService", "svmTrackingFeedbackService",
-                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService",
+                            "licensedbsyncService"
                     }), required = true)
             @RequestParam(value = "serviceName") String serviceName
     ) throws TException {
@@ -225,7 +227,8 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                     schema = @Schema(type = "string", allowableValues = {
                             "cvesearchService", "svmsyncService", "svmmatchService",
                             "deleteattachmentService", "svmTrackingFeedbackService",
-                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService",
+                            "licensedbsyncService"
                     }), required = true)
             @RequestParam(value = "serviceName") String serviceName
     ) throws TException {
@@ -267,7 +270,8 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                     schema = @Schema(type = "string", allowableValues = {
                             "cvesearchService", "svmsyncService", "svmmatchService",
                             "deleteattachmentService", "svmTrackingFeedbackService",
-                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService",
+                            "licensedbsyncService"
                     }), required = true)
             @RequestParam(value = "serviceName") String serviceName
     ) throws TException {
@@ -321,7 +325,8 @@ public class ScheduleAdminController implements RepresentationModelProcessor<Rep
                     schema = @Schema(type = "string", allowableValues = {
                             "cvesearchService", "svmsyncService", "svmmatchService",
                             "deleteattachmentService", "svmTrackingFeedbackService",
-                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService"
+                            "svmListUpdateService", "srcAttachmentUploadService", "importDepartmentService",
+                            "licensedbsyncService"
                     }))
             @RequestParam(value = "serviceName", required = false) String serviceName
     ) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/schedule/Sw360ScheduleService.java
@@ -206,7 +206,8 @@ public class Sw360ScheduleService {
                 ThriftClients.SVM_TRACKING_FEEDBACK_SERVICE,
                 ThriftClients.SVM_LIST_UPDATE_SERVICE,
                 ThriftClients.SRC_UPLOAD_SERVICE,
-                ThriftClients.IMPORT_DEPARTMENT_SERVICE
+                ThriftClients.IMPORT_DEPARTMENT_SERVICE,
+                ThriftClients.LICENSEDB_SYNC_SERVICE
         );
 
         Map<String, Map<String, Object>> result = new java.util.LinkedHashMap<>();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
@@ -11,9 +11,11 @@ package org.eclipse.sw360.rest.resourceserver.license;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,5 +63,25 @@ public class Sw360LicenseServiceTest {
         RequestStatus result = licenseService.updateLicense(new License(), new User());
 
         assertThat(result).isEqualTo(RequestStatus.SUCCESS);
+    }
+
+    @Test
+    public void importLicenseDBInformation_returnsRequestSummary_whenUserIsAdmin() throws TException {
+        User adminUser = new User("admin@sw360.org", "sw360").setUserGroup(UserGroup.ADMIN);
+        RequestSummary expected = new RequestSummary().setRequestStatus(RequestStatus.SUCCESS);
+        when(licenseClient.importAllLicenseDBLicenses(any())).thenReturn(expected);
+
+        RequestSummary result = licenseService.importLicenseDBInformation(adminUser);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void importLicenseDBInformation_throwsBadRequestClientException_whenUserIsNotAdmin() {
+        User nonAdminUser = new User("user@sw360.org", "sw360").setUserGroup(UserGroup.USER);
+
+        assertThatThrownBy(() -> licenseService.importLicenseDBInformation(nonAdminUser))
+                .isInstanceOf(BadRequestClientException.class)
+                .hasMessageContaining("not admin");
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -126,6 +126,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         Mockito.doNothing().when(licenseServiceMock).uploadLicense(any(), any(), anyBoolean(), anyBoolean());
         given(this.licenseServiceMock.deleteLicenseType(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.licenseServiceMock.importOsadlInformation(any())).willReturn(requestSummary);
+        given(this.licenseServiceMock.importLicenseDBInformation(any())).willReturn(requestSummary);
         given(this.licenseServiceMock.addLicenseType(any(),any() , any())).willReturn(RequestStatus.SUCCESS);
         given(this.sw360ReportServiceMock.getLicenseBuffer()).willReturn(ByteBuffer.allocate(10000));
         obligation1 = new Obligation();
@@ -435,6 +436,14 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
     @Test
     public void should_document_import_osadl_info() throws Exception {
         mockMvc.perform(post("/api/licenses/import/OSADL")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void should_document_import_licensedb_info() throws Exception {
+        mockMvc.perform(post("/api/licenses/import/LicenseDB")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk());

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ScheduleSpecTest.java
@@ -73,6 +73,8 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
                         "cvesearchService", Map.of("isScheduled", true, "firstOffsetSeconds", 0,
                                 "intervalSeconds", 86400, "nextSynchronization", "2026-05-13T00:00:00"),
                         "svmsyncService", Map.of("isScheduled", false, "firstOffsetSeconds", 3600,
+                                "intervalSeconds", 86400, "nextSynchronization", "N/A"),
+                        "licensedbsyncService", Map.of("isScheduled", false, "firstOffsetSeconds", 3600,
                                 "intervalSeconds", 86400, "nextSynchronization", "N/A")
                 ));
 
@@ -136,8 +138,10 @@ public class ScheduleSpecTest extends TestRestDocsSpecBase {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.cvesearchService").exists())
                 .andExpect(jsonPath("$.svmsyncService").exists())
+                .andExpect(jsonPath("$.licensedbsyncService").exists())
                 .andExpect(jsonPath("$.cvesearchService.isScheduled").value(true))
-                .andExpect(jsonPath("$.svmsyncService.isScheduled").value(false));
+                .andExpect(jsonPath("$.svmsyncService.isScheduled").value(false))
+                .andExpect(jsonPath("$.licensedbsyncService.isScheduled").value(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds the LicenseDB sync engine as the second part of the SW360 and LicenseDB integration.

This builds on the HTTP client added in #4268 and adds the complete flow for fetching licenses and obligations from LicenseDB and storing them in SW360.

## Changes

- added `importAllLicenseDBLicenses()` in `LicenseDatabaseHandler`
- reads the LicenseDB URL, credentials, and enabled flag from `LICENSEDB_REST`
- fetches active obligations from `/api/v1/obligations/export`
- fetches active licenses from `/api/v1/licenses/export`
- imports obligations first because licenses reference them by UUID
- matches existing data using `externalIds["licensedb-id"]`
- falls back to shortname matching during the first sync
- preserves SW360 specific fields like `checked`, `FSFLibre`, `whitelist`, and manually added obligations
- stores the last successful sync time in the `licensedb-sync-state` CouchDB document
- added `LicenseDBDataMapper` to map LicenseDB DTOs to SW360 Thrift objects
- maps obligation types like `RISK`, `RESTRICTION`, `RIGHT`, and `OBLIGATION`

## Endpoint

- added ADMIN only endpoint `POST /api/licenses/import/LicenseDB`

## Suggested reviewers

* @GMishx 
* @deo002 
* @Farooq-Fateh-Aftab 