### PR TITLE
fix(docker): fix location of jwt-keystore.jks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # is triggered by buildkit images
 
 # Where code compiles
-FROM maven:3-eclipse-temurin-21-noble@sha256:08733049ae318e8af58235278ff2f5fdfc81958ec11e7bc34635b2e0537fcfad AS sw360build
+FROM maven:3-eclipse-temurin-21-noble@sha256:d7e7f57407437c014571f1ad5a9955f03fc3edcb1d964067ef351fa38e798665 AS sw360build
 
 ARG COUCHDB_HOST=localhost
 
@@ -70,7 +70,7 @@ COPY --from=sw360build /sw360_keycloak_listener /sw360_keycloak_listener
 #--------------------------------------------------------------------------------------------------
 # Runtime SW360 image
 
-FROM tomcat:11-jre21-temurin-noble@sha256:59cb924b1a76508eb7769f102299293d6abcd0e62d22b1b2ba18324090e3b38a AS sw360
+FROM tomcat:11-jre21-temurin-noble@sha256:c2f18f28400c7de3703741fb6ceda2c10357961bea6169e882f5e638492766e3 AS sw360
 
 # Default environment variables that can be overridden at runtime
 # For more information, please check the documentation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ WORKDIR /build/sw360
 RUN --mount=type=bind,target=/build/sw360,rw \
     --mount=type=cache,target=/root/.m2 \
     mvn clean package \
+    --no-transfer-progress \
     -P deploy \
     -Dbase.deploy.dir="${PWD}" \
     -Dtest=org.eclipse.sw360.rest.resourceserver.restdocs.* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ COPY ./scripts/docker-config .
 # Bundled JWT signing keystore (acts as a first-run fallback; the entrypoint
 # copies it to /etc/sw360/jwt-keystore.jks if no persistent keystore exists).
 # Operators can replace it with their own keystore via the 'etc' named volume.
-COPY rest/authorization-server/src/main/resources/jwt-keystore.jks ./jwt-keystore.jks
+COPY rest/rest-common/src/main/resources/jwt-keystore.jks ./jwt-keystore.jks
 
 # Tomcat manager for debugging portlets
 # Make entrypoint executable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,4 +77,4 @@ secrets:
   COUCHDB_SECRETS:
     file: ./config/couchdb/default_secrets
   JWT_KEYSTORE:
-    file: ./rest/authorization-server/src/main/resources/jwt-keystore.jks
+    file: ./rest/rest-common/src/main/resources/jwt-keystore.jks


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

1. Fix the path of `jwt-keystore.jks` in docker images.
2. Update the image version of Maven and Tomcat.
3. Add `--no-transfer-progress` to `Dockerfile` so dependency download logs are not flooded.