### PR TITLE
fix(Search): Search by version  in the advance search

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -534,6 +534,9 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             } else if (input.startsWith("(") && input.contains("\"")) {
                 // Wildcard query with parentheses - prepend field name
                 return fieldName + ":" + input;
+            } else if (fieldName.equals("version")) {
+                // Keep wildcard behavior for version prefix searches (e.g. 2.5 -> 2.5.x).
+                return fieldName + ":" + prepareWildcardQuery(input);
             } else if (fieldName.equals("businessUnit") || fieldName.equals("tag") || fieldName.equals("projectResponsible")
                     || fieldName.equals("createdBy") || fieldName.equals("email")
                     || fieldName.equals("moderators") || fieldName.equals("requestingUser")) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -136,7 +136,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
 
     @Operation(
             summary = "List all of the service's components.",
-            description = "List all of the service's components.",
+            description = "List all of the service's components. For `createdOn`, clients can pass either an exact date (`YYYY-MM-DD`) or a Lucene range query like `[startDate TO endDate]`.",
             tags = {"Components"}
     )
     @ApiResponses(value = {
@@ -165,8 +165,8 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             @RequestParam(value = "mainLicenses", required = false) String mainLicenses,
             @Parameter(description = "Created by user to filter (email).")
             @RequestParam(value = "createdBy", required = false) String createdBy,
-            @Parameter(description = "Date component was created on (YYYY-MM-DD).",
-                    schema = @Schema(type = "string", format = "date"))
+            @Parameter(description = "Created date filter. Supported formats: exact (`=`) as `YYYY-MM-DD` (example: `2026-06-30`), less-than-or-equal (`<=`) as range `[1970-01-01 TO <enteredDate>]` (example: `[1970-01-01 TO 2026-06-30]`), greater-than-or-equal (`>=`) as range `[<enteredDate> TO 9999-01-01]` (example: `[2026-06-30 TO 9999-01-01]`), and between as range `[<startDate> TO <endDate>]` (example: `[2026-06-29 TO 2026-06-30]`).",
+                    schema = @Schema(type = "string", example = "2026-06-30"))
             @RequestParam(value = "createdOn", required = false) String createdOn,
             @Parameter(description = "Properties which should be present for each component in the result")
             @RequestParam(value = "fields", required = false) List<String> fields,


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
This PR enables searching by **version** in the advanced search and improves the OpenAPI documentation for the components list endpoint's `createdOn` filter.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4378*)
> * Did you add or update any new dependencies that are required for your change?



**1. Search by `version` in advanced search**

In `NouveauLuceneAwareDatabaseConnector.formatSubquery`, the `version` field previously fell through to the generic branch and was emitted as a plain `version:<input>` term, so prefix/partial version searches did not behave as expected. A dedicated `version` check is now added that runs the value through `prepareWildcardQuery(...)`, keeping wildcard/prefix behavior for version searches (e.g. `2.5` → matches `2.5.x`):

**2. OpenAPI docs for the components `createdOn` filter**

`ComponentController` (`GET /api/components`) documentation is clarified so API consumers know the supported `createdOn` formats: * Updated the endpoint description to note that `createdOn` accepts either an exact date
  (`YYYY-MM-DD`) or a Lucene range query like `[startDate TO endDate]`. * Expanded the `createdOn` parameter description with concrete examples for exact (`=`),  `<=`, `>=`, and between (range) queries, and set a `@Schema` example of `2026-06-30`.

Issue: https://github.com/eclipse-sw360/sw360/issues/4378

### Suggest Reviewer
> @GMishx .

### How To Test?
1. **Version advanced search**
   * Use the advanced/refine search with a partial `version` filter (e.g. `2.5`).
   * Expected: results include versions that start with the entered value (e.g. `2.5`,
     `2.5.1`, `2.5.x`), instead of requiring an exact version match.

2. **Components `createdOn` API docs**
   * Open the generated OpenAPI/Swagger docs for `GET /api/components`.
   * Expected: the `createdOn` parameter shows the exact-date and range-query formats with
     examples (`2026-06-30`, `[1970-01-01 TO 2026-06-30]`, `[2026-06-30 TO 9999-01-01]`,
     `[2026-06-29 TO 2026-06-30]`).
   * Sanity-check the endpoint still filters correctly for an exact date and a range query.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
