### PR TITLE
fix(authserver): Migrated the tests from junit4 to junit6

### DIFF
--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2017, 2019, 2026. Part of the SW360 Portal Project.
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -133,6 +133,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
@@ -1,10 +1,10 @@
 /*
-* SPDX-FileCopyrightText: © 2024 Siemens AG
+* SPDX-FileCopyrightText: © 2024, 2026 Siemens AG
 * SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.authserver;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.*;
 

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2019, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,8 +9,8 @@
  */
 package org.eclipse.sw360.rest.authserver;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -18,13 +18,13 @@ import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A POST request for an access token with grant type 'client_credentials' and
  * custom auth header should NOT be possible.
  */
-@Ignore("Keeeping this test for reference for header bases auth, but it is not needed anymore for now")
+@Disabled("Keeeping this test for reference for header bases auth, but it is not needed anymore for now")
 public class GrantTypeClientCredentialsCustomHeaderAuthTest extends IntegrationTestBase {
 
     @Test

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
 
 package org.eclipse.sw360.rest.authserver;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import java.io.IOException;

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,8 +37,7 @@ import org.eclipse.sw360.rest.authserver.client.service.Sw360UserDetailsService;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360UserMirrorService;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
@@ -52,12 +51,10 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = Sw360AuthorizationServer.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestRestTemplate
 @ActiveProfiles({"dev", "test"})
@@ -93,7 +90,7 @@ public abstract class IntegrationTestBase {
     @Autowired
     protected PasswordEncoder encoder;
 
-    @Before
+    @BeforeEach
     public void setup() throws TException {
         setupTestUser();
         UserService.Client mockedUserService = mock(UserService.Client.class);

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/SecurityEncryptorTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/SecurityEncryptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2018. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2018, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,18 +10,15 @@
 
 package org.eclipse.sw360.rest.authserver;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.SealedObject;
 
 import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.decrypt;
 import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.encrypt;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(SpringRunner.class)
 public class SecurityEncryptorTest {
 
     @Test

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepositoryTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2019, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,15 +12,15 @@ package org.eclipse.sw360.rest.authserver.client.persistence;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.rest.authserver.IntegrationTestBase;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Of course it would be possible to test only the repo down to the db without
@@ -39,7 +39,7 @@ public class OAuthClientRepositoryTest extends IntegrationTestBase {
     @Autowired
     private OAuthClientRepository uut;
 
-    @Before
+    @BeforeEach
     public void setup() {
         uut.getAll().stream().forEach(uut::remove);
     }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientControllerTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2019, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,7 @@ import org.eclipse.sw360.rest.authserver.IntegrationTestBase;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.security.Sw360ClientSecretEncoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -34,8 +34,8 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -120,9 +120,9 @@ public class OAuthClientControllerTest extends IntegrationTestBase {
         assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
         JsonNode response = new ObjectMapper().readTree(responseEntity.getBody());
         String disclosedSecret = response.get("client_secret").asText();
-        assertNotNull("client_secret must be present on creation response", disclosedSecret);
-        assertFalse("disclosed client_secret must be plaintext, not a BCrypt hash: " + disclosedSecret,
-                Sw360ClientSecretEncoder.looksLikeBcrypt(disclosedSecret));
+        assertNotNull(disclosedSecret, "client_secret must be present on creation response");
+        assertFalse(Sw360ClientSecretEncoder.looksLikeBcrypt(disclosedSecret),
+                "disclosed client_secret must be plaintext, not a BCrypt hash: " + disclosedSecret);
         assertThat(response.get("scope").toString(), is(oneOf("[\"READ\",\"WRITE\"]", "[\"WRITE\",\"READ\"]")));
     }
 

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsServiceTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsServiceTest.java
@@ -10,12 +10,12 @@
 package org.eclipse.sw360.rest.authserver.client.service;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -29,14 +29,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.when;
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class Sw360ClientDetailsServiceTest {
     @Mock
     private OAuthClientRepository clientRepo;
     @InjectMocks
     private Sw360ClientDetailsService service;
     private OAuthClientEntity entity;
-    @Before
+    @BeforeEach
     public void setUp() {
         // @Value-injected fallbacks are not populated by @InjectMocks; supply
         // sane defaults via reflection so the TokenSettings builder doesn't

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/LegacyClientSecretUpgraderTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/LegacyClientSecretUpgraderTest.java
@@ -11,13 +11,13 @@ package org.eclipse.sw360.rest.authserver.security;
 
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -28,15 +28,15 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LegacyClientSecretUpgraderTest {
     private final BCryptPasswordEncoder bcrypt = new BCryptPasswordEncoder();
 
@@ -44,12 +44,12 @@ public class LegacyClientSecretUpgraderTest {
     private OAuthClientRepository repo;
     private LegacyClientSecretUpgrader upgrader;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         upgrader = new LegacyClientSecretUpgrader(repo, bcrypt);
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         Sw360ClientSecretEncoder.UPGRADE_CTX.remove();
     }
@@ -68,10 +68,10 @@ public class LegacyClientSecretUpgraderTest {
         verify(repo).getByClientId(clientId);
         ArgumentCaptor<OAuthClientEntity> persisted = ArgumentCaptor.forClass(OAuthClientEntity.class);
         verify(repo).update(persisted.capture());
-        assertTrue("persisted secret must be BCrypt-encoded but was: " + persisted.getValue().getClientSecret(),
-                Sw360ClientSecretEncoder.looksLikeBcrypt(persisted.getValue().getClientSecret()));
-        assertTrue("BCrypt hash must verify against the original raw secret",
-                bcrypt.matches(rawSecret, persisted.getValue().getClientSecret()));
+        assertTrue(Sw360ClientSecretEncoder.looksLikeBcrypt(persisted.getValue().getClientSecret()),
+                "persisted secret must be BCrypt-encoded but was: " + persisted.getValue().getClientSecret());
+        assertTrue(bcrypt.matches(rawSecret, persisted.getValue().getClientSecret()),
+                "BCrypt hash must verify against the original raw secret");
         // Thread-local must always be cleared so the next request starts clean.
         assertNull(Sw360ClientSecretEncoder.UPGRADE_CTX.get());
     }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/Sw360ClientSecretEncoderTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/Sw360ClientSecretEncoderTest.java
@@ -9,19 +9,19 @@
  */
 package org.eclipse.sw360.rest.authserver.security;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Sw360ClientSecretEncoderTest {
     private final Sw360ClientSecretEncoder encoder = new Sw360ClientSecretEncoder();
 
-    @After
+    @AfterEach
     public void cleanup() {
         Sw360ClientSecretEncoder.UPGRADE_CTX.remove();
     }
@@ -29,16 +29,16 @@ public class Sw360ClientSecretEncoderTest {
     @Test
     public void encode_alwaysProducesBcrypt() {
         String encoded = encoder.encode("plaintext-secret");
-        assertTrue("encoded value must be a BCrypt hash but was: " + encoded,
-                Sw360ClientSecretEncoder.looksLikeBcrypt(encoded));
+        assertTrue(Sw360ClientSecretEncoder.looksLikeBcrypt(encoded),
+                "encoded value must be a BCrypt hash but was: " + encoded);
     }
 
     @Test
     public void matches_bcryptStored_delegatesToBcrypt_andDoesNotPopulateUpgradeCtx() {
         String stored = new BCryptPasswordEncoder().encode("plaintext-secret");
         assertTrue(encoder.matches("plaintext-secret", stored));
-        assertNull("modern matches must not stash anything for upgrade",
-                Sw360ClientSecretEncoder.UPGRADE_CTX.get());
+        assertNull(Sw360ClientSecretEncoder.UPGRADE_CTX.get(),
+                "modern matches must not stash anything for upgrade");
     }
 
     @Test
@@ -52,8 +52,8 @@ public class Sw360ClientSecretEncoderTest {
     public void matches_legacyRawStored_correctSecret_populatesUpgradeCtx() {
         String stored = "legacy-fixture-not-a-real-secret";
         assertTrue(encoder.matches(stored, stored));
-        assertEquals("legacy match must stash raw secret for the upgrader",
-                stored, Sw360ClientSecretEncoder.UPGRADE_CTX.get());
+        assertEquals(stored, Sw360ClientSecretEncoder.UPGRADE_CTX.get(),
+                "legacy match must stash raw secret for the upgrader");
     }
 
     @Test

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/Sw360JwtAuthenticationConverterTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/Sw360JwtAuthenticationConverterTest.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.sw360.rest.authserver.security;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class Sw360JwtAuthenticationConverterTest {
 

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/authproviders/Sw360UserAuthenticationProviderTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/security/authproviders/Sw360UserAuthenticationProviderTest.java
@@ -10,7 +10,7 @@
 package org.eclipse.sw360.rest.authserver.security.authproviders;
 
 import org.eclipse.sw360.rest.authserver.client.service.Sw360UserDetailsService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.FactorGrantedAuthority;


### PR DESCRIPTION
# [Migration of auth-server test cases from `JUnit4` to `JUnit6`](https://docs.junit.org/6.1.0/migrating-from-junit4.html)

This PR upgrades our auth-server test suite from `JUnit 4` to `JUnit 6 (Jupiter)`. Beyond simply bumping framework versions, this PR refactors our auth-server test base classes to aggressively optimize Spring Boot's application context caching.

## Required Changes & Engineering Analogies

### 1. Eradication of `@RunWith(SpringJUnit4ClassRunner.class)` 
`JUnit 4`, every single test class had to explicitly declare how it was supposed to be executed via the runner. In `JUnit 6`, the execution model shifted to an Extensibility framework. Because our `TestRestDocsSpecBase` uses `@SpringBootTest` (which is meta-annotated with `@ExtendWith(SpringExtension.class)`), it acts as a master blueprint. Child classes now automatically inherit this execution blueprint. Redundant declarations create unnecessary noise and have been removed.

### 2. Assertion reorders
Total 6 message-first asserts moved to Jupiter's message-last order (incl. one 3-arg `assertEquals`).

### 3. Build
Added `mockito-junit-jupiter` (test scope, `${mockito.version}`) to `rest/authorization-server/pom.xml` — required because `MockitoExtension` lives in that artifact, which the root pom excludes from `spring-boot-starter-test`.

## Impact
 - **Performance:** Drastic reduction in total test suite execution time due to 100% Application Context cache hit rates

 - **Maintainability:** Child test classes are strictly focused on test logic, entirely free of framework lifecycle boilerplate

 - **Modernization:** Fully aligned with JUnit 6 / Jupiter standards, unblocking future tooling upgrades

## Checklist
  - [x] Removed `@RunWith` from all auth-server test classes
  - [x] Verified local test suite execution passes cleanly without state bleed
  - [x] As of now, the `auth-server` tests under `rest` is upgraded form `Junit 4` to `JUnit 6` 
  
## AI Disclosure
  - [x] This documentation was generated with the help of AI (Gemini 3.1 Pro - Extended Thinking)
