### PR TITLE
fix(tests): Migrated misc remaining tests to junit6

### DIFF
--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright Siemens AG, 2017-2019. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2017-2019, 2026. Part of the SW360 Portal Project.
   ~ Copyright Bosch.IO GmbH 2020
   ~
   ~ This program and the accompanying materials are made
@@ -182,6 +182,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/SW360RestHealthIndicatorTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/SW360RestHealthIndicatorTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Bosch.IO GmbH 2020
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,9 +20,8 @@ import org.eclipse.sw360.datahandler.thrift.health.Status;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -30,7 +30,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.MalformedURLException;
 import java.util.Collections;
@@ -38,7 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -49,7 +48,6 @@ import static org.mockito.Mockito.when;
     was not enough to avoid this bug.
  */
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = Sw360ResourceServer.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class SW360RestHealthIndicatorTest {
 
@@ -69,7 +67,7 @@ public class SW360RestHealthIndicatorTest {
 
     private DatabaseInstanceCloudant databaseInstanceMock;
 
-    @Before
+    @BeforeEach
     public void before() throws TException{
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789").setUserGroup(UserGroup.ADMIN));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2026. Part of the SW360 Portal Project.
  * Copyright Bosch Software Innovations GmbH, 2018.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse
@@ -40,8 +40,8 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class TestHelper {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpControllerTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/admin/attachment/AttachmentCleanUpControllerTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Rajnish Kumar<rk2452003@gmail.com>, 2025. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,12 +13,11 @@ package org.eclipse.sw360.rest.resourceserver.admin.attachment;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.Link;
 import org.springframework.http.HttpStatus;
@@ -26,13 +26,14 @@ import org.springframework.http.ResponseEntity;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class AttachmentCleanUpControllerTest {
 
     @Mock
@@ -44,8 +45,6 @@ public class AttachmentCleanUpControllerTest {
     @InjectMocks
     private AttachmentCleanUpController attachmentCleanUpController;
 
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
 
     @Test
     public void testProcess() {
@@ -53,10 +52,10 @@ public class AttachmentCleanUpControllerTest {
         RepositoryLinksResource result = attachmentCleanUpController.process(resource);
         Optional<Link> linkOptional = result.getLink("attachmentCleanUp");
 
-        assertTrue("Link 'attachmentCleanUp' should be present", linkOptional.isPresent());
+        assertTrue(linkOptional.isPresent(), "Link 'attachmentCleanUp' should be present");
 
         Link link = linkOptional.get();
-        assertTrue("Link href should contain '/api/attachmentCleanUp'", link.getHref().contains("/api/attachmentCleanUp"));
+        assertTrue(link.getHref().contains("/api/attachmentCleanUp"), "Link href should contain '/api/attachmentCleanUp'");
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright Bosch.IO GmbH 2020.
  * Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,13 +21,13 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.core.ThriftServiceProvider;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,12 +41,12 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class Sw360AttachmentServiceTest {
 
     @Mock
@@ -63,9 +64,9 @@ public class Sw360AttachmentServiceTest {
 
     private int sourceIdCounter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws TTransportException {
-        doReturn(thriftService).when(attachmentService).getThriftAttachmentClient();
+        lenient().doReturn(thriftService).when(attachmentService).getThriftAttachmentClient();
     }
 
     private static String attachmentId(int idx) {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelperAuthCachingTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelperAuthCachingTest.java
@@ -16,11 +16,11 @@ import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.rest.resourceserver.obligation.Sw360ObligationService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RestControllerHelperAuthCachingTest {
 
     @Mock
@@ -44,7 +44,7 @@ public class RestControllerHelperAuthCachingTest {
     @Mock
     private Sw360ObligationService obligationService;
 
-    @After
+    @AfterEach
     public void tearDown() {
         SecurityContextHolder.clearContext();
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandlerTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandlerTest.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotWritableException;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseServiceTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Aman Kumar, 2026. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,11 +16,11 @@ import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +29,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class Sw360LicenseServiceTest {
 
     @Mock
@@ -36,7 +37,7 @@ public class Sw360LicenseServiceTest {
 
     private Sw360LicenseService licenseService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws TException {
         // Constructing with new() leaves @Value fields (e.g. thriftServerUrl) null.
         // Safe here because getThriftLicenseClient() is stubbed before any field read.

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright Siemens AG, 2026.
- * Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,16 +12,16 @@ package org.eclipse.sw360.rest.resourceserver.project;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -33,7 +32,7 @@ public class Sw360ProjectServiceTest {
 
     private Sw360ProjectService projectService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         projectService = spy(new Sw360ProjectService(mock(RestControllerHelper.class)));
     }
@@ -45,7 +44,7 @@ public class Sw360ProjectServiceTest {
 
         int result = projectService.countProjectsByReleaseIds(emptyReleaseIds);
 
-        assertEquals("Expected 0 for empty release-id set", 0, result);
+        assertEquals(0, result, "Expected 0 for empty release-id set");
         verify(projectService, never()).getThriftProjectClient();
     }
 
@@ -56,22 +55,22 @@ public class Sw360ProjectServiceTest {
 
         int result = projectService.countProjectsByReleaseIds(nullReleaseIds);
 
-        assertEquals("Expected 0 for null release-id set", 0, result);
+        assertEquals(0, result, "Expected 0 for null release-id set");
         verify(projectService, never()).getThriftProjectClient();
     }
 
     @Test
     public void should_verify_CommonUtils_identifies_null_and_empty_collections() {
-        assertTrue("Empty set should be identified as empty",
-                CommonUtils.isNullOrEmptyCollection(Collections.emptySet()));
+        assertTrue(CommonUtils.isNullOrEmptyCollection(Collections.emptySet()),
+                "Empty set should be identified as empty");
 
-        assertTrue("Null collection should be identified as empty",
-                CommonUtils.isNullOrEmptyCollection(null));
+        assertTrue(CommonUtils.isNullOrEmptyCollection(null),
+                "Null collection should be identified as empty");
 
         Set<String> nonEmpty = new HashSet<>();
         nonEmpty.add("item");
-        assertFalse("Non-empty set should not be identified as empty",
-                CommonUtils.isNullOrEmptyCollection(nonEmpty));
+        assertFalse(CommonUtils.isNullOrEmptyCollection(nonEmpty),
+                "Non-empty set should not be identified as empty");
     }
 
     @Test
@@ -82,7 +81,7 @@ public class Sw360ProjectServiceTest {
 
         boolean isEmptyOrNull = CommonUtils.isNullOrEmptyCollection(releaseIds);
 
-        assertFalse("Non-empty release IDs should NOT trigger guard", isEmptyOrNull);
+        assertFalse(isEmptyOrNull, "Non-empty release IDs should NOT trigger guard");
     }
 
     @Test
@@ -96,7 +95,7 @@ public class Sw360ProjectServiceTest {
 
         int result = projectService.countProjectsByReleaseIds(releaseIds);
 
-        assertEquals("Expected count from Thrift client for non-empty input", 2, result);
+        assertEquals(2, result, "Expected count from Thrift client for non-empty input");
         verify(projectService, times(1)).getThriftProjectClient();
         verify(projectClient, times(1)).getCountByReleaseIds(releaseIds);
     }
@@ -114,7 +113,7 @@ public class Sw360ProjectServiceTest {
 
         int result = projectService.countProjectsByReleaseIds(releaseIds);
 
-        assertEquals("Expected 0 when Thrift call fails", 0, result);
+        assertEquals(0, result, "Expected 0 when Thrift call fails");
         verify(projectService, times(1)).getThriftProjectClient();
         verify(projectClient, times(1)).getCountByReleaseIds(releaseIds);
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportControllerContentDispositionTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportControllerContentDispositionTest.java
@@ -12,13 +12,13 @@ package org.eclipse.sw360.rest.resourceserver.report;
 
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Method;
 
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SW360ReportControllerContentDispositionTest {
 
     @SuppressWarnings("rawtypes")
@@ -44,7 +44,7 @@ public class SW360ReportControllerContentDispositionTest {
 
     private Method setContentDispositionMethod;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         setContentDispositionMethod = SW360ReportController.class
                 .getDeclaredMethod("setContentDisposition", HttpServletResponse.class, String.class);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
@@ -14,20 +14,11 @@ import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.Source;
-import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
-import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
-import org.eclipse.sw360.datahandler.thrift.attachments.LicenseInfoUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
-import org.eclipse.sw360.datahandler.thrift.projects.Project;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
+import org.eclipse.sw360.datahandler.thrift.projects.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
@@ -35,23 +26,27 @@ import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SW360ReportServiceTest {
 
     @Mock
@@ -76,7 +71,7 @@ public class SW360ReportServiceTest {
     private Project parentProject;
     private Project subProject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         testUser = new User();
         testUser.setEmail("test@example.com");
@@ -165,8 +160,8 @@ public class SW360ReportServiceTest {
         ByteBuffer result = sw360ReportService.getLicenseInfoBuffer(testUser, "parentId", reportBean);
 
         // Then
-        assertNotNull("Report buffer should not be null", result);
-        assertTrue("Report buffer should have content", result.remaining() > 0);
+        assertNotNull(result, "Report buffer should not be null");
+        assertTrue(result.remaining() > 0, "Report buffer should have content");
 
         // Verify that attachment usages were fetched for BOTH parent and sub-project
         verify(attachmentService, times(1)).getAttachmentUsages("parentId");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/TokenCapabilityAuthoritiesTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/TokenCapabilityAuthoritiesTest.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.sw360.rest.resourceserver.security;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilterTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilterTest.java
@@ -12,8 +12,8 @@ package org.eclipse.sw360.rest.resourceserver.security.apiToken;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -36,7 +36,7 @@ public class ApiTokenAuthenticationFilterTest {
     private AuthenticationEntryPoint authenticationEntryPoint;
     private FilterChain filterChain;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         SecurityContextHolder.clearContext();
         authenticationManager = mock(AuthenticationManager.class);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/basic/Sw360CustomUserDetailsServiceTest.java
@@ -13,18 +13,18 @@ package org.eclipse.sw360.rest.resourceserver.security.basic;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class Sw360CustomUserDetailsServiceTest {
 
     @Mock
@@ -35,7 +35,7 @@ public class Sw360CustomUserDetailsServiceTest {
 
     private User user;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         user = new User();
         user.setEmail("admin@sw360.org");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverterTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverterTest.java
@@ -15,11 +15,11 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.security.TokenCapabilityAuthorities;
 import org.eclipse.sw360.rest.resourceserver.security.basic.Sw360GrantedAuthority;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class Sw360JWTAccessTokenConverterTest {
 
     @Mock
@@ -41,7 +41,7 @@ public class Sw360JWTAccessTokenConverterTest {
 
     private Sw360JWTAccessTokenConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         converter = new Sw360JWTAccessTokenConverter();
         ReflectionTestUtils.setField(converter, "userService", userService);


### PR DESCRIPTION
# [Migration of remaining resource-server test cases from `JUnit4` to `JUnit6`](https://docs.junit.org/6.1.0/migrating-from-junit4.html)

This PR upgrades our remaining misc. resource-server test suite from `JUnit 4` to `JUnit 6 (Jupiter)`. Beyond simply bumping framework versions, this PR refactors our resource-server test base classes to aggressively optimize Spring Boot's application context caching.

## Required Changes & Engineering Analogies

- **Imports/annotations:** `org.junit.*` → `org.junit.jupiter.api.*`; `@Before/@After` → `@BeforeEach/@AfterEach`; `org.junit.Assert` → `Assertions`.
- **Runners → extensions:** `@RunWith(MockitoJUnitRunner)` → `@ExtendWith(MockitoExtension)`; `@Rule MockitoRule` → `@ExtendWith(MockitoExtension)`; `@RunWith(SpringRunner)` dropped where `@SpringBootTest` already supplies `SpringExtension`.
- **Assertion reorders:** 12 message-first asserts moved to Jupiter's message-last order across `Sw360ProjectServiceTest`, `SW360ReportServiceTest`, `AttachmentCleanUpControllerTest`.
- **Build:** added `mockito-junit-jupiter` (test scope, `${mockito.version}`) to `rest/resource-server/pom.xml` — required because `MockitoExtension` lives in that artifact, which the root pom excludes from `spring-boot-starter-test`.
- **Strictness fix:** `Sw360AttachmentServiceTest` — marked the shared `@BeforeEach`   `getThriftAttachmentClient()` stub `lenient()`. `MockitoExtension` checks unnecessary stubs per-test (vs. the runner's class-level check), so one test that doesn't use the shared stub  otherwise failed with `UnnecessaryStubbingException`.

## Checklist
  - [x] Removed `@RunWith` from all remaining resource-server test classes
  - [x] Verified local test suite execution passes cleanly without state bleed
  - [x] As of now, the `resource-server` tests under `rest` is upgraded form `Junit 4` to `JUnit 6` 
  
## AI Disclosure
  - [x] This documentation was generated with the help of AI (Gemini 3.1 Pro - Extended Thinking)
