### PR TITLE
fix(Release): Allow modification of vendor in release

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -555,10 +555,19 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "The release object to be updated.",
                     schema = @Schema(implementation = Release.class))
             @RequestBody Map<String, Object> reqBodyMap
-    ) throws TException {
+    ) throws URISyntaxException, TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Release sw360Release = releaseService.getReleaseForUserById(id, user);
         Release updateRelease = setBackwardCompatibleFieldsInRelease(reqBodyMap);
+        // Normalize vendorId from a possible self-link URI to a bare ID and drop the
+        // DB-loaded vendor object so ThriftValidate.prepareRelease cannot overwrite it.
+        if (updateRelease.isSetVendorId()) {
+            URI vendorURI = new URI(updateRelease.getVendorId());
+            String path = vendorURI.getPath();
+            String vendorId = path.substring(path.lastIndexOf('/') + 1);
+            updateRelease.setVendorId(vendorId);
+            sw360Release.unsetVendor();
+        }
         attachmentService.preserveImmutableAttachmentFields(
                 updateRelease.getAttachments(), sw360Release.getAttachments(), user);
         attachmentService.setCheckedAttachmentDataFromRequest(


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
When a client sends `PATCH /api/releases/{id}` with a new `vendorId`, the vendor change was **silently discarded** for releases that already had a vendor assigned. The release would be saved with the original vendor unchanged, with no error returned.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4403*)
> * Did you add or update any new dependencies that are required for your change?

Closes:  https://github.com/eclipse-sw360/sw360/issues/4403

### Suggest Reviewer
> @GMishx 

### How To Test?
1. Create a release and assign **vendor A**.
2. Send `PATCH /api/releases/{id}` with body `{ "vendorId": "<vendor-B-id>" }`.
3. Fetch the release via `GET /api/releases/{id}` — vendor must now be **vendor B**, not vendor A.
4. Repeat step 2 using a full self-link URI as the value
   (e.g. `http://localhost:8080/api/vendors/<vendor-B-id>`) — vendor change must still apply.
5. Send a PATCH **without** a `vendorId` field — the existing vendor must remain unchanged.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
