### PR TITLE
fix(Rest): Escape Lucene special characters in query sanitization for Tag serarch

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -527,6 +527,10 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         }
 
         final Function<String, String> addType = input -> {
+            if (fieldName.equals("tag")) {
+                return fieldName + ":\"" + sanitizeTagQueryInput(input) + "\"";
+            }
+
             // Handle pre-formatted queries from prepareWildcardQuery
             if (input.startsWith("\"") && input.endsWith("\"")) {
                 // Exact phrase search - just prepend field name
@@ -625,6 +629,17 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         } else {
             for (String removeStr : LUCENE_SPECIAL_CHARACTERS) {
                 input = input.replaceAll(removeStr, " ");
+            }
+            return input.replaceAll("\\s+", " ").trim();
+        }
+    }
+
+    private static String sanitizeTagQueryInput(String input) {
+        if (isNullOrEmpty(input)) {
+            return nullToEmpty(input);
+        } else {
+            for (String specialCharacter : LUCENE_SPECIAL_CHARACTERS) {
+                input = input.replaceAll("(" + specialCharacter + ")", "\\\\$1");
             }
             return input.replaceAll("\\s+", " ").trim();
         }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #4322 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
