### PR TITLE
fix: replace localhost with keycloak service name for JWT cert fetch

### DIFF
--- a/config/sw360/.env.backend
+++ b/config/sw360/.env.backend
@@ -46,7 +46,7 @@ ENABLE_DISKSPACE=false
 # validation paths.
 SW360_SECURITY_JWT_ISSUERS_0_ISSUER_URI=http://localhost:8080/authorization
 SW360_SECURITY_JWT_ISSUERS_1_ISSUER_URI=http://localhost:8083/realms/sw360
-#SW360_SECURITY_JWT_ISSUERS_1_JWK_SET_URI=http://localhost:8083/realms/sw360/protocol/openid-connect/certs
+SW360_SECURITY_JWT_ISSUERS_1_JWK_SET_URI=http://keycloak:8080/realms/sw360/protocol/openid-connect/certs
 
 #
 # Email configs


### PR DESCRIPTION
fixes: #4294

Problem:
When running the application stack locally via Docker, the backend service was unable to fetch Keycloak's JWKS (JSON Web Key Set) endpoint. This caused JWT validation to fail silently during local development. The root cause was the JWK_SET_URI being set to localhost:8083, which is not resolvable from within a Docker container since containers operate on an isolated internal network.

Solution:
Updated SW360_SECURITY_JWT_ISSUERS_1_JWK_SET_URI in config/sw360/.env.backend to use the internal Docker service hostname keycloak:8080 instead of localhost:8083, allowing the backend container to correctly reach Keycloak over the Docker bridge network.

Changes:
config/sw360/.env.backend — replaced localhost:8083 with keycloak:8080 in the JWKS URI config

Impact:
Fixes JWT token validation in local Docker environments
No changes to production configuration
No API or functional behavior affected