### PR TITLE
fix(nouveau): add lucene_version to nouveau index

### DIFF
--- a/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/designdocument/NouveauIndexFunction.java
+++ b/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/designdocument/NouveauIndexFunction.java
@@ -26,6 +26,9 @@ public class NouveauIndexFunction {
     private Map<String, String> fieldAnalyzer;
     @SerializedName("index")
     private final String index;
+    // TODO: This has to be updated when we update the Lucene version in the future. For now, it is fixed to 10.
+    @SerializedName("lucene_version")
+    private final int lucene_version = 10;
 
     public NouveauIndexFunction(String index) {
         if (index == null || index.isEmpty()) {
@@ -56,6 +59,14 @@ public class NouveauIndexFunction {
         return index;
     }
 
+    public int getLuceneVersion() {
+        return lucene_version;
+    }
+
+    public NouveauIndexFunction setLuceneVersion(int lucene_version) {
+        throw new UnsupportedOperationException("Lucene version is fixed to 10 and cannot be changed.");
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -66,6 +77,6 @@ public class NouveauIndexFunction {
 
     @Override
     public int hashCode() {
-        return Objects.hash(defaultAnalyzer, fieldAnalyzer, index);
+        return Objects.hash(defaultAnalyzer, fieldAnalyzer, index, lucene_version);
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Nouveau now expects [field `lucene_version` while defining an index](https://docs.couchdb.org/en/stable/ddocs/nouveau.html#lucene-version-upgrade) with lucene version, which is currently set to 10 and needs to be updated in future.

The change has been tested with couchdb 3.5.1 and 3.5.2.1 and is working without issues.

### How To Test?
Test the changes with various versions of couchdb.

/cc @bibhuti230185 