### PR TITLE
feat(search): Add search support for moderation requests

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import com.google.common.base.Joiner;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
@@ -22,6 +23,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 
 import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
@@ -73,8 +76,51 @@ public class ModerationSearchHandler {
         connector.addDesignDoc(searchView);
     }
 
-    public List<ModerationRequest> search(String text, final Map<String, Set<String>> subQueryRestrictions ) {
+    public List<ModerationRequest> search(String text, final Map<String, Set<String>> subQueryRestrictions) {
         return connector.searchViewWithRestrictionsWithAnd(ModerationRequest.class, luceneSearchView.getIndexName(),
                 text, subQueryRestrictions);
+    }
+
+    public Map<PaginationData, List<ModerationRequest>> search(String text,
+            final Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) {
+        Map<String, Map<String, Set<String>>> restrictions = new java.util.HashMap<>();
+        Map<String, Set<String>> orRestrictions = new java.util.HashMap<>();
+        Map<String, Set<String>> andRestrictions = new java.util.HashMap<>();
+
+        if (subQueryRestrictions != null) {
+            for (Map.Entry<String, Set<String>> entry : subQueryRestrictions.entrySet()) {
+                if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                    continue;
+                }
+
+                String fieldName = entry.getKey();
+                Set<String> values = entry.getValue();
+
+                if (isModeratorOrRequestingUserField(fieldName)) {
+                    orRestrictions.put(fieldName, values);
+                } else {
+                    andRestrictions.put(fieldName, values);
+                }
+            }
+        }
+
+        if (!orRestrictions.isEmpty()) {
+            restrictions.put("OR", orRestrictions);
+        }
+        if (!andRestrictions.isEmpty()) {
+            restrictions.put("AND", andRestrictions);
+        }
+
+        List<String> queryFilters = NouveauLuceneAwareDatabaseConnector.createComplexQuery(
+                ModerationRequest.class, text, restrictions);
+        String finalQuery = Joiner.on(" AND ").join(queryFilters);
+
+        return connector.searchView(ModerationRequest.class, luceneSearchView.getIndexName(), finalQuery,
+                pageData, "timestamp", pageData.isAscending());
+    }
+
+    private static boolean isModeratorOrRequestingUserField(String fieldName) {
+        return ModerationRequest._Fields.MODERATORS.getFieldName().equals(fieldName)
+                || ModerationRequest._Fields.REQUESTING_USER.getFieldName().equals(fieldName);
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -126,7 +126,6 @@ public class ProjectSearchHandler {
                 .searchViewWithRestrictionsWithAnd(Project.class,
                         luceneSearchView.getIndexName(), text, subQueryRestrictions,
                         pageData, sortColumn, pageData.isAscending());
-
         PaginationData respPageData = resultProjectList.keySet().iterator().next();
         List<Project> projectList = resultProjectList.values().iterator().next();
 

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -264,6 +264,11 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
+    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) throws TException {
+        return handler.searchModerationRequestsByExactValues(subQueryRestrictions, pageData);
+    }
+
+    @Override
     public List<ModerationRequest> getRequestsByRequestingUser(User user) throws TException {
         assertUser(user);
 
@@ -369,9 +374,11 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
-    public List<ModerationRequest> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions)
-            throws TException {
-        return modSearchHandler.search(text, subQueryRestrictions);
+    public List<ModerationRequest> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData) throws TException {
+        Map<PaginationData, List<ModerationRequest>> result = modSearchHandler.search(text, subQueryRestrictions,
+                pageData);
+        return result.values().iterator().next();
     }
 
     @Override

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -138,6 +138,11 @@ public class ModerationDatabaseHandler {
         return repository.getRequestsByModeratorAndRequestingUserWithPaginationNoFilter(moderator, pageData);
     }
 
+    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) {
+        return repository.searchModerationRequestsByExactValues(subQueryRestrictions, pageData);
+    }
+
+
     public Map<PaginationData, List<ModerationRequest>> getRequestsByModerator(String moderator, PaginationData pageData, boolean open) {
         return repository.getRequestsByModerator(moderator, pageData, open);
     }

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
@@ -163,6 +163,68 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         return getConnector().getQueryResult(qb, ModerationRequest.class);
     }
 
+    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        final boolean ascending = pageData.isAscending();
+        final int skip = pageData.getDisplayStart();
+        final Map<String, Object> typeSelector = eq("type", "moderation");
+        final Map<String, Object> restrictionsSelector = getQueryFromRestrictions(subQueryRestrictions);
+        final Map<String, Object> finalSelector = and(List.of(typeSelector, restrictionsSelector));
+
+        PostFindOptions qb = getConnector().getQueryBuilder()
+                .selector(finalSelector)
+                .limit(rowsPerPage)
+                .skip(skip)
+                .useIndex(Collections.singletonList(MR_BY_DATE_IDX))
+                .addSort(Collections.singletonMap("timestamp", ascending ? "asc" : "desc"))
+                .build();
+        return getConnector().getQueryResult(qb, ModerationRequest.class);
+    }
+
+    private Map<String, Object> getQueryFromRestrictions(Map<String, Set<String>> subQueryRestrictions) {
+        List<Map<String, Object>> andConditions = new ArrayList<>();
+        List<Map<String, Object>> moderatorOrRequestingUserConditions = new ArrayList<>();
+        for (Map.Entry<String, Set<String>> entry : subQueryRestrictions.entrySet()) {
+            if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+                final String fieldName = entry.getKey();
+                final List<String> values = entry.getValue().stream()
+                        .filter(Objects::nonNull)
+                        .map(String::trim)
+                        .filter(value -> !value.isEmpty())
+                        .toList();
+
+                if (values.isEmpty()) {
+                    continue;
+                }
+
+                final Map<String, Object> condition;
+                if (ModerationRequest._Fields.MODERATORS.getFieldName().equals(fieldName)) {
+                    condition = values.size() == 1
+                            ? elemMatch(fieldName, values.get(0))
+                            : or(values.stream().map(value -> elemMatch(fieldName, value)).toList());
+                } else {
+                    condition = values.size() == 1
+                            ? eq(fieldName, values.get(0))
+                            : or(values.stream().map(value -> eq(fieldName, value)).toList());
+                }
+
+                if (ModerationRequest._Fields.MODERATORS.getFieldName().equals(fieldName)
+                        || ModerationRequest._Fields.REQUESTING_USER.getFieldName().equals(fieldName)) {
+                    moderatorOrRequestingUserConditions.add(condition);
+                } else {
+                    andConditions.add(condition);
+                }
+            }
+        }
+
+        if (!moderatorOrRequestingUserConditions.isEmpty()) {
+            andConditions.add(moderatorOrRequestingUserConditions.size() == 1
+                    ? moderatorOrRequestingUserConditions.get(0)
+                    : or(moderatorOrRequestingUserConditions));
+        }
+        return and(andConditions);
+    }
+
     public Map<PaginationData, List<ModerationRequest>> getRequestsByModerator(String moderator, PaginationData pageData, boolean open) {
         Map<PaginationData, List<ModerationRequest>> paginatedModerations = queryViewWithPagination(moderator, pageData, open);
         List<ModerationRequest> moderationList = paginatedModerations.values().iterator().next();
@@ -371,7 +433,7 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         }
         return countByModerationState;
     }
-    
+
     public Map<String, Long> getCountByModerationStateAndRequestingUser(String moderator, String requestingUser) {
         Map<String, Long> countByState = Maps.newHashMap();
         List<String[]> keys = prepareKeys(moderator, requestingUser, true);

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -534,7 +534,9 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             } else if (input.startsWith("(") && input.contains("\"")) {
                 // Wildcard query with parentheses - prepend field name
                 return fieldName + ":" + input;
-            } else if (fieldName.equals("businessUnit") || fieldName.equals("tag") || fieldName.equals("projectResponsible") || fieldName.equals("createdBy") || fieldName.equals("email")) {
+            } else if (fieldName.equals("businessUnit") || fieldName.equals("tag") || fieldName.equals("projectResponsible")
+                    || fieldName.equals("createdBy") || fieldName.equals("email")
+                    || fieldName.equals("moderators") || fieldName.equals("requestingUser")) {
                 return fieldName + ":\"" + input + "\"";
             } else if (fieldName.equals("createdOn") || fieldName.equals("timestamp")) {
                 try {

--- a/libraries/datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/datahandler/src/main/thrift/moderation.thrift
@@ -338,7 +338,12 @@ service ModerationService {
     /**
      * search moderation requests in database that match subQueryRestrictions
      **/
-    list<ModerationRequest> refineSearch(1: string text, 2: map<string, set<string>> subQueryRestrictions);
+    list<ModerationRequest> refineSearch(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: PaginationData pageData);
+
+    /**
+     * search moderation requests in database that match subQueryRestrictions without lucene search
+     **/
+    list<ModerationRequest> searchModerationRequestsByExactValues(1: map<string, set<string>> subQueryRestrictions, 2: PaginationData pageData);
 
     /**
      * get count of moderation requests by moderation state

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -166,15 +166,11 @@ public class ModerationRequestController implements RepresentationModelProcessor
             }
             moderationRequests = sw360ModerationRequestService.refineSearch(filterMap, pageable);
         } else {
-            if (filterMap.isEmpty()) {
-                moderationRequests = sw360ModerationRequestService.getRequestsByModerator(sw360User, pageable);
-            } else {
-                String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
-                String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
-                addFilterValue(filterMap, moderatorKey, sw360User.getEmail());
-                addFilterValue(filterMap, requestingUserKey, sw360User.getEmail());
-                moderationRequests = sw360ModerationRequestService.searchModerationRequestsByExactValues(filterMap, pageable);
-            }
+            String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
+            String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
+            addFilterValue(filterMap, moderatorKey, sw360User.getEmail());
+            addFilterValue(filterMap, requestingUserKey, sw360User.getEmail());
+            moderationRequests = sw360ModerationRequestService.searchModerationRequestsByExactValues(filterMap, pageable);
         }
 
         Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData =

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -26,6 +26,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
@@ -79,6 +80,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService.isOpenModerationRequest;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -124,12 +126,56 @@ public class ModerationRequestController implements RepresentationModelProcessor
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
             HttpServletRequest request,
+            @Parameter(description = "The type of document for which the request was generated")
+            @RequestParam(value = "type", required = false) String documentType,
+            @Parameter(description = "The name of the document")
+            @RequestParam(value = "documentName", required = false) String documentName,
+            @Parameter(description = "The requesting user's email")
+            @RequestParam(value = "requestingUser", required = false) String requestingUser,
+            @Parameter(description = "The requesting user's department")
+            @RequestParam(value = "requestingUserDepartment", required = false) String requestingUserDepartment,
+            @Parameter(description = "The state of the request")
+            @RequestParam(value = "moderationState", required = false) String moderationState,
+            @Parameter(description = "Date request was created on (YYYY-MM-DD).",
+                    schema = @Schema(type = "string", format = "date"))
+            @RequestParam(value = "requestDate", required = false) String requestDate,
+            @Parameter(description = "List requests by lucene search, default false")
+            @RequestParam(value = "luceneSearch", required = false, defaultValue = "false") boolean luceneSearch,
+            @Parameter(description = "Moderators , as a comma separated list.")
+            @RequestParam(value = "moderators", required = false) String moderators,
             @Parameter(description = "Fetch all details of the moderation request")
             @RequestParam(value = "allDetails", required = false) boolean allDetails
     ) throws TException, ResourceClassNotFoundException, URISyntaxException, PaginationParameterException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
-        List<ModerationRequest> moderationRequests = sw360ModerationRequestService.getRequestsByModerator(sw360User, pageable);
+        List<ModerationRequest> moderationRequests = new ArrayList<>();
+        Map<String, Set<String>> filterMap = getFilterMap(documentType, documentName, requestingUser,
+            requestingUserDepartment, moderationState, requestDate, moderators);
+
+        if (luceneSearch) {
+            String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
+            String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
+            addFilterValue(filterMap, moderatorKey, sw360User.getEmail());
+            addFilterValue(filterMap, requestingUserKey, sw360User.getEmail());
+
+            if (filterMap.containsKey(ModerationRequest._Fields.DOCUMENT_NAME.getFieldName())) {
+                Set<String> values = filterMap.get(ModerationRequest._Fields.DOCUMENT_NAME.getFieldName()).stream()
+                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
+                        .collect(Collectors.toSet());
+                filterMap.put(Project._Fields.NAME.getFieldName(), values);
+            }
+            moderationRequests = sw360ModerationRequestService.refineSearch(filterMap, pageable);
+        } else {
+            if (filterMap.isEmpty()) {
+                moderationRequests = sw360ModerationRequestService.getRequestsByModerator(sw360User, pageable);
+            } else {
+                String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
+                String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
+                addFilterValue(filterMap, moderatorKey, sw360User.getEmail());
+                addFilterValue(filterMap, requestingUserKey, sw360User.getEmail());
+                moderationRequests = sw360ModerationRequestService.searchModerationRequestsByExactValues(filterMap, pageable);
+            }
+        }
 
         Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData =
                 new HashMap<>();
@@ -138,6 +184,46 @@ public class ModerationRequestController implements RepresentationModelProcessor
         modRequestsWithPageData.put(paginationData, moderationRequests);
 
         return getModerationResponseEntity(pageable, request, allDetails, modRequestsWithPageData);
+    }
+
+    /**
+     * Create a map of filters with the field name in the key and expected value in the value (as set).
+     * @return Filter map from the user's request.
+     */
+    private @NonNull Map<String, Set<String>> getFilterMap(
+            String documentType, String documentName, String requestingUser,
+            String requestingUserDepartment, String moderationState, String requestDate, String moderators
+    ) {
+        Map<String, Set<String>> filterMap = new HashMap<>();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(documentType)) {
+            filterMap.put(ModerationRequest._Fields.DOCUMENT_TYPE.getFieldName(), CommonUtils.splitToSet(documentType));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(documentName)) {
+            filterMap.put(ModerationRequest._Fields.DOCUMENT_NAME.getFieldName(), Collections.singleton(documentName));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(requestingUser)) {
+            filterMap.put(ModerationRequest._Fields.REQUESTING_USER.getFieldName(), CommonUtils.splitToSet(requestingUser));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(requestingUserDepartment)) {
+            filterMap.put(ModerationRequest._Fields.REQUESTING_USER_DEPARTMENT.getFieldName(), CommonUtils.splitToSet(requestingUserDepartment));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(moderationState)) {
+            filterMap.put(ModerationRequest._Fields.MODERATION_STATE.getFieldName(), CommonUtils.splitToSet(moderationState));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(requestDate)) {
+            filterMap.put(ModerationRequest._Fields.TIMESTAMP.getFieldName(), CommonUtils.splitToSet(requestDate));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(moderators)) {
+            filterMap.put(ModerationRequest._Fields.MODERATORS.getFieldName(), CommonUtils.splitToSet(moderators));
+        }
+        return filterMap;
+    }
+
+    private void addFilterValue(Map<String, Set<String>> filterMap, String key, String value) {
+        Set<String> existingValues = filterMap.get(key);
+        Set<String> mutableValues = existingValues == null ? new HashSet<>() : new HashSet<>(existingValues);
+        mutableValues.add(value);
+        filterMap.put(key, mutableValues);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
@@ -25,6 +25,7 @@ import org.eclipse.sw360.datahandler.thrift.RemoveModeratorRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -138,6 +139,20 @@ public class Sw360ModerationRequestService {
     public List<ModerationRequest> getRequestsByModerator(User sw360User, Pageable pageable) throws TException {
         PaginationData pageData = pageableToPaginationData(pageable);
         return getThriftModerationClient().getRequestsByModeratorWithPaginationNoFilter(sw360User, pageData);
+    }
+
+    /**
+     * Get paginated list of moderation requests based on search parameters provided by users
+     * without lucene search
+     *
+     * @param filterMap Filter parameters
+     * @param pageable  Pageable information from request
+     * @return Paginated list of moderation requests.
+     * @throws TException Exception in case of error.
+     */
+    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> filterMap, Pageable pageable) throws TException {
+        PaginationData pageData = pageableToPaginationData(pageable);
+        return getThriftModerationClient().searchModerationRequestsByExactValues(filterMap, pageData);
     }
 
     /**
@@ -508,5 +523,17 @@ public class Sw360ModerationRequestService {
      */
     public RequestStatus deleteClearingRequest(String crId, User user) throws TException {
         return getThriftModerationClient().deleteClearingRequest(crId, user);
+    }
+
+    /**
+     * Return moderation requests based on search parameters
+     *
+     * @param filterMap Filters set by the user
+     * @return List<ModerationRequest> the list of moderation requests
+     * @throws TException if Thrift communication fails
+     */
+    public List<ModerationRequest> refineSearch(Map<String, Set<String>> filterMap, Pageable pageable) throws TException {
+        PaginationData pageData = pageableToPaginationData(pageable);
+        return getThriftModerationClient().refineSearch(null, filterMap, pageData);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
@@ -438,8 +438,8 @@ public class ModerationRequestTest extends TestIntegrationBase {
 
     @Test
     public void should_list_moderation_requests_empty_page() throws IOException, TException {
-        given(moderationServiceMock.getRequestsByModerator(any(), any())).willReturn(java.util.List.of());
-        given(moderationServiceMock.getTotalCountOfRequests(any())).willReturn(0L);
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any())).willReturn(java.util.List.of());
+        given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(0L);
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);
@@ -453,6 +453,46 @@ public class ModerationRequestTest extends TestIntegrationBase {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertTrue(response.getBody() != null && response.getBody().contains("_embedded"));
     }
+
+        @Test
+        public void should_search_moderation_requests_with_exact_filters() throws IOException, TException {
+        ModerationRequest mrSearch = new ModerationRequest(openMr);
+        mrSearch.setId("MR-S1");
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any()))
+            .willReturn(new java.util.ArrayList<>(java.util.List.of(mrSearch)));
+
+        HttpHeaders headers = getHeaders(port);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+            "http://localhost:" + port + "/api/moderationrequest?type=RELEASE&documentName=Release%201&requestingUser=admin@sw360.org&requestingUserDepartment=DEPT&moderationState=INPROGRESS&requestDate=2026-01-01&moderators=admin@sw360.org&page=0&page_entries=10",
+            HttpMethod.GET,
+            request,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody() != null && response.getBody().contains("MR-S1"));
+        }
+
+        @Test
+        public void should_search_moderation_requests_with_lucene() throws IOException, TException {
+        ModerationRequest mrSearch = new ModerationRequest(openMr);
+        mrSearch.setId("MR-L1");
+        given(moderationServiceMock.refineSearch(any(), any()))
+            .willReturn(new java.util.ArrayList<>(java.util.List.of(mrSearch)));
+
+        HttpHeaders headers = getHeaders(port);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+            "http://localhost:" + port + "/api/moderationrequest?documentName=Release&luceneSearch=true&page=0&page_entries=10",
+            HttpMethod.GET,
+            request,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody() != null && response.getBody().contains("MR-L1"));
+        }
 
     @Test
     public void should_error_on_invalid_state() throws IOException, TException {
@@ -521,8 +561,8 @@ public class ModerationRequestTest extends TestIntegrationBase {
         mr2.setId("MR-3");
         java.util.List<ModerationRequest> list = new java.util.ArrayList<>(java.util.List.of(mr1, mr2));
 
-        given(moderationServiceMock.getRequestsByModerator(any(), any())).willReturn(list);
-        given(moderationServiceMock.getTotalCountOfRequests(any())).willReturn(2L);
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any())).willReturn(list);
+        given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(2L);
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);
@@ -561,8 +601,8 @@ public class ModerationRequestTest extends TestIntegrationBase {
         dupMr.setDocumentCreationInfoAdditions(new org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformation().setId("DC1"));
         dupMr.setDocumentCreationInfoDeletions(new org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformation().setId("DC1"));
 
-        given(moderationServiceMock.getRequestsByModerator(any(), any())).willReturn(new java.util.ArrayList<>(java.util.List.of(dupMr)));
-        given(moderationServiceMock.getTotalCountOfRequests(any())).willReturn(1L);
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any())).willReturn(new java.util.ArrayList<>(java.util.List.of(dupMr)));
+        given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(1L);
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
@@ -172,13 +172,14 @@ public class ModerationRequestSpecTest extends TestRestDocsSpecBase {
         given(this.releaseServiceMock.getReleaseForUserById(eq(moderationRequest.getDocumentId()), any())).willReturn(releaseAdditions);
         given(this.userServiceMock.getUserByEmail(moderationRequest.getRequestingUser())).willReturn(new User("test.admin@sw360.org", "DEPT").setId("12345"));
         given(this.userServiceMock.getUserByEmailOrExternalId(testUserId)).willReturn(user);
-        given(this.moderationRequestServiceMock.getRequestsByModerator(any(), any())).willReturn(new ArrayList<>(moderationRequests));
-        given(this.moderationRequestServiceMock.getTotalCountOfRequests(any())).willReturn((long) moderationRequests.size());
+        given(this.moderationRequestServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn((long) moderationRequests.size());
         given(this.moderationRequestServiceMock.getModerationRequestById(eq(moderationRequest.getId()))).willReturn(moderationRequest);
         given(this.moderationRequestServiceMock.getRequestsByState(any(), any(), eq(false), anyBoolean())).willReturn(requestsByState);
         given(this.moderationRequestServiceMock.acceptRequest(eq(moderationRequest), eq("Changes looks good."), any())).willReturn(ModerationState.APPROVED);
         given(this.moderationRequestServiceMock.assignRequest(eq(moderationRequest), any())).willReturn(ModerationState.INPROGRESS);
         given(this.moderationRequestServiceMock.getRequestsByRequestingUser(any(), any())).willReturn(requestsByState);
+                given(this.moderationRequestServiceMock.searchModerationRequestsByExactValues(anyMap(), any())).willReturn(new ArrayList<>(moderationRequests));
+                given(this.moderationRequestServiceMock.refineSearch(anyMap(), any())).willReturn(new ArrayList<>(moderationRequests));
     }
 
     @Test
@@ -276,6 +277,56 @@ public class ModerationRequestSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("page.number").description("Number of the current page"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
+    }
+
+    @Test
+    public void should_document_search_moderationrequests_with_exact_filters() throws Exception {
+        mockMvc.perform(get("/api/moderationrequest")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .queryParam("type", "RELEASE")
+                        .queryParam("documentName", "Release 1")
+                        .queryParam("requestingUser", "test.admin@sw360.org")
+                        .queryParam("requestingUserDepartment", "DEPT")
+                        .queryParam("moderationState", "INPROGRESS")
+                        .queryParam("requestDate", "2026-01-01")
+                        .queryParam("moderators", "admin@sw360.org")
+                        .queryParam("page", "0")
+                        .queryParam("page_entries", "5")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("type").description("The type of document for filtering moderation requests."),
+                                parameterWithName("documentName").description("The document name used for exact matching."),
+                                parameterWithName("requestingUser").description("The requesting user's email used for exact matching."),
+                                parameterWithName("requestingUserDepartment").description("The requesting user's department used for exact matching."),
+                                parameterWithName("moderationState").description("The moderation state used for exact matching."),
+                                parameterWithName("requestDate").description("Date when the request was created (YYYY-MM-DD)."),
+                                parameterWithName("moderators").description("Moderators list as comma separated values."),
+                                parameterWithName("page").description("Page of moderation requests"),
+                                parameterWithName("page_entries").description("Amount of requests per page")
+                        )
+                ));
+    }
+
+    @Test
+    public void should_document_search_moderationrequests_with_lucene() throws Exception {
+        mockMvc.perform(get("/api/moderationrequest")
+                        .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                        .queryParam("documentName", "Release")
+                        .queryParam("luceneSearch", "true")
+                        .queryParam("page", "0")
+                        .queryParam("page_entries", "5")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("documentName").description("The document name used as wildcard input for lucene search."),
+                                parameterWithName("luceneSearch").description("Set to `true` to use lucene-based search."),
+                                parameterWithName("page").description("Page of moderation requests"),
+                                parameterWithName("page_entries").description("Amount of requests per page")
+                        )
+                ));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Added search support for moderatiion requests based on key value pairs. It will be used in the Advanced Search component in frontend.

By default, only the moderation requests in which the user is a requesting user or a moderator are shown. If there are other moderators or requesting user in the search parameters then requests of all the users in the search parameters along with the requests of the current user are shown. 

### How To Test?
Try making api calls to the GET moderationrequests endpoint via curl/swagger with luceneSearch as true/false and various search parameters.
 
### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
