### PR TITLE
fix(#4066): invaild pURL validation error

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
@@ -190,15 +190,24 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT).setMessage("Invalid Pacakge Type!");
         }
 
+        String purlError = validatePurl(pkg.getPurl());
+        if (purlError != null) {
+            log.error(String.format("Invalid PURL for package: '%s' - %s", SW360Utils.printName(pkg), purlError));
+            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT)
+                    .setMessage(purlError);
+        }
+
         try {
             PackageURL purl = new PackageURL(pkg.getPurl());
             pkg.setPackageManager(PackageManager.valueOf(purl.getType().toUpperCase()));
         } catch (MalformedPackageURLException e) {
             log.error(String.format("Invalid PURL for package: '%s'", SW360Utils.printName(pkg)), e);
-            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT).setMessage("Invalid Pacakge URL!");
+            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT)
+                    .setMessage(e.getMessage() + " in '" + pkg.getPurl() + "'. Expected format: pkg:type/namespace/name@version");
         } catch (IllegalArgumentException e) {
             log.error(String.format("Invalid Package Manager for package: '%s'", SW360Utils.printName(pkg)), e);
-            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT).setMessage("Invalid Pacakge Manager!");
+            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT)
+                    .setMessage("Unsupported package manager type in pURL '" + pkg.getPurl() + "'. " + e.getMessage());
         }
 
         // Prepare package for database
@@ -283,15 +292,21 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return RequestStatus.INVALID_INPUT;
         }
 
+        String purlError = validatePurl(updatedPkg.getPurl());
+        if (purlError != null) {
+            log.error(String.format("Invalid PURL for package: %s - %s", packageId, purlError));
+            throw fail(400, "%s", purlError);
+        }
+
         try {
             PackageURL purl = new PackageURL(updatedPkg.getPurl());
             updatedPkg.setPackageManager(PackageManager.valueOf(purl.getType().toUpperCase()));
         } catch (MalformedPackageURLException e) {
             log.error(String.format("Invalid PURL for package: %s", packageId), e);
-            return RequestStatus.INVALID_INPUT;
+            throw fail(400, "%s in '%s'. Expected format: pkg:type/namespace/name@version", e.getMessage(), updatedPkg.getPurl());
         } catch (IllegalArgumentException e) {
             log.error(String.format("Invalid Package Manager for package: %s", packageId), e);
-            return RequestStatus.INVALID_INPUT;
+            throw fail(400, "Unsupported package manager type in pURL '%s'. %s", updatedPkg.getPurl(), e.getMessage());
         }
 
         // Prepare package for database
@@ -451,5 +466,78 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public Map<PaginationData, List<Package>> getPackagesWithPagination(PaginationData pageData) {
           return packageRepository.getPackagesWithPagination(pageData);
+    }
+
+    /**
+     * Validates pURL structure and returns error message with position, or null if valid.
+     */
+    private String validatePurl(String purl) {
+        if (purl == null || purl.isEmpty()) {
+            return "pURL is empty or null. Expected format: pkg:type/namespace/name@version";
+        }
+        if (!purl.startsWith("pkg:")) {
+            return "pURL must start with 'pkg:' but found '" + purl.substring(0, Math.min(4, purl.length()))
+                    + "' at position 1 in '" + purl + "'";
+        }
+
+        // Strip subpath (#) and qualifiers (?)
+        String core = purl.substring(4);
+        int hashIdx = core.indexOf('#');
+        if (hashIdx >= 0) core = core.substring(0, hashIdx);
+        int qIdx = core.indexOf('?');
+        if (qIdx >= 0) core = core.substring(0, qIdx);
+
+        // Type: everything before first '/'
+        int slashIdx = core.indexOf('/');
+        if (slashIdx < 0) {
+            return "pURL is missing '/' separator after type at position " + (5 + core.length())
+                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
+        }
+
+        String type = core.substring(0, slashIdx);
+        if (type.isEmpty()) {
+            return "pURL has empty type at position 5 in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
+        }
+        if (Character.isDigit(type.charAt(0))) {
+            return "pURL type '" + type + "' starts with a digit '" + type.charAt(0)
+                    + "' at position 5 in '" + purl + "'. Type must start with a letter";
+        }
+        for (int i = 0; i < type.length(); i++) {
+            char c = type.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '.' && c != '+' && c != '-') {
+                return "pURL type '" + type + "' contains invalid character '" + c
+                        + "' at position " + (5 + i) + " in '" + purl + "'";
+            }
+        }
+
+        // Name/version part: everything after type/
+        String rest = core.substring(slashIdx + 1);
+        if (rest.isEmpty()) {
+            return "pURL is missing package name after '/' at position " + (5 + slashIdx + 1)
+                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
+        }
+
+        // Version: after last '@'
+        int atIdx = rest.lastIndexOf('@');
+        if (atIdx < 0) {
+            return "pURL is missing version separator '@' at position " + (5 + slashIdx + 1 + rest.length())
+                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
+        }
+
+        String version = rest.substring(atIdx + 1);
+        if (version.isEmpty()) {
+            return "pURL has empty version after '@' at position " + (5 + slashIdx + 1 + atIdx + 1)
+                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
+        }
+
+        String namespaceName = rest.substring(0, atIdx);
+        int lastSlash = namespaceName.lastIndexOf('/');
+        String name = lastSlash >= 0 ? namespaceName.substring(lastSlash + 1) : namespaceName;
+        if (name.isEmpty()) {
+            return "pURL has empty package name before '@' at position " + (5 + slashIdx + 1 + atIdx)
+                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
+        }
+
+        return null; // valid
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
@@ -195,10 +195,12 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
             pkg.setPackageManager(PackageManager.valueOf(purl.getType().toUpperCase()));
         } catch (MalformedPackageURLException e) {
             log.error(String.format("Invalid PURL for package: '%s'", SW360Utils.printName(pkg)), e);
-            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT).setMessage("Invalid Pacakge URL!");
+            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT)
+                    .setMessage(e.getMessage() + " in '" + pkg.getPurl() + "'. Expected format: pkg:type/namespace/name@version");
         } catch (IllegalArgumentException e) {
             log.error(String.format("Invalid Package Manager for package: '%s'", SW360Utils.printName(pkg)), e);
-            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT).setMessage("Invalid Pacakge Manager!");
+            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT)
+                    .setMessage("Unsupported package manager type in pURL '" + pkg.getPurl() + "'. " + e.getMessage());
         }
 
         // Prepare package for database
@@ -288,10 +290,10 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
             updatedPkg.setPackageManager(PackageManager.valueOf(purl.getType().toUpperCase()));
         } catch (MalformedPackageURLException e) {
             log.error(String.format("Invalid PURL for package: %s", packageId), e);
-            return RequestStatus.INVALID_INPUT;
+            throw fail(400, "%s in '%s'. Expected format: pkg:type/namespace/name@version", e.getMessage(), updatedPkg.getPurl());
         } catch (IllegalArgumentException e) {
             log.error(String.format("Invalid Package Manager for package: %s", packageId), e);
-            return RequestStatus.INVALID_INPUT;
+            throw fail(400, "Unsupported package manager type in pURL '%s'. %s", updatedPkg.getPurl(), e.getMessage());
         }
 
         // Prepare package for database
@@ -452,4 +454,5 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
     public Map<PaginationData, List<Package>> getPackagesWithPagination(PaginationData pageData) {
           return packageRepository.getPackagesWithPagination(pageData);
     }
+
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
@@ -190,13 +190,6 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT).setMessage("Invalid Pacakge Type!");
         }
 
-        String purlError = validatePurl(pkg.getPurl());
-        if (purlError != null) {
-            log.error(String.format("Invalid PURL for package: '%s' - %s", SW360Utils.printName(pkg), purlError));
-            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT)
-                    .setMessage(purlError);
-        }
-
         try {
             PackageURL purl = new PackageURL(pkg.getPurl());
             pkg.setPackageManager(PackageManager.valueOf(purl.getType().toUpperCase()));
@@ -290,12 +283,6 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 DatabaseHandlerUtil.isAllIdInSetExists(Sets.newHashSet(updatedPkg.getReleaseId()), packageRepository)) {
             log.error(String.format("Invalid linked release id %s for package: %s ", updatedPkg.getReleaseId(), packageId));
             return RequestStatus.INVALID_INPUT;
-        }
-
-        String purlError = validatePurl(updatedPkg.getPurl());
-        if (purlError != null) {
-            log.error(String.format("Invalid PURL for package: %s - %s", packageId, purlError));
-            throw fail(400, "%s", purlError);
         }
 
         try {
@@ -468,76 +455,4 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
           return packageRepository.getPackagesWithPagination(pageData);
     }
 
-    /**
-     * Validates pURL structure and returns error message with position, or null if valid.
-     */
-    private String validatePurl(String purl) {
-        if (purl == null || purl.isEmpty()) {
-            return "pURL is empty or null. Expected format: pkg:type/namespace/name@version";
-        }
-        if (!purl.startsWith("pkg:")) {
-            return "pURL must start with 'pkg:' but found '" + purl.substring(0, Math.min(4, purl.length()))
-                    + "' at position 1 in '" + purl + "'";
-        }
-
-        // Strip subpath (#) and qualifiers (?)
-        String core = purl.substring(4);
-        int hashIdx = core.indexOf('#');
-        if (hashIdx >= 0) core = core.substring(0, hashIdx);
-        int qIdx = core.indexOf('?');
-        if (qIdx >= 0) core = core.substring(0, qIdx);
-
-        // Type: everything before first '/'
-        int slashIdx = core.indexOf('/');
-        if (slashIdx < 0) {
-            return "pURL is missing '/' separator after type at position " + (5 + core.length())
-                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
-        }
-
-        String type = core.substring(0, slashIdx);
-        if (type.isEmpty()) {
-            return "pURL has empty type at position 5 in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
-        }
-        if (Character.isDigit(type.charAt(0))) {
-            return "pURL type '" + type + "' starts with a digit '" + type.charAt(0)
-                    + "' at position 5 in '" + purl + "'. Type must start with a letter";
-        }
-        for (int i = 0; i < type.length(); i++) {
-            char c = type.charAt(i);
-            if (!Character.isLetterOrDigit(c) && c != '.' && c != '+' && c != '-') {
-                return "pURL type '" + type + "' contains invalid character '" + c
-                        + "' at position " + (5 + i) + " in '" + purl + "'";
-            }
-        }
-
-        // Name/version part: everything after type/
-        String rest = core.substring(slashIdx + 1);
-        if (rest.isEmpty()) {
-            return "pURL is missing package name after '/' at position " + (5 + slashIdx + 1)
-                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
-        }
-
-        // Version: after last '@'
-        int atIdx = rest.lastIndexOf('@');
-        if (atIdx < 0) {
-            return "pURL is missing version separator '@' at position " + (5 + slashIdx + 1 + rest.length())
-                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
-        }
-
-        String version = rest.substring(atIdx + 1);
-        if (version.isEmpty()) {
-            return "pURL has empty version after '@' at position " + (5 + slashIdx + 1 + atIdx + 1)
-                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
-        }
-
-        String namespaceName = rest.substring(0, atIdx);
-        int lastSlash = namespaceName.lastIndexOf('/');
-        String name = lastSlash >= 0 ? namespaceName.substring(lastSlash + 1) : namespaceName;
-        if (name.isEmpty()) {
-            return "pURL has empty package name before '@' at position " + (5 + slashIdx + 1 + atIdx)
-                    + " in '" + purl + "'. Expected format: pkg:type/namespace/name@version";
-        }
-
-        return null; // valid
-    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
@@ -51,12 +51,12 @@ public class SW360PackageService {
             pkg.setCreatedBy(sw360User.getEmail());
             return pkg;
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE
-                && documentRequestSummary.getMessage().equals(SW360Constants.DUPLICATE_PACKAGE_BY_PURL) ) {
+                && SW360Constants.DUPLICATE_PACKAGE_BY_PURL.equals(documentRequestSummary.getMessage()) ) {
             throw new DataIntegrityViolationException("sw360 package with same purl '" + pkg.getPurl() + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
             throw new DataIntegrityViolationException("sw360 package with same name and version '" + pkg.getName() + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
-            throw new BadRequestClientException("Dependent document Id/ids not valid.");
+            throw new BadRequestClientException(documentRequestSummary.getMessage());
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
             throw new BadRequestClientException("Package name field cannot be empty or contain only whitespace character");
         }
@@ -68,7 +68,14 @@ public class SW360PackageService {
         rch.checkForCyclicOrInvalidDependencies(sw360PackageClient, pkg, sw360User);
 
         RequestStatus requestStatus;
-        requestStatus = sw360PackageClient.updatePackage(pkg, sw360User);
+        try {
+            requestStatus = sw360PackageClient.updatePackage(pkg, sw360User);
+        } catch (SW360Exception e) {
+            if (e.getErrorCode() == 400) {
+                throw new BadRequestClientException(e.getWhy());
+            }
+            throw e;
+        }
 
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new BadRequestClientException("Invalid Purl or linked release id.");


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * this issue was raised due to invalid pURLs. So, it would be great to show the error be like Invalid pURL or something which can be transparent to the user instead of non-transparent error Dependent document Id/ids not valid.(*Refer to issue #4066*)

Closes #4066

### Suggest Reviewer
> @GMishx @amritkv 

### How To Test?
> Try to Add Package/ Edit Package
Enter a pURL like : pkg:github@test/version@1.2.3 or something similar where purl starts with `pkg:<package_manager>
Hit Add Package / Update Packages?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
