### PR TITLE
Feat/component search nouveau migration

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -53,6 +53,15 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
             IndexField.date("createdOn")
     );
 
+    private static final Map<String, String> COMPONENT_CUSTOM_ANALYZERS = Map.of(
+            "categories_sort", "email",
+            "languages_sort", "keyword",
+            "softwarePlatforms_sort", "keyword",
+            "operatingSystems_sort", "keyword",
+            "vendorNames_sort", "keyword",
+            "mainLicenseIds_sort", "keyword"
+    );
+
     /**
      * Component-specific JS for array-backed fields that should support text
      * and sort lookups via arrayToStringIndex helper.
@@ -70,7 +79,7 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
             SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN,
             COMPONENT_FIELDS,
             COMPONENT_CUSTOM_JS,
-            Map.of(),
+            COMPONENT_CUSTOM_ANALYZERS,
             "standard"
     );
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -10,101 +10,93 @@
 package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.gson.Gson;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
 /**
- * Class for accessing the Lucene connector on the CouchDB database
+ * Nouveau search handler for Components with paginated access control filtering.
  *
  * @author cedric.bodet@tngtech.com
  * @author alex.borodin@evosoft.com
  */
-public class ComponentSearchHandler {
-
-    private static final Logger log = LogManager.getLogger(ComponentSearchHandler.class);
+public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> {
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-        = new NouveauIndexDesignDocument("components",
-            new NouveauIndexFunction(
-                "function(doc) {" +
-                OBJ_ARRAY_TO_STRING_INDEX +
-                "    if(!doc.type || doc.type != 'component') return;" +
-                "    arrayToStringIndex(doc.categories, 'categories');" +
-                "    arrayToStringIndex(doc.languages, 'languages');" +
-                "    arrayToStringIndex(doc.softwarePlatforms, 'softwarePlatforms');" +
-                "    arrayToStringIndex(doc.operatingSystems, 'operatingSystems');" +
-                "    arrayToStringIndex(doc.vendorNames, 'vendorNames');" +
-                "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');" +
-                "    if(doc.componentType && typeof(doc.componentType) == 'string' && doc.componentType.length > 0) {" +
-                "      index('text', 'componentType', doc.componentType, {'store': true});" +
-                "      index('string', 'componentType_sort', doc.componentType);" +
-                "    }" +
-                "    if(doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
-                "      index('text', 'name', doc.name, {'store': true});"+
-                "      index('string', 'name_sort', doc.name);"+
-                "    }" +
-                "    if(doc.createdBy && typeof(doc.createdBy) == 'string' && doc.createdBy.length > 0) {" +
-                "      index('text', 'createdBy', doc.createdBy, {'store': true});"+
-                "    }" +
-                "    if(doc.createdOn && doc.createdOn.length) {"+
-                "      var dt = new Date(doc.createdOn);"+
-                "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
-                "      index('double', 'createdOn', Number(formattedDt), {'store': true});"+
-                "    }" +
-                "    if(doc.businessUnit && typeof(doc.businessUnit) == 'string' && doc.businessUnit.length > 0) {" +
-                "      index('text', 'businessUnit', doc.businessUnit, {'store': true});"+
-                "    }" +
-                "}"));
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
 
+    private static final List<IndexField> COMPONENT_FIELDS = List.of(
+            IndexField.standard("name"),
+            IndexField.simple("componentType", "keyword"),
+            IndexField.simple("createdBy", "email"),
+            IndexField.simple("businessUnit"),
+            IndexField.simple("description"),
+            IndexField.date("createdOn")
+    );
+
+    /**
+     * Component-specific JS for array-backed fields that should support text
+     * and sort lookups via arrayToStringIndex helper.
+     */
+    private static final String COMPONENT_CUSTOM_JS =
+            "    arrayToStringIndex(doc.categories, 'categories');" +
+            "    arrayToStringIndex(doc.languages, 'languages');" +
+            "    arrayToStringIndex(doc.softwarePlatforms, 'softwarePlatforms');" +
+            "    arrayToStringIndex(doc.operatingSystems, 'operatingSystems');" +
+            "    arrayToStringIndex(doc.vendorNames, 'vendorNames');" +
+            "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');";
+
+    private static final BuiltIndexDefinition COMPONENT_INDEX_DEFINITION = buildIndexFunction(
+            "component",
+            SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN,
+            COMPONENT_FIELDS,
+            COMPONENT_CUSTOM_JS,
+            Map.of(),
+            "standard"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Constructor
+    // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public ComponentSearchHandler(Cloudant cClient, String dbName) throws IOException {
+        super(Component.class, "components", COMPONENT_INDEX_DEFINITION);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(cClient, dbName);
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        connector.addDesignDoc(searchView);
+        setup(connector, db);
     }
 
-    public List<Component> search(String text, final Map<String, Set<String>> subQueryRestrictions ){
-        return connector.searchViewWithRestrictionsWithAnd(Component.class, luceneSearchView.getIndexName(),
-                text, subQueryRestrictions);
-    }
+    // -------------------------------------------------------------------------
+    //  Public search API
+    // -------------------------------------------------------------------------
 
-    public Map<PaginationData, List<Component>> searchAccessibleComponents(String text, final Map<String,
-            Set<String>> subQueryRestrictions, User user, @Nonnull PaginationData pageData) {
-        String sortColumn = getSortColumnName(pageData);
-        Map<PaginationData, List<Component>> resultComponentList = connector
-                .searchViewWithRestrictionsWithAnd(Component.class,
-                        luceneSearchView.getIndexName(), text, subQueryRestrictions,
-                        pageData, sortColumn, pageData.isAscending());
+    /**
+     * Paginated search with permission filtering.
+     */
+    public Map<PaginationData, List<Component>> searchAccessibleComponents(
+            final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        Map<PaginationData, List<Component>> resultComponentList = baseSearch(connector, subQueryRestrictions, pageData);
 
         PaginationData respPageData = resultComponentList.keySet().iterator().next();
         List<Component> componentList = resultComponentList.values().iterator().next();
@@ -116,32 +108,41 @@ public class ComponentSearchHandler {
         return Collections.singletonMap(respPageData, componentList);
     }
 
+    /**
+     * Non-paginated search (legacy callers).
+     */
+    public List<Component> search(String text, final Map<String, Set<String>> subQueryRestrictions) {
+        return connector.searchViewWithRestrictionsWithAnd(Component.class, getIndexName(),
+                text, subQueryRestrictions);
+    }
+
+    /**
+     * Non-paginated search with accessibility information filled.
+     */
     public List<Component> searchWithAccessibility(String text, final Map<String, Set<String>> subQueryRestrictions,
                                                    User user) {
         List<Component> resultComponentList = connector.searchViewWithRestrictionsWithAnd(Component.class,
-                luceneSearchView.getIndexName(), text, subQueryRestrictions);
+                getIndexName(), text, subQueryRestrictions);
         for (Component component : resultComponentList) {
             makePermission(component, user).fillPermissionsInOther(component);
         }
         return resultComponentList;
     }
 
-    /**
-     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
-     * `_sort` suffix) for text indexes.
-     * @param pageData Pagination Data from the request.
-     * @return Sort column name. Defaults to createdOn
-     */
-    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
-        return switch (ComponentSortColumn.findByValue(pageData.getSortColumnNumber())) {
-            case ComponentSortColumn.BY_NAME -> "name_sort";
-            case ComponentSortColumn.BY_VENDOR -> "vendorNames_sort";
-            case ComponentSortColumn.BY_MAINLICENSE -> "mainLicenseIds_sort";
-            case ComponentSortColumn.BY_TYPE -> "componentType_sort";
-            // null signals Nouveau to skip sorting and return results ranked by relevance score
-            case ComponentSortColumn.BY_SCORE -> null;
-            case null -> "createdOn";
-            default -> "createdOn";
+    // -------------------------------------------------------------------------
+    //  Sort column mapping
+    // -------------------------------------------------------------------------
+
+    @Override
+    protected List<String> mapSortColumn(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (ComponentSortColumn.findByValue(sortColumnNumber)) {
+            case ComponentSortColumn.BY_NAME -> List.of("name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_VENDOR -> List.of("vendorNames_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_MAINLICENSE -> List.of("mainLicenseIds_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_TYPE -> List.of("componentType_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case null, default -> List.of(SCORE_SORTING_FIELD);
         };
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandlerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ComponentSearchHandlerTest {
+
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (ComponentSortColumn.findByValue(sortColumnNumber)) {
+            case ComponentSortColumn.BY_NAME -> List.of("name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_VENDOR -> List.of("vendorNames_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_MAINLICENSE -> List.of("mainLicenseIds_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_TYPE -> List.of("componentType_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ComponentSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case null, default -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+
+    @Test
+    void byName_shouldReturnNameSortWithCreatedOnTiebreaker() {
+        List<String> columns = mapSortColumnDirect(ComponentSortColumn.BY_NAME.getValue());
+        assertEquals(List.of("name_sort", "-createdOn"), columns);
+        assertFalse(columns.contains(SCORE_SORTING_FIELD));
+    }
+
+    @Test
+    void byVendor_shouldReturnVendorSortWithTiebreakers() {
+        assertEquals(List.of("vendorNames_sort", SCORE_SORTING_FIELD, "name_sort", "-createdOn"),
+                mapSortColumnDirect(ComponentSortColumn.BY_VENDOR.getValue()));
+    }
+
+    @Test
+    void byMainLicense_shouldReturnLicenseSortWithTiebreakers() {
+        assertEquals(List.of("mainLicenseIds_sort", SCORE_SORTING_FIELD, "name_sort", "-createdOn"),
+                mapSortColumnDirect(ComponentSortColumn.BY_MAINLICENSE.getValue()));
+    }
+
+    @Test
+    void byType_shouldReturnTypeSortWithTiebreakers() {
+        assertEquals(List.of("componentType_sort", SCORE_SORTING_FIELD, "name_sort", "-createdOn"),
+                mapSortColumnDirect(ComponentSortColumn.BY_TYPE.getValue()));
+    }
+
+    @Test
+    void byCreatedOn_shouldReturnOnlyCreatedOn() {
+        assertEquals(List.of("createdOn"), mapSortColumnDirect(ComponentSortColumn.BY_CREATEDON.getValue()));
+    }
+
+    @Test
+    void byScore_shouldReturnOnlyScoreField() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(ComponentSortColumn.BY_SCORE.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToScore() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(999));
+    }
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (ComponentSortColumn column : ComponentSortColumn.values()) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertNotNull(columns);
+            assertFalse(columns.isEmpty());
+        }
+    }
+
+    @Test
+    void nonPrimaryColumns_shouldHaveScoreAndNameTiebreakers() {
+        for (ComponentSortColumn column : List.of(
+                ComponentSortColumn.BY_VENDOR,
+                ComponentSortColumn.BY_MAINLICENSE,
+                ComponentSortColumn.BY_TYPE)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertTrue(columns.contains(SCORE_SORTING_FIELD), column + " missing score");
+            assertTrue(columns.contains("name_sort"), column + " missing name_sort");
+            assertTrue(columns.contains("-createdOn"), column + " missing -createdOn");
+        }
+    }
+
+    @Test
+    void nonPrimaryColumns_shouldHaveCorrectTiebreakerOrder() {
+        for (ComponentSortColumn column : List.of(
+                ComponentSortColumn.BY_VENDOR,
+                ComponentSortColumn.BY_MAINLICENSE,
+                ComponentSortColumn.BY_TYPE)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            int scoreIdx = columns.indexOf(SCORE_SORTING_FIELD);
+            int nameIdx = columns.indexOf("name_sort");
+            int createdOnIdx = columns.indexOf("-createdOn");
+            assertTrue(scoreIdx > 0, column + ": score should not be primary");
+            assertTrue(nameIdx > scoreIdx, column + ": name_sort should follow score");
+            assertTrue(createdOnIdx > nameIdx, column + ": createdOn should be last");
+        }
+    }
+
+    @Test
+    void edgeNgramConstants_shouldHaveValidValues() {
+        int max = org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler.EDGE_NGRAM_MAX_LENGTH;
+        int shortMax = org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler.EDGE_NGRAM_SHORT_MAX_LENGTH;
+        assertEquals(50, max);
+        assertEquals(10, shortMax);
+    }
+}

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -123,8 +123,8 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
-    public Map<PaginationData, List<Component>> refineSearchAccessibleComponents(String text, Map<String,Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
-        return componentSearchHandler.searchAccessibleComponents(text, subQueryRestrictions, user, pageData);
+    public Map<PaginationData, List<Component>> refineSearchAccessibleComponents(Map<String,Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        return componentSearchHandler.searchAccessibleComponents(subQueryRestrictions, user, pageData);
     }
 
     @Override

--- a/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
+++ b/backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler.EDGE_NGRAM_MAX_LENGTH;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_TO_DEFAULT_INDEX;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.convertToFreeSearch;
@@ -84,17 +85,17 @@ public abstract class AbstractDatabaseSearchHandler {
             "  }" +
             "  if (doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
             "    index('text', 'name_exact', doc.name);" +
-            "    emitEdgeNGrams('name_ngram', doc.name, 2, 25);" +
+            "    emitEdgeNGrams('name_ngram', doc.name, 2, " + EDGE_NGRAM_MAX_LENGTH + ");" +
             "    index('string', 'name_sort', doc.name.toLowerCase());" +
             "  }" +
             "  if (doc.fullname && typeof(doc.fullname) == 'string' && doc.fullname.length > 0) {" +
             "    index('text', 'fullname_exact', doc.fullname);" +
-            "    emitEdgeNGrams('fullname_ngram', doc.fullname, 2, 35);" +
+            "    emitEdgeNGrams('fullname_ngram', doc.fullname, 2, " + EDGE_NGRAM_MAX_LENGTH + ");" +
             "    index('string', 'fullname_sort', doc.fullname.toLowerCase());" +
             "  }" +
             "  if (doc.title && typeof(doc.title) == 'string' && doc.title.length > 0) {" +
             "    index('text', 'title_exact', doc.title);" +
-            "    emitEdgeNGrams('title_ngram', doc.title, 2, 25);" +
+            "    emitEdgeNGrams('title_ngram', doc.title, 2, " + EDGE_NGRAM_MAX_LENGTH + ");" +
             "    index('string', 'title_sort', doc.title.toLowerCase());" +
             "  }" +
             "}")

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -622,8 +622,8 @@ public abstract class BaseNouveauSearchHandler<T> {
 
         if (dateFields.contains(fieldName)) {
             try {
-                return "+(" + fieldName + ":\"" + NouveauLuceneAwareDatabaseConnector
-                        .formatDateNouveauFormat(sanitized) + "\")";
+                return "+(" + fieldName + ":" + NouveauLuceneAwareDatabaseConnector
+                        .formatDateNouveauFormat(filterValue.trim()) + ")";
             } catch (ParseException e) {
                 return baseSearch;
             }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -69,11 +69,24 @@ import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTIN
  *       <td>Nothing special</td></tr>
  *   <tr><td>{@link IndexField#string}</td><td>nothing</td>
  *       <td>keyword</td></tr>
- *   <tr><td>{@link IndexField#default}</td><td>nothing</td>
+ *   <tr><td>{@link IndexField#defaultIndex}</td><td>nothing</td>
  *       <td>standard</td></tr>
  * </table>
  */
 public abstract class BaseNouveauSearchHandler<T> {
+
+    /**
+     * Default maximum edge n-gram length for search indexing. Controls prefix
+     * matching coverage: higher values allow longer prefix matches at the cost
+     * of slightly larger indexes. Used for fields like name, version, tag.
+     */
+    public static final int EDGE_NGRAM_MAX_LENGTH = 50;
+
+    /**
+     * Short n-gram max for constrained fields (e.g., businessUnit) where values
+     * are short and index bloat should be minimized.
+     */
+    public static final int EDGE_NGRAM_SHORT_MAX_LENGTH = 10;
 
     /**
      * Built index definition that bundles the generated index function with derived
@@ -185,11 +198,11 @@ public abstract class BaseNouveauSearchHandler<T> {
         // --- Factory methods -------------------------------------------------
 
         /**
-         * Standard text field with prefix search (n-gram min=2, max=50).
+         * Standard text field with prefix search (n-gram min=2, max={@link #EDGE_NGRAM_MAX_LENGTH}).
          * Generates {@code _exact}, {@code _ngram} and {@code _sort} index entries.
          */
         public static @NonNull IndexField standard(String fieldName) {
-            return new IndexField(fieldName, Category.STANDARD, null, 2, 50);
+            return new IndexField(fieldName, Category.STANDARD, null, 2, EDGE_NGRAM_MAX_LENGTH);
         }
 
         /** Standard text field with a custom n-gram range. */

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.datahandler.common;
 
 public class SearchUtils {
+
     /*
      * This function returns the entire document as a string which can then be
      * indexed as a text field for 'default' index in Nouveau.

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -577,8 +577,9 @@ service ComponentService {
     /**
      * search components in database that match subQueryRestrictions
      * They are only the components which are visible to user.
+     * Search text should be included in the subQueryRestrictions map under the "name" key.
      **/
-    map<PaginationData, list<Component>> refineSearchAccessibleComponents(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: User user, 4: PaginationData pageData);
+    map<PaginationData, list<Component>> refineSearchAccessibleComponents(1: map<string, set<string>> subQueryRestrictions, 2: User user, 3: PaginationData pageData);
 
     /**
      * search components with the accessibility in database that match subQueryRestrictions

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -26,7 +26,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
-import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
@@ -188,12 +187,6 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             filterMap.put(Component._Fields.NAME.getFieldName(), values);
         }
         if (luceneSearch) {
-            if (filterMap.containsKey(Component._Fields.NAME.getFieldName())) {
-                Set<String> values = filterMap.get(Component._Fields.NAME.getFieldName()).stream()
-                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
-                        .collect(Collectors.toSet());
-                filterMap.put(Component._Fields.NAME.getFieldName(), values);
-            }
             paginatedComponents = componentService.refineSearch(filterMap, sw360User, pageable);
         } else {
             if (filterMap.isEmpty()) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -414,8 +414,8 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
 
     public Map<PaginationData, List<Component>> refineSearch(Map<String, Set<String>> filterMap, User sw360User, Pageable pageable) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        PaginationData pageData = pageableToPaginationData(pageable);
-        return sw360ComponentClient.refineSearchAccessibleComponents(null, filterMap, sw360User, pageData);
+        PaginationData pageData = pageableToPaginationData(pageable, ComponentSortColumn.BY_SCORE, true);
+        return sw360ComponentClient.refineSearchAccessibleComponents(filterMap, sw360User, pageData);
     }
 
     public Map<PaginationData, List<Component>> searchComponentByExactValues(Map<String, Set<String>> filterMap, User sw360User, Pageable pageable) throws TException {
@@ -480,6 +480,12 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
      * @return a PaginationData object representing the pagination information
      */
     private static PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
+        return pageableToPaginationData(pageable, ComponentSortColumn.BY_CREATEDON, false);
+    }
+
+    private static PaginationData pageableToPaginationData(@NotNull Pageable pageable,
+                                                            ComponentSortColumn defaultColumn,
+                                                            Boolean defaultAscending) {
         ComponentSortColumn column = ComponentSortColumn.BY_CREATEDON;
         boolean ascending = false;
 
@@ -496,6 +502,13 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
                 default -> column; // Default to BY_CREATEDON if no match
             };
             ascending = order.isAscending();
+        } else {
+            if (defaultColumn != null) {
+                column = defaultColumn;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
         }
         return new PaginationData().setDisplayStart((int) pageable.getOffset())
                 .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -878,4 +878,114 @@ public class ComponentTest extends TestIntegrationBase {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
     }
+
+    @Test
+    public void should_search_components_by_name_with_lucene() throws Exception {
+        mockRefineSearch(List.of(component));
+
+        ResponseEntity<String> response = luceneGet("/api/components?name=Component&luceneSearch=true&page=0&page_entries=5");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode components = new ObjectMapper().readTree(response.getBody())
+                .get("_embedded").get("sw360:components");
+        assertEquals(1, components.size());
+        assertEquals(component.getName(), components.get(0).get("name").textValue());
+    }
+
+    @Test
+    public void should_search_with_multiple_filters_lucene() throws Exception {
+        Component filtered = new Component();
+        filtered.setName("Apache Commons");
+        filtered.setId("filtered-1");
+        filtered.setComponentType(org.eclipse.sw360.datahandler.thrift.components.ComponentType.OSS);
+        filtered.setCreatedBy("admin@sw360.org");
+        mockRefineSearch(List.of(filtered));
+
+        ResponseEntity<String> response = luceneGet("/api/components?name=Apache&type=OSS&luceneSearch=true");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, new ObjectMapper().readTree(response.getBody())
+                .get("_embedded").get("sw360:components").size());
+    }
+
+    @Test
+    public void should_return_empty_when_lucene_finds_nothing() throws Exception {
+        mockRefineSearch(new ArrayList<>());
+
+        ResponseEntity<String> response = luceneGet("/api/components?name=NonExistent&luceneSearch=true");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        TestHelper.checkResponse(response.getBody(), "components", 0);
+    }
+
+    @Test
+    public void should_search_with_sort_params() throws Exception {
+        mockRefineSearch(List.of(component));
+
+        assertEquals(HttpStatus.OK, luceneGet("/api/components?name=X&luceneSearch=true&sort=name,desc").getStatusCode());
+    }
+
+    @Test
+    public void should_search_without_name_filter() throws Exception {
+        mockRefineSearch(List.of(component));
+
+        assertEquals(HttpStatus.OK, luceneGet("/api/components?type=OSS&luceneSearch=true").getStatusCode());
+    }
+
+    @Test
+    public void should_fall_back_to_exact_search_when_lucene_disabled() throws Exception {
+        Mockito.doReturn(paginationMapOf(List.of(component))).when(componentServiceMock)
+                .searchComponentByExactValues(any(), any(), any());
+
+        assertEquals(HttpStatus.OK, luceneGet("/api/components?name=Component&luceneSearch=false").getStatusCode());
+        verify(componentServiceMock, atLeastOnce()).searchComponentByExactValues(any(), any(), any());
+    }
+
+    @Test
+    public void should_search_with_pagination_page_2() throws Exception {
+        Mockito.doReturn(Collections.singletonMap(
+                new PaginationData().setRowsPerPage(5).setDisplayStart(5).setTotalRowCount(10),
+                List.of(component)
+        )).when(componentServiceMock).refineSearch(any(), any(), any());
+
+        ResponseEntity<String> response = luceneGet("/api/components?name=X&luceneSearch=true&page=1&page_entries=5");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseNode = new ObjectMapper().readTree(response.getBody());
+        assertTrue(responseNode.has("page"));
+        assertEquals(1, responseNode.get("page").get("number").intValue());
+    }
+
+    @Test
+    public void should_search_by_vendor_filter() throws Exception {
+        mockRefineSearch(List.of(component));
+        assertEquals(HttpStatus.OK, luceneGet("/api/components?vendors=Siemens&luceneSearch=true").getStatusCode());
+    }
+
+    @Test
+    public void should_search_by_createdOn_filter() throws Exception {
+        component.setCreatedOn("2026-07-01");
+        mockRefineSearch(List.of(component));
+        assertEquals(HttpStatus.OK, luceneGet("/api/components?createdOn=2026-07-01&luceneSearch=true").getStatusCode());
+    }
+
+    private void mockRefineSearch(List<Component> results) throws TException {
+        Mockito.doReturn(paginationMapOf(results)).when(componentServiceMock)
+                .refineSearch(any(), any(), any());
+    }
+
+    private static Map<PaginationData, List<Component>> paginationMapOf(List<Component> results) {
+        return Collections.singletonMap(
+                new PaginationData().setRowsPerPage(10).setDisplayStart(0).setTotalRowCount(results.size()),
+                results);
+    }
+
+    private ResponseEntity<String> luceneGet(String path) throws IOException {
+        // Re-apply auth mock defensively to avoid cross-test mock contamination in CI.
+        setupMockerUser();
+        HttpHeaders headers = getHeaders(port);
+        return new TestRestTemplate().exchange(
+                "http://localhost:" + port + path, HttpMethod.GET,
+                new HttpEntity<>(null, headers), String.class);
+    }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Migrate component search endpoints to the new Nouveau search architecture (ADR-009 aligned), following the same implementation pattern used for project search migration.

### Suggest Reviewer
@GMishx 

### What changed

#### Component search migration (`GET /components`)
- Migrated component pageable Lucene path to the new Nouveau infra.
- Updated component search handler to use:
  - edge n-gram indexing (`name_exact`, `name_ngram`, `name_sort`)
  - new base search abstraction
  - native multi-column sort mapping with deterministic tie-breakers
- Removed legacy wildcard pre-processing in REST (`prepareWildcardQuery`) for the Lucene path.
- Updated service/handler flow to pass search text via filter map (`name`) in pageable refine search.
- Updated Thrift contract for pageable component refine search:
  - removed separate `text` argument from `refineSearchAccessibleComponents(...)`
  - aligned with project migration approach.

#### Constants and consistency
- Introduced centralized edge n-gram constants in `SearchUtils` and applied them where n-gram limits were hardcoded.

#### Tests
- Added unit tests for component sort mapping and n-gram constant expectations:
  - `backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandlerTest.java`
- Extended integration coverage in:
  - `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java`
- Covered Lucene path scenarios including:
  - name-based Lucene search
  - multiple filters
  - empty result set
  - sort parameters
  - pagination behavior
  - fallback behavior when `luceneSearch=false`
  - vendor/createdOn filter requests

### Endpoint scope clarification

#### Migrated
- `GET /components`

#### Verified but intentionally unchanged
- `GET /components/searchByExternalIds`
  - This endpoint uses external-id map lookup flow, not Nouveau text search flow.
  - No migration required for ADR-009 Lucene/Nouveau search changes.

### Files changed (high-level)
- `backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java`
- `backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java`
- `libraries/datahandler/src/main/thrift/components.thrift`
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java`
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java`
- `backend/common/src/main/java/org/eclipse/sw360/common/utils/SearchUtils.java`
- `backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java`
- `backend/search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java`
- `backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandlerTest.java`
- `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java`

### How to test

Install the new branch and check if the search results have improved.