### PR TITLE
Add releases to vulnerabilities payload only if all details flag is enabled

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -122,6 +123,8 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
             @RequestParam(value = "search", required = false) String searchText,
             @Parameter(description = "Filter for CVE ID")
             @RequestParam(value = "cveId", required = false) String cveId,
+            @Parameter(description = "Fetch all details about the vulnerabilities such as associated releases")
+            @RequestParam(value = "allDetails", required = false) boolean allDetails,
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
             HttpServletRequest request
@@ -144,7 +147,7 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
 
         List<EntityModel<VulnerabilityApiDTO>> vulnResources = Lists.newArrayList();
         for (Vulnerability v: paginationResult.getResources()) {
-            Set<Release> releaseList = getReleaseRelationsInfo(v, user);
+            Set<Release> releaseList = allDetails ? getReleaseRelationsInfo(v, user) : Collections.<Release>emptySet();
             VulnerabilityApiDTO vulnerabilityApiDTO = new VulnerabilityApiDTO();
             restControllerHelper.setDataVulApiDTO(vulnerabilityApiDTO, v, releaseList);
             vulnResources.add(EntityModel.of(vulnerabilityApiDTO));


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Send associated releases with the ```/vulnerabilities``` endpoint only if ```allDetails``` flag is enabled.

### How To Test?
Make a curl request to the ```/vulnerabilities``` endpoint, once with ```allDetails``` set as true and once as false.
```
curl -X 'GET' \
  'http://localhost:8080/resource/api/vulnerabilities?allDetails=false&page=0&page_entries=10' \
  -H 'accept: application/vnd.hal+json' \
  -H 'Authorization: Basic abc'
```

And,
```
curl -X 'GET' \
  'http://localhost:8080/resource/api/vulnerabilities?allDetails=true&page=0&page_entries=10' \
  -H 'accept: application/vnd.hal+json' \
  -H 'Authorization: Basic abc'
```

Response:
```
{
  "_embedded": {
    "sw360:vulnerabilityApiDTOes": [
      {
      ...
        "cwe": "CWE-123",
        **"releases"**: [
               ...
            ],
        ...
  },
  "page": {
    "size": 10,
    "totalElements": 1,
    "totalPages": 1,
    "number": 0
  }
}
```
releases array should be there in the second api request

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
