### PR TITLE
fix(rest): show ECC pill in red when open ECC exists.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3238,8 +3238,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
         }
 
+        Sw360ProjectService.ProjectEccCounts eccCounts = projectService.getProjectEccCounts(id, sw360User);
+
         return new ResponseEntity<>(new ProjectDetailTabCounts(vulnerabilityCount, vulnerabilityRatedCount,
-                obligationCount, obligationNonOpenCount), HttpStatus.OK);
+                obligationCount, obligationNonOpenCount,
+                eccCounts.classifiedCount(), eccCounts.openCount()), HttpStatus.OK);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
@@ -33,11 +33,19 @@ public class ProjectDetailTabCounts {
     @Schema(description = "Count of obligations whose status is not OPEN")
     private final int obligationNonOpenCount;
 
+    @Schema(description = "Count of releases with a classified ECC status")
+    private final int eccClassifiedCount;
+
+    @Schema(description = "Count of releases with ECC status OPEN")
+    private final int eccOpenCount;
+
     public ProjectDetailTabCounts(int vulnerabilityCount, int vulnerabilityRatedCount, int obligationCount,
-            int obligationNonOpenCount) {
+            int obligationNonOpenCount, int eccClassifiedCount, int eccOpenCount) {
         this.vulnerabilityCount = vulnerabilityCount;
         this.vulnerabilityRatedCount = vulnerabilityRatedCount;
         this.obligationCount = obligationCount;
         this.obligationNonOpenCount = obligationNonOpenCount;
+        this.eccClassifiedCount = eccClassifiedCount;
+        this.eccOpenCount = eccOpenCount;
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -41,6 +41,7 @@ import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
@@ -150,6 +151,9 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         public String toString() {
             return this.name();
         }
+    }
+
+    public record ProjectEccCounts(int classifiedCount, int openCount) {
     }
 
     public static final ExecutorService releaseExecutor = Executors.newFixedThreadPool(10);
@@ -1019,6 +1023,29 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             }
             return project.getReleaseIdToUsage().keySet();
         }
+    }
+
+    public ProjectEccCounts getProjectEccCounts(String projectId, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        List<ReleaseClearingStatusData> releaseClearingStatusData = sw360ProjectClient
+                .getReleaseClearingStatuses(projectId, sw360User);
+
+        int eccClassifiedCount = 0;
+        int eccOpenCount = 0;
+        for (ReleaseClearingStatusData clearingStatusData : CommonUtils.nullToEmptyList(releaseClearingStatusData)) {
+            Release release = clearingStatusData.release;
+            if (release == null || release.getEccInformation() == null
+                    || release.getEccInformation().getEccStatus() == null) {
+                continue;
+            }
+
+            eccClassifiedCount++;
+            if (ECCStatus.OPEN.equals(release.getEccInformation().getEccStatus())) {
+                eccOpenCount++;
+            }
+        }
+
+        return new ProjectEccCounts(eccClassifiedCount, eccOpenCount);
     }
 
     public void addEmbeddedLinkedProject(Project sw360Project, User sw360User, HalResource<Project> projectResource,

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -46,6 +46,7 @@ import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -312,6 +313,10 @@ public class ProjectTest extends TestIntegrationBase {
         given(this.vulnerabilityServiceMock.getVulnerabilitiesByProjectId(eq(project1.getId()), any())).willReturn(new ArrayList<>());
         given(this.vulnerabilityServiceMock.getProjectVulnerabilityRatingByProjectId(eq(project1.getId()), any())).willReturn(new ArrayList<>());
         given(this.vulnerabilityServiceMock.fillVulnerabilityMetadata(any(), any())).willReturn(new HashMap<>());
+
+        // Default ECC counts mock (returns zeros)
+        given(this.projectServiceMock.getProjectEccCounts(any(), any())).willReturn(
+                new Sw360ProjectService.ProjectEccCounts(0, 0));
     }
 
     // ========== CORE PROJECT OPERATIONS ==========
@@ -957,6 +962,10 @@ public class ProjectTest extends TestIntegrationBase {
         obligationList.setLinkedObligationStatus(linkedObligationStatus);
         given(this.projectServiceMock.getObligationData(eq(project1.getLinkedObligationId()), any())).willReturn(obligationList);
 
+        // Mock ECC counts: 2 classified (release1=OPEN, release2=APPROVED), 1 open
+        given(this.projectServiceMock.getProjectEccCounts(eq(project1.getId()), any())).willReturn(
+                new Sw360ProjectService.ProjectEccCounts(2, 1));
+
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
                 new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/" + project1.getId() + "/tabCounts",
@@ -970,6 +979,8 @@ public class ProjectTest extends TestIntegrationBase {
         assertEquals(2, responseBody.get("vulnerabilityRatedCount").asInt());
         assertEquals(2, responseBody.get("obligationCount").asInt());
         assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
+        assertEquals(2, responseBody.get("eccClassifiedCount").asInt());
+        assertEquals(1, responseBody.get("eccOpenCount").asInt());
     }
 
     @Test
@@ -988,6 +999,10 @@ public class ProjectTest extends TestIntegrationBase {
         obligationList.setLinkedObligationStatus(linkedObligationStatus);
         given(this.projectServiceMock.getObligationData(eq(project1.getLinkedObligationId()), any())).willReturn(obligationList);
 
+        // Mock ECC counts: 2 classified (release1=OPEN, release2=APPROVED), 1 open
+        given(this.projectServiceMock.getProjectEccCounts(eq(project1.getId()), any())).willReturn(
+                new Sw360ProjectService.ProjectEccCounts(2, 1));
+
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
                 new TestRestTemplate().exchange("http://localhost:" + port + "/api/projects/" + project1.getId() + "/tabCounts",
@@ -1001,6 +1016,8 @@ public class ProjectTest extends TestIntegrationBase {
         assertEquals(-1, responseBody.get("vulnerabilityRatedCount").asInt());
         assertEquals(2, responseBody.get("obligationCount").asInt());
         assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
+        assertEquals(2, responseBody.get("eccClassifiedCount").asInt());
+        assertEquals(1, responseBody.get("eccOpenCount").asInt());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -579,6 +579,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.deselectedAttachmentUsagesFromRequest(any(), eq(selectedUsages), any(), any(), any())).willReturn(deselectedUsagesFromRequest);
         given(this.projectServiceMock.selectedAttachmentUsagesFromRequest(any(), eq(selectedUsages), any(), any(), any())).willReturn(selectedUsagesFromRequest);
         given(this.projectServiceMock.removeOrphanObligations(eq(obligationStatusMap), any(), eq(project8), any(), eq(obligationLists))).willReturn(RequestStatus.SUCCESS);
+        given(this.projectServiceMock.getProjectEccCounts(any(), any())).willReturn(new Sw360ProjectService.ProjectEccCounts(1, 0));
         given(this.projectServiceMock.getProjectForUserById(eq(projectForAtt.getId()), any())).willReturn(projectForAtt);
         given(this.projectServiceMock.getProjectForUserById(eq(SPDXProject.getId()), any())).willReturn(SPDXProject);
         given(this.projectServiceMock.getProjectForUserById(eq(cycloneDXProject.getId()), any())).willReturn(cycloneDXProject);
@@ -2434,7 +2435,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("vulnerabilityCount").description("Count of vulnerabilities linked to the project; returns -1 when vulnerability display is disabled for the project"),
                                 fieldWithPath("vulnerabilityRatedCount").description("Count of vulnerabilities with project relevance other than NOT_CHECKED; returns -1 when vulnerability display is disabled for the project"),
                                 fieldWithPath("obligationCount").description("Count of obligations linked to the project"),
-                                fieldWithPath("obligationNonOpenCount").description("Count of obligations whose status is not OPEN")
+                                fieldWithPath("obligationNonOpenCount").description("Count of obligations whose status is not OPEN"),
+                                fieldWithPath("eccClassifiedCount").description("Count of releases with a classified ECC status"),
+                                fieldWithPath("eccOpenCount").description("Count of releases with ECC status OPEN")
                         )));
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: Closes #4356 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?

1: Login sw360
2: Navigate to Projects
3: Search for ex: XYZ release
4: ECC field is red if ECC state of one of the components is open
5: Add the total number of components with open ECC state in the expected result

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
