### PR TITLE
fix(search): handle stray quotes

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -527,28 +527,30 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         }
 
         final Function<String, String> addType = input -> {
+            String normalizedInput = normalizeRestrictionInput(input);
+
             // Handle pre-formatted queries from prepareWildcardQuery
-            if (input.startsWith("\"") && input.endsWith("\"")) {
+            if (isValidQuotedPhrase(input)) {
                 // Exact phrase search - just prepend field name
                 return fieldName + ":" + input;
             } else if (input.startsWith("(") && input.contains("\"")) {
                 // Wildcard query with parentheses - prepend field name
-                return fieldName + ":" + input;
+                return fieldName + ":" + normalizedInput;
             } else if (fieldName.equals("version")) {
                 // Keep wildcard behavior for version prefix searches (e.g. 2.5 -> 2.5.x).
-                return fieldName + ":" + prepareWildcardQuery(input);
+                return fieldName + ":" + prepareWildcardQuery(normalizedInput);
             } else if (fieldName.equals("businessUnit") || fieldName.equals("tag") || fieldName.equals("projectResponsible")
                     || fieldName.equals("createdBy") || fieldName.equals("email")
                     || fieldName.equals("moderators") || fieldName.equals("requestingUser")) {
-                return fieldName + ":\"" + input + "\"";
+                return fieldName + ":\"" + normalizedInput + "\"";
             } else if (fieldName.equals("createdOn") || fieldName.equals("timestamp")) {
                 try {
                     return fieldName + ":" + formatDateNouveauFormat(input);
                 } catch (ParseException e) {
-                    return fieldName + ":" + input;
+                    return fieldName + ":" + normalizedInput;
                 }
             } else {
-                return fieldName + ":" + input;
+                return fieldName + ":" + normalizedInput;
             }
         };
 
@@ -557,6 +559,48 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
                 .map(addType)
                 .toList());
         return "( " + OR.join(queryParts) + " ) ";
+    }
+
+    /**
+     * Check if a string starts and ends with {@code "} and only there. Meaning
+     * it needs no sanitization.
+     * @param input Input string to check.
+     * @return True if the input is a valid phrase, false otherwise.
+     */
+    private static boolean isValidQuotedPhrase(@NotNull String input) {
+        return input.startsWith("\"") && input.endsWith("\"") && countQuotes(input) == 2;
+    }
+
+    private static int countQuotes(@NotNull String input) {
+        return (int) input.chars().filter(ch -> ch == '"').count();
+    }
+
+    /**
+     * Sanitize the search input for rogue quotes {@code "}
+     *
+     * <ol>
+     *   <li>Check if input does not contain quotes or is valid, return as is.</li>
+     *   <li>Check if input starts and ends with quotes (exact match needed), trim it.</li>
+     *   <li>Replace all {@code "} with {@code \"}.</li>
+     *   <li>If the input was trimmed, add quotes back to the start and end.</li>
+     * </ol>
+     *
+     * @param input Input to sanitize.
+     * @return Sanitized string.
+     */
+    private static @NotNull String normalizeRestrictionInput(@NotNull String input) {
+        if (!input.contains("\"") || isValidQuotedPhrase(input)) {
+            return input;
+        }
+
+        boolean hasOuterQuotes = input.length() >= 2 && input.startsWith("\"") && input.endsWith("\"");
+        String inputToEscape = hasOuterQuotes ? input.substring(1, input.length() - 1) : input;
+        String escaped = inputToEscape.replace("\"", "\\\"");
+
+        if (hasOuterQuotes) {
+            return "\"" + escaped + "\"";
+        }
+        return escaped;
     }
 
     public static @NotNull String prepareWildcardQuery(@NotNull String query) {

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnectorTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnectorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.couchdb.lucene;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+
+public class NouveauLuceneAwareDatabaseConnectorTest {
+
+    @Test
+    public void testFormatSubqueryWithValidQuotedPhrase() throws Exception {
+        String query = formatSubquery(Set.of("\"AB CD E\""), "tag");
+
+        Assert.assertEquals("( tag:\"AB CD E\" ) ", query);
+    }
+
+    @Test
+    public void testFormatSubqueryEscapesMalformedOpeningQuote() throws Exception {
+        String query = formatSubquery(Set.of("\"AB CD E"), "tag");
+
+        Assert.assertEquals("( tag:\"\\\"AB CD E\" ) ", query);
+    }
+
+    @Test
+    public void testFormatSubqueryEscapesMalformedClosingQuote() throws Exception {
+        String query = formatSubquery(Set.of("AB CD E\""), "tag");
+
+        Assert.assertEquals("( tag:\"AB CD E\\\"\" ) ", query);
+    }
+
+    @Test
+    public void testFormatSubqueryEscapesEmbeddedRogueQuote() throws Exception {
+        String query = formatSubquery(Set.of("AB \"CD E"), "tag");
+
+        Assert.assertEquals("( tag:\"AB \\\"CD E\" ) ", query);
+    }
+
+    @Test
+    public void testFormatSubqueryKeepsPreformattedWildcardClause() throws Exception {
+        String wildcardClause = "(\"ab cd e\"^20 OR (ab* AND cd* AND e*)^5 OR (ab* OR cd* OR e*))";
+
+        String query = formatSubquery(Collections.singleton(wildcardClause), "tag");
+
+        String expected = "( tag:(\\\"ab cd e\\\"^20 OR (ab* AND cd* AND e*)^5 OR (ab* OR cd* OR e*)) ) ";
+
+        Assert.assertEquals(expected, query);
+    }
+
+    @Test
+    public void testNormalizeRestrictionInputCases() throws Exception {
+        Assert.assertEquals("\"ABC\\\"XYZ\"", normalizeRestrictionInput("\"ABC\"XYZ\""));
+        Assert.assertEquals("\\\"ABC\\\"XYZ", normalizeRestrictionInput("\"ABC\"XYZ"));
+        Assert.assertEquals("\\\"ABC", normalizeRestrictionInput("\"ABC"));
+        Assert.assertEquals("\"ABC\\\"X\\\"YZ\"", normalizeRestrictionInput("\"ABC\"X\"YZ\""));
+        Assert.assertEquals("ABC\\\"", normalizeRestrictionInput("ABC\""));
+        Assert.assertEquals("ABC", normalizeRestrictionInput("ABC"));
+        Assert.assertEquals("\"ABC\"", normalizeRestrictionInput("\"ABC\""));
+        Assert.assertEquals("A\\\"BC", normalizeRestrictionInput("A\"BC"));
+    }
+
+    private static String formatSubquery(Set<String> filterSet, String fieldName) throws Exception {
+        Method method = NouveauLuceneAwareDatabaseConnector.class
+                .getDeclaredMethod("formatSubquery", Set.class, String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, filterSet, fieldName);
+    }
+
+    private static String normalizeRestrictionInput(String input) throws Exception {
+        Method method = NouveauLuceneAwareDatabaseConnector.class
+                .getDeclaredMethod("normalizeRestrictionInput", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, input);
+    }
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Sanitize the search input for stray quotes `"` in search input preventing following exception:

```
2026-06-29 10:24:37 ERROR NouveauLuceneAwareDatabaseConnector:357 - Nouveau query failed: {"error":"bad_request","reason":"Syntax Error, cannot parse ( tag:\"\"AB CD E\" ) : Lexical error at line 1, column 20.  Encountered: <EOF> after prefix \"\\\" ) \" (in lexical state 2) ","errors":[{"code":"bad_request","message":"bad_request: Syntax Error, cannot parse ( tag:\"\"AB CD E\" ) : Lexical error at line 1, column 20.  Encountered: <EOF> after prefix \"\\\" ) \" (in lexical state 2) "}],"trace":"8d384ffedd"}
com.ibm.cloud.sdk.core.service.exception.BadRequestException: bad_request: Syntax Error, cannot parse ( tag:""AB CD E" ) : Lexical error at line 1, column 20.  Encountered: <EOF> after prefix "\" ) " (in lexical state 2) 
      at com.ibm.cloud.sdk.core.service.BaseService.processServiceCall(BaseService.java:550)
      at com.ibm.cloud.sdk.core.service.BaseService$IBMCloudSDKServiceCall.execute(BaseService.java:602)
      at org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.queryNouveau(LuceneAwareCouchDbConnector.java:196)
      at org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.callLuceneDirectly(NouveauLuceneAwareDatabaseConnector.java:352)
      at org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.searchView(NouveauLuceneAwareDatabaseConnector.java:309)
      at org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.searchIds(NouveauLuceneAwareDatabaseConnector.java:203)
      at org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.searchView(NouveauLuceneAwareDatabaseConnector.java:161)
      at org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.searchViewWithRestrictionsWithAnd(NouveauLuceneAwareDatabaseConnector.java:417)
      at org.eclipse.sw360.datahandler.db.ProjectSearchHandler.search(ProjectSearchHandler.java:126)
      at org.eclipse.sw360.projects.ProjectHandler.refineSearchPageable(ProjectHandler.java:102)
      at org.eclipse.sw360.datahandler.thrift.projects.ProjectService$Processor$refineSearchPageable.getResult(ProjectService.java:5924)
      at org.eclipse.sw360.datahandler.thrift.projects.ProjectService$Processor$refineSearchPageable.getResult(ProjectService.java:5901)
```

Closes https://github.com/eclipse-sw360/sw360/issues/4322

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. Try to search for fields with values containing `"`
2. Try to search for values with unbalanced `"`