### PR TITLE
Add admin endpoints for LicenseDB sync and health monitoring

### DIFF
--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDBSyncReport.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDBSyncReport.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.db;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LicenseDBSyncReport {
+    private String type = "licensedb-sync-report";
+    private String syncType;
+    private String startDate;
+    private String endDate;
+    private int processingSeconds;
+    private String status;
+    private String message;
+    private int totalElements;
+    private int totalAffectedElements;
+}

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDBSyncReportRepository.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDBSyncReportRepository.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.db;
+
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
+
+import com.ibm.cloud.cloudant.v1.model.DesignDocumentViewsMapReduce;
+import com.ibm.cloud.cloudant.v1.model.PostFindOptions;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.and;
+import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.eq;
+
+public class LicenseDBSyncReportRepository extends DatabaseRepositoryCloudantClient<LicenseDBSyncReport> {
+
+    private static final String ALL = "function(doc) { if (doc.type == 'licensedb-sync-report') emit(null, doc._id) }";
+    private static final String SYNC_REPORT_IDX = "syncReportIdx";
+
+    public LicenseDBSyncReportRepository(DatabaseConnectorCloudant db) {
+        super(db, LicenseDBSyncReport.class);
+        Map<String, DesignDocumentViewsMapReduce> views = new HashMap<>();
+        views.put("all", createMapReduce(ALL, null));
+        initStandardDesignDocument(views, db);
+
+        createIndex(SYNC_REPORT_IDX, "byTypeStatusEndDate",
+                new String[]{"type", "status", "endDate"}, db);
+    }
+
+    public LicenseDBSyncReport getLatestReport() {
+        return queryLatest(null);
+    }
+
+    public LicenseDBSyncReport getLatestSuccessfulReport() {
+        return queryLatest("SUCCESS");
+    }
+
+    private LicenseDBSyncReport queryLatest(String statusFilter) {
+        Map<String, Object> typeSelector = eq("type", "licensedb-sync-report");
+        Map<String, Object> selector;
+        if (statusFilter != null) {
+            Map<String, Object> statusSelector = eq("status", statusFilter);
+            selector = and(List.of(typeSelector, statusSelector));
+        } else {
+            selector = typeSelector;
+        }
+
+        PostFindOptions query = getConnector().getQueryBuilder()
+                .selector(selector)
+                .useIndex(Collections.singletonList(SYNC_REPORT_IDX))
+                .addSort(Collections.singletonMap("endDate", "desc"))
+                .limit(1L)
+                .build();
+
+        List<LicenseDBSyncReport> results = getConnector().getQueryResult(query, LicenseDBSyncReport.class);
+        return results.isEmpty() ? null : results.get(0);
+    }
+}

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -100,6 +100,7 @@ public class LicenseDatabaseHandler {
     private final ObligationNodeRepository obligationNodeRepository;
     private final LicenseTypeRepository licenseTypeRepository;
     private final LicenseObligationListRepository obligationListRepository;
+    private final LicenseDBSyncReportRepository syncReportRepository;
     private final LicenseModerator moderator;
     private final CustomPropertiesRepository customPropertiesRepository;
     private final DatabaseRepositoryCloudantClient[] repositories;
@@ -108,7 +109,6 @@ public class LicenseDatabaseHandler {
     private static boolean IMPORT_STATUS = false;
     private static long IMPORT_TIME = 0;
     private static final long TIME_OUT = 1800000; // 30 minutes: 30 * 60 * 1000;
-    private static final String LICENSEDB_SYNC_STATE_DOC_ID = "licensedb-sync-state";
     private String obligationText;
     private final Logger log = LogManager.getLogger(LicenseDatabaseHandler.class);
 
@@ -126,6 +126,7 @@ public class LicenseDatabaseHandler {
         licenseTypeRepository = new LicenseTypeRepository(db);
         customPropertiesRepository = new CustomPropertiesRepository(db);
         obligationListRepository = new LicenseObligationListRepository(db);
+        syncReportRepository = new LicenseDBSyncReportRepository(db);
 
         repositories = new DatabaseRepositoryCloudantClient[]{
                 licenseRepository,
@@ -1164,13 +1165,16 @@ public class LicenseDatabaseHandler {
 
         IMPORT_STATUS = true;
         IMPORT_TIME = currentTime;
+        String startTime = Instant.now().toString();
 
         try {
             String enabled = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_ENABLED);
             if (!"true".equals(enabled)) {
                 log.info("LicenseDB integration is disabled. Skipping sync.");
-                return requestSummary.setRequestStatus(RequestStatus.FAILURE)
+                requestSummary.setRequestStatus(RequestStatus.FAILURE)
                         .setMessage("LicenseDB integration is disabled.");
+                createSyncReport("FULL", startTime, requestSummary);
+                return requestSummary;
             }
             String baseUrl = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_BASE_URL);
             String username = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_USERNAME);
@@ -1178,32 +1182,30 @@ public class LicenseDatabaseHandler {
 
             if (isNullOrEmpty(baseUrl) || isNullOrEmpty(username) || isNullOrEmpty(password)) {
                 log.error("LicenseDB configuration is incomplete (missing baseUrl, username, or password).");
-                return requestSummary.setRequestStatus(RequestStatus.FAILURE)
+                requestSummary.setRequestStatus(RequestStatus.FAILURE)
                         .setMessage("LicenseDB configuration is incomplete.");
+                createSyncReport("FULL", startTime, requestSummary);
+                return requestSummary;
             }
 
             LicenseDBConnector connector = createLicenseDBConnector(baseUrl, username, password);
 
             // Fetch obligations first because license records reference them by UUID
-            List<LicenseDBObligationDTO> obligationDTOs;
-            List<LicenseDBLicenseDTO> licenseDTOs;
-            try {
-                obligationDTOs = connector.fetchAllObligations();
-                licenseDTOs = connector.fetchAllLicenses();
-            } catch (IOException e) {
-                String msg = "LicenseDB sync failed (connection error): " + e.getMessage();
-                log.error(msg, e);
-                return requestSummary.setRequestStatus(RequestStatus.FAILURE).setMessage(msg);
-            }
+            List<LicenseDBObligationDTO> obligationDTOs = connector.fetchAllObligations();
+            List<LicenseDBLicenseDTO> licenseDTOs = connector.fetchAllLicenses();
             log.info("LicenseDB sync: fetched {} active obligations and {} active licenses",
                     obligationDTOs.size(), licenseDTOs.size());
 
-            return processLicenseDBSync(obligationDTOs, licenseDTOs, requestSummary);
+            RequestSummary result = processLicenseDBSync(obligationDTOs, licenseDTOs, requestSummary);
+            createSyncReport("FULL", startTime, result);
+            return result;
 
         } catch (SW360Exception e) {
             String msg = "LicenseDB sync failed: " + e.getMessage();
             log.error(msg, e);
-            return requestSummary.setRequestStatus(RequestStatus.FAILURE).setMessage(msg);
+            requestSummary.setRequestStatus(RequestStatus.FAILURE).setMessage(msg);
+            createSyncReport("FULL", startTime, requestSummary);
+            return requestSummary;
         } finally {
             IMPORT_STATUS = false;
         }
@@ -1360,7 +1362,6 @@ public class LicenseDatabaseHandler {
                 "{\"licensesCreated\":%d,\"licensesUpdated\":%d,\"obligationsCreated\":%d,\"obligationsUpdated\":%d}",
                 licensesCreated, licensesUpdated, obligationsCreated, obligationsUpdated);
         log.info("LicenseDB sync complete: {}", message);
-        updateLastSyncTimestamp();
         return requestSummary.setTotalElements(total).setTotalAffectedElements(affected)
                 .setMessage(message).setRequestStatus(RequestStatus.SUCCESS);
     }
@@ -1428,34 +1429,152 @@ public class LicenseDatabaseHandler {
         }
     }
 
-    private void updateLastSyncTimestamp() {
-        try {
-            String now = Instant.now().toString();
-            Document existing = null;
+    private Instant readLastSyncTimestamp() {
+        LicenseDBSyncReport report = syncReportRepository.getLatestSuccessfulReport();
+        if (report != null && report.getEndDate() != null) {
             try {
-                existing = db.getDocument(LICENSEDB_SYNC_STATE_DOC_ID);
-            } catch (SW360Exception e) {
-                // The sync state document does not exist yet so create a new one
+                return Instant.parse(report.getEndDate());
+            } catch (Exception e) {
+                log.warn("Could not parse endDate from sync report: {}", e.getMessage());
             }
-            if (existing != null) {
-                Map<String, Object> props = existing.getProperties() != null
-                        ? new HashMap<>(existing.getProperties())
-                        : new HashMap<>();
-                props.put("lastSyncTimestamp", now);
-                existing.setProperties(props);
-                db.update(existing);
-            } else {
-                Document doc = new Document();
-                doc.setId(LICENSEDB_SYNC_STATE_DOC_ID);
-                Map<String, Object> props = new HashMap<>();
-                props.put("type", "licensedb-sync-state");
-                props.put("lastSyncTimestamp", now);
-                doc.setProperties(props);
-                db.add(doc);
+        }
+        return Instant.EPOCH;
+    }
+
+    public Map<String, String> getLicenseDBSyncStatus(User user) {
+        Map<String, String> status = new HashMap<>();
+        try {
+            status.put("enabled", "true".equals(SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_ENABLED)) ? "true" : "false");
+        } catch (SW360Exception e) {
+            status.put("enabled", "false");
+        }
+        status.put("importRunning", String.valueOf(IMPORT_STATUS));
+
+        Instant last = readLastSyncTimestamp();
+        status.put("lastSyncTimestamp", last.equals(Instant.EPOCH) ? "never" : last.toString());
+
+        LicenseDBSyncReport latestReport = syncReportRepository.getLatestReport();
+        if (latestReport != null) {
+            status.put("lastSyncStatus", latestReport.getStatus() != null ? latestReport.getStatus() : "");
+            status.put("lastSyncType", latestReport.getSyncType() != null ? latestReport.getSyncType() : "");
+            status.put("lastSyncStartDate", latestReport.getStartDate() != null ? latestReport.getStartDate() : "");
+            status.put("lastSyncEndDate", latestReport.getEndDate() != null ? latestReport.getEndDate() : "");
+            status.put("lastSyncProcessingSeconds", String.valueOf(latestReport.getProcessingSeconds()));
+            status.put("lastSyncMessage", latestReport.getMessage() != null ? latestReport.getMessage() : "");
+        }
+
+        return status;
+    }
+
+    public boolean pingLicenseDBHealth(User user) {
+        try {
+            String enabled = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_ENABLED);
+            if (!"true".equals(enabled)) {
+                return false;
             }
-            log.info("LicenseDB sync state updated: lastSyncTimestamp={}", now);
+            String baseUrl = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_BASE_URL);
+            String username = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_USERNAME);
+            String password = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_PASSWORD);
+            if (isNullOrEmpty(baseUrl) || isNullOrEmpty(username) || isNullOrEmpty(password)) {
+                return false;
+            }
+            return createLicenseDBConnector(baseUrl, username, password).pingHealth();
+        } catch (SW360Exception e) {
+            log.warn("LicenseDB health check failed (config error): {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public RequestSummary importIncrementalLicenseDBLicenses(User user) {
+        RequestSummary requestSummary = new RequestSummary().setTotalAffectedElements(0).setMessage("");
+        Timestamp ts = Timestamp.from(Instant.now());
+        long currentTime = ts.getTime();
+        if (IMPORT_STATUS && ((IMPORT_TIME + TIME_OUT) > currentTime)) {
+            return requestSummary.setRequestStatus(RequestStatus.PROCESSING);
+        }
+
+        IMPORT_STATUS = true;
+        IMPORT_TIME = currentTime;
+        String startTime = Instant.now().toString();
+
+        try {
+            String enabled = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_ENABLED);
+            if (!"true".equals(enabled)) {
+                log.info("LicenseDB integration is disabled. Skipping incremental sync.");
+                requestSummary.setRequestStatus(RequestStatus.FAILURE)
+                        .setMessage("LicenseDB integration is disabled.");
+                createSyncReport("INCREMENTAL", startTime, requestSummary);
+                return requestSummary;
+            }
+            String baseUrl = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_BASE_URL);
+            String username = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_USERNAME);
+            String password = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_PASSWORD);
+
+            if (isNullOrEmpty(baseUrl) || isNullOrEmpty(username) || isNullOrEmpty(password)) {
+                log.error("LicenseDB configuration is incomplete (missing baseUrl, username, or password).");
+                requestSummary.setRequestStatus(RequestStatus.FAILURE)
+                        .setMessage("LicenseDB configuration is incomplete.");
+                createSyncReport("INCREMENTAL", startTime, requestSummary);
+                return requestSummary;
+            }
+
+            Instant since = readLastSyncTimestamp();
+            log.info("LicenseDB incremental sync: fetching changes since {}", since);
+
+            LicenseDBConnector connector = createLicenseDBConnector(baseUrl, username, password);
+
+            List<LicenseDBLicenseDTO> changedLicenses = connector.fetchChangedLicensesSince(since);
+
+            if (changedLicenses.isEmpty()) {
+                log.info("LicenseDB incremental sync: no changes since {}", since);
+                requestSummary.setRequestStatus(RequestStatus.SUCCESS)
+                        .setMessage("No changes since last sync.");
+                createSyncReport("INCREMENTAL", startTime, requestSummary);
+                return requestSummary;
+            }
+
+            List<LicenseDBObligationDTO> obligationDTOs = connector.fetchAllObligations();
+
+            log.info("LicenseDB incremental sync: fetched {} obligations and {} changed licenses to process",
+                    obligationDTOs.size(), changedLicenses.size());
+
+            RequestSummary result = processLicenseDBSync(obligationDTOs, changedLicenses, requestSummary);
+            createSyncReport("INCREMENTAL", startTime, result);
+            return result;
+
+        } catch (SW360Exception e) {
+            String msg = "LicenseDB incremental sync failed: " + e.getMessage();
+            log.error(msg, e);
+            requestSummary.setRequestStatus(RequestStatus.FAILURE).setMessage(msg);
+            createSyncReport("INCREMENTAL", startTime, requestSummary);
+            return requestSummary;
+        } finally {
+            IMPORT_STATUS = false;
+        }
+    }
+
+    private void createSyncReport(String syncType, String startTime, RequestSummary result) {
+        try {
+            String endTime = Instant.now().toString();
+            long startMillis = Instant.parse(startTime).toEpochMilli();
+            long endMillis = Instant.parse(endTime).toEpochMilli();
+            int processingSeconds = (int) ((endMillis - startMillis) / 1000);
+
+            LicenseDBSyncReport report = new LicenseDBSyncReport();
+            report.setSyncType(syncType);
+            report.setStartDate(startTime);
+            report.setEndDate(endTime);
+            report.setProcessingSeconds(processingSeconds);
+            report.setStatus(result.getRequestStatus() != null ? result.getRequestStatus().name() : "UNKNOWN");
+            report.setMessage(result.getMessage());
+            report.setTotalElements(result.getTotalElements());
+            report.setTotalAffectedElements(result.getTotalAffectedElements());
+            syncReportRepository.add(report);
+
+            log.info("LicenseDB sync report created: syncType={}, status={}, duration={}s",
+                    syncType, result.getRequestStatus(), processingSeconds);
         } catch (Exception e) {
-            log.warn("Failed to update LicenseDB sync state: {}", e.getMessage());
+            log.warn("Failed to create LicenseDB sync report: {}", e.getMessage());
         }
     }
 

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
@@ -7,20 +7,28 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
+
 package org.eclipse.sw360.licenses.tools;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -49,37 +57,108 @@ public class LicenseDBConnector {
         this.tokenManager = Objects.requireNonNull(tokenManager, "tokenManager must not be null");
     }
 
-    public List<LicenseDBLicenseDTO> fetchAllLicenses() throws IOException {
+    public List<LicenseDBLicenseDTO> fetchAllLicenses() throws SW360Exception {
         List<LicenseDBLicenseDTO> all = doGet(baseUrl + "/api/v1/licenses/export", LICENSE_LIST_TYPE);
         return all.stream()
                 .filter(LicenseDBLicenseDTO::isActive)
                 .collect(Collectors.toList());
     }
 
-    public List<LicenseDBObligationDTO> fetchAllObligations() throws IOException {
+    public List<LicenseDBObligationDTO> fetchAllObligations() throws SW360Exception {
         List<LicenseDBObligationDTO> all = doGet(baseUrl + "/api/v1/obligations/export", OBLIGATION_LIST_TYPE);
         return all.stream()
                 .filter(LicenseDBObligationDTO::isActive)
                 .collect(Collectors.toList());
     }
 
-    private <T> List<T> doGet(String url, TypeReference<List<T>> typeRef) throws IOException {
-        String token = tokenManager.getValidToken();
-        HttpGet request = new HttpGet(url);
-        request.setHeader("Authorization", "Bearer " + token);
-        request.setHeader("Accept", "application/json");
+    public boolean pingHealth() {
+        try {
+            doGetAsNode(baseUrl + "/api/v1/health");
+            return true;
+        } catch (SW360Exception e) {
+            log.warn("LicenseDB health ping failed: {} ({})", e.getMessage(), e.getClass().getSimpleName());
+            return false;
+        }
+    }
 
-        try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(REQUEST_CONFIG).build()) {
-            return httpClient.execute(request, response -> {
+    // LicenseDB audits are ordered by timestamp desc, so we can stop once older entries are reached.
+    public List<LicenseDBLicenseDTO> fetchChangedLicensesSince(Instant since) throws SW360Exception {
+        List<LicenseDBLicenseDTO> changed = new ArrayList<>();
+        int page = 1;
+        while (true) {
+            JsonNode root = doGetAsNode(baseUrl + "/api/v1/audits?page=" + page + "&limit=50");
+            JsonNode data = root.path("data");
+            if (data.isEmpty()) break;
+            boolean reachedOldEntries = false;
+            for (JsonNode audit : data) {
+                Instant ts;
+                try {
+                    ts = Instant.parse(audit.path("timestamp").asText());
+                } catch (DateTimeParseException e) {
+                    log.warn("LicenseDB audit entry has unparseable timestamp '{}', skipping",
+                            audit.path("timestamp").asText());
+                    continue;
+                }
+                if (ts.isBefore(since)) {
+                    reachedOldEntries = true;
+                    break;
+                }
+                if ("LICENSE".equals(audit.path("type").asText())) {
+                    try {
+                        LicenseDBLicenseDTO dto = objectMapper.treeToValue(
+                                audit.path("entity"), LicenseDBLicenseDTO.class);
+                        if (dto != null && dto.isActive()) changed.add(dto);
+                    } catch (IOException e) {
+                        log.warn("Failed to parse audit entity, skipping: {}", e.getMessage());
+                    }
+                }
+            }
+            if (reachedOldEntries) break;
+            int totalPages = root.path("paginationmeta").path("total_pages").asInt(1);
+            if (page >= totalPages) break;
+            page++;
+        }
+        return changed;
+    }
+
+    private <T> List<T> doGet(String url, TypeReference<List<T>> typeRef) throws SW360Exception {
+        return executeGet(url, response -> {
+            try (InputStream content = response.getEntity().getContent()) {
+                return objectMapper.readValue(content, typeRef);
+            }
+        });
+    }
+
+    private JsonNode doGetAsNode(String url) throws SW360Exception {
+        return executeGet(url, response -> {
+            try (InputStream content = response.getEntity().getContent()) {
+                return objectMapper.readTree(content);
+            }
+        });
+    }
+
+    private <T> T executeGet(String url, HttpClientResponseHandler<T> bodyHandler) throws SW360Exception {
+        try {
+            String token = tokenManager.getValidToken();
+            HttpGet request = new HttpGet(url);
+            request.setHeader("Authorization", "Bearer " + token);
+            request.setHeader("Accept", "application/json");
+            try (CloseableHttpClient httpClient = HttpClients.custom()
+                    .setDefaultRequestConfig(REQUEST_CONFIG).build();
+                 CloseableHttpResponse response = httpClient.execute(request)) {
                 int code = response.getCode();
                 if (code != 200) {
-                    log.error("LicenseDB export failed with HTTP {} for: {}", code, url);
-                    throw new IOException("LicenseDB export returned HTTP: " + code);
+                    log.error("LicenseDB request failed with HTTP {} for: {}", code, url);
+                    SW360Exception ex = new SW360Exception("LicenseDB request failed for " + url + ": HTTP " + code);
+                    ex.setErrorCode(code);
+                    throw ex;
                 }
-                try (InputStream content = response.getEntity().getContent()) {
-                    return objectMapper.readValue(content, typeRef);
-                }
-            });
+                return bodyHandler.handleResponse(response);
+            }
+        } catch (SW360Exception e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SW360Exception("LicenseDB request failed for " + url + ": " + e.getMessage());
         }
     }
 }

--- a/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.sw360.datahandler.db.ObligationElementSearchHandler;
 import org.apache.thrift.TException;
 import java.nio.ByteBuffer;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -348,6 +349,30 @@ public class LicenseHandler implements LicenseService.Iface {
             return new RequestSummary().setRequestStatus(RequestStatus.FAILURE);
         }
         return handler.importAllLicenseDBLicenses(user);
+    }
+
+    @Override
+    public RequestSummary importIncrementalLicenseDBLicenses(User user) throws TException {
+        if (user != null && !PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user)) {
+            return new RequestSummary().setRequestStatus(RequestStatus.FAILURE);
+        }
+        return handler.importIncrementalLicenseDBLicenses(user);
+    }
+
+    @Override
+    public Map<String, String> getLicenseDBSyncStatus(User user) throws TException {
+        if (!PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user)) {
+            return new HashMap<>();
+        }
+        return handler.getLicenseDBSyncStatus(user);
+    }
+
+    @Override
+    public boolean pingLicenseDBHealth(User user) throws TException {
+        if (!PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user)) {
+            return false;
+        }
+        return handler.pingLicenseDBHealth(user);
     }
 
     @Override

--- a/libraries/datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/datahandler/src/main/thrift/licenses.thrift
@@ -317,6 +317,12 @@ service LicenseService {
 
     RequestSummary importAllLicenseDBLicenses(1: User user);
 
+    RequestSummary importIncrementalLicenseDBLicenses(1: User user);
+
+    map<string, string> getLicenseDBSyncStatus(1: User user);
+
+    bool pingLicenseDBHealth(1: User user);
+
     /**
      * delete obligation from database if user has permissions
      **/

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/licensedb/LicenseDBAdminController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/licensedb/LicenseDBAdminController.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.admin.licensedb;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.springframework.data.rest.webmvc.BasePathAwareController;
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@BasePathAwareController
+@RequiredArgsConstructor
+@SecurityRequirement(name = "tokenAuth")
+@SecurityRequirement(name = "basic")
+@PreAuthorize("hasAuthority('ADMIN')")
+public class LicenseDBAdminController implements RepresentationModelProcessor<RepositoryLinksResource> {
+
+    public static final String LICENSEDB_URL = "/licenseDB";
+
+    @NonNull
+    private final RestControllerHelper restControllerHelper;
+
+    @NonNull
+    private final Sw360LicenseDBAdminService licenseDBService;
+
+    @Override
+    @PreAuthorize("hasAuthority('READ')")
+    public RepositoryLinksResource process(RepositoryLinksResource resource) {
+        resource.add(linkTo(LicenseDBAdminController.class).slash("api" + LICENSEDB_URL).withRel("licenseDB"));
+        return resource;
+    }
+
+    @Operation(
+            summary = "Check LicenseDB connectivity and sync state.",
+            description = "Pings LicenseDB and returns connectivity status along with current sync state.",
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Health status returned successfully."),
+            @ApiResponse(responseCode = "403", description = "User is not an admin.")
+    })
+    @GetMapping(value = LICENSEDB_URL + "/health")
+    public ResponseEntity<LicenseDBSyncStatus> getHealth() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        LicenseDBSyncStatus health = licenseDBService.getHealth(sw360User);
+        return new ResponseEntity<>(health, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Get LicenseDB sync status.",
+            description = "Returns the current sync state from local storage. Does not ping LicenseDB.",
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Sync status returned successfully."),
+            @ApiResponse(responseCode = "403", description = "User is not an admin.")
+    })
+    @GetMapping(value = LICENSEDB_URL + "/syncStatus")
+    public ResponseEntity<LicenseDBSyncStatus> getSyncStatus() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        LicenseDBSyncStatus status = licenseDBService.getSyncStatus(sw360User);
+        return new ResponseEntity<>(status, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Trigger a full LicenseDB sync.",
+            description = "Imports all active licenses and obligations from LicenseDB into SW360.",
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Full sync completed successfully."),
+            @ApiResponse(responseCode = "403", description = "User is not an admin."),
+            @ApiResponse(responseCode = "500", description = "Full sync failed.")
+    })
+    @PostMapping(value = LICENSEDB_URL + "/sync")
+    public ResponseEntity<RequestSummary> triggerFullSync() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary summary = licenseDBService.triggerFullSync(sw360User);
+        HttpStatus status = summary.getRequestStatus() == RequestStatus.SUCCESS ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR;
+        return new ResponseEntity<>(summary, status);
+    }
+
+    @Operation(
+            summary = "Trigger an incremental LicenseDB sync.",
+            description = "Imports licenses changed in LicenseDB since the last successful sync.",
+            tags = {"Admin"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Incremental sync completed successfully."),
+            @ApiResponse(responseCode = "403", description = "User is not an admin."),
+            @ApiResponse(responseCode = "500", description = "Incremental sync failed.")
+    })
+    @PostMapping(value = LICENSEDB_URL + "/sync/incremental")
+    public ResponseEntity<RequestSummary> triggerIncrementalSync() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        RequestSummary summary = licenseDBService.triggerIncrementalSync(sw360User);
+        HttpStatus status = summary.getRequestStatus() == RequestStatus.SUCCESS ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR;
+        return new ResponseEntity<>(summary, status);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/licensedb/LicenseDBSyncStatus.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/licensedb/LicenseDBSyncStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.admin.licensedb;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LicenseDBSyncStatus {
+
+    private Boolean enabled;
+    private Boolean connected;
+    private Boolean importRunning;
+    private String lastSyncTimestamp;
+    private String lastSyncStatus;
+    private String lastSyncType;
+    private String lastSyncStartDate;
+    private String lastSyncEndDate;
+    private Integer lastSyncProcessingSeconds;
+    private String lastSyncMessage;
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/licensedb/Sw360LicenseDBAdminService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/admin/licensedb/Sw360LicenseDBAdminService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.admin.licensedb;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+import static org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper.throwIfNotAdmin;
+
+@Service
+public class Sw360LicenseDBAdminService {
+
+    public RequestSummary triggerFullSync(User user) throws TException {
+        throwIfNotAdmin(user);
+        return ThriftClients.makeLicenseClient().importAllLicenseDBLicenses(user);
+    }
+
+    public RequestSummary triggerIncrementalSync(User user) throws TException {
+        throwIfNotAdmin(user);
+        return ThriftClients.makeLicenseClient().importIncrementalLicenseDBLicenses(user);
+    }
+
+    public LicenseDBSyncStatus getHealth(User user) throws TException {
+        throwIfNotAdmin(user);
+        LicenseService.Iface client = ThriftClients.makeLicenseClient();
+        Map<String, String> raw = client.getLicenseDBSyncStatus(user);
+        boolean connected = client.pingLicenseDBHealth(user);
+
+        LicenseDBSyncStatus status = mapToSyncStatus(raw);
+        status.setConnected(connected);
+        return status;
+    }
+
+    public LicenseDBSyncStatus getSyncStatus(User user) throws TException {
+        throwIfNotAdmin(user);
+        Map<String, String> raw = ThriftClients.makeLicenseClient().getLicenseDBSyncStatus(user);
+        return mapToSyncStatus(raw);
+    }
+
+    private LicenseDBSyncStatus mapToSyncStatus(Map<String, String> raw) {
+        LicenseDBSyncStatus status = new LicenseDBSyncStatus();
+        status.setEnabled(Boolean.parseBoolean(raw.getOrDefault("enabled", "false")));
+        status.setImportRunning(Boolean.parseBoolean(raw.getOrDefault("importRunning", "false")));
+        status.setLastSyncTimestamp(raw.get("lastSyncTimestamp"));
+        status.setLastSyncStatus(raw.get("lastSyncStatus"));
+        status.setLastSyncType(raw.get("lastSyncType"));
+        status.setLastSyncStartDate(raw.get("lastSyncStartDate"));
+        status.setLastSyncEndDate(raw.get("lastSyncEndDate"));
+        String seconds = raw.get("lastSyncProcessingSeconds");
+        if (seconds != null && !seconds.isEmpty()) {
+            try {
+                status.setLastSyncProcessingSeconds(Integer.parseInt(seconds));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        status.setLastSyncMessage(raw.get("lastSyncMessage"));
+        return status;
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ApiSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ApiSpecTest.java
@@ -162,6 +162,7 @@ public class ApiSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("sw360:databaseSanitation").description("The <<resources-databaseSanitation,DatabaseSanitation resource>>"),
                                 linkWithRel("sw360:moderationRequests").description("The <<resources-moderationRequest,ModerationRequest resource>>"),
                                 linkWithRel("sw360:fossology").description("The <<resources-fossology,Fossology resource>>"),
+                                linkWithRel("sw360:licenseDB").description("The <<resources-licenseDB,LicenseDB resource>>"),
                                 linkWithRel("sw360:schedule").description("The <<resources-schedule,Schedule resource>>"),
                                 linkWithRel("sw360:ecc").description("The <<resources-ecc,Ecc resource>>"),
                                 linkWithRel("sw360:attachmentCleanUp").description("The <<resources-attachmentCleanUp,attachmentCleanUp resource>>"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseDBAdminSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseDBAdminSpecTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.restdocs;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+
+import org.eclipse.sw360.rest.resourceserver.admin.licensedb.LicenseDBSyncStatus;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class LicenseDBAdminSpecTest extends TestRestDocsSpecBase {
+
+    @Value("${sw360.test-user-id}")
+    private String testUserId;
+
+    @Value("${sw360.test-user-password}")
+    private String testUserPassword;
+
+    @BeforeEach
+    public void before() throws TException, IOException {
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
+                new User("admin@sw360.org", "sw360").setId("123456789"));
+
+        LicenseDBSyncStatus syncStatus = new LicenseDBSyncStatus();
+        syncStatus.setEnabled(true);
+        syncStatus.setImportRunning(false);
+        syncStatus.setLastSyncTimestamp("2026-07-18T10:00:00Z");
+
+        LicenseDBSyncStatus health = new LicenseDBSyncStatus();
+        health.setEnabled(true);
+        health.setConnected(true);
+        health.setImportRunning(false);
+        health.setLastSyncTimestamp("2026-07-18T10:00:00Z");
+
+        RequestSummary fullSyncSummary = new RequestSummary()
+                .setRequestStatus(RequestStatus.SUCCESS)
+                .setTotalAffectedElements(42)
+                .setMessage("{\"licensesCreated\":30,\"licensesUpdated\":12}");
+
+        RequestSummary incrementalSyncSummary = new RequestSummary()
+                .setRequestStatus(RequestStatus.SUCCESS)
+                .setTotalAffectedElements(5)
+                .setMessage("{\"licensesCreated\":2,\"licensesUpdated\":3}");
+
+        given(this.licenseDBAdminService.getHealth(any())).willReturn(health);
+        given(this.licenseDBAdminService.getSyncStatus(any())).willReturn(syncStatus);
+        given(this.licenseDBAdminService.triggerFullSync(any())).willReturn(fullSyncSummary);
+        given(this.licenseDBAdminService.triggerIncrementalSync(any())).willReturn(incrementalSyncSummary);
+    }
+
+    @Test
+    public void should_document_get_licensedb_health() throws Exception {
+        mockMvc.perform(get("/api/licenseDB/health")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.connected").value(true))
+                .andExpect(jsonPath("$.importRunning").value(false));
+    }
+
+    @Test
+    public void should_document_get_licensedb_sync_status() throws Exception {
+        mockMvc.perform(get("/api/licenseDB/syncStatus")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.importRunning").value(false));
+    }
+
+    @Test
+    public void should_document_trigger_full_sync() throws Exception {
+        mockMvc.perform(post("/api/licenseDB/sync")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestStatus").value("SUCCESS"));
+    }
+
+    @Test
+    public void should_document_trigger_incremental_sync() throws Exception {
+        mockMvc.perform(post("/api/licenseDB/sync/incremental")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestStatus").value("SUCCESS"));
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
@@ -33,6 +33,7 @@ import org.eclipse.sw360.rest.resourceserver.SW360RestHealthIndicator;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.admin.attachment.Sw360AttachmentCleanUpService;
 import org.eclipse.sw360.rest.resourceserver.admin.fossology.Sw360FossologyAdminServices;
+import org.eclipse.sw360.rest.resourceserver.admin.licensedb.Sw360LicenseDBAdminService;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.changelog.Sw360ChangeLogService;
 import org.eclipse.sw360.rest.resourceserver.clearingrequest.Sw360ClearingRequestService;
@@ -160,6 +161,9 @@ public abstract class TestRestDocsSpecBase {
 
     @MockitoBean
     Sw360FossologyAdminServices fossologyAdminServices;
+
+    @MockitoBean
+    Sw360LicenseDBAdminService licenseDBAdminService;
 
     @MockitoBean
     FossologyService.Iface fossologyClient;


### PR DESCRIPTION
## Summary

This PR adds admin controls for the LicenseDB sync lifecycle.

It builds on the sync engine from #4292 and adds a small admin API to check LicenseDB connectivity, view the current sync status, trigger a full sync, and run an incremental sync based on changes from LicenseDB.

## What changed

* Added admin endpoints for LicenseDB health, sync status, full sync, and incremental sync
* Added a service layer to keep the controller thin
* Added a LicenseDB health check to verify connectivity
* Added incremental sync support using the LicenseDB audits API
* Reused the existing full-sync logic where possible
* Added report based sync status and timestamp lookup without fixed state documents
* Added Thrift methods for sync status and health checks with admin access control

## Endpoints

* `GET /api/licenseDB/health`
* `GET /api/licenseDB/syncStatus`
* `POST /api/licenseDB/sync`
* `POST /api/licenseDB/sync/incremental`

All endpoints require `ADMIN` authority.

## Suggested reviewers

@GMishx
@deo002
@Farooq-Fateh-Aftab