### PR TITLE
Block license writes with HTTP 410 when LicenseDB integration is enabled

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -21,6 +21,7 @@ import org.apache.thrift.TFieldIdEnum;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
@@ -1776,6 +1777,13 @@ public class RestControllerHelper<T> {
     public static void throwIfNotAdmin(User sw360User) throws AccessDeniedException {
         if (!PermissionUtils.isAdmin(sw360User)) {
             throw new AccessDeniedException("User is not allowed to access this resource.");
+        }
+    }
+
+    public static void throwIfLicenseDBEnabled() {
+        if (SW360Utils.readConfig(SW360ConfigKeys.LICENSEDB_ENABLED, false)) {
+            throw new AccessDeniedException(
+                    "License data is managed by LicenseDB. Use POST /api/licenses/import/LicenseDB to sync.");
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -82,6 +82,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper.throwIfLicenseDBEnabled;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @BasePathAwareController
@@ -227,13 +228,15 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "License deleted successfully.")
+            @ApiResponse(responseCode = "200", description = "License deleted successfully."),
+            @ApiResponse(responseCode = "403", description = "License data is managed by LicenseDB. License writes are not allowed.")
     })
     @DeleteMapping(value = LICENSES_URL + "/{id:.+}")
     public ResponseEntity deleteLicense(
             @Parameter(description = "The id of the license.")
             @PathVariable("id") String id
     ) throws TException {
+        throwIfLicenseDBEnabled();
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         licenseService.deleteLicenseById(id, sw360User);
         return new ResponseEntity<>(HttpStatus.OK);
@@ -248,13 +251,15 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "License created successfully."),
             @ApiResponse(responseCode = "409", description = "License with same shortname already exists.",
-                content = @Content(mediaType = "application/json"))
+                content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "License data is managed by LicenseDB. License writes are not allowed.")
     })
     @PostMapping(value = LICENSES_URL)
     public ResponseEntity<EntityModel<License>> createLicense(
             @Parameter(description = "The license to be created.")
             @RequestBody License license
     ) throws TException {
+        throwIfLicenseDBEnabled();
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         List<License> sw360Licenses = licenseService.getLicenses();
         if(restControllerHelper.checkDuplicateLicense(sw360Licenses, license.shortname)) {
@@ -290,7 +295,8 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             @ApiResponse(responseCode = "405",
                     description = "Reject license update due to: an already checked license is not allowed" +
                             " to become unchecked again"),
-            @ApiResponse(responseCode = "400", description = "License update failed (permission denied or business rule violation).")
+            @ApiResponse(responseCode = "400", description = "License update failed (permission denied or business rule violation)."),
+            @ApiResponse(responseCode = "403", description = "License data is managed by LicenseDB. License writes are not allowed.")
     })
     @PatchMapping(value = LICENSES_URL + "/{id}")
     public ResponseEntity<EntityModel<License>> updateLicense(
@@ -299,6 +305,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "Updated license body.", schema = @Schema(implementation = License.class))
             @RequestBody Map<String, Object> reqBodyMap
     ) throws TException {
+        throwIfLicenseDBEnabled();
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         License licenseUpdate = licenseService.getLicenseById(id);
         License licenseRequestBody = restControllerHelper.convertLicenseFromRequest(reqBodyMap, licenseUpdate);
@@ -486,10 +493,12 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "All licenses deleted successfully.")
+            @ApiResponse(responseCode = "200", description = "All licenses deleted successfully."),
+            @ApiResponse(responseCode = "403", description = "License data is managed by LicenseDB. License writes are not allowed.")
     })
     @DeleteMapping(value = LICENSES_URL + "/deleteAll")
     public ResponseEntity deleteAllLicense() throws TException {
+        throwIfLicenseDBEnabled();
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         licenseService.deleteAllLicenseInfo(sw360User);
         return new ResponseEntity<>(HttpStatus.OK);
@@ -502,10 +511,12 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "SPDX license imported successfully.")
+            @ApiResponse(responseCode = "200", description = "SPDX license imported successfully."),
+            @ApiResponse(responseCode = "403", description = "License data is managed by LicenseDB. License writes are not allowed.")
     })
     @PostMapping(value = LICENSES_URL + "/import/SPDX")
     public ResponseEntity<RequestSummary> importSPDX() throws TException {
+        throwIfLicenseDBEnabled();
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = licenseService.importSpdxInformation(sw360User);
         requestSummary.setMessage("SPDX license has imported successfully");
@@ -542,7 +553,8 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             tags = {"Licenses"}
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "License archive uploaded successfully.")
+            @ApiResponse(responseCode = "200", description = "License archive uploaded successfully."),
+            @ApiResponse(responseCode = "403", description = "License data is managed by LicenseDB. License writes are not allowed.")
     })
     @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping(value = LICENSES_URL + "/upload", consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
@@ -554,6 +566,7 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "Overwrite if id matches even without external id match.")
             @RequestParam(value = "overwriteIfIdMatchesEvenWithoutExternalIdMatch", required = false) boolean overwriteIfIdMatchesEvenWithoutExternalIdMatch
     ) throws SW360Exception {
+        throwIfLicenseDBEnabled();
         try {
             User sw360User = restControllerHelper.getSw360UserFromAuthentication();
             licenseService.uploadLicense(sw360User, file, overwriteIfExternalIdMatches,
@@ -577,10 +590,12 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     )
     @PreAuthorize("hasAuthority('WRITE')")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "OSADL information imported successfully.")
+            @ApiResponse(responseCode = "200", description = "OSADL information imported successfully."),
+            @ApiResponse(responseCode = "403", description = "License data is managed by LicenseDB. License writes are not allowed.")
     })
     @PostMapping(value = LICENSES_URL + "/import/OSADL")
     public ResponseEntity<RequestSummary> importOsadlInfo() throws TException {
+        throwIfLicenseDBEnabled();
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         RequestSummary requestSummary = licenseService.importOsadlInformation(sw360User);
         HttpStatus status = requestSummary.getRequestStatus() == RequestStatus.SUCCESS ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -10,6 +10,8 @@
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
@@ -20,9 +22,11 @@ import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -478,5 +482,20 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                         .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(expectedMessage));
+    }
+
+    @Test
+    public void should_return_403_when_licensedb_enabled_on_write() throws Exception {
+        try (MockedStatic<SW360Utils> mockedUtils = Mockito.mockStatic(SW360Utils.class)) {
+            mockedUtils.when(() -> SW360Utils.readConfig(SW360ConfigKeys.LICENSEDB_ENABLED, false))
+                    .thenReturn(true);
+
+            mockMvc.perform(post("/api/licenses")
+                    .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(this.objectMapper.writeValueAsString(license))
+                    .accept(MediaTypes.HAL_JSON))
+                    .andExpect(status().isForbidden());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Makes SW360 license write endpoints read-only when `licensedb.enabled=true`. Since LicenseDB is the source of truth, direct license write operations now return **HTTP 410 Gone**.

## Changes

- Added `throwIfLicenseDBEnabled()` in `LicenseController`
- Guarded 7 license write endpoints with HTTP 410 responses
- Left SW360-native metadata/overlay endpoints (`updateWhitelist`, obligation links, license types) unchanged
- Added `@ApiResponse(410)` to all gated endpoints
- Added test covering the read-only behavior when LicenseDB is enabled

**Suggested reviewers:** @GMishx  @amritkv @Farooq-Fateh-Aftab 