### PR TITLE
Feat/release search nouveau migration

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -2378,12 +2378,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return releaseRepository.searchReleaseByNamePaginated(name, pageData);
     }
 
-    public Map<PaginationData, List<Release>> searchAccessibleReleasesByText(ReleaseSearchHandler searchHandler, String searchText, User user, PaginationData pageData) {
-        Map<PaginationData, List<Release>> searchResult = searchHandler.search(searchText, pageData);
-        PaginationData respPageData = searchResult.keySet().iterator().next();
-        List<Release> releaseList = searchResult.values().iterator().next();
-        return Collections.singletonMap(respPageData, getAccessibleReleaseList(releaseList, user));
-    }
 
     public Map<PaginationData, List<Release>> getAccessibleNewReleasesWithSrc(User user, PaginationData pageData) {
         Map<PaginationData, List<Release>> searchResult = releaseRepository.getAccessibleNewReleasesWithSrc(pageData);

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -10,98 +10,136 @@
 package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.gson.Gson;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseSortColumn;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
+import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
+import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
 /**
- * Lucene search for the Release class
+ * Nouveau search handler for Releases with paginated access control filtering.
  *
  * @author thomas.maier@evosoft.com
  */
-public class ReleaseSearchHandler {
+public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-        = new NouveauIndexDesignDocument("releases",
-            new NouveauIndexFunction(
-                "function(doc) {" +
-                "  if(doc.type == 'release') {" +
-                "    if (doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
-                "      index('text', 'name', doc.name, {'store': true});" +
-                "      index('string', 'name_sort', doc.name);" +
-                "    }" +
-                "    if (doc.version && typeof(doc.version) == 'string' && doc.version.length > 0) {" +
-                "      index('text', 'version', doc.version, {'store': true});" +
-                "      index('string', 'version_sort', doc.version);" +
-                "    }" +
-                "    if(doc.createdOn && doc.createdOn.length) {"+
-                "      var dt = new Date(doc.createdOn);"+
-                "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
-                "      index('double', 'createdOn', Number(formattedDt), {'store': true});"+
-                "    }" +
-                "    index('text', 'id', doc._id, {'store': true});" +
-                "  }" +
-                "}"));
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
+
+    private static final List<IndexField> RELEASE_FIELDS = List.of(
+            IndexField.standard("name"),
+            IndexField.standard("version"),
+            IndexField.simple("clearingState", "keyword"),
+            IndexField.simple("mainlineState", "keyword"),
+            IndexField.simple("createdBy", "email"),
+            IndexField.simple("componentType", "keyword"),
+            IndexField.date("createdOn")
+    );
+
+    /**
+     * Release-specific JS for array-backed fields that should support text
+     * and sort lookups via arrayToStringIndex helper.
+     */
+    private static final String RELEASE_CUSTOM_JS =
+            "    arrayToStringIndex(doc.languages, 'languages');" +
+            "    arrayToStringIndex(doc.operatingSystems, 'operatingSystems');" +
+            "    arrayToStringIndex(doc.softwarePlatforms, 'softwarePlatforms');" +
+            "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');";
+
+    /**
+     * Analyzer overrides for fields created by {@code arrayToStringIndex}.
+     * The helper generates {@code <field>_sort} string indexes that require
+     * the {@code keyword} analyzer for correct sorting behavior.
+     */
+    private static final Map<String, String> RELEASE_CUSTOM_ANALYZERS = Map.of(
+            "languages_sort", "keyword",
+            "operatingSystems_sort", "keyword",
+            "softwarePlatforms_sort", "keyword",
+            "mainLicenseIds_sort", "keyword"
+    );
+
+    private static final BuiltIndexDefinition RELEASE_INDEX_DEFINITION = buildIndexFunction(
+            "release",
+            SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN,
+            RELEASE_FIELDS,
+            RELEASE_CUSTOM_JS,
+            RELEASE_CUSTOM_ANALYZERS,
+            "standard"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Constructor
+    // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public ReleaseSearchHandler(Cloudant cClient, String dbName) throws IOException {
+        super(Release.class, "releases", RELEASE_INDEX_DEFINITION);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(cClient, dbName);
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        connector.addDesignDoc(searchView);
+        setup(connector, db);
     }
 
-    public Map<PaginationData, List<Release>> search(String searchText, PaginationData pageData) {
-        String sortColumn = getSortColumnName(pageData);
-        Map<PaginationData, List<Release>> resultReleaseList = connector
-                .searchViewWithRestrictionsWithAnd(Release.class,
-                        luceneSearchView.getIndexName(), null,
-                        Map.of(Release._Fields.NAME.getFieldName(),
-                                Collections.singleton(prepareWildcardQuery(searchText))
-                        ),
-                        pageData, sortColumn, pageData.isAscending());
+    // -------------------------------------------------------------------------
+    //  Public search API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Paginated search with permission filtering.
+     */
+    public Map<PaginationData, List<Release>> searchAccessibleReleases(
+            final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        Map<PaginationData, List<Release>> resultReleaseList = baseSearch(connector, subQueryRestrictions, pageData);
 
         PaginationData respPageData = resultReleaseList.keySet().iterator().next();
         List<Release> releaseList = resultReleaseList.values().iterator().next();
+
+        releaseList = releaseList.stream().filter(release ->
+                makePermission(release, user).isActionAllowed(RequestedAction.READ))
+                .toList();
 
         return Collections.singletonMap(respPageData, releaseList);
     }
 
     /**
-     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
-     * `_sort` suffix) for text indexes.
-     * @param pageData Pagination Data from the request.
-     * @return Sort column name. Defaults to createdOn
+     * Non-paginated search (legacy callers).
      */
-    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
-        return switch (ReleaseSortColumn.findByValue(pageData.getSortColumnNumber())) {
-            case ReleaseSortColumn.BY_NAME -> "name_sort";
-            case ReleaseSortColumn.BY_VERSION -> "version_sort";
-            // null signals Nouveau to skip sorting and return results ranked by relevance score
-            case ReleaseSortColumn.BY_SCORE -> null;
-            case null -> "createdOn";
-            default -> "createdOn";
+    public List<Release> search(String text, final Map<String, Set<String>> subQueryRestrictions) {
+        return connector.searchViewWithRestrictionsWithAnd(Release.class, getIndexName(),
+                text, subQueryRestrictions);
+    }
+
+    // -------------------------------------------------------------------------
+    //  Sort column mapping
+    // -------------------------------------------------------------------------
+
+    @Override
+    protected List<String> mapSortColumn(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (ReleaseSortColumn.findByValue(sortColumnNumber)) {
+            case ReleaseSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_VERSION -> List.of("version_sort", "name_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_CLEARING_STATE -> List.of("clearingState_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_MAINLINE_STATE -> List.of("mainlineState_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case null, default -> List.of(SCORE_SORTING_FIELD);
         };
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandlerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseSortColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReleaseSearchHandlerTest {
+
+    /**
+     * Mirror of {@link ReleaseSearchHandler#mapSortColumn(int)} so we can test
+     * sorting logic without needing a CouchDB connection.
+     */
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (ReleaseSortColumn.findByValue(sortColumnNumber)) {
+            case ReleaseSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_VERSION -> List.of("version_sort", "name_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_CLEARING_STATE -> List.of("clearingState_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_MAINLINE_STATE -> List.of("mainlineState_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case ReleaseSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case null, default -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+
+    @Test
+    void byName_shouldReturnNameSortWithVersionAndCreatedOnTiebreakers() {
+        List<String> columns = mapSortColumnDirect(ReleaseSortColumn.BY_NAME.getValue());
+        assertEquals(List.of("name_sort", "-version_sort", "-createdOn"), columns);
+        assertFalse(columns.contains(SCORE_SORTING_FIELD));
+    }
+
+    @Test
+    void byVersion_shouldReturnVersionSortWithNameAndCreatedOnTiebreakers() {
+        assertEquals(List.of("version_sort", "name_sort", "-createdOn"),
+                mapSortColumnDirect(ReleaseSortColumn.BY_VERSION.getValue()));
+    }
+
+    @Test
+    void byClearingState_shouldReturnClearingStateSortWithTiebreakers() {
+        assertEquals(List.of("clearingState_sort", SCORE_SORTING_FIELD, "name_sort", "-createdOn"),
+                mapSortColumnDirect(ReleaseSortColumn.BY_CLEARING_STATE.getValue()));
+    }
+
+    @Test
+    void byMainlineState_shouldReturnMainlineStateSortWithTiebreakers() {
+        assertEquals(List.of("mainlineState_sort", SCORE_SORTING_FIELD, "name_sort", "-createdOn"),
+                mapSortColumnDirect(ReleaseSortColumn.BY_MAINLINE_STATE.getValue()));
+    }
+
+    @Test
+    void byCreatedOn_shouldReturnOnlyCreatedOn() {
+        assertEquals(List.of("createdOn"), mapSortColumnDirect(ReleaseSortColumn.BY_CREATEDON.getValue()));
+    }
+
+    @Test
+    void byScore_shouldReturnOnlyScoreField() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(ReleaseSortColumn.BY_SCORE.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToScore() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(999));
+    }
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (ReleaseSortColumn column : ReleaseSortColumn.values()) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertNotNull(columns);
+            assertFalse(columns.isEmpty());
+        }
+    }
+
+    @Test
+    void nonPrimaryColumns_shouldHaveScoreAndNameTiebreakers() {
+        for (ReleaseSortColumn column : List.of(
+                ReleaseSortColumn.BY_CLEARING_STATE,
+                ReleaseSortColumn.BY_MAINLINE_STATE)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertTrue(columns.contains(SCORE_SORTING_FIELD), column + " missing score");
+            assertTrue(columns.contains("name_sort"), column + " missing name_sort");
+            assertTrue(columns.contains("-createdOn"), column + " missing -createdOn");
+        }
+    }
+
+    @Test
+    void nonPrimaryColumns_shouldHaveCorrectTiebreakerOrder() {
+        for (ReleaseSortColumn column : List.of(
+                ReleaseSortColumn.BY_CLEARING_STATE,
+                ReleaseSortColumn.BY_MAINLINE_STATE)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            int scoreIdx = columns.indexOf(SCORE_SORTING_FIELD);
+            int nameIdx = columns.indexOf("name_sort");
+            int createdOnIdx = columns.indexOf("-createdOn");
+            assertTrue(scoreIdx > 0, column + ": score should not be primary");
+            assertTrue(nameIdx > scoreIdx, column + ": name_sort should follow score");
+            assertTrue(createdOnIdx > nameIdx, column + ": createdOn should be last");
+        }
+    }
+}

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -29,6 +29,7 @@ import com.ibm.cloud.cloudant.v1.Cloudant;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -141,7 +142,15 @@ public class ComponentHandler implements ComponentService.Iface {
 
     @Override
     public Map<PaginationData, List<Release>> searchAccessibleReleases(String searchText, User user, PaginationData pageData) throws TException {
-        return handler.searchAccessibleReleasesByText(releaseSearchHandler, searchText, user, pageData) ;
+        Map<String, Set<String>> filterMap = Map.of(
+                Release._Fields.NAME.getFieldName(), Collections.singleton(searchText)
+        );
+        return releaseSearchHandler.searchAccessibleReleases(filterMap, user, pageData);
+    }
+
+    @Override
+    public Map<PaginationData, List<Release>> refineSearchAccessibleReleases(Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) throws TException {
+        return releaseSearchHandler.searchAccessibleReleases(subQueryRestrictions, user, pageData);
     }
 
     @Override

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -592,6 +592,11 @@ service ComponentService {
     map<PaginationData, list<Release>> searchAccessibleReleases(1: string text, 2: User user, 3: PaginationData pageData);
 
     /**
+     * Paginated search for releases with multi-field filter map and access control.
+     */
+    map<PaginationData, list<Release>> refineSearchAccessibleReleases(1: map<string, set<string>> subQueryRestrictions, 2: User user, 3: PaginationData pageData);
+
+    /**
      *  list accessible releases with pagination for ECC page
      */
     map<PaginationData, list<Release>> getAccessibleReleasesWithPagination(1: User user, 2: PaginationData pageData);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -1352,8 +1352,20 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
      */
     public Map<PaginationData, List<Release>> refineSearch(String searchText, User sw360User, Pageable pageable) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        PaginationData pageData = pageableToPaginationData(pageable);
-        return sw360ComponentClient.searchAccessibleReleases(searchText, sw360User, pageData);
+        Map<String, Set<String>> filterMap = Map.of(
+                Release._Fields.NAME.getFieldName(), Collections.singleton(searchText)
+        );
+        PaginationData pageData = pageableToPaginationData(pageable, ReleaseSortColumn.BY_SCORE, true);
+        return sw360ComponentClient.refineSearchAccessibleReleases(filterMap, sw360User, pageData);
+    }
+
+    /**
+     * Multi-field paginated search for releases using the nouveau search infrastructure.
+     */
+    public Map<PaginationData, List<Release>> refineSearch(Map<String, Set<String>> filterMap, User sw360User, Pageable pageable) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        PaginationData pageData = pageableToPaginationData(pageable, ReleaseSortColumn.BY_SCORE, true);
+        return sw360ComponentClient.refineSearchAccessibleReleases(filterMap, sw360User, pageData);
     }
 
     public void addEmbeddedLinkedRelease(Release sw360Release, User sw360User, HalResource<ReleaseLink> releaseResource, Set<String> releaseIdsInBranch) {
@@ -1600,12 +1612,18 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
     }
 
     /**
-     * Converts a Pageable object to a PaginationData object.
+     * Converts a Pageable object to a PaginationData object for releases.
      *
      * @param pageable the Pageable object to convert
      * @return a PaginationData object representing the pagination information
      */
     private static PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
+        return pageableToPaginationData(pageable, ReleaseSortColumn.BY_CREATEDON, false);
+    }
+
+    private static PaginationData pageableToPaginationData(@NotNull Pageable pageable,
+                                                            ReleaseSortColumn defaultColumn,
+                                                            Boolean defaultAscending) {
         ReleaseSortColumn column = ReleaseSortColumn.BY_CREATEDON;
         boolean ascending = false;
 
@@ -1616,10 +1634,19 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
                 case "createdOn" -> ReleaseSortColumn.BY_CREATEDON;
                 case "name" -> ReleaseSortColumn.BY_NAME;
                 case "version" -> ReleaseSortColumn.BY_VERSION;
+                case "clearingState" -> ReleaseSortColumn.BY_CLEARING_STATE;
+                case "mainlineState" -> ReleaseSortColumn.BY_MAINLINE_STATE;
                 case "score" -> ReleaseSortColumn.BY_SCORE;
-                default -> column; // Default to BY_CREATEDON if no match
+                default -> column;
             };
             ascending = order.isAscending();
+        } else {
+            if (defaultColumn != null) {
+                column = defaultColumn;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
         }
         return new PaginationData().setDisplayStart((int) pageable.getOffset())
                 .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -177,7 +177,7 @@ public class ReleaseTest extends TestIntegrationBase {
 
         release.setPackageIds(linkedPackages);
         given(this.releaseServiceMock.getReleasesForUser(any())).willReturn(releaseList);
-        given(this.releaseServiceMock.refineSearch(any(),any(),any())).willReturn(
+        given(this.releaseServiceMock.refineSearch(any(String.class),any(),any())).willReturn(
                 Collections.singletonMap(
                         new PaginationData().setRowsPerPage(releaseList.size()).setDisplayStart(0).setTotalRowCount(releaseList.size()),
                         releaseList

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -381,7 +381,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         projectList.add(project);
 
         given(this.releaseServiceMock.getReleasesForUser(any())).willReturn(releaseList);
-        given(this.releaseServiceMock.refineSearch(any(),any(),any())).willReturn(
+        given(this.releaseServiceMock.refineSearch(any(String.class),any(),any())).willReturn(
                 Collections.singletonMap(
                         new PaginationData().setRowsPerPage(releaseList.size()).setDisplayStart(0).setTotalRowCount(releaseList.size()),
                         releaseList


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

Migrates `ReleaseSearchHandler` from the legacy inline JavaScript index to the declarative `BaseNouveauSearchHandler` DSL.

### Changes

- **`ReleaseSearchHandler.java`** — Rewritten to extend `BaseNouveauSearchHandler<Release>` with `IndexField` DSL declarations for `name`, `version`, `clearingState`, `mainlineState`, `createdBy`, `componentType`, `createdOn`. Adds `arrayToStringIndex` support for `languages`, `operatingSystems`, `softwarePlatforms`, `mainLicenseIds`. Implements `mapSortColumn()` with multi-field tiebreaker sort chains.
- **`components.thrift`** — Added new `refineSearchAccessibleReleases` method accepting a multi-field filter map for advanced search queries.
- **`ComponentHandler.java`** — Updated to use new handler methods directly; added `Collections` import.
- **`ComponentDatabaseHandler.java`** — Removed dead `searchAccessibleReleasesByText` method (no longer needed).
- **`Sw360ReleaseService.java`** — Added overloaded `refineSearch(Map<String, Set<String>>)` for multi-field search; enhanced `pageableToPaginationData` with default sort column/ascending parameters; added `clearingState` and `mainlineState` to sort property mapping.
- **`ReleaseTest.java` / `ReleaseSpecTest.java`** — Fixed ambiguous `refineSearch` mock by using typed `any(String.class)` matcher.
- **`ReleaseSearchHandlerTest.java`** *(new)* — Unit tests covering all sort column mappings and tiebreaker ordering.

### Suggest Reviewer

@GMishx

### How To Test?

1.  Verify release search endpoint `GET /api/releases?name=Test&luceneSearch=true&sort=name,asc` returns sorted results with pagination.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] If code is AI-generated, mention the tool and model used: **GitHub Copilot (Claude)**
