### PR TITLE
fix(Project): Fixed vendor selection upon edit

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -965,6 +965,13 @@ public class RestControllerHelper<T> {
         if (project.isSetLinkedProjects()) {
             embeddedProject.setLinkedProjects(project.getLinkedProjects());
         }
+        // fillVendor() unsets vendorId and replaces it with the full Vendor object,
+        // so derive the ID back from the vendor object when present.
+        if (project.getVendor() != null && project.getVendor().getId() != null) {
+            embeddedProject.setVendorId(project.getVendor().getId());
+        } else if (project.isSetVendorId()) {
+            embeddedProject.setVendorId(project.getVendorId());
+        }
         return embeddedProject;
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2975,6 +2975,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             Vendor vendor = sw360Project.getVendor();
             Vendor vendorHalResource = restControllerHelper.convertToEmbeddedVendor(vendor);
             halProject.addEmbeddedResource("sw360:vendors", vendorHalResource);
+            // Restore vendorId so it remains a direct field in the response.
+            if (vendor.getId() != null) {
+                sw360Project.setVendorId(vendor.getId());
+            }
             sw360Project.setVendor(null);
         }
 
@@ -4363,6 +4367,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             Vendor vendor = sw360Project.getVendor();
             HalResource<Vendor> vendorHalResource = restControllerHelper.addEmbeddedVendor(vendor.getFullname());
             halProject.addEmbeddedResource("sw360:vendors", vendorHalResource);
+            // Restore vendorId so it remains a direct field in the response.
+            if (vendor.getId() != null) {
+                projectDTO.setVendorId(vendor.getId());
+            }
             projectDTO.setVendor(null);
         }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -1982,6 +1982,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
                                 fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
                                 fieldWithPath("phaseOutSince").description("The project phase-out date"),
+                                fieldWithPath("vendorId").description("The id of the vendor"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 subsectionWithPath("_embedded.sw360:vendors").description("An array of all component vendors with full name and link to their <<resources-vendor-get,Vendor resource>>"),
                                 subsectionWithPath("_embedded.createdBy").description("The user who created this project")
@@ -2042,6 +2043,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
                                 fieldWithPath("phaseOutSince").description("The project phase-out date"),
                                 fieldWithPath("considerReleasesFromExternalList").description("Consider list of releases from existing external list"),
+                                fieldWithPath("vendorId").description("The id of the vendor"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 subsectionWithPath("_embedded.sw360:vendors").description("An array of all component vendors with full name and link to their <<resources-vendor-get,Vendor resource>>"),
                                 subsectionWithPath("_embedded.createdBy").description("The user who created this project")


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

>

This PR fixes a bug where `vendorId` was missing from the `GET /projects` and `GET /projects/{id}` API responses, causing the vendor selector to render empty when a user opened the **Edit Project** dialog in the UI.

### Root Cause

The backend `fillVendor()` method resolves the stored `vendorId` into a full `Vendor` object on the `Project` entity. In the REST layer, after that `Vendor` object is embedded as a HAL resource (`sw360:vendors`), `setVendor(null)` is called to keep the flat JSON clean. Because `fillVendor()` had already unset `vendorId`, the field was absent from every project response – so the frontend had no ID to pre-populate the vendor selector.

> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4310*)

### Changes

| File | Change |
|------|--------|
| `ProjectController.java` (×2) | Before calling `setVendor(null)`, restore `vendorId` from `vendor.getId()` so it remains a direct field in the JSON response |
| `RestControllerHelper.java` | In `convertToEmbeddedProject()`, derive `vendorId` from the hydrated `Vendor` object (or fall back to the raw field) when building embedded project representations |


Closes https://github.com/eclipse-sw360/sw360/issues/4310

### Suggest Reviewer
> @GMishx  @deo002 

### How To Test?
> 1. Create (or use an existing) project that has a **vendor** assigned.
> 2. Call `GET /api/projects` (list) or `GET /api/projects/{id}` (detail) – confirm that the `vendorId` field is present and non-null in the JSON response.
>3. Open the **Edit Project** dialog in the UI and verify the vendor field is  pre-populated correctly.
>4. Save the project without changing the vendor; confirm the vendor is preserved.
>5. Change the vendor, save, and re-fetch – confirm the new `vendorId` is returned.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

### Frontend Releated PR
https://github.com/eclipse-sw360/sw360-frontend/pull/1816
