### PR TITLE
fix(Attachments): Fixed `Checked By` for attachment update

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -573,14 +573,67 @@ public class Sw360AttachmentService {
             attachment.setCheckStatus(CheckStatus.NOTCHECKED);
         }
         if (!CheckStatus.NOTCHECKED.equals(attachment.getCheckStatus())) {
-            attachment.setCheckedBy(attachment.getCheckedBy() != null ? attachment.getCheckedBy() : user.getEmail());
-            attachment.setCheckedTeam(attachment.getCheckedTeam() != null ? attachment.getCheckedTeam() : user.getDepartment());
-            attachment.setCheckedOn(attachment.getCheckedOn() != null ? attachment.getCheckedOn() : SW360Utils.getCreatedOn());
+            // checkedBy/checkedTeam/checkedOn are backend-owned audit fields.
+            // Never trust the values sent by the client - always derive the checker
+            // identity from the authenticated user and use the server-side date.
+            attachment.setCheckedBy(user.getEmail());
+            attachment.setCheckedTeam(user.getDepartment());
+            attachment.setCheckedOn(SW360Utils.getCreatedOn());
         } else {
             attachment.unsetCheckedBy();
             attachment.unsetCheckedTeam();
             attachment.setCheckedComment("");
             attachment.unsetCheckedOn();
+        }
+    }
+    /**
+     * Authoritatively resolves the attachment check audit fields
+     * ({@code checkedBy}, {@code checkedTeam}, {@code checkedOn}) using the authenticated
+     * user, ignoring whatever the client sent for those fields. Only
+     * {@code attachmentContentId}, {@code checkStatus} and {@code checkedComment} from the
+     * request are honoured to describe the check state.
+     *
+     *   1. check status unchanged vs. the stored attachment -> the original
+     *       checker identity and date are preserved, so an unrelated update (e.g. a
+     *       full attachment-list resubmit) does not rewrite who checked it.
+     *   2. check status changed (accepted/rejected, or switched between them) or
+     *       the attachment is new -> the current user (from the token) and the server
+     *       date are stamped.
+     *
+     * @param incomingAttachments attachments coming from the request body
+     * @param storedAttachments   attachments currently persisted for the entity
+     * @param user                the authenticated user derived from the token
+     */
+    public void setCheckedAttachmentDataFromRequest(Set<Attachment> incomingAttachments,
+            Set<Attachment> storedAttachments, User user) {
+        if (CommonUtils.isNullOrEmptyCollection(incomingAttachments)) {
+            return;
+        }
+        Map<String, Attachment> storedMap = new HashMap<>();
+        if (storedAttachments != null) {
+            storedAttachments.forEach(att -> storedMap.put(att.getAttachmentContentId(), att));
+        }
+        for (Attachment incoming : incomingAttachments) {
+            if (incoming.getCheckStatus() == null) {
+                incoming.setCheckStatus(CheckStatus.NOTCHECKED);
+            }
+            Attachment stored = storedMap.get(incoming.getAttachmentContentId());
+            if (CheckStatus.NOTCHECKED.equals(incoming.getCheckStatus())) {
+                incoming.unsetCheckedBy();
+                incoming.unsetCheckedTeam();
+                incoming.unsetCheckedOn();
+                incoming.setCheckedComment("");
+            } else if (stored != null && incoming.getCheckStatus().equals(stored.getCheckStatus())) {
+                // Check status unchanged: keep the original checker, ignore client-sent values.
+                incoming.setCheckedBy(stored.getCheckedBy());
+                incoming.setCheckedTeam(stored.getCheckedTeam());
+                incoming.setCheckedOn(stored.getCheckedOn());
+            } else {
+                // New/changed check decision: stamp the authenticated user and server date.
+                incoming.setCheckedBy(user.getEmail());
+                incoming.setCheckedTeam(user.getDepartment());
+                incoming.setCheckedOn(SW360Utils.getCreatedOn());
+            }
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -100,7 +100,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.eclipse.sw360.datahandler.common.WrappedException.wrapSW360Exception;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @BasePathAwareController
@@ -439,9 +438,8 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
         if (updateComponentDto.getAttachments() != null && !updateComponentDto.getAttachments().isEmpty()) {
             attachmentService.preserveImmutableAttachmentFields(
                     updateComponentDto.getAttachments(), sw360Component.getAttachments(), user);
-            updateComponentDto.getAttachments().forEach(attachment ->
-                wrapSW360Exception(() -> attachmentService.fillCheckedAttachmentData(attachment, user))
-            );
+            attachmentService.setCheckedAttachmentDataFromRequest(
+                    updateComponentDto.getAttachments(), sw360Component.getAttachments(), user);
         }
 
         sw360Component = restControllerHelper.updateComponent(sw360Component, updateComponentDto);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -1976,6 +1976,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         if (updateProject.getAttachments() != null && !updateProject.getAttachments().isEmpty()) {
             attachmentService.preserveImmutableAttachmentFields(
                     updateProject.getAttachments(), sw360Project.getAttachments(), user);
+            attachmentService.setCheckedAttachmentDataFromRequest(
+                    updateProject.getAttachments(), sw360Project.getAttachments(), user);
         }
         sw360Project = this.restControllerHelper.updateProject(sw360Project, updateProject, reqBodyMap,
                 mapOfProjectFieldsToRequestBody);
@@ -2885,6 +2887,13 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Project updateProject = convertToProject(reqBodyMap);
         updateProject.unsetReleaseIdToUsage();
         sw360Project.unsetReleaseIdToUsage();
+
+        if (!CommonUtils.isNullOrEmptyCollection(updateProject.getAttachments())) {
+            attachmentService.preserveImmutableAttachmentFields(
+                    updateProject.getAttachments(), sw360Project.getAttachments(), user);
+            attachmentService.setCheckedAttachmentDataFromRequest(
+                    updateProject.getAttachments(), sw360Project.getAttachments(), user);
+        }
 
         try {
             addOrPatchDependencyNetworkToProject(updateProject, reqBodyMap, ProjectOperation.UPDATE);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -561,6 +561,8 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         Release updateRelease = setBackwardCompatibleFieldsInRelease(reqBodyMap);
         attachmentService.preserveImmutableAttachmentFields(
                 updateRelease.getAttachments(), sw360Release.getAttachments(), user);
+        attachmentService.setCheckedAttachmentDataFromRequest(
+                updateRelease.getAttachments(), sw360Release.getAttachments(), user);
 
         // Apply the same clearing state edit rules as the frontend:
         // Only clearing admin/expert can change clearing state, and only to

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
@@ -19,6 +19,8 @@ import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.core.ThriftServiceProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -218,5 +220,108 @@ public class Sw360AttachmentServiceTest {
         String filename7 = "_//_\\_";
         String sanitized7 = CommonUtils.sanitizeFilename(filename7);
         assertThat(sanitized7).isEqualTo(CommonUtils.DEFAULT_ATTACHMENT_FILENAME);
+    }
+    // ---- checkedBy / checkedTeam / checkedOn ownership tests ----
+    private static final String USER_B_EMAIL = "userB@sw360.org";
+    private static final String USER_B_DEPT = "DEPT_B";
+    private static User userB() {
+        return new User(USER_B_EMAIL, USER_B_DEPT);
+    }
+    private static Attachment att(String contentId, CheckStatus status, String checkedBy, String checkedTeam,
+            String checkedOn) {
+        Attachment a = new Attachment(contentId, "file-" + contentId);
+        if (status != null) {
+            a.setCheckStatus(status);
+        }
+        if (checkedBy != null) {
+            a.setCheckedBy(checkedBy);
+        }
+        if (checkedTeam != null) {
+            a.setCheckedTeam(checkedTeam);
+        }
+        if (checkedOn != null) {
+            a.setCheckedOn(checkedOn);
+        }
+        return a;
+    }
+    @Test
+    public void testCheckStatusChangedStampsAuthenticatedUserAndIgnoresClientCheckedBy() {
+        // stored: accepted by userA
+        Attachment stored = att("c1", CheckStatus.ACCEPTED, "userA@sw360.org", "DEPT_A", "2026-01-01");
+        // incoming: userB rejects it but (maliciously) still sends userA as checkedBy
+        Attachment incoming = att("c1", CheckStatus.REJECTED, "userA@sw360.org", "DEPT_A", "2026-01-01");
+        incoming.setCheckedComment("rejecting now");
+        attachmentService.setCheckedAttachmentDataFromRequest(
+                new HashSet<>(Collections.singletonList(incoming)),
+                new HashSet<>(Collections.singletonList(stored)), userB());
+        assertThat(incoming.getCheckStatus()).isEqualTo(CheckStatus.REJECTED);
+        assertThat(incoming.getCheckedBy()).isEqualTo(USER_B_EMAIL);
+        assertThat(incoming.getCheckedTeam()).isEqualTo(USER_B_DEPT);
+        assertThat(incoming.getCheckedOn()).isEqualTo(SW360Utils.getCreatedOn());
+        // client-supplied comment is honoured
+        assertThat(incoming.getCheckedComment()).isEqualTo("rejecting now");
+    }
+    @Test
+    public void testCheckStatusUnchangedPreservesOriginalChecker() {
+        // stored: accepted by userA
+        Attachment stored = att("c1", CheckStatus.ACCEPTED, "userA@sw360.org", "DEPT_A", "2026-01-01");
+        // incoming: still accepted, full-list resubmit during an unrelated edit by userB
+        Attachment incoming = att("c1", CheckStatus.ACCEPTED, "spoofed@sw360.org", "SPOOF", "2099-12-31");
+        attachmentService.setCheckedAttachmentDataFromRequest(
+                new HashSet<>(Collections.singletonList(incoming)),
+                new HashSet<>(Collections.singletonList(stored)), userB());
+        // original checker is preserved, spoofed values ignored, not rewritten to userB
+        assertThat(incoming.getCheckedBy()).isEqualTo("userA@sw360.org");
+        assertThat(incoming.getCheckedTeam()).isEqualTo("DEPT_A");
+        assertThat(incoming.getCheckedOn()).isEqualTo("2026-01-01");
+    }
+    @Test
+    public void testNewCheckedAttachmentStampsAuthenticatedUser() {
+        // no stored counterpart (newly added, pre-accepted), client spoofs checkedBy
+        Attachment incoming = att("cNew", CheckStatus.ACCEPTED, "spoofed@sw360.org", "SPOOF", "2099-12-31");
+        attachmentService.setCheckedAttachmentDataFromRequest(
+                new HashSet<>(Collections.singletonList(incoming)),
+                Collections.emptySet(), userB());
+        assertThat(incoming.getCheckedBy()).isEqualTo(USER_B_EMAIL);
+        assertThat(incoming.getCheckedTeam()).isEqualTo(USER_B_DEPT);
+        assertThat(incoming.getCheckedOn()).isEqualTo(SW360Utils.getCreatedOn());
+    }
+    @Test
+    public void testNotCheckedClearsCheckedFields() {
+        Attachment stored = att("c1", CheckStatus.ACCEPTED, "userA@sw360.org", "DEPT_A", "2026-01-01");
+        Attachment incoming = att("c1", CheckStatus.NOTCHECKED, "userA@sw360.org", "DEPT_A", "2026-01-01");
+        incoming.setCheckedComment("stale");
+        attachmentService.setCheckedAttachmentDataFromRequest(
+                new HashSet<>(Collections.singletonList(incoming)),
+                new HashSet<>(Collections.singletonList(stored)), userB());
+        assertThat(incoming.isSetCheckedBy()).isFalse();
+        assertThat(incoming.isSetCheckedTeam()).isFalse();
+        assertThat(incoming.isSetCheckedOn()).isFalse();
+        assertThat(incoming.getCheckedComment()).isEmpty();
+    }
+    @Test
+    public void testNullCheckStatusDefaultsToNotCheckedAndClears() {
+        Attachment incoming = att("c1", null, "spoofed@sw360.org", "SPOOF", "2099-12-31");
+        attachmentService.setCheckedAttachmentDataFromRequest(
+                new HashSet<>(Collections.singletonList(incoming)),
+                Collections.emptySet(), userB());
+        assertThat(incoming.getCheckStatus()).isEqualTo(CheckStatus.NOTCHECKED);
+        assertThat(incoming.isSetCheckedBy()).isFalse();
+        assertThat(incoming.isSetCheckedTeam()).isFalse();
+        assertThat(incoming.isSetCheckedOn()).isFalse();
+    }
+    @Test
+    public void testNullIncomingIsNoOp() {
+        // should simply return without throwing
+        attachmentService.setCheckedAttachmentDataFromRequest(null,
+                new HashSet<>(Collections.singletonList(att("c1", CheckStatus.ACCEPTED, "a", "b", "c"))), userB());
+    }
+    @Test
+    public void testFillCheckedAttachmentDataNeverTrustsClientCheckedBy() throws TException {
+        Attachment incoming = att("c1", CheckStatus.ACCEPTED, "spoofed@sw360.org", "SPOOF", "2099-12-31");
+        attachmentService.fillCheckedAttachmentData(incoming, userB());
+        assertThat(incoming.getCheckedBy()).isEqualTo(USER_B_EMAIL);
+        assertThat(incoming.getCheckedTeam()).isEqualTo(USER_B_DEPT);
+        assertThat(incoming.getCheckedOn()).isEqualTo(SW360Utils.getCreatedOn());
     }
 }


### PR DESCRIPTION
## Description
When updating a project (or component/release), the attachment's **`checkedBy`** (and `checkedTeam`, `checkedOn`) were taken **straight from the frontend request**.

So if **userB** changed an attachment to **Rejected** that **userA** had **Accepted**, SW360 still stored it as *checked by userA* — the wrong person got recorded.

## Root cause
`Sw360AttachmentService.fillCheckedAttachmentData` kept the client-supplied value:

```java
attachment.setCheckedBy(attachment.getCheckedBy() != null ? attachment.getCheckedBy() : user.getEmail());
```

Because the frontend always sends `checkedBy`, the backend never replaced it with the real logged-in user.

## Fix
The backend now **owns** the check-audit fields and ignores what the client sends for them.

- Accepts from the request **only**: `attachmentContentId`, `checkStatus`, `checkedComment`.
- Sets `checkedBy` / `checkedTeam` / `checkedOn` from the **authenticated user** (token) + server date.
- **Transition-aware** (avoids a reverse bug):
  - Check status **changed** → stamp the **current user** as checker.
  - Check status **unchanged** → keep the **original checker** (an unrelated edit must not rewrite it).
  - Status **NOTCHECKED** → clear the checked fields.

This mirrors how `createdBy` already works on creation.

## Changes
| File | Change |
|------|--------|
| `Sw360AttachmentService.java` | Hardened `fillCheckedAttachmentData` (never trusts client); added transition-aware `setCheckedAttachmentDataFromRequest` |
| `ProjectController.java` | Wired into `patchProject` **and** `patchProjectWithNetwork` |
| `ComponentController.java` | Wired in; removed dead call + unused import |
| `ReleaseController.java` | Wired in |
| `Sw360AttachmentServiceTest.java` | 7 new unit tests |

## Behavior (before → after)
| Scenario | Before | After |
|----------|--------|-------|
| userB rejects what userA accepted | stored as userA ❌ | stored as userB ✅ |
| Client spoofs `checkedBy` in payload | trusted ❌ | ignored, real user used ✅ |
| Unrelated edit resends full attachment list | could rewrite checker | original checker preserved ✅ |
| Status set to NOTCHECKED | inconsistent | checked fields cleared ✅ |

### Checklist
- [x] The test cases in this PR are generated using Claude Opus 4.8 model

Linked frontend PR : https://github.com/eclipse-sw360/sw360-frontend/pull/1879

Closes : https://github.com/eclipse-sw360/sw360/issues/4373