### PR TITLE
fix(Project): Allowed ampersand character to save exact  as symbol

### DIFF
--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360XSSRequestWrapper.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/Sw360XSSRequestWrapper.java
@@ -126,16 +126,25 @@ public class Sw360XSSRequestWrapper extends HttpServletRequestWrapper {
     /**
      * Applies HTML encoding to a string value using OWASP ESAPI Encoder.
      * The function unescape the input first to prevent double encoding (`&lt;` => `&amp;lt;`).
+     * Sanitizes a user supplied value against XSS while preserving the literal ampersand.
+     * <p>
+     * The value is canonicalized ({@code unescapeHtml4}) to defeat entity-based bypasses, then
+     * run through OWASP {@code Encode.forHtmlContent(...)} to encode {@code &}, {@code <},
+     * {@code >} and to sanitize invalid/control Unicode. Since {@code forHtmlContent} produces
+     * {@code &amp;} only from a literal {@code &}, we restore just that sequence so values like
+     * {@code "A&B"} are not corrupted to {@code "A&amp;B"}; {@code <}/{@code >} stay encoded.
      *
      * @implNote `.forHtmlContent` is chosen over `.forHtml` to prevent encoding quotes.
      * @param value The string to sanitize.
-     * @return The HTML-encoded string, or null if the input was null.
+     * @return The sanitized string, or {@code null} if the input was {@code null}.
      */
     public static String stripXSS(String value) {
         if (value == null) {
             return null;
         }
         String canonicalValue = org.apache.commons.text.StringEscapeUtils.unescapeHtml4(value);
-        return org.owasp.encoder.Encode.forHtmlContent(canonicalValue);
+        String encoded = org.owasp.encoder.Encode.forHtmlContent(canonicalValue);
+        // Restore ONLY the literal ampersand; '&lt;'/'&gt;' stay encoded.
+        return encoded.replace("&amp;", "&");
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
This PR fixes two related defects around handling of the ampersand (`&`) character in project text fields (e.g. `tag`, `businessUnit`): one on the **write** path where `&` was corrupted on save, and one on the **search** path where values containing `&` could not be found.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4375*)
> * Did you add or update any new dependencies that are required for your change?

Issue: https://github.com/eclipse-sw360/sw360/issues/4375

**1. Input corruption on save — `&` stored as `&amp;`**

All incoming REST string values pass through the shared XSS sanitizer `Sw360XSSRequestWrapper.stripXSS(...)` (used by the Jackson 2.x/3.x deserializers and the servlet filter). It HTML-encoded the *entire* value via `Encode.forHtmlContent(...)`, which turned every literal `&` into `&amp;`. Creating a project with `"tag":"A&B"` was therefore stored/returned as `"A&B"`, and the same happened for every other text field.

Fix: keep the industry-standard OWASP encoder (so we retain all of its protections — encoding of `&`, `<`, `>` and sanitization of invalid/control Unicode such as NUL, invalid XML characters and lone surrogates), and then restore **only** the literal ampersand by turning the exact `&amp;` sequence back into `&`. Because `forHtmlContent` produces `&amp;` *only* from a literal `&` (control/invalid chars become `\uFFFD`, quotes are not touched, and `<`/`>` become `&lt;`/`&gt;`), this never re-creates `<`/`>` and no markup canbe reconstructed. The leading `unescapeHtml4(...)` still defeats entity-based bypasses.

### Suggest Reviewer
> @GMishx 

### How To Test?
1. **Save / round-trip**
   * `POST /resource/api/projects` with body containing `"tag":"A&B"`.
   * Expected: the created project is stored and returned with `"tag":"A&B"`
     (previously `"A&amp;B"`). Verify the same for other text fields (e.g.
     `name`, `description`).

2. **Search**
   * `GET /resource/api/projects?tag=A%26B` (ensure `&` is URL-encoded as
     `%26`, and keep `luceneSearch=true`, the default).
   * Expected: the project with tag `A&B` is returned.

3. **Security regression check**
   * `POST` a field value like `<script>alert(1)</script>`.
   * Expected: it is neutralized to `&lt;script&gt;alert(1)&lt;/script&gt;` (angle
     brackets still encoded; control/invalid Unicode still sanitized).

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
