### PR TITLE
feat(search): migrate search to new infra

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/common/utils/SearchUtils.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/utils/SearchUtils.java
@@ -60,8 +60,52 @@ public class SearchUtils {
             "      }" +
             "    }" +
             "    if (result.trim().length > 0) {" +
-            "      index('text', indexName, result.trim(), {'store': true});" +
+            "      index('text', indexName, result.trim());" +
             "      index('string', indexName + '_sort', result.trim());" +
             "    }" +
             "  }";
+
+    /**
+     * This function helps generate edge n_grams for a field. Example:
+     * {@code ["aw", "awe", "awes", "aweso", "awesom", "awesome"]}. The
+     * parameters:
+     * <ul>
+     *     <li><b>fieldName</b>: The index field name to store n-grams as.</li>
+     *     <li><b>text</b>: The text to be processed into n-grams.</li>
+     *     <li><b>minGram</b>: The minimum length of the n-grams.</li>
+     *     <li><b>maxGram</b>: The maximum length of the n-grams.</li>
+     * </ul>
+     */
+    public static final String EMIT_EDGE_N_GRAM_INDEX = """
+              function emitEdgeNGrams(fieldName, text, minGram, maxGram) {
+                if (!text) return;
+                var words = text.toLowerCase().split(/\\\\s+/);
+                for (var i = 0; i < words.length; i++) {
+                  var word = words[i];
+                  var limit = Math.min(word.length, maxGram);
+                  for (var len = minGram; len <= limit; len++) {
+                    index('text', fieldName, word.substring(0, len));
+                  }
+                }
+              }
+            """;
+
+    /**
+     * This function helps indexing dates as yyyymmdd long number. For example,
+     * 2026-01-23 will be indexed as {@code double(20260123)} so it can be
+     * compared and sorted.
+     */
+    public static final String INDEX_DATE_AS_DOUBLE = """
+            function indexDateAsDouble(fieldName, createdOn) {
+              if (createdOn) {
+                var dt = new Date(createdOn);
+                if (!isNaN(dt.getTime())) {
+                  var yyyy = dt.getFullYear().toString();
+                  var mm = (dt.getMonth() + 1).toString().padStart(2, '0');
+                  var dd = dt.getDate().toString().padStart(2, '0');
+                  index('double', fieldName, Number(yyyy + mm + dd));
+                }
+              }
+            }
+            """;
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 
-import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 
 public class ModerationSearchHandler {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -19,8 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -31,9 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.eclipse.sw360.common.utils.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
-import static org.eclipse.sw360.common.utils.SearchUtils.INDEX_DATE_AS_DOUBLE;
-import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
@@ -42,98 +37,91 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-        = new NouveauIndexDesignDocument("projects",
-            new NouveauIndexFunction(
-                "function(doc) {" +
-                EMIT_EDGE_N_GRAM_INDEX +
-                OBJ_ARRAY_TO_STRING_INDEX +
-                INDEX_DATE_AS_DOUBLE +
-                "    if(!doc.type || doc.type != 'project') return;" +
-                "    var businessUnit = '" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "';" +
-                "    if(doc.businessUnit !== undefined && doc.businessUnit != null && doc.businessUnit.length > 0) {" +
-                "      businessUnit = doc.businessUnit;" +
-                "    }" +
-                "    index('text', 'businessUnit_exact', businessUnit);" +
-                "    emitEdgeNGrams('businessUnit_ngram', businessUnit, 2, 10);" +
-                "    if(doc.projectType !== undefined && doc.projectType != null && doc.projectType.length >0) {" +
-                "      index('text', 'projectType', doc.projectType);" +
-                "      index('string', 'projectType_sort', doc.projectType);" +
-                "    }" +
-                "    if(doc.projectResponsible !== undefined && doc.projectResponsible != null && doc.projectResponsible.length >0) {" +
-                "      index('text', 'projectResponsible', doc.projectResponsible);" +
-                "      index('string', 'projectResponsible_sort', doc.projectResponsible);" +
-                "    }" +
-                "    if(doc.name !== undefined && doc.name != null && doc.name.length >0) {" +
-                "      index('text', 'name_exact', doc.name);" +
-                "      emitEdgeNGrams('name_ngram', doc.name, 2, 25);" +
-                "      index('string', 'name_sort', doc.name.toLowerCase());" +
-                "    }" +
-                "    if(doc.description !== undefined && doc.description != null && doc.description.length >0) {" +
-                "      index('text', 'description', doc.description);" +
-                "      index('string', 'description_sort', doc.description);" +
-                "    }" +
-                "    if(doc.version !== undefined && doc.version != null && doc.version.length >0) {" +
-                "      index('text', 'version_exact', doc.version);" +
-                "      emitEdgeNGrams('version_ngram', doc.version, 2, 25);" +
-                "      index('string', 'version_sort', doc.version.toLowerCase());" +
-                "    }" +
-                "    if(doc.state !== undefined && doc.state != null && doc.state.length >0) {" +
-                "      index('text', 'state', doc.state);" +
-                "      index('string', 'state_sort', doc.state);" +
-                "    }" +
-                "    if(doc.clearingState) {" +
-                "      index('text', 'clearingState', doc.clearingState);" +
-                "    }" +
-                "    var tag = '" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "';" +
-                "    if(doc.tag !== undefined && doc.tag != null && doc.tag.length > 0) {" +
-                "      tag = doc.tag;" +
-                "    }" +
-                "    index('text', 'tag_exact', tag);" +
-                "    emitEdgeNGrams('tag_ngram', tag, 2, 25);" +
-                "    index('string', 'tag_sort', tag.toLowerCase());" +
-                "    arrayToStringIndex(doc.additionalData, 'additionalData');" +
-                "    if (doc.createdOn) {" +
-                "      indexDateAsDouble('createdOn', doc.createdOn);" +
-                "    }" +
-                "    if(doc.attachments && doc.attachments.length > 0) {" +
-                "      for(var i in doc.attachments) {" +
-                "        if(doc.attachments[i].createdBy) {" +
-                "          index('text', 'attachmentCreatedBy', doc.attachments[i].createdBy);" +
-                "        }" +
-                "      }" +
-                "    }" +
-                "}")
-                    .setFieldAnalyzer(
-                            Map.ofEntries(
-                                    Map.entry("businessUnit_ngram", "whitespace"),
-                                    Map.entry("businessUnit_sort", "keyword"),
-                                    Map.entry("version", "keyword"),
-                                    Map.entry("projectResponsible", "email"),
-                                    Map.entry("name_ngram", "whitespace"),
-                                    Map.entry("name_sort", "keyword"),
-                                    Map.entry("description_sort", "keyword"),
-                                    Map.entry("version_ngram", "whitespace"),
-                                    Map.entry("version_sort", "keyword"),
-                                    Map.entry("state", "keyword"),
-                                    Map.entry("clearingState", "keyword"),
-                                    Map.entry("tag_ngram", "whitespace"),
-                                    Map.entry("tag_sort", "keyword"),
-                                    Map.entry("attachmentCreatedBy", "email")
-                            )
-                    )
-                    .setDefaultAnalyzer("standard")
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fields common to all projects, grouped by index category.
+     *
+     * <ul>
+     *   <li><b>emptyAware</b>: {@code businessUnit} (ngram 2–10), {@code tag} (ngram 2–10) -
+     *       documents with no value are indexed under
+     *       {@link SW360Constants#PROJECT_SEARCH_EMPTY_TOKEN} so "no value" filter queries work.</li>
+     *   <li><b>standard</b>: {@code name}, {@code version} - full prefix-search support.</li>
+     *   <li><b>simple</b>: {@code projectType}, {@code projectResponsible} (email analyzer),
+     *       {@code description}, {@code state} (keyword), {@code clearingState} (keyword).</li>
+     *   <li><b>date</b>: {@code createdOn} - stored as sortable yyyyMMdd double.</li>
+     * </ul>
+     */
+    private static final List<IndexField> PROJECT_FIELDS = List.of(
+            IndexField.emptyAware("businessUnit", 2, 10),
+            IndexField.emptyAware("tag", 2, 10),
+            IndexField.standard("name"),
+            IndexField.standard("version"),
+            IndexField.simple("description"),
+            IndexField.simple("projectType"),
+            IndexField.simple("projectResponsible", "email"),
+            IndexField.simple("state", "keyword"),
+            IndexField.simple("clearingState", "keyword"),
+            IndexField.date("createdOn")
     );
 
+    /**
+     * Handler-specific JS: index {@code additionalData} as a concatenated text blob and
+     * index the creator email of every attachment.
+     */
+    private static final String PROJECT_CUSTOM_JS =
+            "    arrayToStringIndex(doc.additionalData, 'additionalData');" +
+            "    if(doc.attachments && doc.attachments.length > 0) {" +
+            "      for(var i in doc.attachments) {" +
+            "        if(doc.attachments[i].createdBy) {" +
+            "          index('text', 'attachmentCreatedBy', doc.attachments[i].createdBy);" +
+            "        }" +
+            "      }" +
+            "    }";
+
+    /**
+     * Analyzer overrides that are not auto-generated from {@link #PROJECT_FIELDS}.
+     * <ul>
+     *   <li>{@code attachmentCreatedBy} -> {@code email} (custom JS field)</li>
+     *   <li>{@code additionalData_sort} -> {@code keyword} (created by {@code arrayToStringIndex})</li>
+     * </ul>
+     */
+    private static final Map<String, String> PROJECT_CUSTOM_ANALYZERS = Map.of(
+            "attachmentCreatedBy", "email",
+            "additionalData_sort", "keyword"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Design document
+    // -------------------------------------------------------------------------
+
+    private static final BuiltIndexDefinition PROJECT_INDEX_DEFINITION = buildIndexFunction(
+            "project",
+            SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN,
+            PROJECT_FIELDS,
+            PROJECT_CUSTOM_JS,
+            PROJECT_CUSTOM_ANALYZERS,
+            "standard"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Constructor
+    // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public ProjectSearchHandler(Cloudant client, String dbName) throws IOException {
-        super(Project.class, luceneSearchView);
+        super(Project.class, "projects", PROJECT_INDEX_DEFINITION);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
         setup(connector, db);
     }
+
+    // -------------------------------------------------------------------------
+    //  Public search API
+    // -------------------------------------------------------------------------
 
     public Map<PaginationData, List<Project>> search(final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
         Map<PaginationData, List<Project>> resultProjectList = baseSearch(connector, subQueryRestrictions, pageData);
@@ -146,17 +134,17 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
     }
 
     public List<Project> search(String text, final Map<String, Set<String>> subQueryRestrictions, User user) {
-        return connector.searchProjectViewWithRestrictionsAndFilter(luceneSearchView.getIndexName(), text,
+        return connector.searchProjectViewWithRestrictionsAndFilter(getIndexName(), text,
                 subQueryRestrictions, user);
     }
 
     public List<Project> search(String searchText) {
-        return connector.searchView(Project.class, luceneSearchView.getIndexName(),
+        return connector.searchView(Project.class, getIndexName(),
                 prepareWildcardQuery(searchText));
     }
 
     public List<Project> search(String text, final Map<String, Set<String>> subQueryRestrictions) {
-        return connector.searchViewWithRestrictionsWithAnd(Project.class, luceneSearchView.getIndexName(),
+        return connector.searchViewWithRestrictionsWithAnd(Project.class, getIndexName(),
                 text, subQueryRestrictions);
     }
 
@@ -168,10 +156,10 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
         Map<String, Set<String>> filterMap = getFilterMapForSetReleaseIds(ids);
         List<Project> projectsByReleaseIds;
         if (user != null) {
-            projectsByReleaseIds = connector.searchProjectViewWithRestrictionsAndFilter(luceneSearchView.getIndexName(),
+            projectsByReleaseIds = connector.searchProjectViewWithRestrictionsAndFilter(getIndexName(),
                     null, filterMap, user);
         } else {
-            projectsByReleaseIds = connector.searchViewWithRestrictionsWithAnd(Project.class, luceneSearchView.getIndexName(),
+            projectsByReleaseIds = connector.searchViewWithRestrictionsWithAnd(Project.class, getIndexName(),
                     null, filterMap);
         }
         return new HashSet<>(projectsByReleaseIds);
@@ -188,6 +176,10 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
         filterMap.put(Project._Fields.RELEASE_RELATION_NETWORK.getFieldName(), values);
         return filterMap;
     }
+
+    // -------------------------------------------------------------------------
+    //  Sort column mapping
+    // -------------------------------------------------------------------------
 
     @Override
     protected List<String> mapSortColumn(int sortColumnNumber) {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -10,9 +10,8 @@
 package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
@@ -20,11 +19,9 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,11 +31,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.eclipse.sw360.common.utils.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
+import static org.eclipse.sw360.common.utils.SearchUtils.INDEX_DATE_AS_DOUBLE;
 import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
-public class ProjectSearchHandler {
+public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
@@ -46,86 +46,97 @@ public class ProjectSearchHandler {
         = new NouveauIndexDesignDocument("projects",
             new NouveauIndexFunction(
                 "function(doc) {" +
+                EMIT_EDGE_N_GRAM_INDEX +
                 OBJ_ARRAY_TO_STRING_INDEX +
+                INDEX_DATE_AS_DOUBLE +
                 "    if(!doc.type || doc.type != 'project') return;" +
                 "    var businessUnit = '" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "';" +
                 "    if(doc.businessUnit !== undefined && doc.businessUnit != null && doc.businessUnit.length > 0) {" +
                 "      businessUnit = doc.businessUnit;" +
                 "    }" +
-                "    index('text', 'businessUnit', businessUnit, {'store': true});" +
+                "    index('text', 'businessUnit_exact', businessUnit);" +
+                "    emitEdgeNGrams('businessUnit_ngram', businessUnit, 2, 10);" +
                 "    if(doc.projectType !== undefined && doc.projectType != null && doc.projectType.length >0) {" +
-                "      index('text', 'projectType', doc.projectType, {'store': true});" +
+                "      index('text', 'projectType', doc.projectType);" +
                 "      index('string', 'projectType_sort', doc.projectType);" +
                 "    }" +
                 "    if(doc.projectResponsible !== undefined && doc.projectResponsible != null && doc.projectResponsible.length >0) {" +
-                "      index('text', 'projectResponsible', doc.projectResponsible, {'store': true});" +
+                "      index('text', 'projectResponsible', doc.projectResponsible);" +
                 "      index('string', 'projectResponsible_sort', doc.projectResponsible);" +
                 "    }" +
                 "    if(doc.name !== undefined && doc.name != null && doc.name.length >0) {" +
-                "      index('text', 'name', doc.name, {'store': true});" +
-                "      index('string', 'name_sort', doc.name);" +
+                "      index('text', 'name_exact', doc.name);" +
+                "      emitEdgeNGrams('name_ngram', doc.name, 2, 25);" +
+                "      index('string', 'name_sort', doc.name.toLowerCase());" +
                 "    }" +
                 "    if(doc.description !== undefined && doc.description != null && doc.description.length >0) {" +
-                "      index('text', 'description', doc.description, {'store': true});" +
+                "      index('text', 'description', doc.description);" +
                 "      index('string', 'description_sort', doc.description);" +
                 "    }" +
                 "    if(doc.version !== undefined && doc.version != null && doc.version.length >0) {" +
-                "      index('string', 'version', doc.version, {'store': true});" +
+                "      index('text', 'version_exact', doc.version);" +
+                "      emitEdgeNGrams('version_ngram', doc.version, 2, 25);" +
+                "      index('string', 'version_sort', doc.version.toLowerCase());" +
                 "    }" +
                 "    if(doc.state !== undefined && doc.state != null && doc.state.length >0) {" +
-                "      index('text', 'state', doc.state, {'store': true});" +
+                "      index('text', 'state', doc.state);" +
                 "      index('string', 'state_sort', doc.state);" +
                 "    }" +
                 "    if(doc.clearingState) {" +
-                "      index('text', 'clearingState', doc.clearingState, {'store': true});" +
+                "      index('text', 'clearingState', doc.clearingState);" +
                 "    }" +
                 "    var tag = '" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "';" +
                 "    if(doc.tag !== undefined && doc.tag != null && doc.tag.length > 0) {" +
                 "      tag = doc.tag;" +
                 "    }" +
-                "    index('text', 'tag', tag, {'store': true});" +
+                "    index('text', 'tag_exact', tag);" +
+                "    emitEdgeNGrams('tag_ngram', tag, 2, 25);" +
+                "    index('string', 'tag_sort', tag.toLowerCase());" +
                 "    arrayToStringIndex(doc.additionalData, 'additionalData');" +
-                "    if(doc.releaseRelationNetwork !== undefined && doc.releaseRelationNetwork != null && doc.releaseRelationNetwork.length > 0) {" +
-                "      index('text', 'releaseRelationNetwork', doc.releaseRelationNetwork, {'store': true});" +
-                "    }" +
-                "    if(doc.createdOn && doc.createdOn.length) {"+
-                "      var dt = new Date(doc.createdOn);"+
-                "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
-                "      index('double', 'createdOn', Number(formattedDt), {'store': true});"+
+                "    if (doc.createdOn) {" +
+                "      indexDateAsDouble('createdOn', doc.createdOn);" +
                 "    }" +
                 "    if(doc.attachments && doc.attachments.length > 0) {" +
                 "      for(var i in doc.attachments) {" +
                 "        if(doc.attachments[i].createdBy) {" +
-                "          index('text', 'attachmentCreatedBy', doc.attachments[i].createdBy, {'store': true});" +
+                "          index('text', 'attachmentCreatedBy', doc.attachments[i].createdBy);" +
                 "        }" +
                 "      }" +
                 "    }" +
                 "}")
                     .setFieldAnalyzer(
-                            Map.of("version", "keyword")
+                            Map.ofEntries(
+                                    Map.entry("businessUnit_ngram", "whitespace"),
+                                    Map.entry("businessUnit_sort", "keyword"),
+                                    Map.entry("version", "keyword"),
+                                    Map.entry("projectResponsible", "email"),
+                                    Map.entry("name_ngram", "whitespace"),
+                                    Map.entry("name_sort", "keyword"),
+                                    Map.entry("description_sort", "keyword"),
+                                    Map.entry("version_ngram", "whitespace"),
+                                    Map.entry("version_sort", "keyword"),
+                                    Map.entry("state", "keyword"),
+                                    Map.entry("clearingState", "keyword"),
+                                    Map.entry("tag_ngram", "whitespace"),
+                                    Map.entry("tag_sort", "keyword"),
+                                    Map.entry("attachmentCreatedBy", "email")
+                            )
                     )
+                    .setDefaultAnalyzer("standard")
     );
 
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public ProjectSearchHandler(Cloudant client, String dbName) throws IOException {
+        super(Project.class, luceneSearchView);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        connector.setResultLimit(DatabaseSettings.LUCENE_SEARCH_LIMIT);
-        connector.addDesignDoc(searchView);
+        setup(connector, db);
     }
 
-    public Map<PaginationData, List<Project>> search(String text, final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
-        String sortColumn = getSortColumnName(pageData);
-        Map<PaginationData, List<Project>> resultProjectList = connector
-                .searchViewWithRestrictionsWithAnd(Project.class,
-                        luceneSearchView.getIndexName(), text, subQueryRestrictions,
-                        pageData, sortColumn, pageData.isAscending());
+    public Map<PaginationData, List<Project>> search(final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        Map<PaginationData, List<Project>> resultProjectList = baseSearch(connector, subQueryRestrictions, pageData);
         PaginationData respPageData = resultProjectList.keySet().iterator().next();
         List<Project> projectList = resultProjectList.values().iterator().next();
 
@@ -178,25 +189,18 @@ public class ProjectSearchHandler {
         return filterMap;
     }
 
-    /**
-     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
-     * `_sort` suffix) for text indexes.
-     * @param pageData Pagination Data from the request.
-     * @return Sort column name. Defaults to name_sort
-     */
-    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
-        return switch (ProjectSortColumn.findByValue(pageData.getSortColumnNumber())) {
-            case ProjectSortColumn.BY_CREATEDON -> "createdOn";
-//            case ProjectSortColumn.BY_VENDOR -> "vendor_sort";
-//            case ProjectSortColumn.BY_MAINLICENSE -> "license_sort";
-            case ProjectSortColumn.BY_TYPE -> "projectType_sort";
-            case ProjectSortColumn.BY_DESCRIPTION -> "description_sort";
-            case ProjectSortColumn.BY_RESPONSIBLE -> "projectResponsible_sort";
-            case ProjectSortColumn.BY_STATE -> "state_sort";
-            // null signals Nouveau to skip sorting and return results ranked by relevance score
-            case ProjectSortColumn.BY_SCORE -> null;
-            case null -> "name_sort";
-            default -> "name_sort";
+    @Override
+    protected List<String> mapSortColumn(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (ProjectSortColumn.findByValue(sortColumnNumber)) {
+            case ProjectSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_DESCRIPTION -> List.of("description_sort", SCORE_SORTING_FIELD, revDir + "createdOn");
+            case ProjectSortColumn.BY_RESPONSIBLE -> List.of("projectResponsible_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_STATE -> List.of("state_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case ProjectSortColumn.BY_TYPE -> List.of("projectType_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            // Default sort by scoring
+            case null, default -> List.of(SCORE_SORTING_FIELD);
         };
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareFuzzyQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -97,9 +97,11 @@ public class ProjectHandler implements ProjectService.Iface {
     }
 
     @Override
-    public Map<PaginationData, List<Project>> refineSearchPageable(String text,
-            Map<String, Set<String>> subQueryRestrictions, User user, PaginationData paginationData) throws TException {
-        return searchHandler.search(text, subQueryRestrictions, user, paginationData);
+    public Map<PaginationData, List<Project>> refineSearchPageable(
+            Map<String, Set<String>> subQueryRestrictions, User user,
+            PaginationData paginationData
+    ) throws TException {
+        return searchHandler.search(subQueryRestrictions, user, paginationData);
     }
 
     @Override

--- a/backend/search/src/main/java/org/eclipse/sw360/search/SearchHandler.java
+++ b/backend/search/src/main/java/org/eclipse/sw360/search/SearchHandler.java
@@ -58,7 +58,7 @@ public class SearchHandler implements SearchService.Iface {
     }
 
     @Override
-    public List<SearchResult> searchFiltered(String text, User user, List<String> typeMask) throws TException {
+    public List<SearchResult> searchFiltered(String text, User user, List<String> typeMasks) throws TException {
         if(text == null) {
             throw new TException("Search text was null.");
         }
@@ -66,20 +66,28 @@ public class SearchHandler implements SearchService.Iface {
             return Collections.emptyList();
         }
 
-        // Query user and other database
         Set<SearchResult> results = Sets.newLinkedHashSet();
-        if (typeMask.isEmpty() || typeMask.contains(SW360Constants.TYPE_USER)) {
+        if (typeMasks.isEmpty()) {
+            typeMasks = new ArrayList<>(List.of("project", "component",
+                    "license", "release", "obligation", "user", "vendor",
+                    "document"));
+        }
+        // Query user and other database
+        if (typeMasks.contains(SW360Constants.TYPE_USER)) {
             if (text.contains("pkg:")) {
                 dealWithSpecialCharacters(text, user, results, dbSw360users, List.of(SW360Constants.TYPE_USER));
             } else {
                 results.addAll(dbSw360users.search(text, List.of(SW360Constants.TYPE_USER), user));
             }
         }
-        if(typeMask.isEmpty() || !typeMask.getFirst().equals(SW360Constants.TYPE_USER) || typeMask.size() > 1) {
+        if (
+                (typeMasks.size() == 1 && !typeMasks.contains(SW360Constants.TYPE_USER))
+                || (typeMasks.size() > 1)
+        ) {
             if (text.contains("pkg:")) {
-                dealWithSpecialCharacters(text, user, results, dbSw360db, typeMask);
+                dealWithSpecialCharacters(text, user, results, dbSw360db, typeMasks);
             } else {
-                results.addAll(dbSw360db.search(text, typeMask, user));
+                results.addAll(dbSw360db.search(text, typeMasks, user));
             }
         }
 

--- a/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
+++ b/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
@@ -33,8 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.eclipse.sw360.common.utils.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
-import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_TO_DEFAULT_INDEX;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_TO_DEFAULT_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.convertToFreeSearch;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.sanitizeLuceneString;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;

--- a/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
+++ b/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
@@ -28,10 +28,13 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static org.eclipse.sw360.common.utils.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
 import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_TO_DEFAULT_INDEX;
-import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
+import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.sanitizeLuceneString;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 
 /**
@@ -50,35 +53,61 @@ public abstract class AbstractDatabaseSearchHandler {
             OBJ_TO_DEFAULT_INDEX +
             "  var objString = getObjAsString(doc);" +
             "  if (objString && objString.length > 0) {" +
-            "    index('text', 'default', objString, {'store': true});" +
+            "    index('text', 'default', objString);" +
             "  }" +
             "  if (doc.type && typeof(doc.type) == 'string' && doc.type.length > 0) {" +
-            "    index('text', 'type', doc.type, {'store': true});" +
+            "    index('text', 'type', doc.type);" +
             "  }" +
-            "}"));
+            "}")
+            .setFieldAnalyzer(
+                    Map.ofEntries(
+                            Map.entry("type", "keyword")
+                    )
+            )
+            .setDefaultAnalyzer("standard")
+    );
 
     private static final NouveauIndexDesignDocument luceneFilteredSearchView
         = new NouveauIndexDesignDocument("restrictedSearch", new NouveauIndexFunction(
             "function(doc) {" +
             "  if(!doc.type) return;" +
             OBJ_TO_DEFAULT_INDEX +
+            EMIT_EDGE_N_GRAM_INDEX +
             "  var objString = getObjAsString(doc);" +
             "  if (objString && objString.length > 0) {" +
-            "    index('text', 'default', objString, {'store': true});" +
+            "    index('text', 'default', objString);" +
             "  }" +
             "  if (doc.type && typeof(doc.type) == 'string' && doc.type.length > 0) {" +
-            "    index('text', 'type', doc.type, {'store': true});" +
+            "    index('text', 'type', doc.type);" +
             "  }" +
             "  if (doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
-            "    index('text', 'name', doc.name, {'store': true});" +
+            "    index('text', 'name_exact', doc.name);" +
+            "    emitEdgeNGrams('name_ngram', doc.name, 2, 25);" +
+            "    index('string', 'name_sort', doc.name.toLowerCase());" +
             "  }" +
             "  if (doc.fullname && typeof(doc.fullname) == 'string' && doc.fullname.length > 0) {" +
-            "    index('text', 'fullname', doc.fullname, {'store': true});" +
+            "    index('text', 'fullname_exact', doc.fullname);" +
+            "    emitEdgeNGrams('fullname_ngram', doc.fullname, 2, 35);" +
+            "    index('string', 'fullname_sort', doc.fullname.toLowerCase());" +
             "  }" +
             "  if (doc.title && typeof(doc.title) == 'string' && doc.title.length > 0) {" +
-            "    index('text', 'title', doc.title, {'store': true});" +
+            "    index('text', 'title_exact', doc.title);" +
+            "    emitEdgeNGrams('title_ngram', doc.title, 2, 25);" +
+            "    index('string', 'title_sort', doc.title.toLowerCase());" +
             "  }" +
-            "}"));
+            "}")
+            .setFieldAnalyzer(
+                    Map.ofEntries(
+                            Map.entry("type", "keyword"),
+                            Map.entry("name_ngram", "whitespace"),
+                            Map.entry("fullname_ngram", "whitespace"),
+                            Map.entry("title_ngram", "whitespace"),
+                            Map.entry("name_sort", "keyword"),
+                            Map.entry("fullname_sort", "keyword")
+                    )
+            )
+            .setDefaultAnalyzer("standard")
+    );
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public AbstractDatabaseSearchHandler(String dbName) throws IOException {
@@ -112,7 +141,7 @@ public abstract class AbstractDatabaseSearchHandler {
      * Search the database for a given string
      */
     public List<SearchResult> search(String text, User user) {
-        String queryString = prepareWildcardQuery(text);
+        String queryString = sanitizeLuceneString(text);
         return getSearchResults(queryString, user);
     }
 
@@ -128,7 +157,7 @@ public abstract class AbstractDatabaseSearchHandler {
             typeMask.removeLast();
             final Function<String, String> addType = input -> "type:" + input;
             query = "( " + Joiner.on(" OR ").join(FluentIterable.from(typeMask).transform(addType)) + " ) AND "
-                    + prepareWildcardQuery(text);
+                    + sanitizeLuceneString(text);
             return getSearchResults(query, user);
         }
         return restrictedSearch(text, typeMask, user);
@@ -146,34 +175,40 @@ public abstract class AbstractDatabaseSearchHandler {
             typeMask.removeLast();
             final Function<String, String> addType = input -> "type:" + input;
             query = "( " + Joiner.on(" OR ").join(FluentIterable.from(typeMask).transform(addType)) + " ) AND "
-                    + prepareWildcardQuery(text);
+                    + sanitizeLuceneString(text);
             return getSearchResults(query, user);
         }
         return restrictedSearch(text, typeMask, user);
     }
 
     public List<SearchResult> restrictedSearch(String text, List<String> typeMask, User user) {
-        String query = text;
-        final Function<String, String> addType = input -> "type:" + input;
-        final Function<String, String> addField = input -> input + ": (" + prepareWildcardQuery(text) + " )";
-        List<String> typeField = new ArrayList<String>();
+        String query;
         if (typeMask == null || typeMask.isEmpty()) {
-            typeField.add("name");
-            typeField.add("fullname");
-            typeField.add("title");
-            query = "( " + Joiner.on(" OR ").join(FluentIterable.from(typeField).transform(addField)) + " ) ";
+            Map<String, String> subQueryRestrictions = Map.of(
+                    "name", text,
+                    "fullname", text,
+                    "title", text
+            );
+            // Type check is only on Package. Thus considered irrelevant here.
+            query = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, subQueryRestrictions);
         } else {
+            Map<String, String> subQueryRestrictions = new HashMap<>();
             if (typeMask.contains("project") || typeMask.contains("component") || typeMask.contains("release") || typeMask.contains("package")) {
-                typeField.add("name");
+                subQueryRestrictions.put("name", text);
             }
             if (typeMask.contains("license") || typeMask.contains("user") || typeMask.contains("vendor")) {
-                typeField.add("fullname");
+                subQueryRestrictions.put("fullname", text);
             }
             if (typeMask.contains("obligations")) {
-                typeField.add("title");
+                subQueryRestrictions.put("title", text);
             }
-            query = "( " + Joiner.on(" OR ").join(FluentIterable.from(typeMask).transform(addType)) + " ) AND " + "( "
-                    + Joiner.on(" OR ").join(FluentIterable.from(typeField).transform(addField)) + " ) ";
+            String valueQuery = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, subQueryRestrictions);
+            Map<String, String> typeRestrictions = new HashMap<>();
+            for (String typeM : typeMask) {
+                typeRestrictions.put("type", typeM);
+            }
+            String typeQuery = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, typeRestrictions);
+            query = "( " + valueQuery + " ) AND ( " + typeQuery + " )";
         }
         return getFilteredSearchResults(query, user);
     }

--- a/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
+++ b/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
@@ -16,6 +16,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
@@ -24,7 +25,7 @@ import org.eclipse.sw360.nouveau.NouveauResult;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import java.util.Map;
 
 import static org.eclipse.sw360.common.utils.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
 import static org.eclipse.sw360.common.utils.SearchUtils.OBJ_TO_DEFAULT_INDEX;
+import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.convertToFreeSearch;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.sanitizeLuceneString;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 
@@ -56,7 +58,7 @@ public abstract class AbstractDatabaseSearchHandler {
             "    index('text', 'default', objString);" +
             "  }" +
             "  if (doc.type && typeof(doc.type) == 'string' && doc.type.length > 0) {" +
-            "    index('text', 'type', doc.type);" +
+            "    index('string', 'type', doc.type);" +
             "  }" +
             "}")
             .setFieldAnalyzer(
@@ -78,7 +80,7 @@ public abstract class AbstractDatabaseSearchHandler {
             "    index('text', 'default', objString);" +
             "  }" +
             "  if (doc.type && typeof(doc.type) == 'string' && doc.type.length > 0) {" +
-            "    index('text', 'type', doc.type);" +
+            "    index('string', 'type', doc.type);" +
             "  }" +
             "  if (doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
             "    index('text', 'name_exact', doc.name);" +
@@ -141,7 +143,7 @@ public abstract class AbstractDatabaseSearchHandler {
      * Search the database for a given string
      */
     public List<SearchResult> search(String text, User user) {
-        String queryString = sanitizeLuceneString(text);
+        String queryString = convertToFreeSearch(text);
         return getSearchResults(queryString, user);
     }
 
@@ -175,7 +177,7 @@ public abstract class AbstractDatabaseSearchHandler {
             typeMask.removeLast();
             final Function<String, String> addType = input -> "type:" + input;
             query = "( " + Joiner.on(" OR ").join(FluentIterable.from(typeMask).transform(addType)) + " ) AND "
-                    + sanitizeLuceneString(text);
+                    + "( " + convertToFreeSearch(text) + " )";
             return getSearchResults(query, user);
         }
         return restrictedSearch(text, typeMask, user);
@@ -183,14 +185,14 @@ public abstract class AbstractDatabaseSearchHandler {
 
     public List<SearchResult> restrictedSearch(String text, List<String> typeMask, User user) {
         String query;
-        if (typeMask == null || typeMask.isEmpty()) {
+        if (CommonUtils.isNullOrEmptyCollection(typeMask)) {
             Map<String, String> subQueryRestrictions = Map.of(
                     "name", text,
                     "fullname", text,
                     "title", text
             );
             // Type check is only on Package. Thus considered irrelevant here.
-            query = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, subQueryRestrictions);
+            query = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, subQueryRestrictions, false);
         } else {
             Map<String, String> subQueryRestrictions = new HashMap<>();
             if (typeMask.contains("project") || typeMask.contains("component") || typeMask.contains("release") || typeMask.contains("package")) {
@@ -202,28 +204,28 @@ public abstract class AbstractDatabaseSearchHandler {
             if (typeMask.contains("obligations")) {
                 subQueryRestrictions.put("title", text);
             }
-            String valueQuery = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, subQueryRestrictions);
+            String valueQuery = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, subQueryRestrictions, false);
             Map<String, String> typeRestrictions = new HashMap<>();
             for (String typeM : typeMask) {
                 typeRestrictions.put("type", typeM);
             }
-            String typeQuery = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, typeRestrictions);
+            String typeQuery = NouveauLuceneAwareDatabaseConnector.convertToRestrictiveQueryWithOr(User.class, typeRestrictions, false);
             query = "( " + valueQuery + " ) AND ( " + typeQuery + " )";
         }
         return getFilteredSearchResults(query, user);
     }
 
-    private @NotNull List<SearchResult> getSearchResults(String queryString, User user) {
+    private @NonNull List<SearchResult> getSearchResults(String queryString, User user) {
         NouveauResult queryLucene = connector.searchView(luceneSearchView.getIndexName(), queryString);
         return convertLuceneResultAndFilterForVisibility(queryLucene, user);
     }
 
-    private @NotNull List<SearchResult> getFilteredSearchResults(String queryString, User user) {
+    private @NonNull List<SearchResult> getFilteredSearchResults(String queryString, User user) {
         NouveauResult queryLucene = connector.searchView(luceneFilteredSearchView.getIndexName(), queryString);
         return convertLuceneResultAndFilterForVisibility(queryLucene, user);
     }
 
-    private @NotNull List<SearchResult> convertLuceneResultAndFilterForVisibility(NouveauResult queryLucene, User user) {
+    private @NonNull List<SearchResult> convertLuceneResultAndFilterForVisibility(NouveauResult queryLucene, User user) {
         List<SearchResult> results = new ArrayList<>();
         if (queryLucene != null) {
             for (NouveauResult.Hits hit : queryLucene.getHits()) {
@@ -241,7 +243,7 @@ public abstract class AbstractDatabaseSearchHandler {
     /**
      * Transforms a LuceneResult row into a Thrift SearchResult object
      */
-    private static @NotNull SearchResult makeSearchResult(@NotNull NouveauResult.Hits hit) {
+    private static @NonNull SearchResult makeSearchResult(NouveauResult.@NonNull Hits hit) {
         SearchResult result = new SearchResult();
 
         // Set row properties

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -10,21 +10,33 @@
 package org.eclipse.sw360.datahandler.cloudantclient;
 
 import com.google.gson.Gson;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
+import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.common.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_DATE_AS_DOUBLE;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.sanitizeLuceneString;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
@@ -32,36 +44,402 @@ import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTIN
 /**
  * Base class to provide helpers and other infrastructure which will help in
  * preparing and performing Nouveau search.
+ *
+ * <h2>Field spec DSL</h2>
+ * Subclasses declare their index schema using {@link IndexField} factory methods and pass the
+ * resulting {@link BuiltIndexDefinition} to the constructor.
+ * Metadata is derived automatically from those fields for query routing in {@link #baseSearch}.
+ *
+ * <h2>Quick reference – field categories</h2>
+ * <table border="1">
+ *   <tr><th>Category</th><th>Example fields</th><th>Index suffixes</th><th>Auto analyzers</th></tr>
+ *   <tr><td>{@link IndexField#standard}</td><td>name, version</td>
+ *       <td>_exact (text), _ngram (edge n-gram), _sort (string)</td>
+ *       <td>_ngram->whitespace, _sort->keyword</td></tr>
+ *   <tr><td>{@link IndexField#simple}</td><td>projectType, state, clearingState</td>
+ *       <td>base (text), _sort (string)</td>
+ *       <td>_sort->keyword; base override via {@code simple(field, analyzer)}</td></tr>
+ *   <tr><td>{@link IndexField#emptyAware}</td><td>businessUnit, tag</td>
+ *       <td>same as standard, but empty docs get a sentinel token</td>
+ *       <td>_ngram->whitespace, _sort->keyword</td></tr>
+ *   <tr><td>{@link IndexField#date}</td><td>createdOn</td>
+ *       <td>double (yyyyMMdd via {@code indexDateAsDouble})</td><td>–</td></tr>
+ * </table>
  */
 public abstract class BaseNouveauSearchHandler<T> {
+
+    /**
+     * Built index definition that bundles the generated index function with derived
+     * field-metadata required for query routing.
+     */
+    public static final class BuiltIndexDefinition {
+        private final NouveauIndexFunction indexFunction;
+        private final Set<String> tieredFields;
+        private final Set<String> emptyAwareFields;
+        private final Set<String> dateFields;
+        private final Set<String> doubleFields;
+
+        private BuiltIndexDefinition(
+                NouveauIndexFunction indexFunction,
+                Set<String> tieredFields,
+                Set<String> emptyAwareFields,
+                Set<String> dateFields,
+                Set<String> doubleFields
+        ) {
+            this.indexFunction = indexFunction;
+            this.tieredFields = Set.copyOf(tieredFields);
+            this.emptyAwareFields = Set.copyOf(emptyAwareFields);
+            this.dateFields = Set.copyOf(dateFields);
+            this.doubleFields = Set.copyOf(doubleFields);
+        }
+
+        public NouveauIndexFunction getIndexFunction() {
+            return indexFunction;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    //  IndexField: public DSL for declaring index schema
+    // -------------------------------------------------------------------------
+
+    /**
+     * Describes how a single CouchDB document field should be indexed and queried.
+     * Use the static factory methods ({@link #standard}, {@link #simple},
+     * {@link #emptyAware}, {@link #date}) to create instances.
+     */
+    public static final class IndexField {
+
+        /** Supported indexing categories. */
+        public enum Category {
+            /**
+             * Full-text field with prefix search support.
+             * Generates: {@code <field>_exact} (text), {@code <field>_ngram} (edge n-gram),
+             * {@code <field>_sort} (string).
+             * Auto-analyzers: {@code _ngram->whitespace, _sort->keyword}.
+             */
+            STANDARD,
+
+            /**
+             * Controlled-value or enum field (no n-gram).
+             * Generates: {@code <field>} (text), {@code <field>_sort} (string).
+             * Auto-analyzers: {@code _sort->keyword};
+             * base field defaults to the index default unless overridden via
+             * {@link #simple(String, String)}.
+             */
+            SIMPLE,
+
+            /**
+             * Same as {@link #STANDARD} but substitutes an empty-token sentinel
+             * ({@link SW360Constants#PROJECT_SEARCH_EMPTY_TOKEN}) when the field is
+             * absent/empty, enabling "no value" filter queries.
+             */
+            EMPTY_AWARE,
+
+            /**
+             * Date field stored as a sortable {@code double} (yyyyMMdd integer).
+             * Uses the {@code indexDateAsDouble} JS helper.
+             */
+            DATE,
+
+            /**
+             * Create index for numbers as {@code double}.
+             */
+            DOUBLE
+        }
+
+        private final String fieldName;
+        private final Category category;
+        @Nullable private final String baseAnalyzerOverride;
+        private final int ngramMin;
+        private final int ngramMax;
+
+        private IndexField(
+                String fieldName, Category category,
+                @Nullable String baseAnalyzerOverride, int ngramMin,
+                int ngramMax
+        ) {
+            this.fieldName = fieldName;
+            this.category = category;
+            this.baseAnalyzerOverride = baseAnalyzerOverride;
+            this.ngramMin = ngramMin;
+            this.ngramMax = ngramMax;
+        }
+
+        // --- Factory methods -------------------------------------------------
+
+        /**
+         * Standard text field with prefix search (n-gram min=2, max=50).
+         * Generates {@code _exact}, {@code _ngram} and {@code _sort} index entries.
+         */
+        public static @NonNull IndexField standard(String fieldName) {
+            return new IndexField(fieldName, Category.STANDARD, null, 2, 50);
+        }
+
+        /** Standard text field with a custom n-gram range. */
+        public static @NonNull IndexField standard(String fieldName, int ngramMin, int ngramMax) {
+            return new IndexField(fieldName, Category.STANDARD, null, ngramMin, ngramMax);
+        }
+
+        /**
+         * Simple field (base text + {@code _sort} only).
+         * The base text field uses the default index analyzer.
+         */
+        public static IndexField simple(String fieldName) {
+            return new IndexField(fieldName, Category.SIMPLE, null, 0, 0);
+        }
+
+        /**
+         * Simple field with an explicit analyzer for the base text index.
+         * Common values: {@code "email"} for email addresses, {@code "keyword"} for enum fields.
+         */
+        public static IndexField simple(String fieldName, String baseAnalyzer) {
+            return new IndexField(fieldName, Category.SIMPLE, baseAnalyzer, 0, 0);
+        }
+
+        /**
+         * Empty-aware standard field (n-gram min=2, max=50).
+         * Documents with a missing/empty field value are indexed under the sentinel token
+         * ({@link SW360Constants#PROJECT_SEARCH_EMPTY_TOKEN}) so they can be found via
+         * an "empty" filter.
+         */
+        public static IndexField emptyAware(String fieldName) {
+            return new IndexField(fieldName, Category.EMPTY_AWARE, null, 2, 50);
+        }
+
+        /** Empty-aware standard field with a custom n-gram range. */
+        public static IndexField emptyAware(String fieldName, int ngramMin, int ngramMax) {
+            return new IndexField(fieldName, Category.EMPTY_AWARE, null, ngramMin, ngramMax);
+        }
+
+        /**
+         * Date field stored as a sortable {@code double} (yyyyMMdd integer).
+         * Supports range queries like {@code [20240101 TO 20241231]}.
+         */
+        public static IndexField date(String fieldName) {
+            return new IndexField(fieldName, Category.DATE, null, 0, 0);
+        }
+
+        /** Number fields index as Nouveau field type {@code double}. */
+        public static IndexField doubleField(String fieldName) {
+            return new IndexField(fieldName, Category.DOUBLE, null, 0, 0);
+        }
+
+        // --- Accessors -------------------------------------------------------
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public Category getCategory() {
+            return category;
+        }
+
+        // --- JS snippet generation -------------------------------------------
+
+        /**
+         * Returns the JavaScript indexing snippet for this field, ready to be embedded
+         * in the CouchDB design-document index function body.
+         *
+         * @param emptyToken Sentinel value used for absent fields in
+         *                   {@link Category#EMPTY_AWARE} (e.g. {@code "__EMPTY__"}).
+         */
+        public @NonNull String toJsSnippet(String emptyToken) {
+            return switch (category) {
+                case STANDARD -> String.format(
+                    "    if(doc.%1$s !== undefined && doc.%1$s != null && typeof(doc.%1$s) == 'string' && doc.%1$s.length > 0) {" +
+                    "      index('text', '%1$s_exact', doc.%1$s);" +
+                    "      emitEdgeNGrams('%1$s_ngram', doc.%1$s, %2$d, %3$d);" +
+                    "      index('string', '%1$s_sort', doc.%1$s.toLowerCase());" +
+                    "    }",
+                    fieldName, ngramMin, ngramMax);
+                case SIMPLE -> String.format(
+                    "    if(doc.%1$s !== undefined && doc.%1$s != null && typeof(doc.%1$s) == 'string' && doc.%1$s.length > 0) {" +
+                    "      index('text', '%1$s', doc.%1$s);" +
+                    "      index('string', '%1$s_sort', doc.%1$s.toLowerCase());" +
+                    "    }",
+                    fieldName);
+                case EMPTY_AWARE -> String.format(
+                    "    var %1$s = '%4$s';" +
+                    "    if(doc.%1$s !== undefined && doc.%1$s != null && typeof(doc.%1$s) == 'string' && doc.%1$s.length > 0) {" +
+                    "      %1$s = doc.%1$s;" +
+                    "    }" +
+                    "    index('text', '%1$s_exact', %1$s);" +
+                    "    emitEdgeNGrams('%1$s_ngram', %1$s, %2$d, %3$d);" +
+                    "    index('string', '%1$s_sort', %1$s.toLowerCase());",
+                    fieldName, ngramMin, ngramMax, emptyToken);
+                case DATE -> String.format(
+                    "    if(doc.%1$s) {" +
+                    "      indexDateAsDouble('%1$s', doc.%1$s);" +
+                    "    }",
+                    fieldName);
+                case DOUBLE -> String.format(
+                    "    if(doc.%1$s !== undefined && doc.%1$s != null && (typeof(doc.%1$s) == 'number' || typeof(doc.%1$s) == 'bigint')) {" +
+                    "      index('double', '%1$s', doc.%1$s);" +
+                    "    }",
+                    fieldName);
+            };
+        }
+
+        // --- Analyzer contributions ------------------------------------------
+
+        /**
+         * Writes analyzer overrides for this field into {@code map}.
+         *
+         * <ul>
+         *   <li>{@link Category#STANDARD} / {@link Category#EMPTY_AWARE}:
+         *       {@code _ngram->whitespace, _sort->keyword}</li>
+         *   <li>{@link Category#SIMPLE}: {@code _sort->keyword};
+         *       base field entry added only when a {@code baseAnalyzerOverride} was given.</li>
+         *   <li>{@link Category#DATE}, {@link Category#DOUBLE}: no entries (double fields need no text analyzer).</li>
+         * </ul>
+         */
+        public void contributeAnalyzers(Map<String, String> map) {
+            switch (category) {
+                case STANDARD, EMPTY_AWARE -> {
+                    map.put(fieldName + "_ngram", "whitespace");
+                    map.put(fieldName + "_sort", "keyword");
+                }
+                case SIMPLE -> {
+                    if (baseAnalyzerOverride != null) {
+                        map.put(fieldName, baseAnalyzerOverride);
+                    }
+                    map.put(fieldName + "_sort", "keyword");
+                }
+                case DATE, DOUBLE -> { /* double fields need no Lucene text analyzers */ }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    //  Static builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a {@link NouveauIndexFunction} from the given field specs plus optional custom JS.
+     *
+     * <p>The preamble always includes the three JS helper functions
+     * ({@code emitEdgeNGrams}, {@code arrayToStringIndex}, {@code indexDateAsDouble}) so that
+     * {@code customJs} can call any of them freely.</p>
+     *
+     * <p>Analyzer priority (highest wins):
+     * {@code customAnalyzers} &gt; auto-generated from field specs.</p>
+     *
+     * @param docType         CouchDB {@code doc.type} value used as an early-exit guard
+     *                        (e.g. {@code "project"}).
+     * @param emptyToken      Sentinel string for empty-aware fields
+     *                        (use {@link SW360Constants#PROJECT_SEARCH_EMPTY_TOKEN}).
+     * @param fields          Ordered list of field specs.
+     * @param customJs        Raw JS appended after the generated per-field snippets
+     *                        (may be {@code null}).
+     * @param customAnalyzers Additional per-field analyzer entries; override auto-generated ones.
+     * @param defaultAnalyzer Default Lucene analyzer name (e.g. {@code "standard"}).
+     * @return A built definition containing the index function and derived query metadata.
+     */
+    protected static @NonNull BuiltIndexDefinition buildIndexFunction(
+            String docType,
+            String emptyToken,
+            @NonNull List<IndexField> fields,
+            @Nullable String customJs,
+            Map<String, String> customAnalyzers,
+            String defaultAnalyzer
+    ) {
+        StringBuilder js = new StringBuilder("function(doc) {");
+        js.append(EMIT_EDGE_N_GRAM_INDEX);
+        js.append(OBJ_ARRAY_TO_STRING_INDEX);
+        js.append(INDEX_DATE_AS_DOUBLE);
+        js.append("  if(!doc.type || doc.type != '").append(docType).append("') return;");
+        for (IndexField field : fields) {
+            js.append(field.toJsSnippet(emptyToken));
+        }
+        if (customJs != null && !customJs.isEmpty()) {
+            js.append(customJs);
+        }
+        js.append("}");
+
+        // Collect analyzers: field specs first, then custom overrides take precedence
+        Map<String, String> analyzers = new LinkedHashMap<>();
+        for (IndexField f : fields) {
+            f.contributeAnalyzers(analyzers);
+        }
+        analyzers.putAll(customAnalyzers);
+
+        Set<String> tieredFields = new HashSet<>();
+        Set<String> emptyAwareFields = new HashSet<>();
+        Set<String> dateFields = new HashSet<>();
+        Set<String> doubleFields = new HashSet<>();
+        for (IndexField field : fields) {
+            switch (field.getCategory()) {
+                case STANDARD -> tieredFields.add(field.getFieldName());
+                case EMPTY_AWARE -> {
+                    tieredFields.add(field.getFieldName());
+                    emptyAwareFields.add(field.getFieldName());
+                }
+                case DATE -> dateFields.add(field.getFieldName());
+                case DOUBLE -> doubleFields.add(field.getFieldName());
+                case SIMPLE -> { /* no special query routing required */ }
+            }
+        }
+
+        NouveauIndexFunction indexFunction = new NouveauIndexFunction(js.toString())
+                .setFieldAnalyzer(analyzers)
+                .setDefaultAnalyzer(defaultAnalyzer);
+
+        return new BuiltIndexDefinition(indexFunction, tieredFields, emptyAwareFields, dateFields, doubleFields);
+    }
+
+    // -------------------------------------------------------------------------
+    //  Instance state
+    // -------------------------------------------------------------------------
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
     private final Class<T> clazz;
     private final NouveauIndexDesignDocument luceneSearchView;
 
-    /**
-     * Setup the basic properties
-     * @param clazz Which type of objects we are dealing with?
-     * @param luceneSearchView The Lucene search view to use for this handler.
-     */
-    protected BaseNouveauSearchHandler(
-            Class<T> clazz, NouveauIndexDesignDocument luceneSearchView
-    ) {
-        this.clazz = clazz;
-        this.luceneSearchView = luceneSearchView;
-    }
+    /** Set of base field names that have {@code _exact} and {@code _ngram} index variants. */
+    private final Set<String> tieredFields;
+    /** Subset of tiered fields that use the empty-token substitution. */
+    private final Set<String> emptyAwareFields;
+    /** Set of field names indexed as sortable double dates. */
+    private final Set<String> dateFields;
+    /** Set of field names indexed as double numbers. */
+    private final Set<String> doubleFields;
+
+    // -------------------------------------------------------------------------
+    //  Constructor
+    // -------------------------------------------------------------------------
 
     /**
+     * @param clazz            The type of objects this handler returns.
+     * @param indexName        The index name under `_design/lucene`.
+     * @param builtIndex       Built index definition from {@link #buildIndexFunction}.
+     */
+    protected BaseNouveauSearchHandler(
+            Class<T> clazz, String indexName, @NonNull BuiltIndexDefinition builtIndex
+    ) {
+        this.clazz = clazz;
+        this.luceneSearchView = new NouveauIndexDesignDocument(indexName, builtIndex.getIndexFunction());
+        this.tieredFields = builtIndex.tieredFields;
+        this.emptyAwareFields = builtIndex.emptyAwareFields;
+        this.dateFields = builtIndex.dateFields;
+        this.doubleFields = builtIndex.doubleFields;
+    }
+
+    // -------------------------------------------------------------------------
+    //  Setup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Register the CouchDB design document and initialise the connector limit.
+     * Call this once in the subclass constructor, passing the same {@code fields} list
+     * that was used in {@link #buildIndexFunction}.
      *
-     * @param connector
-     * @param db
-     * @return
-     * @throws IOException
+     * @param connector Nouveau-aware connector for this handler.
+     * @param db        Cloudant database connector for Gson access.
      */
     public NouveauDesignDocument setup(
-            NouveauLuceneAwareDatabaseConnector connector,
-            DatabaseConnectorCloudant db
+            @NonNull NouveauLuceneAwareDatabaseConnector connector,
+            @NonNull DatabaseConnectorCloudant db
     ) throws IOException {
         Gson gson = db.getInstance().getGson();
         NouveauDesignDocument searchView = new NouveauDesignDocument();
@@ -72,52 +450,141 @@ public abstract class BaseNouveauSearchHandler<T> {
         return searchView;
     }
 
+    // -------------------------------------------------------------------------
+    //  Search
+    // -------------------------------------------------------------------------
+
     /**
-     * Perform a base search for a given type of given fields and their values.
+     * Perform a base search for a given type with the provided field restrictions and pagination.
      *
-     * @param connector            Nouveau Aware DB Connector to use
-     * @param subQueryRestrictions Map of fields to search and their respective expected values.
+     * <p>Query routing is metadata-driven from the {@link BuiltIndexDefinition} passed to
+     * the constructor.</p>
+     *
+     * @param connector            Nouveau Aware DB Connector to use.
+     * @param subQueryRestrictions Map of field names to their accepted values.
      * @param pageData             Pagination information.
-     * @return Result of search, paginated.
+     * @return Paginated search results.
      */
-    protected final Map<PaginationData, List<T>> baseSearch(
+    protected final @NonNull @Unmodifiable Map<PaginationData, List<T>> baseSearch(
             NouveauLuceneAwareDatabaseConnector connector,
-            final Map<String, Set<String>> subQueryRestrictions,
+            final @NonNull Map<String, Set<String>> subQueryRestrictions,
             PaginationData pageData
     ) {
         List<String> sortColumns = getSortColumns(pageData);
-        Map<String, String> simplifiedSubQueryRestrictions = new HashMap<>();
+        Map<String, String> simplified = new HashMap<>();
         for (var restriction : subQueryRestrictions.entrySet()) {
-            simplifiedSubQueryRestrictions.put(restriction.getKey(),
-                    String.join(" ", restriction.getValue()));
+            simplified.put(restriction.getKey(), String.join(" ", restriction.getValue()));
         }
-        Map<PaginationData, List<T>> resultProjectList = connector.
-                searchViewWithRestrictionsWithAnd(
-                        clazz, luceneSearchView.getIndexName(),
-                        simplifiedSubQueryRestrictions, pageData, sortColumns
-                );
-        PaginationData respPageData = resultProjectList.keySet().iterator().next();
-        List<T> projectList = resultProjectList.values().iterator().next();
-        return Collections.singletonMap(respPageData, projectList);
+
+        String query = buildQueryFromRestrictions(simplified);
+        Map<PaginationData, List<T>> result = connector.searchView(
+                clazz, luceneSearchView.getIndexName(), query, pageData, sortColumns);
+        PaginationData respPageData = result.keySet().iterator().next();
+        List<T> items = result.values().iterator().next();
+        return Collections.singletonMap(respPageData, items);
     }
 
+    /**
+     * Simple text search (no pagination) - sanitises the input before forwarding to the connector.
+     */
     public final List<T> search(
-            NouveauLuceneAwareDatabaseConnector connector, String searchText
+            @NonNull NouveauLuceneAwareDatabaseConnector connector, String searchText
     ) {
         return connector.searchView(clazz, luceneSearchView.getIndexName(),
                 sanitizeLuceneString(searchText));
     }
 
+    protected final String getIndexName() {
+        return luceneSearchView.getIndexName();
+    }
+
+    // -------------------------------------------------------------------------
+    //  Metadata-driven query building
+    // -------------------------------------------------------------------------
+
     /**
-     * Get the sorting columns for given lucene query.
+     * Build a Lucene query string from a simplified restriction map, using registered
+     * field metadata for per-field routing.
      *
-     * @param pageData Pagination Data from the request.
-     * @return Sorting columns with direction ({@code -} prefix for descending)
-     * @implNote Not to prefix the score sorting field. It must be sent as-is.
+     * @param restrictions Map of {@code fieldName -> filterValue} (multi-value sets should
+     *                     already be joined into a single string by the caller).
+     * @return A Lucene query string that can be passed directly to
+     *         {@link NouveauLuceneAwareDatabaseConnector#searchView}.
+     */
+    private @NonNull String buildQueryFromRestrictions(
+            @NonNull Map<String, String> restrictions
+    ) {
+        List<String> parts = new ArrayList<>();
+        for (var entry : restrictions.entrySet()) {
+            String fieldName = entry.getKey();
+            String filterValue = entry.getValue();
+            if (CommonUtils.isNullEmptyOrWhitespace(filterValue)) {
+                continue;
+            }
+            parts.add(createFieldQueryRestriction(fieldName, filterValue));
+        }
+        return String.join(" AND ", parts);
+    }
+
+    /**
+     * Build a single Lucene restriction clause for one field-value pair.
+     *
+     * <p>Routing order:
+     * <ol>
+     *   <li>Empty-aware field with the empty-token sentinel -> exact {@code _exact} lookup.</li>
+     *   <li>Tiered field -> n-gram / exact / sort query via
+     *       {@link NouveauLuceneAwareDatabaseConnector#buildFieldQuery}.</li>
+     *   <li>Date field -> value formatted as yyyyMMdd double via
+     *       {@link NouveauLuceneAwareDatabaseConnector#formatDateNouveauFormat}.</li>
+     *   <li>All other fields -> simple quoted term on the base field.</li>
+     * </ol>
+     * </p>
+     */
+    private String createFieldQueryRestriction(String fieldName, String filterValue) {
+        // Empty-aware: must query the _exact sub-field (the base field is not indexed)
+        if (emptyAwareFields.contains(fieldName)
+                && SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(filterValue)) {
+            return fieldName + "_exact:\"" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "\"";
+        }
+
+        String sanitized = sanitizeLuceneString(filterValue);
+        boolean quoted = NouveauLuceneAwareDatabaseConnector.isValidQuotedPhrase(filterValue);
+        String baseSearch = "+(" + fieldName + (quoted ? ":" : ":\"") + sanitized + (quoted ? "" : "\"") + ")";
+
+        if (tieredFields.contains(fieldName)) {
+            if (!quoted) {
+                return "+(" + NouveauLuceneAwareDatabaseConnector.buildFieldQuery(
+                        fieldName + "_exact", fieldName + "_ngram", filterValue, true) + ")";
+            }
+            // Quoted input -> exact sort-field look-up (keyword field stores lowercased value)
+            return "+(" + fieldName + "_sort:" + sanitized.toLowerCase(Locale.ROOT) + ")";
+        }
+
+        if (dateFields.contains(fieldName)) {
+            try {
+                return "+(" + fieldName + ":\"" + NouveauLuceneAwareDatabaseConnector
+                        .formatDateNouveauFormat(sanitized) + "\")";
+            } catch (ParseException e) {
+                return baseSearch;
+            }
+        }
+
+        return baseSearch;
+    }
+
+    // -------------------------------------------------------------------------
+    //  Sorting
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return the sort column list for the given pagination state.
+     *
+     * @param pageData Pagination data from the request.
+     * @return Sort column names with direction ({@code -} prefix = descending).
+     * @implNote The score-sorting field must <em>not</em> be direction-prefixed; pass it as-is.
      */
     protected final @NonNull @Unmodifiable List<String> getSortColumns(@NonNull PaginationData pageData) {
         List<String> columns = mapSortColumn(pageData.getSortColumnNumber());
-        // Flip direction is not Ascending of sorting columns.
         return columns.stream().map(c -> {
             if (!SCORE_SORTING_FIELD.equals(c) && !pageData.isAscending()) {
                 if (c.startsWith("-")) {
@@ -129,5 +596,23 @@ public abstract class BaseNouveauSearchHandler<T> {
         }).toList();
     }
 
+    /**
+     * Map a sort column number (from the UI/API) to a list of Lucene sort fields.
+     *
+     * <p>Return sort fields in priority order. Prefix a field with {@code "-"} to indicate
+     * descending-by-default direction (the direction is flipped automatically by
+     * {@link #getSortColumns} when the client requests ascending order). Do <em>not</em>
+     * prefix {@link org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector#SCORE_SORTING_FIELD}.</p>
+     *
+     * <p>Example implementation:
+     * <pre>{@code
+     * return switch (ProjectSortColumn.findByValue(sortColumnNumber)) {
+     *     case BY_NAME -> List.of("name_sort", "-version_sort", "-createdOn");
+     *     case BY_CREATEDON -> List.of("createdOn");
+     *     case null, default -> List.of(SCORE_SORTING_FIELD);
+     * };
+     * }</pre>
+     * </p>
+     */
     protected abstract List<String> mapSortColumn(int sortColumnNumber);
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.cloudantclient;
+
+import com.google.gson.Gson;
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
+import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NonNull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.sanitizeLuceneString;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+
+/**
+ * Base class to provide helpers and other infrastructure which will help in
+ * preparing and performing Nouveau search.
+ */
+public abstract class BaseNouveauSearchHandler<T> {
+
+    private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
+
+    private final Class<T> clazz;
+    private final NouveauIndexDesignDocument luceneSearchView;
+
+    /**
+     * Setup the basic properties
+     * @param clazz Which type of objects we are dealing with?
+     * @param luceneSearchView The Lucene search view to use for this handler.
+     */
+    protected BaseNouveauSearchHandler(
+            Class<T> clazz, NouveauIndexDesignDocument luceneSearchView
+    ) {
+        this.clazz = clazz;
+        this.luceneSearchView = luceneSearchView;
+    }
+
+    /**
+     *
+     * @param connector
+     * @param db
+     * @return
+     * @throws IOException
+     */
+    public NouveauDesignDocument setup(
+            NouveauLuceneAwareDatabaseConnector connector,
+            DatabaseConnectorCloudant db
+    ) throws IOException {
+        Gson gson = db.getInstance().getGson();
+        NouveauDesignDocument searchView = new NouveauDesignDocument();
+        searchView.setId(DDOC_NAME);
+        searchView.addNouveau(luceneSearchView, gson);
+        connector.setResultLimit(DatabaseSettings.LUCENE_SEARCH_LIMIT);
+        connector.addDesignDoc(searchView);
+        return searchView;
+    }
+
+    /**
+     * Perform a base search for a given type of given fields and their values.
+     *
+     * @param connector            Nouveau Aware DB Connector to use
+     * @param subQueryRestrictions Map of fields to search and their respective expected values.
+     * @param pageData             Pagination information.
+     * @return Result of search, paginated.
+     */
+    protected final Map<PaginationData, List<T>> baseSearch(
+            NouveauLuceneAwareDatabaseConnector connector,
+            final Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData
+    ) {
+        List<String> sortColumns = getSortColumns(pageData);
+        Map<String, String> simplifiedSubQueryRestrictions = new HashMap<>();
+        for (var restriction : subQueryRestrictions.entrySet()) {
+            simplifiedSubQueryRestrictions.put(restriction.getKey(),
+                    String.join(" ", restriction.getValue()));
+        }
+        Map<PaginationData, List<T>> resultProjectList = connector.
+                searchViewWithRestrictionsWithAnd(
+                        clazz, luceneSearchView.getIndexName(),
+                        simplifiedSubQueryRestrictions, pageData, sortColumns
+                );
+        PaginationData respPageData = resultProjectList.keySet().iterator().next();
+        List<T> projectList = resultProjectList.values().iterator().next();
+        return Collections.singletonMap(respPageData, projectList);
+    }
+
+    public final List<T> search(
+            NouveauLuceneAwareDatabaseConnector connector, String searchText
+    ) {
+        return connector.searchView(clazz, luceneSearchView.getIndexName(),
+                sanitizeLuceneString(searchText));
+    }
+
+    /**
+     * Get the sorting columns for given lucene query.
+     *
+     * @param pageData Pagination Data from the request.
+     * @return Sorting columns with direction ({@code -} prefix for descending)
+     * @implNote Not to prefix the score sorting field. It must be sent as-is.
+     */
+    protected final @NonNull @Unmodifiable List<String> getSortColumns(@NonNull PaginationData pageData) {
+        List<String> columns = mapSortColumn(pageData.getSortColumnNumber());
+        // Flip direction is not Ascending of sorting columns.
+        return columns.stream().map(c -> {
+            if (!SCORE_SORTING_FIELD.equals(c) && !pageData.isAscending()) {
+                if (c.startsWith("-")) {
+                    return c.substring(1);
+                }
+                return "-" + c;
+            }
+            return c;
+        }).toList();
+    }
+
+    protected abstract List<String> mapSortColumn(int sortColumnNumber);
+}

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.sw360.common.utils;
+package org.eclipse.sw360.datahandler.common;
 
 public class SearchUtils {
     /*

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -726,7 +726,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
      *   )
      * </pre>
      */
-    private static @NonNull String buildFieldQuery(
+    public static @NonNull String buildFieldQuery(
             @NonNull String fieldExact, @NonNull String fieldNgram, String rawInput,
             boolean isExactSearch
     ) {
@@ -800,9 +800,13 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         if (CommonUtils.isNullEmptyOrWhitespace(input)) {
             return "";
         }
-        String sanitized = input;
+        boolean hasOuterQuotes = input.length() >= 2 && input.startsWith("\"") && input.endsWith("\"");
+        String sanitized = hasOuterQuotes ? input.substring(1, input.length() - 1) : input;
         for (var replacementPair : LUCENE_ESCAPE_LIST) {
             sanitized = sanitized.replaceAll(replacementPair.getLeft(), replacementPair.getRight());
+        }
+        if (hasOuterQuotes) {
+            sanitized = "\"" + sanitized.trim() + "\"";
         }
         return normalizeRestrictionInput(sanitized.trim());
     }
@@ -813,7 +817,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
      * @param input Input string to check.
      * @return True if the input is a valid phrase, false otherwise.
      */
-    private static boolean isValidQuotedPhrase(@NotNull String input) {
+    public static boolean isValidQuotedPhrase(@NotNull String input) {
         return input.startsWith("\"") && input.endsWith("\"") && countQuotes(input) == 2;
     }
 
@@ -1058,7 +1062,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         }
     }
 
-    private static @NotNull String formatDateNouveauFormat(@NotNull String date) throws ParseException {
+    public static @NotNull String formatDateNouveauFormat(@NotNull String date) throws ParseException {
         if (date.startsWith("[") && date.toUpperCase().contains(RANGE_TO)) {
             return formatDateRangesNouveauFormat(date);
         }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -12,9 +12,13 @@ package org.eclipse.sw360.datahandler.couchdb.lucene;
 import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TFieldIdEnum;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
@@ -28,6 +32,7 @@ import org.eclipse.sw360.nouveau.NouveauResult;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -37,11 +42,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -77,6 +85,13 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
 
     private static final List<String> LUCENE_SPECIAL_CHARACTERS = Arrays.asList("[\\\\\\+\\-\\!\\~\\*\\?\\\"\\^\\:\\(\\)\\{\\}\\[\\]]", "\\&\\&", "\\|\\|", "/", "@");
 
+    private static final List<Pair<String, String>> LUCENE_ESCAPE_LIST =
+            Arrays.asList(
+                    Pair.of("([+\\-!\\(\\)\\{\\}\\[\\]\\^\"\\~\\*\\?\\:\\\\/])", "\\\\$1"),
+                    Pair.of("&&", "\\\\&&"),
+                    Pair.of("\\|\\|", "\\\\||")
+            );
+
     /**
      * Maximum number of results to return
      */
@@ -95,7 +110,8 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     /**
      * Update NouveauDesignDocument index for a database. First gets the design
      * from DB if exists and update the index map to not overwrite existing
-     * indexes. Then puts the design to the DB.
+     * indexes. Then puts the design to the DB. At the same time, check if any
+     * of the index exists and does not match. If none match, then return.
      * @param designDocument Design Document to create/add
      * @return True on success.
      * @throws RuntimeException If something goes wrong.
@@ -107,15 +123,23 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
             return putNouveauDesignDocument(designDocument);
         }
 
+        AtomicBoolean indexMissMatched = new AtomicBoolean(false);
         if (!designDocument.equals(documentFromDb)) {
             designDocument.setRev(documentFromDb.getRev());
             if (documentFromDb.getNouveau() != null) {
                 // Add missing indexes from existing DDOC as to not overwrite them
+                // Check if any index definition exists but does not match
                 documentFromDb.getNouveau().asMap().forEach((key, value) -> {
                     if (! designDocument.getNouveau().has(key)) {
                         designDocument.getNouveau().add(key, value);
+                    } else if (!designDocument.getNouveau().get(key).equals(value)) {
+                        indexMissMatched.set(true);
                     }
                 });
+            }
+            if (!indexMissMatched.get()) {
+                // No miss-match found
+                return true;
             }
             return putNouveauDesignDocument(designDocument);
         }
@@ -154,6 +178,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     /**
      * Search with lucene with pagination support
      */
+    @Deprecated
     public <T> Map<PaginationData, List<T>> searchView(
             Class<T> type, String indexName, String queryString,
             PaginationData pageData, String sortColumn, boolean sortAscending
@@ -186,6 +211,63 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     }
 
     /**
+     * Search with lucene with pagination support
+     */
+    public <T> Map<PaginationData, List<T>> searchView(
+            Class<T> type, String indexName, String queryString,
+            PaginationData pageData, List<String> sortColumns
+    ) {
+        Map<PaginationData, List<String>> idMap = searchIds(
+                indexName, queryString, pageData, sortColumns
+        );
+
+        PaginationData respPageData = idMap.keySet().iterator().next();
+        List<String> orderedIds = idMap.values().iterator().next();
+        List<T> collections = connector.get(type, orderedIds);
+
+        // Reorder results from connector.get to the order returned by `searchIds`
+        // since connector.get does not guarantee order preservation because of
+        // HashSet used.
+        Map<String, T> docMap = new LinkedHashMap<>();
+        for (T doc : collections) {
+            String id = null;
+            if (TBase.class.isAssignableFrom(doc.getClass())) {
+                TBase tbase = (TBase) doc;
+                TFieldIdEnum idEnum = tbase.fieldForId(1);
+                id = tbase.getFieldValue(idEnum).toString();
+            }
+            if (id != null) {
+                docMap.put(id, doc);
+            }
+        }
+        collections = orderedIds.stream()
+                .map(docMap::get)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return Collections.singletonMap(respPageData, collections);
+    }
+
+    /**
+     * Search with lucene for ids with pagination support.
+     */
+    public <T> Map<PaginationData, List<String>> searchIds(
+            String indexName, String queryString, PaginationData pageData,
+            List<String> sortColumns
+    ) {
+        NouveauResult queryNouveauResult = searchView(
+                indexName, queryString, sortColumns, pageData
+        );
+        if (queryNouveauResult != null) {
+            pageData.setTotalRowCount(queryNouveauResult.getTotalHits());
+//            queryNouveauResult.getHits().sort(new NouveauResultComparator());
+        } else {
+            pageData.setTotalRowCount(0);
+        }
+        return Collections.singletonMap(pageData, getIdsFromResult(queryNouveauResult, pageData));
+    }
+
+    /**
      * Search with lucene using the previously declared search function only for ids
      */
     public <T> List<String> searchIds(Class<T> type, String indexName, String queryString) {
@@ -196,6 +278,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     /**
      * Search with lucene for ids with pagination support.
      */
+    @Deprecated
     public <T> Map<PaginationData, List<String>> searchIds(
             Class<T> type, String indexName, String queryString,
             PaginationData pageData, String sortColumn, boolean sortAscending
@@ -299,6 +382,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     /**
      * Search with lucene with pagination support
      */
+    @Deprecated
     private @Nullable NouveauResult searchView(String indexName, String queryString, boolean includeDocs,
                                                PaginationData pageData, String sortColumn,
                                                boolean sortAscending) {
@@ -307,6 +391,20 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         }
 
         return callLuceneDirectly(indexName, queryString, includeDocs, pageData, sortColumn, sortAscending);
+    }
+
+    /**
+     * Search with lucene with pagination support
+     */
+    private @Nullable NouveauResult searchView(
+            String indexName, String queryString, List<String> sortColumns,
+            PaginationData pageData
+    ) {
+        if (isNullOrEmpty(queryString)) {
+            return null;
+        }
+
+        return callLuceneDirectly(indexName, queryString, pageData, sortColumns);
     }
 
     private @Nullable NouveauResult callLuceneDirectly(String indexName, String queryString, boolean includeDocs) {
@@ -323,6 +421,58 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return null;
     }
 
+    private @Nullable NouveauResult callLuceneDirectly(
+            String indexName, String queryString,
+            @NotNull PaginationData pageData, List<String> sortColumns
+    ) {
+        final int pageSize = pageData.getRowsPerPage() > 0 ? pageData.getRowsPerPage() : DatabaseSettings.LUCENE_SEARCH_LIMIT;
+        final int requiredPage = pageData.getDisplayStart() / pageSize;
+        final int limit = calculateFetchLimit(requiredPage + 1, pageSize);
+
+        NouveauQuery query = new NouveauQuery(queryString);
+        query.setIncludeDocs(false);
+        query.setSort(sortColumns);
+        query.setLimit(limit);
+        query.reset();
+
+        NouveauResult result = null;
+        try {
+            result = queryNouveau(indexName, query);
+        } catch (ServiceResponseException e) {
+            log.error("Nouveau query failed: {}", e.getResponseBody(), e);
+        }
+        return result;
+    }
+
+    /**
+     * Calculates the top-N limit to fetch from CouchDB Nouveau in a single query.
+     */
+    private static int calculateFetchLimit(int pageNumber, int pageSize) {
+        int page = Math.max(1, pageNumber);
+        int size = Math.max(1, pageSize);
+        return page * size;
+    }
+
+    /**
+     * Extracts the requested page sublist in Java memory from the single top-N result set.
+     */
+    private static List<NouveauResult.Hits> extractPageSublist(
+            List<NouveauResult.Hits> allHits, int offset, int pageSize
+    ) {
+        if (CommonUtils.isNullOrEmptyCollection(allHits)) {
+            return List.of();
+        }
+        int startIndex = Math.max(0, offset);
+        int size = Math.max(1, pageSize);
+
+        if (startIndex >= allHits.size()) {
+            return List.of();
+        }
+        int endIndex = Math.min(startIndex + size, allHits.size());
+        return allHits.subList(startIndex, endIndex);
+    }
+
+    @Deprecated
     private @Nullable NouveauResult callLuceneDirectly(String indexName, String queryString, boolean includeDocs,
                                                        @NotNull PaginationData pageData, String sortColumn,
                                                        boolean sortAscending) {
@@ -333,8 +483,6 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         query.setIncludeDocs(includeDocs);
         if (sortColumn != null && !sortColumn.isEmpty()) {
             query.setSort(sortAscending ? sortColumn : "-" + sortColumn);
-        } else {
-            query.setSort(null);
         }
         query.setLimit(limit);
 
@@ -383,10 +531,26 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     ////////////////////
     // HELPER METHODS //
     ////////////////////
+    @Deprecated
     private static @NotNull List<String> getIdsFromResult(NouveauResult result) {
         List<String> ids = new ArrayList<>();
         if (result != null) {
             for (NouveauResult.Hits hit : result.getHits()) {
+                ids.add(hit.getId());
+            }
+        }
+        return ids;
+    }
+
+    private static @NotNull List<String> getIdsFromResult(
+            NouveauResult result, PaginationData pageData
+    ) {
+        List<String> ids = new ArrayList<>();
+        if (result != null) {
+            List<NouveauResult.Hits> hits = extractPageSublist(
+                    result.getHits(), pageData.getDisplayStart(), pageData.getRowsPerPage()
+            );
+            for (NouveauResult.Hits hit : hits) {
                 ids.add(hit.getId());
             }
         }
@@ -407,7 +571,9 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     /**
      * Search the database for a given string and types, with pagination support.
      * This function uses `AND` to join the restrictions.
+     * @deprecated Use the other one instead.
      */
+    @Deprecated
     public <T> Map<PaginationData, List<T>> searchViewWithRestrictionsWithAnd(
             Class<T> type, String indexName, String text,
             final @NotNull Map<String, Set<String>> subQueryRestrictions,
@@ -420,7 +586,9 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     /**
      * Search the database for a given string and types, with pagination support.
      * This function uses `OR` to join the restrictions.
+     * @deprecated Use the other one instead.
      */
+    @Deprecated
     public <T> Map<PaginationData, List<T>> searchViewWithRestrictionsWithOr(
             Class<T> type, String indexName, String text,
             final @NotNull Map<String, Set<String>> subQueryRestrictions,
@@ -430,12 +598,264 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return searchView(type, indexName, query, pageData, sortColumn, sortAscending);
     }
 
+    @Deprecated
     private static <T> @NotNull String convertToRestrictiveQueryWithAnd(Class<T> type, String text, @NotNull Map<String, Set<String>> subQueryRestrictions) {
         return AND.join(convertToRestrictiveQuery(type, text, subQueryRestrictions));
     }
 
+    @Deprecated
     private static <T> @NotNull String convertToRestrictiveQueryWithOr(Class<T> type, String text, @NotNull Map<String, Set<String>> subQueryRestrictions) {
         return OR.join(convertToRestrictiveQuery(type, text, subQueryRestrictions));
+    }
+
+    /**
+     * Search the database for a given string and types, with pagination support.
+     * This function uses `AND` to join the restrictions.
+     */
+    public <T> Map<PaginationData, List<T>> searchViewWithRestrictionsWithAnd(
+            Class<T> type, String indexName,
+            final @NotNull Map<String, String> subQueryRestrictions,
+            PaginationData pageData, List<String> sortColumns
+    ) {
+        String query = convertToRestrictiveQueryWithAnd(type, subQueryRestrictions, true);
+        return searchView(type, indexName, query, pageData, sortColumns);
+    }
+
+    /**
+     * Search the database for a given string and types, with pagination support.
+     * This function uses `OR` to join the restrictions.
+     */
+    public <T> Map<PaginationData, List<T>> searchViewWithRestrictionsWithOr(
+            Class<T> type, String indexName,
+            final @NotNull Map<String, String> subQueryRestrictions,
+            PaginationData pageData, List<String> sortColumns
+    ) {
+        String query = convertToRestrictiveQueryWithOr(type, subQueryRestrictions, true);
+        return searchView(type, indexName, query, pageData, sortColumns);
+    }
+
+    private static <T> @NotNull String convertToRestrictiveQueryWithAnd(Class<T> type, @NotNull Map<String, String> subQueryRestrictions, boolean isExactSearch) {
+        return AND.join(convertToRestrictiveQuery(type, subQueryRestrictions, isExactSearch));
+    }
+
+    public static <T> @NotNull String convertToRestrictiveQueryWithOr(Class<T> type, @NotNull Map<String, String> subQueryRestrictions, boolean isExactSearch) {
+        return OR.join(convertToRestrictiveQuery(type, subQueryRestrictions, isExactSearch));
+    }
+
+    private static <T> @NotNull List<String> convertToRestrictiveQuery(
+            Class<T> type, @NotNull Map<String, String> subQueryRestrictions,
+            boolean isExactSearch
+    ) {
+        List<String> subQueries = new ArrayList<>();
+        for (Map.Entry<String, String> restriction : subQueryRestrictions.entrySet()) {
+            final String filterValue = restriction.getValue();
+
+            if (CommonUtils.isNotNullEmptyOrWhitespace(filterValue)) {
+                final String fieldName = restriction.getKey();
+                subQueries.add(createAQueryRestriction(fieldName, filterValue, isExactSearch));
+            }
+        }
+
+        if (type == Package.class && subQueryRestrictions.containsKey("orphanPackageCheckBox")) {
+            // get all packages with name field and then negate with releaseId field to find orphan packages
+            subQueries.add("((name:*) NOT (releaseId:*))");
+        }
+        return subQueries;
+    }
+
+    private static @NotNull String createAQueryRestriction(
+            @NotNull final String fieldName, @NotNull String filterValue,
+            boolean isExactSearch
+    ) {
+        if (EMPTY_SEARCH_FIELDS.contains(fieldName)
+                && SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(filterValue)) {
+            return fieldName + ":\"" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "\"";
+        }
+
+        String sanitized = sanitizeLuceneString(filterValue);
+        boolean quoted = isValidQuotedPhrase(filterValue);
+        // Handle pre-formatted queries from prepareWildcardQuery
+        final String baseSearch = "+(" + fieldName + (quoted ? ":" : ":\"") + sanitized + (quoted ? "" : "\"") + ")";
+        return switch (fieldName) {
+            // Field which have `_exact`, `_ngram` and `_sort` indexes.
+            case "businessUnit", "name", "version", "tag"
+                    -> {
+                if (!quoted) {
+                    // Non-exact match
+                    yield "+(" + buildFieldQuery(fieldName + "_exact", fieldName + "_ngram", filterValue, isExactSearch) + ")";
+                }
+                // Exact match with quoted input
+                yield "+(" + fieldName + "_sort:" + sanitized.toLowerCase(Locale.ROOT) + ")";
+            }
+            case "createdOn"
+                    -> {
+                try {
+                    yield "+(" + fieldName + ":\"" + formatDateNouveauFormat(sanitized) + "\")";
+                } catch (ParseException e) {
+                    yield baseSearch;
+                }
+            }
+            // Other fields which does not have `_exact` and `_ngram` indexes.
+            // Encase them in `"` to make sure string is not mangled because of spaces.
+            default -> baseSearch;
+        };
+    }
+
+    /**
+     * Constructs a tiered Lucene query string for a target field.
+     * <p>
+     *     If the input is a quoted string, returns a simple exact match query
+     *     like: {@code +<fieldExact>:<input>}.
+     * </p>
+     * <p>
+     *     If the input contains single token, returns
+     *     {@code (<fieldExact>:<input>^100 OR <fieldNgram>:<input>)}.
+     * </p>
+     * <p>
+     *     Otherwise, creates a 2 tiered query with exact match query boost
+     *     which looks like following. This will boost the exact match to top
+     *     and then score everything based on Lucene internal scoring.
+     * </p>
+     * <pre>
+     *   (
+     *     <fieldExact>:"<input>"^100
+     *     OR
+     *     (
+     *       <fieldExact>:<token[0]> AND <fieldExact>:<token[1]> AND <fieldNgram>:<token[n]>
+     *     )
+     *   )
+     * </pre>
+     */
+    private static @NonNull String buildFieldQuery(
+            @NonNull String fieldExact, @NonNull String fieldNgram, String rawInput,
+            boolean isExactSearch
+    ) {
+        if (CommonUtils.isNullEmptyOrWhitespace(rawInput)) {
+            return "";
+        }
+
+        String trimmed = rawInput.trim();
+
+        // Exact phrase search if quoted, no magic
+        if (isValidQuotedPhrase(trimmed) && trimmed.length() > 2) {
+            // + name_exact:"My test project"
+            return "+" + fieldExact + ":" + sanitizeLuceneString(trimmed);
+        }
+
+        List<String> tokens = Arrays.stream(trimmed.split("\\s+"))
+                .map(NouveauLuceneAwareDatabaseConnector::sanitizeLuceneString)
+                .filter(CommonUtils::isNotNullEmptyOrWhitespace)
+                .toList();
+
+        if (tokens.isEmpty()) {
+            return "";
+        }
+
+        // Single-word query pattern
+        if (tokens.size() == 1) {
+            String token = tokens.getFirst().toLowerCase(Locale.ROOT);
+            if (!isValidQuotedPhrase(token)) {
+                token = "\"" + token + "\"";
+            }
+            // (name_exact:"my"^100 OR name_ngram:"my")
+            return String.format("(%s:%s^100 OR %s:%s)", fieldExact, token, fieldNgram, token);
+        }
+
+        // Multi-word tiered query pattern
+        String fullPhrase = String.join(" ", tokens);
+        String phraseClause = fieldExact + ":\"" + fullPhrase + "\"^100";
+
+        StringBuilder andClause = new StringBuilder();
+        andClause.append("(");
+        List<String> clauses = new ArrayList<>();
+        for (Iterator<String> it = tokens.iterator(); it.hasNext();) {
+            String token = it.next();
+            String fieldName = isExactSearch ? fieldExact : fieldNgram;
+            if (!it.hasNext()) {
+                // Last token always uses n-gram for prefix matching
+                fieldName = fieldNgram;
+            }
+            clauses.add(fieldName + ":\"" + token.toLowerCase(Locale.ROOT) + "\"");
+        }
+        AND.appendTo(andClause, clauses);
+        andClause.append(")");
+
+        /*
+         * ( name_exact:"My test project"^100 OR ( name_exact:"my" AND name_exact:"test" AND name_ngram:"project" ) )
+         */
+        return String.format("(%s OR %s)", phraseClause, andClause);
+    }
+
+    /**
+     * Sanitize the input so it can be parsed by Lucene following:
+     * <ol>
+     *     <li>Escape all characters from Nouveau docs.</li>
+     *     <li>Normalize input for stray double quotes while preserving ones at start and end.</li>
+     * </ol>
+     * @see <a href="https://archive.softwareheritage.org/swh:1:cnt:7cbaec66195ec3aa965637c3f79acde0434e2ad2;origin=https://github.com/apache/couchdb;path=/src/docs/src/ddocs/nouveau.rst;lines=645">Nouveau Lucene Escaping</a>
+     * @param input Input string to normalize and sanitize
+     * @return Normalized and sanitized string which can be used in Nouveau query.
+     */
+    public static @NonNull String sanitizeLuceneString(String input) {
+        if (CommonUtils.isNullEmptyOrWhitespace(input)) {
+            return "";
+        }
+        String sanitized = input;
+        for (var replacementPair : LUCENE_ESCAPE_LIST) {
+            sanitized = sanitized.replaceAll(replacementPair.getLeft(), replacementPair.getRight());
+        }
+        return normalizeRestrictionInput(sanitized.trim());
+    }
+
+    /**
+     * Check if a string starts and ends with {@code "} and only there. Meaning
+     * it needs no sanitization.
+     * @param input Input string to check.
+     * @return True if the input is a valid phrase, false otherwise.
+     */
+    private static boolean isValidQuotedPhrase(@NotNull String input) {
+        return input.startsWith("\"") && input.endsWith("\"") && countQuotes(input) == 2;
+    }
+
+    private static int countQuotes(@NotNull String input) {
+        return (int) input.chars().filter(ch -> ch == '"').count();
+    }
+
+    /**
+     * Sanitize the search input for rogue quotes {@code "}
+     *
+     * <ol>
+     *   <li>Check if input does not contain quotes or is valid, return as is.</li>
+     *   <li>Check if input starts and ends with quotes (exact match needed), trim it.</li>
+     *   <li>Replace all {@code "} with {@code \"}.</li>
+     *   <li>If the input was trimmed, add quotes back to the start and end.</li>
+     * </ol>
+     *
+     * @param input Input to sanitize.
+     * @return Sanitized string.
+     */
+    private static @NotNull String normalizeRestrictionInput(@NotNull String input) {
+        if (!input.contains("\"") || isValidQuotedPhrase(input)) {
+            return input;
+        }
+
+        boolean hasOuterQuotes = input.length() >= 2 && input.startsWith("\"") && input.endsWith("\"");
+        String inputToEscape = hasOuterQuotes ? input.substring(1, input.length() - 1) : input;
+        String escaped = inputToEscape.replaceAll("\"", "\\\\\"");
+
+        if (hasOuterQuotes) {
+            return "\"" + escaped + "\"";
+        }
+        return escaped;
+    }
+
+    /**
+     * Convert a string to old {@code term*} format for "I don't know search".
+     * Useful for default searches (un-restricted).
+     */
+    public static @NonNull String convertToFreeSearch(@NonNull String input) {
+        String sanitized = sanitizeLuceneString(input);
+        return "(\"" + String.join("*\" OR \"", sanitized.split("\\s+")) + "*\")";
     }
 
     /**
@@ -496,6 +916,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return subQueries;
     }
 
+    @Deprecated
     private static <T> @NotNull List<String> convertToRestrictiveQuery(Class<T> type, String text, @NotNull Map<String, Set<String>> subQueryRestrictions) {
         List<String> subQueries = new ArrayList<>();
         for (Map.Entry<String, Set<String>> restriction : subQueryRestrictions.entrySet()) {
@@ -519,6 +940,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return subQueries;
     }
 
+    @Deprecated
     private static @NotNull String formatSubquery(@NotNull Set<String> filterSet, final String fieldName) {
         List<String> queryParts = new ArrayList<>();
         if (EMPTY_SEARCH_FIELDS.contains(fieldName)
@@ -624,6 +1046,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return projectList.stream().filter(ProjectPermissions.isVisible(user)).collect(Collectors.toList());
     }
 
+    @Deprecated
     private static String sanitizeQueryInput(String input) {
         if (isNullOrEmpty(input)) {
             return nullToEmpty(input);

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -391,7 +391,7 @@ service ProjectService {
      * returns a list of projects which match `text` and the
      * `subQueryRestrictions` and are visible to the `user`. The request is pageable
      */
-    map<PaginationData, list<Project>> refineSearchPageable(1: string text, 2: map<string,set<string>>  subQueryRestrictions, 3: User user, 4: PaginationData pageData);
+    map<PaginationData, list<Project>> refineSearchPageable(1: map<string,set<string>> subQueryRestrictions, 2: User user, 3: PaginationData pageData);
 
     /**
      * list of projects which are visible to the `user` and match the `name`

--- a/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
+++ b/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
@@ -37,6 +37,7 @@ import java.util.Map;
 public class LuceneAwareCouchDbConnector {
     public static String DEFAULT_NOUVEAU_PREFIX = "_nouveau";
     public static String DEFAULT_DESIGN_PREFIX = ""; // '_design/' not needed with Cloudant SDK
+    public static String SCORE_SORTING_FIELD = "relevance"; ///< Use to sort by score
 
     private final NouveauAwareDatabase database;
 

--- a/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/NouveauQuery.java
+++ b/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/NouveauQuery.java
@@ -30,7 +30,7 @@ public class NouveauQuery {
     @SerializedName("q")
     private String query;
     private List<Range> ranges;
-    private String sort;
+    private List<String> sort;
     private Boolean update;
 
     public static class Range {
@@ -109,8 +109,21 @@ public class NouveauQuery {
      * Sort the results by given sort order. Example: "fieldname<type>" or "-fieldname<type>".
      * @param sort Sort order
      */
-    public void setSort(String sort) {
+    public void setSort(List<String> sort) {
         this.sort = sort;
+    }
+
+    /**
+     * @param sort Sort order
+     * @deprecated Use {@link #setSort(List)} instead.
+     */
+    @Deprecated
+    public void setSort(String sort) {
+        if (sort == null) {
+            this.sort = null;
+        } else {
+            this.sort = List.of(sort);
+        }
     }
 
     /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/OpenAPIPaginationHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/OpenAPIPaginationHelper.java
@@ -32,7 +32,7 @@ public class OpenAPIPaginationHelper {
     @Schema(description = "Number of entries per page", type = "int",
             defaultValue = "10", name = "page_entries")
     private int pageEntries;
-    @Schema(description = "Sorting of entries", type = "string",
+    @Schema(description = "Sorting of entries with 'column name, direction'", type = "string",
             example = "name,desc", name = "sort")
     private String sort;
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -32,6 +32,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -177,6 +178,10 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Projects", description = "Operations related to Projects on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`score` (default), " +
+        "`createdOn`, `name`, `vendor`, `license`, `type`, `description`, " +
+        "`projectResponsible` or `state`].")
 public class ProjectController implements RepresentationModelProcessor<RepositoryLinksResource> {
     private static final String CREATED_BY = "createdBy";
     private static final String ATTACHMENT_TYPE = "attachmentType";
@@ -299,19 +304,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
 
         if (luceneSearch && !filterMap.isEmpty()) {
-            if (filterMap.containsKey(Project._Fields.NAME.getFieldName())) {
-                Set<String> values = filterMap.get(Project._Fields.NAME.getFieldName()).stream()
-                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
-                        .collect(Collectors.toSet());
-                filterMap.put(Project._Fields.NAME.getFieldName(), values);
-            }
-            if (filterMap.containsKey(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY)) {
-                Set<String> values = filterMap.get(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY).stream()
-                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
-                        .collect(Collectors.toSet());
-                filterMap.put(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY, values);
-            }
-
             paginatedProjects = projectService.refineSearch(filterMap, sw360User, pageable);
         } else {
             if (filterMap.isEmpty()) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1274,8 +1274,8 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         PaginationData pageData = pageableToPaginationData(pageable,
                 // Can be sorted on name and createdOn, but using different default value for score sorting
-                ProjectSortColumn.BY_TYPE, true);
-        return sw360ProjectClient.refineSearchPageable(null, filterMap, sw360User, pageData);
+                ProjectSortColumn.BY_SCORE, true);
+        return sw360ProjectClient.refineSearchPageable(filterMap, sw360User, pageData);
     }
 
     /**


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This PR is starting point of rewriting the Nouveau/Lucene based search infra which takes advantage of:
1. Pre-computed Edge N-grams to avoid `*` suffix and improve search speed with expense of additional index size.
2. Use of multiple sort columns for tie-breaking.
3. Use 2 tiered search with score boosting.

Check the proposed ADR https://eclipse.dev/sw360/docs/architecture/decisions/adr-009-nouveau-search/ for more information.

This PR is not the complete migration but it provides:
1. Basic core infra to create the indexes and perform search.
2. Migration of Nouveau Search for `/projects` endpoint.
3. Migration of Nouveau Search for `/search` endpoint.

### Suggest Reviewer
@rudra-superrr @bibhuti230185 

### How To Test?
Install the new branch and check if the search results have improved.