### PR TITLE
fix(rest): use SPDX ID as license identifier from admin obligation.

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -641,7 +641,9 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                 if (license.getObligationsAtProjectSize() < 1) {
                     continue;
                 }
-                String licenseName = license.getLicenseName();
+                String licenseIdentifier = (license.isSetLicenseSpdxId()
+                        && !SW360Constants.SPDX_IDENTIFIER_UNKNOWN.equals(license.getLicenseSpdxId()))
+                        ? license.getLicenseSpdxId() : license.getLicenseName();
                 license.getObligationsAtProject().stream().forEach(obl -> {
                     ObligationStatusInfo osInfo = filteredObligationStatusMap.get(obl.getTopic());
                     release.setAttachments(release.getAttachments().stream()
@@ -651,13 +653,13 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                         osInfo.setText(obl.getText());
                         osInfo.setId(obl.getId());
                         osInfo.setObligationType(ThriftEnumUtils.enumByString(obl.getType(), ObligationType.class));
-                        osInfo.addToLicenseIds(licenseName);
+                        osInfo.addToLicenseIds(licenseIdentifier);
                         osInfo.addToReleases(release);
                         obl.setObligationStatusInfo(osInfo);
                     } else {
                         ObligationStatusInfo osi = new ObligationStatusInfo().setText(obl.getText()).setId(obl.getId())
                                 .setObligationType(ThriftEnumUtils.enumByString(obl.getType(), ObligationType.class))
-                                .setReleases(Sets.newHashSet(release)).setLicenseIds(Sets.newHashSet(licenseName));
+                                .setReleases(Sets.newHashSet(release)).setLicenseIds(Sets.newHashSet(licenseIdentifier));
                         filteredObligationStatusMap.put(obl.getTopic(), osi);
                     }
                 });

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -47,6 +47,7 @@ import java.util.stream.StreamSupport;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
 import static org.eclipse.sw360.datahandler.common.SW360Constants.LICENSE_NAME_UNKNOWN;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.SPDX_IDENTIFIER_UNKNOWN;
 import static org.eclipse.sw360.datahandler.common.SW360Constants.OBLIGATION_TOPIC_UNKNOWN;
 
 /**
@@ -68,7 +69,6 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
     private static final String EMPTY = "";
     private static final String OBLIGATION_TEXT_UNKNOWN = "Obligation text unknown";
     private static final Logger log = LogManager.getLogger(CLIParser.class);
-    private static final String SPDX_IDENTIFIER_UNKNOWN = "SPDX identifier unknown";
 
     private static final String OBLIGATION_TOPIC_ELEMENT_NAME = "Topic";
     private static final String OBLIGATION_TEXT_ELEMENT_NAME = "Text";

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -45,6 +45,7 @@ public class SW360Constants {
     public static final String LICENSE_TYPE_OTHERS = "Others";
     public static final String NA = "n/a";
     public static final String LICENSE_NAME_UNKNOWN = "License name unknown";
+    public static final String SPDX_IDENTIFIER_UNKNOWN = "SPDX identifier unknown";
     public static final String OBLIGATION_TOPIC_UNKNOWN = "Obligation topic unknown";
     public static final String NO_ASSERTION = "noassertion";
     public static final String STATUS = "status";


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary
This fix addresses the incorrect use of License Name as the license identifier when mapping admin obligations to releases via CLI XML parsing. FOSSology and other tools provide both a name and a licenseId (SPDX ID) field, but SW360 was using the License Name for obligation identification. This change ensures the SPDX ID is used as the primary identifier (falling back to License Name only when the SPDX ID is absent or unknown).

> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4298*)
> * Did you add or update any new dependencies that are required for your change?


Closes https://github.com/eclipse-sw360/sw360/issues/4298

### Changes:

1. LicenseInfoHandler.java: Use licenseSpdxId instead of licenseName when building obligation status maps, with a fallback to licenseName if the SPDX ID is unset or equals "SPDX identifier unknown".
2. AbstractCLIParser.java: Removed the local SPDX_IDENTIFIER_UNKNOWN constant (now moved to SW360Constants).
3. SW360Constants.java: Promoted SPDX_IDENTIFIER_UNKNOWN to a shared public constant.

### Suggest Reviewer
>  @GMishx 

### How To Test?
1. Upload a CLI XML attachment to a release where the license has a valid SPDX ID set in the admin license list.
2. Link that release to a project and navigate to the project's obligation view.
3. Verify that the obligations are now grouped/identified by SPDX ID (e.g. Apache-2.0) rather than the full license name.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
