### PR TITLE
Feat/archival on thrift removal

### DIFF
--- a/backend/archival/pom.xml
+++ b/backend/archival/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.sw360</groupId>
+        <artifactId>backend</artifactId>
+        <version>20.1.0</version>
+    </parent>
+
+    <artifactId>backend-archival</artifactId>
+    <packaging>war</packaging>
+    <name>backend-archival</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>org.eclipse.sw360.archival.ArchivalApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <artifact.deploy.dir>${backend.deploy.dir}</artifact.deploy.dir>
+        <deploy.name>archival</deploy.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>service-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.sw360</groupId>
+            <artifactId>backend-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalApplication.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+@SpringBootApplication
+public class ArchivalApplication extends SpringBootServletInitializer {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ArchivalApplication.class, args);
+    }
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(ArchivalApplication.class);
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalConstants.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalConstants.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+public final class ArchivalConstants {
+
+    public static final String COUCH_DB_ARCHIVAL = "sw360archives";
+
+    public static final int MANIFEST_VERSION = 1;
+
+    private ArchivalConstants() {}
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.common.utils.UserUtils;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+import org.eclipse.sw360.datahandler.services.archival.ArchivePreview;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/archival")
+public class ArchivalController {
+
+    private final ArchivalHandler handler;
+
+    public ArchivalController(ArchivalHandler handler) {
+        this.handler = handler;
+    }
+
+    @PostMapping("/archive")
+    public ResponseEntity<StreamingResponseBody> archive(
+            @RequestBody ArchiveRequest req,
+            @RequestHeader("X-User-Email") String email,
+            @RequestHeader(value = "X-User-Department", required = false) String department,
+            @RequestHeader(value = "X-User-Group", required = false) String userGroup) {
+        User user = requireAdmin(email, department, userGroup);
+        String filename = "sw360_archive_" + Instant.now().toEpochMilli() + ".tar.gz";
+
+        StreamingResponseBody body = sink -> {
+            try {
+                handler.archive(req, user, sink);
+            } catch (SW360Exception e) {
+                throw new IOException("archive failed: " + e.getMessage(), e);
+            }
+        };
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.parseMediaType("application/gzip"))
+                .body(body);
+    }
+
+    @PostMapping("/preview")
+    public ResponseEntity<ArchivePreview> preview(
+            @RequestBody ArchiveRequest req,
+            @RequestHeader("X-User-Email") String email,
+            @RequestHeader(value = "X-User-Department", required = false) String department,
+            @RequestHeader(value = "X-User-Group", required = false) String userGroup) throws SW360Exception {
+        User user = requireAdmin(email, department, userGroup);
+        return ResponseEntity.ok(handler.preview(req, user));
+    }
+
+    /**
+     * Builds the acting user from the request's X-User-* headers and enforces that
+     * archival is admin-only, returning 403 rather than surfacing the deeper check
+     * as a 500. The provider re-checks as defence in depth.
+     */
+    private static User requireAdmin(String email, String department, String userGroup) {
+        User user = UserUtils.buildUser(email, department, userGroup);
+        if (!PermissionUtils.isAdmin(user)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "archival is restricted to SW360 administrators");
+        }
+        return user;
+    }
+
+    @GetMapping("/records")
+    public List<ArchivalRecord> listRecords() {
+        return handler.getAll();
+    }
+
+    @GetMapping("/records/{id}")
+    public ResponseEntity<ArchivalRecord> getRecord(@PathVariable String id) {
+        ArchivalRecord r = handler.get(id);
+        return r == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(r);
+    }
+
+    @DeleteMapping("/records/{id}")
+    public ResponseEntity<Void> deleteRecord(@PathVariable String id) {
+        return handler.delete(id) ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+                "status", "UP",
+                "service", "archival",
+                "timestamp", Instant.now().toString()
+        );
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalHandler.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalHandler.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.archival.bundle.ArchiveBuilder;
+import org.eclipse.sw360.archival.bundle.CollectedEntity;
+import org.eclipse.sw360.archival.bundle.EntityProvider;
+import org.eclipse.sw360.archival.bundle.Sw360EntityProvider;
+import org.eclipse.sw360.archival.db.ArchivalDatabaseHandler;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+import org.eclipse.sw360.datahandler.services.archival.ArchivePreview;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalStatus;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveManifest;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveRequest;
+import org.eclipse.sw360.datahandler.services.archival.ManifestEntry;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class ArchivalHandler {
+
+    private static final Logger log = LogManager.getLogger(ArchivalHandler.class);
+
+    private static final String SW360_VERSION = "20.0.0-beta";
+
+    /**
+     * Exceptions coming out of the SW360 database handlers frequently carry a null
+     * message, which makes bare getMessage() useless in an error report. Fall back
+     * to the exception type so failures stay diagnosable.
+     */
+    private static String describe(Throwable e) {
+        String message = e.getMessage();
+        return CommonUtils.isNullEmptyOrWhitespace(message) ? e.getClass().getName() : message;
+    }
+
+    private final ArchivalDatabaseHandler db;
+
+    public ArchivalHandler() throws IOException {
+        this.db = new ArchivalDatabaseHandler(
+                DatabaseSettings.getConfiguredClient(),
+                ArchivalConstants.COUCH_DB_ARCHIVAL);
+    }
+
+    ArchivalHandler(ArchivalDatabaseHandler db) {
+        this.db = db;
+    }
+
+    public ArchiveResult archive(ArchiveRequest req, User user, OutputStream sink)
+            throws SW360Exception, IOException {
+        return archive(req, user, sink,
+                new Sw360EntityProvider(req.isIncludeAttachments(), req.isIncludeChangelogs(), user));
+    }
+
+    public ArchiveResult archive(ArchiveRequest req,
+                                 User user,
+                                 OutputStream sink,
+                                 EntityProvider provider) throws SW360Exception, IOException {
+        if (req.getEntityIds() == null || req.getEntityIds().isEmpty()) {
+            throw new SW360Exception("archive request has no entity IDs");
+        }
+
+        String userEmail = user.getEmail();
+        return switch (req.getEntityType()) {
+            case PROJECT -> archiveProjects(req, userEmail, sink, provider);
+            case COMPONENT -> archiveComponents(req, userEmail, sink, provider);
+            case PACKAGE -> archivePackages(req, userEmail, sink, provider);
+            case RELEASE -> archiveSimple(req, userEmail, sink, provider);
+        };
+    }
+
+    /**
+     * Dry run: returns what an archive would do (which dependencies get archived,
+     * kept alive, or block the operation) without touching the database.
+     */
+    public ArchivePreview preview(ArchiveRequest req, User user) throws SW360Exception {
+        if (req.getEntityIds() == null || req.getEntityIds().isEmpty()) {
+            throw new SW360Exception("preview request has no entity IDs");
+        }
+        Sw360EntityProvider provider =
+                new Sw360EntityProvider(req.isIncludeAttachments(), req.isIncludeChangelogs(), user);
+
+        List<ArchivePreview.Entry> entries = new ArrayList<>();
+        for (String entityId : req.getEntityIds()) {
+            try {
+                entries.addAll(provider.preview(req.getEntityType(), entityId));
+            } catch (Exception e) {
+                log.error("preview failed for {} {}", req.getEntityType(), entityId, e);
+                throw new SW360Exception("preview failed for " + entityId + ": " + describe(e));
+            }
+        }
+
+        ArchivePreview preview = new ArchivePreview();
+        preview.setEntries(entries);
+        preview.setArchiveCount((int) entries.stream()
+                .filter(e -> e.getAction() == ArchivePreview.Action.ARCHIVE).count());
+        preview.setKeepAliveCount((int) entries.stream()
+                .filter(e -> e.getAction() == ArchivePreview.Action.KEEP_ALIVE).count());
+        preview.setBlockedCount((int) entries.stream()
+                .filter(e -> e.getAction() == ArchivePreview.Action.BLOCKED).count());
+        return preview;
+    }
+
+    /**
+     * Flat flow: one entity in -> one ArchivalRecord and one CollectedEntity out.
+     * Used for RELEASE and any future leaf types that don't cascade.
+     */
+    private ArchiveResult archiveSimple(ArchiveRequest req,
+                                        String userEmail,
+                                        OutputStream sink,
+                                        EntityProvider provider) throws SW360Exception, IOException {
+        String bundleId = "bundle-" + UUID.randomUUID();
+        Instant now = Instant.now();
+
+        List<ArchivalRecord> records = new ArrayList<>(req.getEntityIds().size());
+        for (String entityId : req.getEntityIds()) {
+            records.add(db.add(newRecord(bundleId, entityId, req.getEntityType(),
+                    ArchivalStatus.IN_PROGRESS, userEmail, now, req.getComment())));
+        }
+
+        List<CollectedEntity> collected = new ArrayList<>(records.size());
+        for (ArchivalRecord r : records) {
+            try {
+                collected.add(provider.collect(r.getEntityType(), r.getEntityId()));
+            } catch (Exception e) {
+                markFailed(r, "collection failed: " + describe(e));
+                throw new SW360Exception("entity collection failed for " + r.getEntityId() + ": " + describe(e));
+            }
+        }
+
+        ArchiveManifest manifest = bundle(bundleId, userEmail, req.getComment(), collected, sink, records);
+        flipStatuses(records, manifest, ArchivalStatus.ARCHIVED);
+        return new ArchiveResult(bundleId, manifest, records);
+    }
+
+    /**
+     * Project flow: each Project produces one Project record + N Release records,
+     * one per linked Release. Releases that are still referenced by another live
+     * Project are bundled with full data but flagged keepAlive — their registry
+     * row goes to KEPT_ALIVE and they are not removed from the live database.
+     * The Project itself is deleted via SW360's existing deleteProject pipeline.
+     */
+    private ArchiveResult archiveProjects(ArchiveRequest req,
+                                          String userEmail,
+                                          OutputStream sink,
+                                          EntityProvider provider) throws SW360Exception, IOException {
+        if (!(provider instanceof Sw360EntityProvider sw360Provider)) {
+            throw new SW360Exception("Project archive requires the live Sw360EntityProvider");
+        }
+
+        String bundleId = "bundle-" + UUID.randomUUID();
+        Instant now = Instant.now();
+
+        List<ArchivalRecord> records = new ArrayList<>();
+        List<CollectedEntity> collected = new ArrayList<>();
+        Map<String, ArchivalRecord> recordByEntityId = new HashMap<>();
+
+        for (String projectId : req.getEntityIds()) {
+            List<CollectedEntity> projectBundle;
+            try {
+                projectBundle = sw360Provider.collectProjectBundle(projectId);
+            } catch (Exception e) {
+                log.error("Project collection failed for {}", projectId, e);
+                throw new SW360Exception("Project collection failed for " + projectId + ": " + describe(e));
+            }
+
+            for (CollectedEntity ce : projectBundle) {
+                ArchivalRecord r = newRecord(bundleId, ce.entityId(), ce.entityType(),
+                        ArchivalStatus.IN_PROGRESS, userEmail, now, req.getComment());
+                r.setEntityName(ce.entityName());
+                ArchivalRecord saved = db.add(r);
+                records.add(saved);
+                recordByEntityId.put(ce.entityId(), saved);
+                collected.add(ce);
+            }
+        }
+
+        ArchiveManifest manifest = bundle(bundleId, userEmail, req.getComment(), collected, sink, records);
+
+        Map<String, ManifestEntry> manifestById = new HashMap<>();
+        for (ManifestEntry e : manifest.getEntries()) manifestById.put(e.getEntityId(), e);
+
+        for (ArchivalRecord r : records) {
+            ManifestEntry m = manifestById.get(r.getEntityId());
+            if (m != null) {
+                r.setAttachmentCount(m.getAttachmentCount());
+                r.setStatus(m.isKeepAlive() ? ArchivalStatus.KEPT_ALIVE : ArchivalStatus.ARCHIVED);
+            } else {
+                r.setStatus(ArchivalStatus.ARCHIVED);
+            }
+            if (!db.update(r)) {
+                log.warn("registry row {} could not be updated to {}", r.getId(), r.getStatus());
+            }
+        }
+
+        for (String projectId : req.getEntityIds()) {
+            ArchivalRecord projectRow = recordByEntityId.get(projectId);
+            try {
+                RequestStatus status = sw360Provider.deleteProject(projectId);
+                if (status != RequestStatus.SUCCESS) {
+                    markFailed(projectRow, "deleteProject returned " + status);
+                }
+            } catch (Exception e) {
+                markFailed(projectRow, "deleteProject failed: " + describe(e));
+            }
+        }
+
+        return new ArchiveResult(bundleId, manifest, records);
+    }
+
+    /**
+     * Component flow: each Component produces one Component record + N Release records.
+     * Releases still referenced by a live Project are flagged keepAlive/KEPT_ALIVE and
+     * unlinked from the Component before it is deleted, so they survive on their own.
+     * Non-shared Releases are deleted alongside the Component.
+     */
+    private ArchiveResult archiveComponents(ArchiveRequest req,
+                                            String userEmail,
+                                            OutputStream sink,
+                                            EntityProvider provider) throws SW360Exception, IOException {
+        if (!(provider instanceof Sw360EntityProvider sw360Provider)) {
+            throw new SW360Exception("Component archive requires the live Sw360EntityProvider");
+        }
+
+        String bundleId = "bundle-" + UUID.randomUUID();
+        Instant now = Instant.now();
+
+        List<ArchivalRecord> records = new ArrayList<>();
+        List<CollectedEntity> collected = new ArrayList<>();
+        Map<String, ArchivalRecord> recordByEntityId = new HashMap<>();
+        Map<String, java.util.Set<String>> sharedReleasesByComponent = new HashMap<>();
+
+        for (String componentId : req.getEntityIds()) {
+            List<CollectedEntity> componentBundle;
+            try {
+                componentBundle = sw360Provider.collectComponentBundle(componentId);
+            } catch (Exception e) {
+                throw new SW360Exception("Component collection failed for " + componentId + ": " + describe(e));
+            }
+
+            java.util.Set<String> shared = new java.util.HashSet<>();
+            for (CollectedEntity ce : componentBundle) {
+                if (ce.entityType() == ArchivalEntityType.RELEASE && ce.keepAlive()) {
+                    shared.add(ce.entityId());
+                }
+                ArchivalRecord r = newRecord(bundleId, ce.entityId(), ce.entityType(),
+                        ArchivalStatus.IN_PROGRESS, userEmail, now, req.getComment());
+                r.setEntityName(ce.entityName());
+                ArchivalRecord saved = db.add(r);
+                records.add(saved);
+                recordByEntityId.put(ce.entityId(), saved);
+                collected.add(ce);
+            }
+            sharedReleasesByComponent.put(componentId, shared);
+        }
+
+        ArchiveManifest manifest = bundle(bundleId, userEmail, req.getComment(), collected, sink, records);
+
+        Map<String, ManifestEntry> manifestById = new HashMap<>();
+        for (ManifestEntry e : manifest.getEntries()) manifestById.put(e.getEntityId(), e);
+
+        for (ArchivalRecord r : records) {
+            ManifestEntry m = manifestById.get(r.getEntityId());
+            if (m != null) {
+                r.setAttachmentCount(m.getAttachmentCount());
+                r.setStatus(m.isKeepAlive() ? ArchivalStatus.KEPT_ALIVE : ArchivalStatus.ARCHIVED);
+            } else {
+                r.setStatus(ArchivalStatus.ARCHIVED);
+            }
+            if (!db.update(r)) {
+                log.warn("registry row {} could not be updated to {}", r.getId(), r.getStatus());
+            }
+        }
+
+        for (String componentId : req.getEntityIds()) {
+            ArchivalRecord componentRow = recordByEntityId.get(componentId);
+            try {
+                RequestStatus status = sw360Provider.deleteComponentRespectingSharedReleases(
+                        componentId, sharedReleasesByComponent.get(componentId));
+                if (status != RequestStatus.SUCCESS) {
+                    markFailed(componentRow, "deleteComponent returned " + status);
+                }
+            } catch (Exception e) {
+                markFailed(componentRow, "deleteComponent failed: " + describe(e));
+            }
+        }
+
+        return new ArchiveResult(bundleId, manifest, records);
+    }
+
+    /**
+     * Package flow: refuse if the parent Release is still live. Otherwise delete
+     * via SW360's existing deletePackage.
+     */
+    private ArchiveResult archivePackages(ArchiveRequest req,
+                                          String userEmail,
+                                          OutputStream sink,
+                                          EntityProvider provider) throws SW360Exception, IOException {
+        if (!(provider instanceof Sw360EntityProvider sw360Provider)) {
+            throw new SW360Exception("Package archive requires the live Sw360EntityProvider");
+        }
+
+        String bundleId = "bundle-" + UUID.randomUUID();
+        Instant now = Instant.now();
+
+        List<ArchivalRecord> records = new ArrayList<>(req.getEntityIds().size());
+        List<CollectedEntity> collected = new ArrayList<>();
+        Map<String, ArchivalRecord> recordByEntityId = new HashMap<>();
+
+        for (String packageId : req.getEntityIds()) {
+            ArchivalRecord r = newRecord(bundleId, packageId, ArchivalEntityType.PACKAGE,
+                    ArchivalStatus.IN_PROGRESS, userEmail, now, req.getComment());
+            ArchivalRecord saved = db.add(r);
+            records.add(saved);
+            recordByEntityId.put(packageId, saved);
+
+            try {
+                if (sw360Provider.packageHasLiveParentRelease(packageId)) {
+                    markFailed(saved, "parent Release is still live; archive the Release first");
+                    continue;
+                }
+                collected.add(sw360Provider.collect(ArchivalEntityType.PACKAGE, packageId));
+            } catch (Exception e) {
+                markFailed(saved, "collection failed: " + describe(e));
+            }
+        }
+
+        ArchiveManifest manifest = bundle(bundleId, userEmail, req.getComment(), collected, sink, records);
+
+        java.util.Set<String> bundledIds = new java.util.HashSet<>();
+        for (ManifestEntry m : manifest.getEntries()) {
+            bundledIds.add(m.getEntityId());
+            ArchivalRecord r = recordByEntityId.get(m.getEntityId());
+            if (r != null) {
+                r.setAttachmentCount(m.getAttachmentCount());
+                r.setStatus(ArchivalStatus.ARCHIVED);
+                if (!db.update(r)) {
+                log.warn("registry row {} could not be updated to {}", r.getId(), r.getStatus());
+            }
+            }
+        }
+
+        for (String packageId : req.getEntityIds()) {
+            if (!bundledIds.contains(packageId)) continue;
+            ArchivalRecord row = recordByEntityId.get(packageId);
+            try {
+                RequestStatus status = sw360Provider.deletePackage(packageId);
+                if (status != RequestStatus.SUCCESS) {
+                    markFailed(row, "deletePackage returned " + status);
+                }
+            } catch (Exception e) {
+                markFailed(row, "deletePackage failed: " + describe(e));
+            }
+        }
+
+        return new ArchiveResult(bundleId, manifest, records);
+    }
+
+    private ArchiveManifest bundle(String bundleId,
+                                   String userEmail,
+                                   String comment,
+                                   List<CollectedEntity> collected,
+                                   OutputStream sink,
+                                   List<ArchivalRecord> records) throws IOException {
+        try {
+            ArchiveBuilder builder = new ArchiveBuilder(bundleId, userEmail, SW360_VERSION, comment);
+            return builder.writeTo(sink, collected);
+        } catch (IOException e) {
+            for (ArchivalRecord r : records) markFailed(r, "bundling failed: " + describe(e));
+            throw e;
+        }
+    }
+
+    private void flipStatuses(List<ArchivalRecord> records,
+                              ArchiveManifest manifest,
+                              ArchivalStatus successStatus) {
+        Map<String, ManifestEntry> byId = new HashMap<>();
+        for (ManifestEntry e : manifest.getEntries()) byId.put(e.getEntityId(), e);
+
+        for (ArchivalRecord r : records) {
+            ManifestEntry e = byId.get(r.getEntityId());
+            if (e != null) r.setAttachmentCount(e.getAttachmentCount());
+            r.setStatus(successStatus);
+            if (!db.update(r)) {
+                log.warn("registry row {} could not be updated to {}", r.getId(), r.getStatus());
+            }
+        }
+    }
+
+    private static ArchivalRecord newRecord(String bundleId,
+                                            String entityId,
+                                            ArchivalEntityType type,
+                                            ArchivalStatus status,
+                                            String userEmail,
+                                            Instant now,
+                                            String comment) {
+        ArchivalRecord r = new ArchivalRecord();
+        r.setId(UUID.randomUUID().toString());
+        r.setBundleId(bundleId);
+        r.setEntityId(entityId);
+        r.setEntityType(type);
+        r.setStatus(status);
+        r.setArchivedBy(userEmail);
+        r.setArchivedAt(now);
+        r.setComment(comment);
+        return r;
+    }
+
+    public ArchivalRecord get(String id) {
+        return db.get(id);
+    }
+
+    public List<ArchivalRecord> getAll() {
+        return db.getAll();
+    }
+
+    public boolean delete(String id) {
+        return db.delete(id);
+    }
+
+    private void markFailed(ArchivalRecord r, String reason) {
+        r.setStatus(ArchivalStatus.FAILED);
+        r.setComment((r.getComment() == null ? "" : r.getComment() + " | ") + reason);
+        try {
+            if (!db.update(r)) {
+                log.warn("registry row {} could not be updated to {}", r.getId(), r.getStatus());
+            }
+        } catch (Exception ignore) {
+            // If updating the registry fails, preserve and propagate the original error.
+        }
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchiveResult.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchiveResult.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveManifest;
+
+import java.util.List;
+
+/** What ArchivalHandler.archive returns alongside the streamed TAR. */
+public record ArchiveResult(String bundleId,
+                            ArchiveManifest manifest,
+                            List<ArchivalRecord> records) {}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/WebConfig.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/WebConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+/**
+ * Cross-origin configuration for the archival API.
+ *
+ * <p>This is not authentication. The service currently trusts the caller and
+ * takes the acting user from the X-User-Email header. CORS only decides which
+ * browser origins the browser itself will let call the API cross-origin, which
+ * matters when the frontend is served from a different host/port than archival
+ * (e.g. localhost:3000 calling a standalone service on :8081).
+ *
+ * <p>In a same-origin deployment no origins need to be configured, so this adds
+ * no CORS mapping and the property defaults to empty. Set
+ * {@code sw360.archival.cors.allowed-origins} for standalone/dev setups.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${sw360.archival.cors.allowed-origins:}")
+    private List<String> allowedOrigins = List.of();
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        List<String> origins = allowedOrigins == null
+                ? List.of()
+                : allowedOrigins.stream().map(String::trim).filter(o -> !o.isEmpty()).toList();
+        if (origins.isEmpty()) {
+            return;
+        }
+        registry.addMapping("/api/**")
+                .allowedOrigins(origins.toArray(String[]::new))
+                .allowedMethods("GET", "POST", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "Accept",
+                        "X-User-Email", "X-User-Department", "X-User-Group")
+                .exposedHeaders("Content-Disposition")
+                .maxAge(3600);
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ArchiveBuilder.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ArchiveBuilder.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.eclipse.sw360.archival.ArchivalConstants;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveManifest;
+import org.eclipse.sw360.datahandler.services.archival.ManifestEntry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Builds the TAR.GZ archive for a set of CollectedEntity instances.
+ */
+public final class ArchiveBuilder {
+
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    private static final int COPY_BUFFER = 64 * 1024;
+
+    private final String bundleId;
+    private final String createdBy;
+    private final String sw360Version;
+    private final String comment;
+
+    public ArchiveBuilder(String bundleId, String createdBy, String sw360Version, String comment) {
+        this.bundleId = bundleId;
+        this.createdBy = createdBy;
+        this.sw360Version = sw360Version;
+        this.comment = comment;
+    }
+
+    public ArchiveManifest writeTo(OutputStream rawOut, List<CollectedEntity> entities) throws IOException {
+        List<ManifestEntry> manifestEntries = new ArrayList<>(entities.size());
+
+        try (GzipCompressorOutputStream gz = new GzipCompressorOutputStream(rawOut);
+             TarArchiveOutputStream tar = new TarArchiveOutputStream(gz)) {
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+
+            for (CollectedEntity entity : entities) {
+                manifestEntries.add(writeEntity(tar, entity));
+            }
+
+            ArchiveManifest manifest = buildManifest(manifestEntries);
+            writeBinaryEntry(tar, "manifest.json", JSON.writeValueAsBytes(manifest));
+
+            tar.finish();
+            return manifest;
+        }
+    }
+
+    private ManifestEntry writeEntity(TarArchiveOutputStream tar, CollectedEntity entity) throws IOException {
+        String folder = folderFor(entity.entityType()) + "/" + entity.entityId() + "/";
+        MessageDigest entityHash = newSha256();
+        long totalAttachmentBytes = 0;
+
+        // documents (project.json, changelogs.json, ...)
+        for (var doc : entity.documents().entrySet()) {
+            byte[] body = doc.getValue();
+            writeBinaryEntry(tar, folder + doc.getKey(), body);
+            entityHash.update(body);
+        }
+
+        // attachments
+        if (entity.attachments() != null) {
+            for (AttachmentSource att : entity.attachments()) {
+                String attId = att.metadata().getAttachmentId();
+                String binPath = folder + "attachments/" + attId + ".bin";
+                String metaPath = folder + "attachments/" + attId + ".meta.json";
+
+                long bytesWritten = streamAttachment(tar, binPath, att, entityHash);
+                totalAttachmentBytes += bytesWritten;
+
+                byte[] metaBytes = JSON.writeValueAsBytes(att.metadata());
+                writeBinaryEntry(tar, metaPath, metaBytes);
+                entityHash.update(metaBytes);
+            }
+        }
+
+        ManifestEntry entry = new ManifestEntry();
+        entry.setEntityId(entity.entityId());
+        entry.setEntityName(entity.entityName());
+        entry.setEntityType(entity.entityType());
+        entry.setEntityVersion(entity.entityVersion());
+        entry.setPath(folder);
+        entry.setAttachmentCount(entity.attachments() == null ? 0 : entity.attachments().size());
+        entry.setAttachmentTotalBytes(totalAttachmentBytes);
+        entry.setChecksum("sha256:" + HexFormat.of().formatHex(entityHash.digest()));
+        entry.setKeepAlive(entity.keepAlive());
+        return entry;
+    }
+
+    private long streamAttachment(TarArchiveOutputStream tar,
+                                  String path,
+                                  AttachmentSource source,
+                                  MessageDigest entityHash) throws IOException {
+        TarArchiveEntry tarEntry = new TarArchiveEntry(path);
+        tarEntry.setSize(source.sizeBytes());
+        tarEntry.setModTime(System.currentTimeMillis());
+        tar.putArchiveEntry(tarEntry);
+
+        long copied = 0;
+        byte[] buf = new byte[COPY_BUFFER];
+        try (InputStream in = source.open()) {
+            int n;
+            while ((n = in.read(buf)) > 0) {
+                tar.write(buf, 0, n);
+                entityHash.update(buf, 0, n);
+                copied += n;
+            }
+        }
+        tar.closeArchiveEntry();
+
+        if (copied != source.sizeBytes()) {
+            throw new IOException("Attachment " + source.metadata().getAttachmentId()
+                    + " size mismatch: declared " + source.sizeBytes() + " but streamed " + copied);
+        }
+        return copied;
+    }
+
+    private void writeBinaryEntry(TarArchiveOutputStream tar, String path, byte[] body) throws IOException {
+        TarArchiveEntry tarEntry = new TarArchiveEntry(path);
+        tarEntry.setSize(body.length);
+        tarEntry.setModTime(System.currentTimeMillis());
+        tar.putArchiveEntry(tarEntry);
+        tar.write(body);
+        tar.closeArchiveEntry();
+    }
+
+    private ArchiveManifest buildManifest(List<ManifestEntry> entries) {
+        ArchiveManifest m = new ArchiveManifest();
+        m.setBundleId(bundleId);
+        m.setCreatedAt(Instant.now());
+        m.setCreatedBy(createdBy);
+        m.setSw360Version(sw360Version);
+        m.setManifestVersion(ArchivalConstants.MANIFEST_VERSION);
+        m.setComment(comment);
+        m.setEntries(entries);
+        return m;
+    }
+
+    private static String folderFor(ArchivalEntityType t) {
+        return switch (t) {
+            case PROJECT -> "projects";
+            case COMPONENT -> "components";
+            case RELEASE -> "releases";
+            case PACKAGE -> "packages";
+        };
+    }
+
+    private static MessageDigest newSha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/AttachmentSource.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/AttachmentSource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/** Streamed handle to one attachment binary
+ *  open() is called when the bundler is ready to copy bytes.
+*/
+
+public interface AttachmentSource {
+
+    AttachmentMetadata metadata();
+
+    long sizeBytes();
+
+    InputStream open() throws IOException;
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ByteArrayAttachmentSource.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ByteArrayAttachmentSource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * AttachmentSource backed by an in-memory byte array.
+ * Suitable for tests and small files; use a streaming source for CouchDB attachments.
+ */
+public final class ByteArrayAttachmentSource implements AttachmentSource {
+
+    private final AttachmentMetadata metadata;
+    private final byte[] body;
+
+    public ByteArrayAttachmentSource(AttachmentMetadata metadata, byte[] body) {
+        this.metadata = metadata;
+        this.body = body;
+        if (metadata.getSizeBytes() != body.length) {
+            metadata.setSizeBytes(body.length);
+        }
+    }
+
+    @Override
+    public AttachmentMetadata metadata() { return metadata; }
+
+    @Override
+    public long sizeBytes() { return body.length; }
+
+    @Override
+    public InputStream open() { return new ByteArrayInputStream(body); }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/CollectedEntity.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/CollectedEntity.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Everything we need to bundle one entity into the TAR.
+ * documents: filename -> serialised JSON bytes (e.g. project.json, changelogs.json).
+ * attachments: lazy handles streamed in directly without loading into memory.
+ */
+public final class CollectedEntity {
+
+    private final String entityId;
+    private final String entityName;
+    private final String entityVersion;
+    private final ArchivalEntityType entityType;
+    private final Map<String, byte[]> documents;
+    private final List<AttachmentSource> attachments;
+    private final boolean keepAlive;
+
+    public CollectedEntity(String entityId,
+                           String entityName,
+                           String entityVersion,
+                           ArchivalEntityType entityType,
+                           Map<String, byte[]> documents,
+                           List<AttachmentSource> attachments) {
+        this(entityId, entityName, entityVersion, entityType, documents, attachments, false);
+    }
+
+    public CollectedEntity(String entityId,
+                           String entityName,
+                           String entityVersion,
+                           ArchivalEntityType entityType,
+                           Map<String, byte[]> documents,
+                           List<AttachmentSource> attachments,
+                           boolean keepAlive) {
+        this.entityId = entityId;
+        this.entityName = entityName;
+        this.entityVersion = entityVersion;
+        this.entityType = entityType;
+        this.documents = documents;
+        this.attachments = attachments;
+        this.keepAlive = keepAlive;
+    }
+
+    public String entityId() { return entityId; }
+    public String entityName() { return entityName; }
+    public String entityVersion() { return entityVersion; }
+    public ArchivalEntityType entityType() { return entityType; }
+    public Map<String, byte[]> documents() { return documents; }
+    public List<AttachmentSource> attachments() { return attachments; }
+    public boolean keepAlive() { return keepAlive; }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/EntityProvider.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/EntityProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+
+/**
+ * Retrieves an entity and its associated data from the live SW360 databases.
+ * Implementations use the existing Project, Component, Release, and Package
+ * database handlers. Keeping this behind an interface allows the archive
+ * workflow to be tested without requiring a running CouchDB instance.
+ */
+public interface EntityProvider {
+
+    boolean includeAttachments();
+
+    boolean includeChangelogs();
+
+    CollectedEntity collect(ArchivalEntityType type, String entityId) throws Exception;
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/InMemoryEntityProvider.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/InMemoryEntityProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test implementation that stores CollectedEntity instances in memory.
+ * Allows tests to prepopulate entities by ID without any SW360 or CouchDB dependencies.
+ */
+public final class InMemoryEntityProvider implements EntityProvider {
+
+    private final Map<String, CollectedEntity> byId = new HashMap<>();
+
+    public InMemoryEntityProvider register(CollectedEntity e) {
+        byId.put(key(e.entityType(), e.entityId()), e);
+        return this;
+    }
+
+    @Override
+    public boolean includeAttachments() { return true; }
+
+    @Override
+    public boolean includeChangelogs() { return true; }
+
+    @Override
+    public CollectedEntity collect(ArchivalEntityType type, String entityId) {
+        CollectedEntity hit = byId.get(key(type, entityId));
+        if (hit == null) {
+            throw new IllegalArgumentException("No entity registered for " + type + "/" + entityId);
+        }
+        return hit;
+    }
+
+    private static String key(ArchivalEntityType type, String id) {
+        return type.name() + ":" + id;
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/Sw360AttachmentSource.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/Sw360AttachmentSource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class Sw360AttachmentSource implements AttachmentSource {
+
+    private final AttachmentConnector connector;
+    private final AttachmentContent content;
+    private final AttachmentMetadata metadata;
+    private final long sizeBytes;
+
+    public Sw360AttachmentSource(AttachmentConnector connector,
+                                 AttachmentContent content,
+                                 AttachmentMetadata metadata,
+                                 long sizeBytes) {
+        this.connector = connector;
+        this.content = content;
+        this.metadata = metadata;
+        this.sizeBytes = sizeBytes;
+    }
+
+    @Override
+    public AttachmentMetadata metadata() { return metadata; }
+
+    @Override
+    public long sizeBytes() { return sizeBytes; }
+
+    @Override
+    public InputStream open() throws IOException {
+        try {
+            return connector.unsafeGetAttachmentStream(content);
+        } catch (SW360Exception e) {
+            throw new IOException("failed to open attachment stream for "
+                    + content.getId() + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/Sw360EntityProvider.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/Sw360EntityProvider.java
@@ -1,0 +1,510 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.Duration;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
+import org.eclipse.sw360.datahandler.db.PackageDatabaseHandler;
+import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.packages.Package;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.ArchivePreview;
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Production EntityProvider that reads from the live SW360 databases.
+ * Wired for RELEASE; PROJECT / COMPONENT / PACKAGE remain stubs for now.
+ *
+ * Planned wiring:
+ *   PROJECT   -> ProjectDatabaseHandler.getProjectByIdIgnoringVisibility(id)
+ *                + ChangeLogsDatabaseHandler.getChangeLogsByDocumentId(id)
+ *                + ProjectObligationRepository, AttachmentUsageRepository
+ *   COMPONENT -> ComponentDatabaseHandler.getComponent(id, user) (+ all linked Releases)
+ *   PACKAGE   -> PackageDatabaseHandler.getPackageById(id)
+ */
+public class Sw360EntityProvider implements EntityProvider {
+
+    private static final Duration ATTACHMENT_DOWNLOAD_TIMEOUT =
+            Duration.durationOf(5, TimeUnit.MINUTES);
+
+    private final boolean includeAttachments;
+    private final boolean includeChangelogs;
+    private final User user;
+
+    private ComponentDatabaseHandler componentHandler;
+    private ProjectDatabaseHandler projectHandler;
+    private PackageDatabaseHandler packageHandler;
+    private AttachmentConnector attachmentConnector;
+
+    public Sw360EntityProvider(boolean includeAttachments, boolean includeChangelogs, User user) {
+        this.includeAttachments = includeAttachments;
+        this.includeChangelogs = includeChangelogs;
+        this.user = user;
+    }
+
+    @Override
+    public boolean includeAttachments() { return includeAttachments; }
+
+    @Override
+    public boolean includeChangelogs() { return includeChangelogs; }
+
+    @Override
+    public CollectedEntity collect(ArchivalEntityType type, String entityId) throws Exception {
+        return switch (type) {
+            case RELEASE -> collectRelease(entityId, false);
+            case PROJECT -> collectProject(entityId);
+            case COMPONENT -> collectComponentOnly(entityId);
+            case PACKAGE -> collectPackage(entityId);
+        };
+    }
+
+    /**
+     * Returns the full bundle for a Project archive: the Project document itself,
+     * followed by one CollectedEntity per linked Release. Each Release is flagged
+     * keepAlive=true when other live Projects still reference it.
+     */
+    public List<CollectedEntity> collectProjectBundle(String projectId) throws Exception {
+        Project project = projectHandler().getProjectByIdIgnoringVisibility(projectId);
+        if (project == null) {
+            throw new SW360Exception("Project " + projectId + " not found");
+        }
+
+        List<CollectedEntity> bundle = new ArrayList<>();
+        bundle.add(collectedFromProject(project));
+
+        if (project.getReleaseIdToUsage() != null) {
+            for (String releaseId : project.getReleaseIdToUsage().keySet()) {
+                bundle.add(collectRelease(releaseId, isReleaseSharedWithOtherProjects(releaseId, projectId)));
+            }
+        }
+        return bundle;
+    }
+
+    private CollectedEntity collectProject(String projectId) throws Exception {
+        Project project = projectHandler().getProjectByIdIgnoringVisibility(projectId);
+        if (project == null) {
+            throw new SW360Exception("Project " + projectId + " not found");
+        }
+        return collectedFromProject(project);
+    }
+
+    private CollectedEntity collectedFromProject(Project project) throws IOException, SW360Exception {
+        Map<String, byte[]> documents = new LinkedHashMap<>();
+        documents.put("project.json", ThriftJson.toJsonBytes(project));
+
+        List<AttachmentSource> attachments = new ArrayList<>();
+        if (includeAttachments && project.getAttachments() != null) {
+            for (Attachment att : project.getAttachments()) {
+                AttachmentSource source = buildAttachmentSource(att);
+                if (source != null) attachments.add(source);
+            }
+        }
+
+        return new CollectedEntity(
+                project.getId(),
+                project.getName(),
+                project.getVersion(),
+                ArchivalEntityType.PROJECT,
+                documents,
+                attachments,
+                false);
+    }
+
+    private CollectedEntity collectRelease(String releaseId, boolean keepAlive) throws Exception {
+        User user = resolveUser();
+        Release release = componentHandler().getRelease(releaseId, user);
+        if (release == null) {
+            throw new SW360Exception("Release " + releaseId + " not found");
+        }
+
+        Map<String, byte[]> documents = new LinkedHashMap<>();
+        documents.put("release.json", ThriftJson.toJsonBytes(release));
+
+        List<AttachmentSource> attachments = new ArrayList<>();
+        if (includeAttachments && release.getAttachments() != null) {
+            for (Attachment att : release.getAttachments()) {
+                AttachmentSource source = buildAttachmentSource(att);
+                if (source != null) attachments.add(source);
+            }
+        }
+
+        return new CollectedEntity(
+                release.getId(),
+                release.getName(),
+                release.getVersion(),
+                ArchivalEntityType.RELEASE,
+                documents,
+                attachments,
+                keepAlive);
+    }
+
+    /**
+     * True if this release is referenced by any Project other than the one being archived.
+     * Backed by ProjectRepository's existing searchByReleaseId view.
+     */
+    private boolean isReleaseSharedWithOtherProjects(String releaseId, String archivedProjectId) throws Exception {
+        User user = resolveUser();
+        return projectHandler().searchByReleaseId(releaseId, user).stream()
+                .anyMatch(p -> p.getId() != null && !p.getId().equals(archivedProjectId));
+    }
+
+    /**
+     * Removes the Project from the live database using SW360's existing
+     * deleteProject pipeline. Linked Releases are deliberately untouched —
+     * SW360's Project delete does not cascade to Releases.
+     */
+    public RequestStatus deleteProject(String projectId) throws Exception {
+        return projectHandler().deleteProject(projectId, resolveUser(), true);
+    }
+
+    // ---------------- PREVIEW ----------------
+
+    /**
+     * Computes what an archive would do without bundling or deleting anything.
+     * Reads entity/release names and runs the same share checks used by the real
+     * flow, so the admin can see shared and blocked dependencies up front.
+     */
+    public List<ArchivePreview.Entry> preview(ArchivalEntityType type, String entityId) throws Exception {
+        return switch (type) {
+            case PROJECT -> previewProject(entityId);
+            case COMPONENT -> previewComponent(entityId);
+            case RELEASE -> previewRelease(entityId);
+            case PACKAGE -> previewPackage(entityId);
+        };
+    }
+
+    private List<ArchivePreview.Entry> previewProject(String projectId) throws Exception {
+        Project project = projectHandler().getProjectByIdIgnoringVisibility(projectId);
+        if (project == null) throw new SW360Exception("Project " + projectId + " not found");
+
+        List<ArchivePreview.Entry> out = new ArrayList<>();
+        out.add(entry(project.getId(), project.getName(), ArchivalEntityType.PROJECT,
+                ArchivePreview.Action.ARCHIVE, "Project will be archived and removed"));
+
+        if (project.getReleaseIdToUsage() != null) {
+            for (String releaseId : project.getReleaseIdToUsage().keySet()) {
+                out.add(previewRelease(releaseId, isReleaseSharedWithOtherProjects(releaseId, projectId)));
+            }
+        }
+        return out;
+    }
+
+    private List<ArchivePreview.Entry> previewComponent(String componentId) throws Exception {
+        User user = resolveUser();
+        Component component = componentHandler().getComponent(componentId, user);
+        if (component == null) throw new SW360Exception("Component " + componentId + " not found");
+
+        List<ArchivePreview.Entry> out = new ArrayList<>();
+        out.add(entry(component.getId(), component.getName(), ArchivalEntityType.COMPONENT,
+                ArchivePreview.Action.ARCHIVE, "Component will be archived and removed"));
+
+        if (component.getReleaseIds() != null) {
+            for (String releaseId : component.getReleaseIds()) {
+                out.add(previewRelease(releaseId, isReleaseSharedWithLiveProjects(releaseId)));
+            }
+        }
+        return out;
+    }
+
+    private List<ArchivePreview.Entry> previewRelease(String releaseId) throws Exception {
+        return List.of(previewRelease(releaseId, isReleaseSharedWithLiveProjects(releaseId)));
+    }
+
+    private ArchivePreview.Entry previewRelease(String releaseId, boolean shared) throws Exception {
+        Release release = componentHandler().getRelease(releaseId, resolveUser());
+        String name = release != null ? release.getName() + " " + nullToEmpty(release.getVersion()) : releaseId;
+        if (shared) {
+            return entry(releaseId, name.trim(), ArchivalEntityType.RELEASE,
+                    ArchivePreview.Action.KEEP_ALIVE, "Still referenced by another live project — kept alive");
+        }
+        return entry(releaseId, name.trim(), ArchivalEntityType.RELEASE,
+                ArchivePreview.Action.ARCHIVE, "Not referenced elsewhere");
+    }
+
+    private List<ArchivePreview.Entry> previewPackage(String packageId) throws Exception {
+        Package pkg = packageHandler().getPackageById(packageId);
+        String name = pkg != null ? pkg.getName() + " " + nullToEmpty(pkg.getVersion()) : packageId;
+        if (packageHasLiveParentRelease(packageId)) {
+            return List.of(entry(packageId, name.trim(), ArchivalEntityType.PACKAGE,
+                    ArchivePreview.Action.BLOCKED, "Parent release is still live — archive the release first"));
+        }
+        return List.of(entry(packageId, name.trim(), ArchivalEntityType.PACKAGE,
+                ArchivePreview.Action.ARCHIVE, "Orphan package — safe to archive"));
+    }
+
+    private static ArchivePreview.Entry entry(String id, String name, ArchivalEntityType type,
+                                              ArchivePreview.Action action, String reason) {
+        ArchivePreview.Entry e = new ArchivePreview.Entry();
+        e.setEntityId(id);
+        e.setEntityName(name);
+        e.setEntityType(type);
+        e.setAction(action);
+        e.setReason(reason);
+        return e;
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    // ---------------- COMPONENT ----------------
+
+    /**
+     * Returns the full bundle for a Component archive: the Component document itself
+     * followed by one CollectedEntity per Release under it. Each Release is flagged
+     * keepAlive=true when a live Project still references it.
+     */
+    public List<CollectedEntity> collectComponentBundle(String componentId) throws Exception {
+        User user = resolveUser();
+        Component component = componentHandler().getComponent(componentId, user);
+        if (component == null) {
+            throw new SW360Exception("Component " + componentId + " not found");
+        }
+
+        List<CollectedEntity> bundle = new ArrayList<>();
+        bundle.add(collectedFromComponent(component));
+
+        if (component.getReleaseIds() != null) {
+            for (String releaseId : component.getReleaseIds()) {
+                bundle.add(collectRelease(releaseId, isReleaseSharedWithLiveProjects(releaseId)));
+            }
+        }
+        return bundle;
+    }
+
+    private CollectedEntity collectComponentOnly(String componentId) throws Exception {
+        User user = resolveUser();
+        Component component = componentHandler().getComponent(componentId, user);
+        if (component == null) {
+            throw new SW360Exception("Component " + componentId + " not found");
+        }
+        return collectedFromComponent(component);
+    }
+
+    private CollectedEntity collectedFromComponent(Component component) throws IOException, SW360Exception {
+        Map<String, byte[]> documents = new LinkedHashMap<>();
+        documents.put("component.json", ThriftJson.toJsonBytes(component));
+
+        List<AttachmentSource> attachments = new ArrayList<>();
+        if (includeAttachments && component.getAttachments() != null) {
+            for (Attachment att : component.getAttachments()) {
+                AttachmentSource source = buildAttachmentSource(att);
+                if (source != null) attachments.add(source);
+            }
+        }
+
+        return new CollectedEntity(
+                component.getId(),
+                component.getName(),
+                null,
+                ArchivalEntityType.COMPONENT,
+                documents,
+                attachments,
+                false);
+    }
+
+    /**
+     * True if this release is referenced by any live Project (any project — no exclusion).
+     * Used by Component archive where there is no "the project we're archiving" to exclude.
+     */
+    private boolean isReleaseSharedWithLiveProjects(String releaseId) throws Exception {
+        User user = resolveUser();
+        return !projectHandler().searchByReleaseId(releaseId, user).isEmpty();
+    }
+
+    /**
+     * Custom Component deletion that respects the keep-alive rule.
+     * For each Release under the Component:
+     *   - if shared with a live Project → unlink it from the Component's releaseIds so
+     *     the Release survives on its own.
+     *   - otherwise → deleteRelease normally.
+     * Then removes the Component itself. Uses only existing SW360 building blocks.
+     * Returns SUCCESS on happy path; if any step failed the caller inspects the
+     * remaining live Releases via the returned status list.
+     */
+    public RequestStatus deleteComponentRespectingSharedReleases(String componentId,
+                                                                 Set<String> sharedReleaseIds) throws Exception {
+        User user = resolveUser();
+        Component component = componentHandler().getComponent(componentId, user);
+        if (component == null) return RequestStatus.FAILURE;
+
+        Set<String> allReleaseIds = component.getReleaseIds() == null
+                ? Collections.emptySet()
+                : new HashSet<>(component.getReleaseIds());
+
+        // Unlink shared Releases so Component delete doesn't cascade into them.
+        if (!sharedReleaseIds.isEmpty()) {
+            Component patched = componentHandler().getComponent(componentId, user);
+            Set<String> keep = new HashSet<>(patched.getReleaseIds());
+            keep.removeAll(sharedReleaseIds);
+            patched.setReleaseIds(keep);
+            componentHandler().updateComponent(patched, user, true);
+        }
+
+        // Delete non-shared Releases individually first (belt and suspenders — the
+        // Component delete would delete them anyway, but doing it here lets us
+        // report per-release failures).
+        for (String releaseId : allReleaseIds) {
+            if (sharedReleaseIds.contains(releaseId)) continue;
+            RequestStatus rs = componentHandler().deleteRelease(releaseId, user, true);
+            if (rs != RequestStatus.SUCCESS) {
+                return rs; // surface the specific failure
+            }
+        }
+
+        // The Component now only owns Releases that were already deleted above (via
+        // its refreshed releaseIds). Delete the Component itself.
+        return componentHandler().deleteComponent(componentId, user, true);
+    }
+
+    // ---------------- PACKAGE ----------------
+
+    private CollectedEntity collectPackage(String packageId) throws Exception {
+        Package pkg = packageHandler().getPackageById(packageId);
+        if (pkg == null) {
+            throw new SW360Exception("Package " + packageId + " not found");
+        }
+
+        Map<String, byte[]> documents = new LinkedHashMap<>();
+        documents.put("package.json", ThriftJson.toJsonBytes(pkg));
+
+        return new CollectedEntity(
+                pkg.getId(),
+                pkg.getName(),
+                pkg.getVersion(),
+                ArchivalEntityType.PACKAGE,
+                documents,
+                new ArrayList<>(),
+                false);
+    }
+
+    /**
+     * True if the Package's parent Release still exists in the live DB.
+     * Used to refuse Package archival when the parent Release is still live.
+     */
+    public boolean packageHasLiveParentRelease(String packageId) throws Exception {
+        Package pkg = packageHandler().getPackageById(packageId);
+        if (pkg == null) return false;
+        String parentReleaseId = pkg.getReleaseId();
+        if (parentReleaseId == null || parentReleaseId.isBlank()) return false;
+        try {
+            User user = resolveUser();
+            Release release = componentHandler().getRelease(parentReleaseId, user);
+            return release != null;
+        } catch (SW360Exception notFound) {
+            return false;
+        }
+    }
+
+    public RequestStatus deletePackage(String packageId) throws Exception {
+        return packageHandler().deletePackage(packageId, resolveUser());
+    }
+
+    private AttachmentSource buildAttachmentSource(Attachment att) throws SW360Exception, IOException {
+        AttachmentContent content = attachmentConnector().getAttachmentContent(att.getAttachmentContentId());
+        if (content == null || Boolean.TRUE.equals(content.isOnlyRemote())) {
+            return null;
+        }
+
+        long size;
+        try (var probe = attachmentConnector().unsafeGetAttachmentStream(content)) {
+            size = probe == null ? 0L : probe.transferTo(java.io.OutputStream.nullOutputStream());
+        }
+
+        AttachmentMetadata metadata = new AttachmentMetadata();
+        metadata.setAttachmentId(content.getId());
+        metadata.setFilename(content.getFilename());
+        metadata.setContentType(content.getContentType());
+        metadata.setSizeBytes(size);
+        metadata.setSha1(att.getSha1());
+        metadata.setAttachmentType(att.getAttachmentType() == null ? null : att.getAttachmentType().name());
+        metadata.setUploadedBy(att.getCreatedBy());
+
+        return new Sw360AttachmentSource(attachmentConnector(), content, metadata, size);
+    }
+
+    private User resolveUser() throws SW360Exception {
+        if (user == null || user.getEmail() == null || user.getEmail().isBlank()) {
+            throw new SW360Exception("archive request has no user; cannot satisfy permission-checked reads");
+        }
+        // Archival is admin-only. The acting user is built from the request's
+        // X-User-* headers (see UserUtils.buildUser), so the group carried in
+        // X-User-Group is what this check reads.
+        if (!PermissionUtils.isAdmin(user)) {
+            throw new SW360Exception("user " + user.getEmail() + " is not an SW360 administrator");
+        }
+        return user;
+    }
+
+    private synchronized ComponentDatabaseHandler componentHandler() throws MalformedURLException {
+        if (componentHandler == null) {
+            componentHandler = new ComponentDatabaseHandler(
+                    DatabaseSettings.getConfiguredClient(),
+                    DatabaseSettings.COUCH_DB_DATABASE,
+                    DatabaseSettings.COUCH_DB_CHANGE_LOGS,
+                    DatabaseSettings.COUCH_DB_ATTACHMENTS);
+        }
+        return componentHandler;
+    }
+
+    private synchronized ProjectDatabaseHandler projectHandler() throws MalformedURLException {
+        if (projectHandler == null) {
+            projectHandler = new ProjectDatabaseHandler(
+                    DatabaseSettings.getConfiguredClient(),
+                    DatabaseSettings.COUCH_DB_DATABASE,
+                    DatabaseSettings.COUCH_DB_CHANGE_LOGS,
+                    DatabaseSettings.COUCH_DB_ATTACHMENTS);
+        }
+        return projectHandler;
+    }
+
+    private synchronized PackageDatabaseHandler packageHandler() throws MalformedURLException {
+        if (packageHandler == null) {
+            packageHandler = new PackageDatabaseHandler(
+                    DatabaseSettings.getConfiguredClient(),
+                    DatabaseSettings.COUCH_DB_DATABASE,
+                    DatabaseSettings.COUCH_DB_CHANGE_LOGS,
+                    DatabaseSettings.COUCH_DB_ATTACHMENTS);
+        }
+        return packageHandler;
+    }
+
+    private synchronized AttachmentConnector attachmentConnector() throws MalformedURLException {
+        if (attachmentConnector == null) {
+            attachmentConnector = new AttachmentConnector(
+                    DatabaseSettings.getConfiguredClient(),
+                    DatabaseSettings.COUCH_DB_ATTACHMENTS,
+                    ATTACHMENT_DOWNLOAD_TIMEOUT);
+        }
+        return attachmentConnector;
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ThriftJson.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ThriftJson.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+
+/**
+ * Serializes Thrift-generated structs to clean JSON. Thrift's defaults emit
+ * internal noise (__isset_bitfield, metaDataMap, schemes); this helper hides
+ * them and serializes only declared fields.
+ */
+public final class ThriftJson {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+            .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+            .setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+            .registerModule(new SimpleModule()
+                    .setMixInAnnotation(Object.class, ThriftMixin.class));
+
+    private ThriftJson() {}
+
+    public static byte[] toJsonBytes(Object thriftObject) throws IOException {
+        return MAPPER.writeValueAsBytes(thriftObject);
+    }
+
+    /**
+     * Mixin applied to every value type. Hides Thrift-generated internals so
+     * the JSON has only the real entity fields.
+     */
+    @SuppressWarnings("unused")
+    private abstract static class ThriftMixin {
+        @JsonIgnore abstract Object getMetaDataMap();
+        @JsonIgnore abstract Object getSchemes();
+        @JsonIgnore abstract Object get__isset_bitfield();
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalDatabaseHandler.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalDatabaseHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.db;
+
+import com.ibm.cloud.cloudant.v1.Cloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ArchivalDatabaseHandler {
+
+    private final ArchivalRepository repository;
+
+    public ArchivalDatabaseHandler(Cloudant client, String dbName) throws MalformedURLException {
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
+        repository = new ArchivalRepository(db);
+    }
+
+    public ArchivalDatabaseHandler(ArchivalRepository repository) {
+        this.repository = repository;
+    }
+
+    public ArchivalRecord add(ArchivalRecord record) throws SW360Exception {
+        ArchivalRecordDocument doc = ArchivalRecordDocument.fromRecord(record);
+        repository.add(doc);
+        return doc.toRecord();
+    }
+
+    public ArchivalRecord get(String id) {
+        ArchivalRecordDocument doc = repository.get(id);
+        return doc == null ? null : doc.toRecord();
+    }
+
+    public List<ArchivalRecord> getAll() {
+        return repository.getAll().stream()
+                .map(ArchivalRecordDocument::toRecord)
+                .collect(Collectors.toList());
+    }
+
+    public List<ArchivalRecord> getByBundleId(String bundleId) {
+        return repository.getByBundleId(bundleId).stream()
+                .map(ArchivalRecordDocument::toRecord)
+                .collect(Collectors.toList());
+    }
+
+    public boolean delete(String id) {
+        return repository.remove(id);
+    }
+
+    /**
+     * Re-fetches the existing doc to keep its _rev, copies the new field values,
+     * and writes it back. Returns true if the row existed and was updated.
+     */
+    public boolean update(ArchivalRecord record) {
+        ArchivalRecordDocument existing = repository.get(record.getId());
+        if (existing == null) return false;
+
+        existing.setBundleId(record.getBundleId());
+        existing.setEntityId(record.getEntityId());
+        existing.setEntityName(record.getEntityName());
+        existing.setEntityType(record.getEntityType());
+        existing.setStatus(record.getStatus());
+        existing.setArchivedBy(record.getArchivedBy());
+        existing.setArchivedAt(record.getArchivedAt());
+        existing.setRestoredBy(record.getRestoredBy());
+        existing.setRestoredAt(record.getRestoredAt());
+        existing.setAttachmentCount(record.getAttachmentCount());
+        existing.setComment(record.getComment());
+
+        try {
+            repository.updateRecord(existing);
+            return true;
+        } catch (SW360Exception e) {
+            return false;
+        }
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRecordDocument.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRecordDocument.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.db;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+
+/**
+ * CouchDB view of an ArchivalRecord.
+ *
+ * DatabaseConnectorCloudant serialises plain POJOs with Gson, so Jackson
+ * annotations are ignored here and only the raw field names matter:
+ *   - "id"       is lifted into the CouchDB _id and stripped from the body
+ *   - "revision" is lifted into the CouchDB _rev and stripped from the body
+ * Because both are stripped, neither survives a read, so docId keeps a durable
+ * copy of the identifier inside the document body.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivalRecordDocument extends ArchivalRecord {
+
+    /**
+     * Must match this class's simple name: DatabaseConnectorCloudant.get() rejects
+     * documents whose "type" field differs from the target class name, which would
+     * silently turn every lookup into a null.
+     */
+    public static final String TYPE = "ArchivalRecordDocument";
+
+    private String docId;
+
+    private String revision;
+
+    private String type = TYPE;
+
+    public String getDocId() { return docId; }
+    public void setDocId(String docId) { this.docId = docId; }
+
+    public String getRevision() { return revision; }
+    public void setRevision(String revision) { this.revision = revision; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public static ArchivalRecordDocument fromRecord(ArchivalRecord r) {
+        ArchivalRecordDocument d = new ArchivalRecordDocument();
+        d.setId(r.getId());
+        d.setDocId(r.getId());
+        d.setBundleId(r.getBundleId());
+        d.setEntityId(r.getEntityId());
+        d.setEntityName(r.getEntityName());
+        d.setEntityType(r.getEntityType());
+        d.setStatus(r.getStatus());
+        d.setArchivedBy(r.getArchivedBy());
+        d.setArchivedAt(r.getArchivedAt());
+        d.setRestoredBy(r.getRestoredBy());
+        d.setRestoredAt(r.getRestoredAt());
+        d.setAttachmentCount(r.getAttachmentCount());
+        d.setComment(r.getComment());
+        return d;
+    }
+
+    public ArchivalRecord toRecord() {
+        ArchivalRecord r = new ArchivalRecord();
+        r.setId(getDocId());
+        r.setBundleId(getBundleId());
+        r.setEntityId(getEntityId());
+        r.setEntityName(getEntityName());
+        r.setEntityType(getEntityType());
+        r.setStatus(getStatus());
+        r.setArchivedBy(getArchivedBy());
+        r.setArchivedAt(getArchivedAt());
+        r.setRestoredBy(getRestoredBy());
+        r.setRestoredAt(getRestoredAt());
+        r.setAttachmentCount(getAttachmentCount());
+        r.setComment(getComment());
+        return r;
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRepository.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/db/ArchivalRepository.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.db;
+
+import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
+import com.ibm.cloud.cloudant.v1.model.Document;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ArchivalRepository extends DatabaseRepositoryCloudantClient<ArchivalRecordDocument> {
+
+    private static final String ALL =
+            "function(doc) { if (doc.type == '" + ArchivalRecordDocument.TYPE + "') emit(null, doc._id) }";
+
+    private static final String BY_BUNDLE_ID =
+            "function(doc) {" +
+            "  if (doc.type == '" + ArchivalRecordDocument.TYPE + "' && doc.bundleId != null) {" +
+            "    emit(doc.bundleId, doc._id);" +
+            "  }" +
+            "}";
+
+    private static final String BY_ENTITY_TYPE =
+            "function(doc) {" +
+            "  if (doc.type == '" + ArchivalRecordDocument.TYPE + "' && doc.entityType != null) {" +
+            "    emit(doc.entityType, doc._id);" +
+            "  }" +
+            "}";
+
+    public ArchivalRepository(DatabaseConnectorCloudant db) {
+        super(db, ArchivalRecordDocument.class);
+        Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
+        views.put("all", createMapReduce(ALL, null));
+        views.put("byBundleId", createMapReduce(BY_BUNDLE_ID, null));
+        views.put("byEntityType", createMapReduce(BY_ENTITY_TYPE, null));
+        initStandardDesignDocument(views, db);
+    }
+
+    public List<ArchivalRecordDocument> getByBundleId(String bundleId) {
+        Set<String> ids = queryForIdsAsValue("byBundleId", bundleId);
+        return get(ids);
+    }
+
+    public List<ArchivalRecordDocument> getByEntityType(String entityType) {
+        Set<String> ids = queryForIdsAsValue("byEntityType", entityType);
+        return get(ids);
+    }
+
+    /**
+     * A document read back from CouchDB has no id or revision: the connector strips
+     * both out of the body on write and only re-injects them for Thrift structs.
+     * Restore them from the durable docId and the document's current revision so the
+     * write actually lands instead of failing on an empty id.
+     */
+    public void updateRecord(ArchivalRecordDocument doc) throws SW360Exception {
+        String id = doc.getDocId() != null ? doc.getDocId() : doc.getId();
+        if (id == null || id.isBlank()) {
+            throw new SW360Exception("cannot update an archival record without an id");
+        }
+        Document current = getConnector().getDocument(id);
+        doc.setId(id);
+        doc.setDocId(id);
+        doc.setRevision(current.getRev());
+        update(doc);
+    }
+}

--- a/backend/archival/src/main/resources/application.yml
+++ b/backend/archival/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+# Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+spring:
+  application:
+    name: sw360-archival
+  jackson:
+    default-property-inclusion: non_null
+
+server:
+  servlet:
+    context-path: /archival
+
+sw360:
+  archival:
+    cors:
+      # Browser origins allowed to call the archival API cross-origin. Empty by
+      # default because in a same-host deployment the frontend and archival share
+      # an origin. Set this when running archival standalone against a separately
+      # hosted frontend, e.g.
+      #   SW360_ARCHIVAL_CORS_ALLOWED_ORIGINS=http://localhost:3000
+      allowed-origins: ''
+
+logging:
+  level:
+    org.eclipse.sw360.archival: INFO

--- a/backend/archival/src/test/java/org/eclipse/sw360/archival/ArchivalHandlerTest.java
+++ b/backend/archival/src/test/java/org/eclipse/sw360/archival/ArchivalHandlerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.archival.bundle.ByteArrayAttachmentSource;
+import org.eclipse.sw360.archival.bundle.CollectedEntity;
+import org.eclipse.sw360.archival.bundle.InMemoryEntityProvider;
+import org.eclipse.sw360.archival.db.ArchivalDatabaseHandler;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalStatus;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveRequest;
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArchivalHandlerTest {
+
+    @Test
+    void archive_writesOneRecordPerEntity_withSharedBundleIdAndArchivedStatus() throws Exception {
+        FakeDb fakeDb = new FakeDb();
+        ArchivalHandler handler = new ArchivalHandler(fakeDb);
+
+        InMemoryEntityProvider provider = new InMemoryEntityProvider()
+                .register(release("rel-1", "Release One"))
+                .register(release("rel-2", "Release Two"))
+                .register(release("rel-3", "Release Three"));
+
+        ArchiveRequest req = new ArchiveRequest();
+        req.setEntityType(ArchivalEntityType.RELEASE);
+        req.setEntityIds(List.of("rel-1", "rel-2", "rel-3"));
+        req.setComment("Q2 cleanup");
+
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        User user = new User().setEmail("taanvi@example.com");
+        ArchiveResult result = handler.archive(req, user, sink, provider);
+
+        List<ArchivalRecord> records = result.records();
+        assertEquals(3, records.size());
+
+        String bundleId = records.get(0).getBundleId();
+        assertNotNull(bundleId);
+        assertTrue(bundleId.startsWith("bundle-"));
+        assertEquals(bundleId, result.bundleId());
+
+        for (ArchivalRecord r : records) {
+            assertEquals(bundleId, r.getBundleId(), "all records share the bundle id");
+            assertEquals(ArchivalStatus.ARCHIVED, r.getStatus());
+            assertEquals(ArchivalEntityType.RELEASE, r.getEntityType());
+            assertEquals("taanvi@example.com", r.getArchivedBy());
+            assertEquals("Q2 cleanup", r.getComment());
+            assertNotNull(r.getArchivedAt());
+        }
+
+        assertEquals(3, fakeDb.added.size(), "3 rows initially added");
+        assertEquals(3, fakeDb.updated.size(), "3 rows flipped to ARCHIVED");
+        assertTrue(sink.size() > 0, "TAR.GZ bytes were streamed to the sink");
+    }
+
+    private static CollectedEntity release(String id, String name) {
+        AttachmentMetadata meta = new AttachmentMetadata();
+        meta.setAttachmentId("att-" + id);
+        meta.setFilename(id + "-source.zip");
+        meta.setContentType("application/zip");
+
+        Map<String, byte[]> docs = new HashMap<>();
+        docs.put("release.json", ("{\"id\":\"" + id + "\"}").getBytes(StandardCharsets.UTF_8));
+
+        byte[] body = ("fake-bytes-for-" + id).getBytes(StandardCharsets.UTF_8);
+        return new CollectedEntity(id, name, "1.0", ArchivalEntityType.RELEASE, docs,
+                List.of(new ByteArrayAttachmentSource(meta, body)));
+    }
+
+    /** Stand-in for ArchivalDatabaseHandler; the real one needs a Cloudant instance. */
+    static class FakeDb extends ArchivalDatabaseHandler {
+        final List<ArchivalRecord> added = new ArrayList<>();
+        final List<ArchivalRecord> updated = new ArrayList<>();
+        final Map<String, ArchivalRecord> byId = new HashMap<>();
+
+        FakeDb() {
+            super((org.eclipse.sw360.archival.db.ArchivalRepository) null);
+        }
+
+        @Override
+        public ArchivalRecord add(ArchivalRecord r) {
+            added.add(r);
+            byId.put(r.getId(), r);
+            return r;
+        }
+
+        @Override
+        public boolean update(ArchivalRecord r) {
+            if (!byId.containsKey(r.getId())) return false;
+            updated.add(r);
+            byId.put(r.getId(), r);
+            return true;
+        }
+    }
+}

--- a/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/ArchiveBuilderTest.java
+++ b/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/ArchiveBuilderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveManifest;
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+import org.eclipse.sw360.datahandler.services.archival.ManifestEntry;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArchiveBuilderTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    void buildsTarGzWithManifestAndAttachments() throws Exception {
+        byte[] sourceZip = "fake-source-zip-bytes".getBytes(StandardCharsets.UTF_8);
+        byte[] sbom = "fake-sbom-bytes".getBytes(StandardCharsets.UTF_8);
+
+        AttachmentMetadata sourceMeta = meta("att-1", "source.zip", "application/zip");
+        AttachmentMetadata sbomMeta = meta("att-2", "sbom.spdx", "text/plain");
+
+        Map<String, byte[]> docs = new LinkedHashMap<>();
+        docs.put("release.json", "{\"name\":\"Apache Commons IO\",\"version\":\"2.11.0\"}".getBytes(StandardCharsets.UTF_8));
+        docs.put("changelogs.json", "[]".getBytes(StandardCharsets.UTF_8));
+
+        CollectedEntity release = new CollectedEntity(
+                "rel-abc-123",
+                "Apache Commons IO",
+                "2.11.0",
+                ArchivalEntityType.RELEASE,
+                docs,
+                List.of(
+                        new ByteArrayAttachmentSource(sourceMeta, sourceZip),
+                        new ByteArrayAttachmentSource(sbomMeta, sbom)));
+
+        ArchiveBuilder builder = new ArchiveBuilder("bundle-1", "taanvi@example.com", "20.0.0-beta", "test bundle");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ArchiveManifest manifest = builder.writeTo(out, List.of(release));
+
+        // Manifest sanity
+        assertEquals("bundle-1", manifest.getBundleId());
+        assertEquals(1, manifest.getManifestVersion());
+        assertEquals(1, manifest.getEntries().size());
+
+        ManifestEntry entry = manifest.getEntries().get(0);
+        assertEquals("rel-abc-123", entry.getEntityId());
+        assertEquals(ArchivalEntityType.RELEASE, entry.getEntityType());
+        assertEquals("releases/rel-abc-123/", entry.getPath());
+        assertEquals(2, entry.getAttachmentCount());
+        assertEquals(sourceZip.length + sbom.length, entry.getAttachmentTotalBytes());
+        assertTrue(entry.getChecksum().startsWith("sha256:"));
+
+        // Round-trip the TAR.GZ and verify the contents
+        Map<String, byte[]> readBack = readArchive(out.toByteArray());
+
+        assertTrue(readBack.containsKey("manifest.json"), "manifest.json present");
+        assertTrue(readBack.containsKey("releases/rel-abc-123/release.json"), "release doc present");
+        assertTrue(readBack.containsKey("releases/rel-abc-123/changelogs.json"), "changelogs present");
+
+        assertArrayEquals(sourceZip, readBack.get("releases/rel-abc-123/attachments/att-1.bin"));
+        assertArrayEquals(sbom, readBack.get("releases/rel-abc-123/attachments/att-2.bin"));
+
+        AttachmentMetadata sourceMetaBack = JSON.readValue(
+                readBack.get("releases/rel-abc-123/attachments/att-1.meta.json"),
+                AttachmentMetadata.class);
+        assertEquals("source.zip", sourceMetaBack.getFilename());
+        assertEquals(sourceZip.length, sourceMetaBack.getSizeBytes());
+
+        // Manifest is JSON-parseable
+        ArchiveManifest manifestBack = JSON.readValue(readBack.get("manifest.json"), ArchiveManifest.class);
+        assertEquals("bundle-1", manifestBack.getBundleId());
+        assertEquals(1, manifestBack.getEntries().size());
+        assertNotNull(manifestBack.getCreatedAt());
+    }
+
+    private static AttachmentMetadata meta(String id, String filename, String contentType) {
+        AttachmentMetadata m = new AttachmentMetadata();
+        m.setAttachmentId(id);
+        m.setFilename(filename);
+        m.setContentType(contentType);
+        return m;
+    }
+
+    private static Map<String, byte[]> readArchive(byte[] tarGz) throws Exception {
+        Map<String, byte[]> out = new HashMap<>();
+        try (TarArchiveInputStream tar = new TarArchiveInputStream(
+                new GzipCompressorInputStream(new ByteArrayInputStream(tarGz)))) {
+            TarArchiveEntry e;
+            while ((e = tar.getNextEntry()) != null) {
+                ByteArrayOutputStream body = new ByteArrayOutputStream();
+                tar.transferTo(body);
+                out.put(e.getName(), body.toByteArray());
+            }
+        }
+        return out;
+    }
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,6 +24,7 @@
 
     <modules>
         <module>common</module>
+        <module>archival</module>
         <module>changelogs</module>
         <module>attachments</module>
         <module>components</module>

--- a/libraries/service-api/pom.xml
+++ b/libraries/service-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>libraries</artifactId>
         <groupId>org.eclipse.sw360</groupId>
-        <version>20.1.0-rc-2</version>
+        <version>20.1.0</version>
     </parent>
 
     <name>service-api</name>

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalEntityType.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalEntityType.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+public enum ArchivalEntityType {
+    PROJECT,
+    COMPONENT,
+    RELEASE,
+    PACKAGE
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalRecord.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalRecord.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivalRecord {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("entityId")
+    private String entityId;
+
+    @JsonProperty("entityName")
+    private String entityName;
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("status")
+    private ArchivalStatus status;
+
+    @JsonProperty("archivedBy")
+    private String archivedBy;
+
+    @JsonProperty("archivedAt")
+    private Instant archivedAt;
+
+    @JsonProperty("restoredBy")
+    private String restoredBy;
+
+    @JsonProperty("restoredAt")
+    private Instant restoredAt;
+
+    @JsonProperty("attachmentCount")
+    private Integer attachmentCount;
+
+    @JsonProperty("comment")
+    private String comment;
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalStatus.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalStatus.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+public enum ArchivalStatus {
+    PENDING,
+    IN_PROGRESS,
+    ARCHIVED,
+    KEPT_ALIVE,
+    PARTIALLY_ARCHIVED,
+    RESTORED,
+    FAILED
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalValidationResult.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivalValidationResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivalValidationResult {
+
+    @JsonProperty("entityId")
+    private String entityId;
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("canArchive")
+    private boolean canArchive;
+
+    @JsonProperty("reason")
+    private Reason reason;
+
+    @JsonProperty("details")
+    private String details;
+
+    public enum Reason {
+        OK,
+        ENTITY_NOT_FOUND,
+        REFERENCED_BY_LIVE_PROJECT,
+        REFERENCED_BY_LIVE_RELEASE,
+        OPEN_CLEARING_REQUEST,
+        PERMISSION_DENIED,
+        UNKNOWN
+    }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchiveManifest.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchiveManifest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchiveManifest {
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("createdAt")
+    private Instant createdAt;
+
+    @JsonProperty("createdBy")
+    private String createdBy;
+
+    @JsonProperty("sw360Version")
+    private String sw360Version;
+
+    @JsonProperty("manifestVersion")
+    private int manifestVersion;
+
+    @JsonProperty("comment")
+    private String comment;
+
+    @JsonProperty("entries")
+    private List<ManifestEntry> entries;
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivePreview.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchivePreview.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * What an archive would do, computed without bundling or deleting anything.
+ * The admin sees this before confirming so shared/blocked dependencies are not
+ * a surprise.
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivePreview {
+
+    public enum Action { ARCHIVE, KEEP_ALIVE, BLOCKED }
+
+    @JsonProperty("entries")
+    private List<Entry> entries;
+
+    @JsonProperty("archiveCount")
+    private int archiveCount;
+
+    @JsonProperty("keepAliveCount")
+    private int keepAliveCount;
+
+    @JsonProperty("blockedCount")
+    private int blockedCount;
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Entry {
+        @JsonProperty("entityId")
+        private String entityId;
+
+        @JsonProperty("entityName")
+        private String entityName;
+
+        @JsonProperty("entityType")
+        private ArchivalEntityType entityType;
+
+        @JsonProperty("action")
+        private Action action;
+
+        @JsonProperty("reason")
+        private String reason;
+    }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchiveRequest.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ArchiveRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchiveRequest {
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("entityIds")
+    private List<String> entityIds;
+
+    @JsonProperty("comment")
+    private String comment;
+
+    @JsonProperty("includeAttachments")
+    private boolean includeAttachments = true;
+
+    @JsonProperty("includeChangelogs")
+    private boolean includeChangelogs = true;
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/AttachmentMetadata.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/AttachmentMetadata.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AttachmentMetadata {
+
+    @JsonProperty("attachmentId")
+    private String attachmentId;
+
+    @JsonProperty("filename")
+    private String filename;
+
+    @JsonProperty("contentType")
+    private String contentType;
+
+    @JsonProperty("sizeBytes")
+    private long sizeBytes;
+
+    @JsonProperty("sha1")
+    private String sha1;
+
+    @JsonProperty("attachmentType")
+    private String attachmentType;
+
+    @JsonProperty("uploadedBy")
+    private String uploadedBy;
+
+    @JsonProperty("uploadedAt")
+    private Instant uploadedAt;
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ManifestEntry.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/ManifestEntry.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ManifestEntry {
+
+    @JsonProperty("entityId")
+    private String entityId;
+
+    @JsonProperty("entityName")
+    private String entityName;
+
+    @JsonProperty("entityType")
+    private ArchivalEntityType entityType;
+
+    @JsonProperty("entityVersion")
+    private String entityVersion;
+
+    @JsonProperty("path")
+    private String path;
+
+    @JsonProperty("attachmentCount")
+    private int attachmentCount;
+
+    @JsonProperty("attachmentTotalBytes")
+    private long attachmentTotalBytes;
+
+    @JsonProperty("checksum")
+    private String checksum;
+
+    @JsonProperty("keepAlive")
+    private boolean keepAlive;
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/RestorePreview.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/RestorePreview.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RestorePreview {
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("entries")
+    private List<Entry> entries;
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Entry {
+        @JsonProperty("entityId")
+        private String entityId;
+
+        @JsonProperty("entityName")
+        private String entityName;
+
+        @JsonProperty("entityType")
+        private ArchivalEntityType entityType;
+
+        @JsonProperty("attachmentCount")
+        private Integer attachmentCount;
+
+        @JsonProperty("conflict")
+        private boolean conflict;
+    }
+}

--- a/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/RestoreResult.java
+++ b/libraries/service-api/src/main/java/org/eclipse/sw360/datahandler/services/archival/RestoreResult.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.services.archival;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RestoreResult {
+
+    @JsonProperty("bundleId")
+    private String bundleId;
+
+    @JsonProperty("entries")
+    private List<Entry> entries;
+
+    @JsonProperty("restoredCount")
+    private int restoredCount;
+
+    @JsonProperty("skippedCount")
+    private int skippedCount;
+
+    @JsonProperty("failedCount")
+    private int failedCount;
+
+    public enum Outcome { RESTORED, SKIPPED, FAILED }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Entry {
+        @JsonProperty("entityId")
+        private String entityId;
+
+        @JsonProperty("entityType")
+        private ArchivalEntityType entityType;
+
+        @JsonProperty("outcome")
+        private Outcome outcome;
+
+        @JsonProperty("reason")
+        private String reason;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <commons-cli.version>1.11.0</commons-cli.version>
     <commons-codec.version>1.22.1</commons-codec.version>
     <commons-configuration.version>1.10</commons-configuration.version>
+    <commons-compress.version>1.28.0</commons-compress.version>
     <commons-csv.version>1.14.1</commons-csv.version>
     <commons-io.version>2.22.0</commons-io.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
@@ -287,6 +288,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons-compress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
       </dependency>
@@ -356,6 +362,11 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.annotation.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>


### PR DESCRIPTION
## Summary

This PR introduces a new backend archival module and service-api DTOs for creating archive bundles of SW360 entities. The current implementation supports archival of Releases end-to-end, including entity JSON export, changelog/metadata structure, attachment streaming, manifest generation, and archival record tracking.

It also extends the archival flow for Projects by collecting the Project and its linked Releases into the same bundle. Linked Releases that are still referenced by other live Projects are marked as `keepAlive` in the manifest and tracked with the `KEPT_ALIVE` archival status instead of being treated as removable archived entities.

## What Changed

### Archival Backend Module

- Added a new `backend/archival` module.
- Added Spring Boot application setup for the archival service.
- Added archival REST controller and request handling flow.
- Added archival database persistence layer:
  - `ArchivalDatabaseHandler`
  - `ArchivalRecordDocument`
  - `ArchivalRepository`
- Added archive result handling and service constants.
- Added security/application configuration for the module.

### Archive Bundle Generation

- Added archive bundle builder that streams archive data to an output stream.
- Added manifest generation for archived entities.
- Added checksum generation for archived entity content.
- Added attachment metadata and byte-count tracking.
- Added support for writing entity documents and attachments into the archive bundle.
- Added archive format documentation.

### Release Archival

- Wired `Sw360EntityProvider` for `RELEASE` archival.
- Reads Release data from SW360 using `ComponentDatabaseHandler`.
- Resolves the requesting user through `UserRepository`.
- Serializes Thrift Release entities to clean JSON using `ThriftJson`.
- Streams release attachments from CouchDB using `Sw360AttachmentSource`.
- Tracks archival records as `IN_PROGRESS`, `ARCHIVED`, or `FAILED`.

### Project Archival

- Added a Project-specific archival flow.
- Collects the Project document itself.
- Collects all Releases linked to the Project.
- Detects whether linked Releases are still referenced by other live Projects.
- Marks shared linked Releases as `keepAlive` in the archive manifest.
- Adds `KEPT_ALIVE` archival status for Releases that are bundled but should remain live.
- Deletes the archived Project using SW360’s existing `deleteProject` flow.
- Does not cascade-delete Releases from the live database.

### Tests

- Added tests for archival handler behavior.
- Added tests for archive bundle generation.

## Testing

- Added unit coverage for the new archival module pieces.