### PR TITLE
fix(tests): Rest test migration junit4 to junit6 cleanup

### DIFF
--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -141,11 +141,6 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <pluginRepositories>

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -191,11 +191,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
             <scope>test</scope>

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -454,7 +454,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_return_400_when_license_update_fails() throws Exception {
-        // Overrides the @Before stub (SUCCESS) for this test only — Mockito applies the last stub wins rule.
+        // Overrides the @BeforeEach stub (SUCCESS) for this test only — Mockito applies the last stub wins rule.
         String expectedMessage = "License update failed with status: " + RequestStatus.FAILURE;
         given(this.licenseServiceMock.updateLicense(any(), any()))
                 .willThrow(new BadRequestClientException(expectedMessage));

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -67,7 +67,7 @@ import org.springframework.util.MultiValueMap;
 import java.io.IOException;
 import java.util.*;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -1385,8 +1385,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_document_link_releases_to_release() throws Exception {
-        assumeTrue("Not running since Releases cannot be interlinked",
-                SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP);
+        assumeTrue(SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP,
+                "Not running since Releases cannot be interlinked");
 
         mockMvc.perform(post("/api/releases/" + release.getId() + "/releases")
                 .contentType(MediaTypes.HAL_JSON)


### PR DESCRIPTION
This PR finishes the test migration from Junit4 to Junit6 under `/rest` module.

Linked PRs: #4260, #4287, #4295, #4296