### PR TITLE
fix(rest): restore deprecated 'attachment' request param for backward compatibility

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -142,6 +142,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -2012,8 +2013,12 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @PathVariable("projectId") String projectId,
             @Parameter(description = "Files to attach")
             @RequestParam("file") MultipartFile[] files,
-            @Parameter(description = "Attachments descriptions")
-            @RequestParam("attachments") String attachmentsJson,
+            @Parameter(description = "Attachments descriptions as JSON array")
+            @RequestParam(value = "attachments", required = false) String attachmentsJson,
+            @Parameter(description = "Single attachment description (deprecated, use 'attachments' instead)",
+                    deprecated = true)
+            @Deprecated
+            @RequestPart(value = "attachment", required = false) Attachment legacyAttachment,
             @Parameter(description = "Comment message.")
             @RequestParam(value = "comment", required = false) String comment,
             HttpServletRequest request
@@ -2023,12 +2028,33 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         ObjectMapper objectMapper = new ObjectMapper();
         List<Map<String, Object>> attachmentsList;
-        try {
-            attachmentsList = objectMapper.readValue(attachmentsJson, new TypeReference<List<Map<String, Object>>>() {
-            });
-        } catch (JsonProcessingException e) {
-            log.error("Failed to parse attachments JSON", e);
-            throw new BadRequestClientException("Failed to parse attachments JSON");
+
+        if (attachmentsJson != null) {
+            // New multi-attachment path
+            try {
+                attachmentsList = objectMapper.readValue(attachmentsJson,
+                        new TypeReference<List<Map<String, Object>>>() {
+                        });
+            } catch (JsonProcessingException e) {
+                log.error("Failed to parse attachments JSON", e);
+                throw new BadRequestClientException("Failed to parse attachments JSON");
+            }
+        } else if (legacyAttachment != null) {
+            // Backward compatibility: convert legacy single Attachment to list
+            Map<String, Object> attachmentMap = new HashMap<>();
+            attachmentMap.put("attachmentContentId", legacyAttachment.getAttachmentContentId());
+            attachmentMap.put("createdComment", legacyAttachment.getCreatedComment());
+            if (legacyAttachment.getAttachmentType() != null) {
+                attachmentMap.put("attachmentType", legacyAttachment.getAttachmentType().name());
+            }
+            if (legacyAttachment.getCheckStatus() != null) {
+                attachmentMap.put("checkStatus", legacyAttachment.getCheckStatus().name());
+            }
+            attachmentsList = new ArrayList<>();
+            attachmentsList.add(attachmentMap);
+        } else {
+            throw new BadRequestClientException(
+                    "Missing required parameter: 'attachments' (or deprecated 'attachment')");
         }
 
         Set<String> uploadedFilenames = new HashSet<>();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2097,6 +2097,28 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         testAttachmentUploadProject("/api/projects/", project.getId());
     }
 
+    @Test
+    public void should_upload_attachment_to_project_with_deprecated_singular_attachment_param() throws Exception {
+        // Test backward compatibility with legacy singular "attachment" parameter
+        Attachment legacyAttachment = new Attachment();
+        legacyAttachment.setFilename("legacy-attachment.jar");
+        legacyAttachment.setAttachmentContentId("legacy-123");
+        legacyAttachment.setAttachmentType(AttachmentType.SOURCE);
+        legacyAttachment.setCheckStatus(CheckStatus.ACCEPTED);
+        legacyAttachment.setCreatedComment("Legacy single file upload");
+
+        String attachmentJson = this.objectMapper.writeValueAsString(legacyAttachment);
+        MockMultipartFile attachmentFile = new MockMultipartFile("attachment", "", "application/json",
+                attachmentJson.getBytes());
+
+        var builder = MockMvcRequestBuilders.multipart("/api/projects/" + project.getId() + "/attachments")
+                .file("file", "@/legacy-attachment.jar".getBytes())
+                .file(attachmentFile)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword));
+        this.mockMvc.perform(builder).andExpect(status().isOk());
+    }
+
 
     @Test
     public void should_document_link_releases() throws Exception {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
@@ -257,7 +257,6 @@ public abstract class TestRestDocsSpecBase {
     }
 
     public void testAttachmentUploadProject(String url, String id) throws Exception {
-        String attachment = "[{ \"filename\":\"spring-core-4.3.4.RELEASE.jar\", \"attachmentType\":\"SOURCE\", \"checkStatus\":\"ACCEPTED\", \"createdComment\":\"Uploading Sources.\" }]";
         /*
          * TODO Suggestion to use better library in future, instead of MockMultipartFile
          * to have better document generation feature. below logic is used to generate
@@ -275,11 +274,8 @@ public abstract class TestRestDocsSpecBase {
         attchList.add(att1);
 
         String attachmentJson = this.objectMapper.writeValueAsString(attchList);
-        MockMultipartFile jsonFile = new MockMultipartFile("attachment", "", "application/json",
-                new ByteArrayInputStream(attachment.getBytes()));
-        MockMultipartFile[] files = new MockMultipartFile[] { jsonFile };
         var builder = MockMvcRequestBuilders.multipart(url + id + "/attachments")
-                .file("file", "@/spring-core-4.3.4.RELEASE.jar".getBytes()).file(files[0])
+                .file("file", "@/spring-core-4.3.4.RELEASE.jar".getBytes())
                 .param("attachments", attachmentJson).contentType(MediaType.MULTIPART_FORM_DATA)
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword));
         this.mockMvc.perform(builder).andExpect(status().isOk()).andDo(this.documentationHandler.document());


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

Restores backward compatibility for the project attachment upload endpoint (`POST /api/projects/{id}/attachments`).

Commit [1e1c5c1](https://github.com/eclipse-sw360/sw360/commit/1e1c5c1d08011368750b564fe4b706a2814d82c6) introduced multi-file upload support but renamed the `attachment` request parameter to `attachments` (plural) and changed its type from `@RequestPart Attachment` to `@RequestParam String`. This broke existing API consumers using the legacy singular `attachment` parameter as documented in the [API guide](https://sw360.siemens.com/resource/docs/api-guide.html#resources-project-attachment-upload).

This PR adds back the legacy `attachment` parameter (`@RequestPart`) marked as `@Deprecated` with `deprecated = true` in OpenAPI, so:
- Existing clients using `attachment` (singular, `Attachment` type) continue to work
- New clients use `attachments` (plural, JSON string array) as introduced in the multi-upload commit
- OpenAPI docs clearly indicate the old parameter is deprecated

No new dependencies added.

### Suggest Reviewer

@GMishx 

### How To Test?

1. Upload a single attachment using the **legacy** parameter name `attachment` with an `Attachment` JSON object (not array) → should succeed
2. Upload multiple attachments using the **new** `attachments` parameter (JSON array) → should succeed as before
3. Verify OpenAPI docs show `attachment` as deprecated

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
