### PR TITLE
Feat/licensedb clipparser enrichment

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
 import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
@@ -106,10 +107,11 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         AttachmentContentProvider contentProvider = attachment -> attachmentDatabaseHandler.getAttachmentContent(attachment.getAttachmentContentId());
 
         // @formatter:off
+        LicenseService.Iface licenseClient = ThriftClients.makeLicenseClient();
         parsers = Lists.newArrayList(
             new SPDXParser(attachmentDatabaseHandler.getAttachmentConnector(), contentProvider),
-            new CLIParser(attachmentDatabaseHandler.getAttachmentConnector(), contentProvider),
-            new CombinedCLIParser(attachmentDatabaseHandler.getAttachmentConnector(), contentProvider, componentDatabaseHandler)
+            new CLIParser(attachmentDatabaseHandler.getAttachmentConnector(), contentProvider, licenseClient),
+            new CombinedCLIParser(attachmentDatabaseHandler.getAttachmentConnector(), contentProvider, componentDatabaseHandler, licenseClient)
         );
 
         outputGenerators = Lists.newArrayList(

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -9,6 +9,9 @@
  */
 package org.eclipse.sw360.licenseinfo.parsers;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -16,13 +19,18 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationAtProject;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -41,6 +49,8 @@ import javax.xml.xpath.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -74,8 +84,36 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
     private static final String OBLIGATION_TEXT_ELEMENT_NAME = "Text";
     private static final String OBLIGATION_LICENSE_ELEMENT_NAME = "Licenses";
 
+    private static final int CACHE_TIMEOUT_MINUTES = 30;
+    private static final int CACHE_MAX_ITEMS = 1000;
+    private static final String ENRICHMENT_ORG = "sw360";
+
+    private LicenseService.Iface licenseClient;
+    private LoadingCache<String, Optional<License>> licenseCache;
+
     public AbstractCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider) {
+        this(attachmentConnector, attachmentContentProvider, null);
+    }
+
+    public AbstractCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider,
+                             LicenseService.Iface licenseClient) {
         super(attachmentConnector, attachmentContentProvider);
+        this.licenseClient = licenseClient;
+        if (licenseClient != null) {
+            this.licenseCache = CacheBuilder.newBuilder()
+                    .expireAfterWrite(CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+                    .maximumSize(CACHE_MAX_ITEMS)
+                    .build(new CacheLoader<String, Optional<License>>() {
+                        @Override
+                        public Optional<License> load(String key) {
+                            try {
+                                return Optional.ofNullable(licenseClient.getByID(key, ENRICHMENT_ORG));
+                            } catch (TException e) {
+                                return Optional.empty();
+                            }
+                        }
+                    });
+        }
     }
 
     public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context,
@@ -240,6 +278,48 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
                 .setId(findNamedAttribute(node, ID_ATTRIBUTE_NAME)
                         .map(Node::getNodeValue)
                         .orElse(EMPTY));
+    }
+
+    protected void enrichFromCouchDB(LicenseInfo licenseInfo) {
+        if (licenseCache == null || !isLicenseDBEnabled()) {
+            return;
+        }
+        if (licenseInfo == null || licenseInfo.getLicenseNamesWithTexts() == null) {
+            return;
+        }
+
+        for (LicenseNameWithText licenseNameWithText : licenseInfo.getLicenseNamesWithTexts()) {
+            License couchDbLicense = null;
+
+            String spdxId = licenseNameWithText.getLicenseSpdxId();
+            if (spdxId != null && !SPDX_IDENTIFIER_UNKNOWN.equals(spdxId)) {
+                try {
+                    couchDbLicense = licenseCache.get(spdxId).orElse(null);
+                } catch (ExecutionException e) {
+                    log.error(e);
+                }
+            }
+
+            if (couchDbLicense == null) {
+                String licenseName = licenseNameWithText.getLicenseName();
+                if (licenseName != null && !LICENSE_NAME_UNKNOWN.equals(licenseName)) {
+                    try {
+                        couchDbLicense = licenseCache.get(licenseName).orElse(null);
+                    } catch (ExecutionException e) {
+                        log.error(e);
+                    }
+                }
+            }
+
+            if (couchDbLicense != null && couchDbLicense.getText() != null) {
+                licenseNameWithText.setLicenseText(couchDbLicense.getText());
+            }
+        }
+    }
+
+    private boolean isLicenseDBEnabled() {
+        return Boolean.parseBoolean(
+                SW360Utils.readConfig(SW360ConfigKeys.LICENSEDB_ENABLED, "false"));
     }
 
     protected class NodeListIterator implements Iterator<Node> {

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CLIParser.java
@@ -26,6 +26,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -64,6 +65,11 @@ public class CLIParser extends AbstractCLIParser {
 
     public CLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider) {
         super(attachmentConnector, attachmentContentProvider);
+    }
+
+    public CLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider,
+                     LicenseService.Iface licenseClient) {
+        super(attachmentConnector, attachmentContentProvider, licenseClient);
     }
 
     @Override
@@ -131,6 +137,7 @@ public class CLIParser extends AbstractCLIParser {
             }
 
             licenseInfo.setLicenseNamesWithTexts(getLicenseNameWithTexts(doc, includeFilesHash));
+            enrichFromCouchDB(licenseInfo);
             licenseInfo.setAssessmentSummary(getAssessmentSummary(doc));
 
             licenseInfo.setSha1Hash(getSha1Hash(doc));
@@ -246,4 +253,5 @@ public class CLIParser extends AbstractCLIParser {
         }
         return obligations;
     }
+
 }

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParser.java
@@ -26,6 +26,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
@@ -59,8 +60,15 @@ public class CombinedCLIParser extends AbstractCLIParser{
 
     private ComponentDatabaseHandler componentDatabaseHandler;
 
-    public CombinedCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider, ComponentDatabaseHandler componentDatabaseHandler) {
+    public CombinedCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider,
+                             ComponentDatabaseHandler componentDatabaseHandler) {
         super(attachmentConnector, attachmentContentProvider);
+        this.componentDatabaseHandler = componentDatabaseHandler;
+    }
+
+    public CombinedCLIParser(AttachmentConnector attachmentConnector, AttachmentContentProvider attachmentContentProvider,
+                             ComponentDatabaseHandler componentDatabaseHandler, LicenseService.Iface licenseClient) {
+        super(attachmentConnector, attachmentContentProvider, licenseClient);
         this.componentDatabaseHandler = componentDatabaseHandler;
     }
 
@@ -127,6 +135,7 @@ public class CombinedCLIParser extends AbstractCLIParser{
         LicenseInfo licenseInfo = new LicenseInfo().setFilenames(Arrays.asList(attachmentContent.getFilename()));
         licenseInfo.setCopyrights(copyrightSetsByExternalId.get(extId));
         licenseInfo.setLicenseNamesWithTexts(licenseNamesWithTextsByExternalId.get(extId));
+        enrichFromCouchDB(licenseInfo);
         LicenseInfoParsingResult parsingResult = new LicenseInfoParsingResult().setLicenseInfo(licenseInfo);
         Release release = releasesByExternalId.get(extId);
         if (release != null) {

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
@@ -12,6 +12,8 @@
 package org.eclipse.sw360.licenseinfo.parsers;
 
 import org.apache.commons.io.input.ReaderInputStream;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
@@ -21,16 +23,19 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.licenseinfo.TestHelper.assertLicenseInfoParsingResult;
@@ -201,7 +206,7 @@ public class CLIParserTest {
                 "</ComponentLicenseInformation>";
         Attachment cliAttachment = new Attachment("A1", "a.xml");
         when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
-                ReaderInputStream.builder().setReader(new StringReader(noLicensesXml)).setCharset(StandardCharsets.UTF_8).get()
+                ReaderInputStream.builder().setReader(new StringReader(noLicensesXml)).get()
         );
         LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project())
                 .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result list"));
@@ -223,7 +228,7 @@ public class CLIParserTest {
                 "</ComponentLicenseInformation>";
         Attachment cliAttachment = new Attachment("A1", "a.xml");
         when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
-                ReaderInputStream.builder().setReader(new StringReader(specialCharsXml)).setCharset(StandardCharsets.UTF_8).get()
+                ReaderInputStream.builder().setReader(new StringReader(specialCharsXml)).get()
         );
         LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project())
                 .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result list"));
@@ -247,10 +252,149 @@ public class CLIParserTest {
                 "</ComponentLicenseInformation>";
         Attachment cliAttachment = new Attachment("A1", "a.xml");
         when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
-                ReaderInputStream.builder().setReader(new StringReader(noObligationsXml)).setCharset(StandardCharsets.UTF_8).get()
+                ReaderInputStream.builder().setReader(new StringReader(noObligationsXml)).get()
         );
         ObligationParsingResult oblRes = parser.getObligations(cliAttachment, new User(), new Project());
         assertThat(oblRes.getStatus(), is(ObligationInfoRequestStatus.SUCCESS));
         assertThat(oblRes.getObligationsAtProjectSize(), is(0));
+    }
+
+    @Test
+    public void testEnrichFromCouchDBReplacesTextWhenSpdxIdMatches() throws Exception {
+        String cliXml =
+                "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n" +
+                "<ComponentLicenseInformation component=\"enrichment_test\" creator=\"test\" date=\"01/01/2024\" componentID=\"-1\" >\n" +
+                "<License type=\"global\" name=\"Apache-2.0\" spdxidentifier=\"Apache-2.0\" > \n" +
+                "<Content><![CDATA[CLIXML license text that should be replaced.\n" +
+                "]]></Content>\n" +
+                "<Files><![CDATA[src/\n" +
+                "]]></Files>\n" +
+                "</License>\n" +
+                "</ComponentLicenseInformation>";
+
+        License couchDbLicense = new License()
+                .setId("Apache-2.0")
+                .setShortname("Apache-2.0")
+                .setText("Canonical Apache 2.0 text from LicenseDB");
+
+        LicenseService.Iface mockLicenseClient = Mockito.mock(LicenseService.Iface.class);
+        when(mockLicenseClient.getByID(eq("Apache-2.0"), any())).thenReturn(couchDbLicense);
+
+        CLIParser enrichedParser = new CLIParser(connector, a -> content, mockLicenseClient);
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(cliXml)).get()
+        );
+
+        try (MockedStatic<SW360Utils> mockedUtils = Mockito.mockStatic(SW360Utils.class)) {
+            mockedUtils.when(() -> SW360Utils.readConfig(SW360ConfigKeys.LICENSEDB_ENABLED, "false"))
+                    .thenReturn("true");
+
+            LicenseInfoParsingResult res = enrichedParser.getLicenseInfos(cliAttachment, new User(), new Project())
+                    .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result"));
+            assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
+            String licenseText = res.getLicenseInfo().getLicenseNamesWithTexts().iterator().next().getLicenseText();
+            assertThat(licenseText, is("Canonical Apache 2.0 text from LicenseDB"));
+        }
+    }
+
+    @Test
+    public void testEnrichFromCouchDBFallsBackToShortnameMatch() throws Exception {
+        String cliXml =
+                "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n" +
+                "<ComponentLicenseInformation component=\"enrichment_test\" creator=\"test\" date=\"01/01/2024\" componentID=\"-1\" >\n" +
+                "<License type=\"global\" name=\"MIT\" spdxidentifier=\"n/a\" > \n" +
+                "<Content><![CDATA[Old MIT text from CLIXML.\n" +
+                "]]></Content>\n" +
+                "<Files><![CDATA[src/\n" +
+                "]]></Files>\n" +
+                "</License>\n" +
+                "</ComponentLicenseInformation>";
+
+        License couchDbLicense = new License()
+                .setId("MIT")
+                .setShortname("MIT")
+                .setText("Canonical MIT text from LicenseDB");
+
+        LicenseService.Iface mockLicenseClient = Mockito.mock(LicenseService.Iface.class);
+        when(mockLicenseClient.getByID(eq("MIT"), any())).thenReturn(couchDbLicense);
+
+        CLIParser enrichedParser = new CLIParser(connector, a -> content, mockLicenseClient);
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(cliXml)).get()
+        );
+
+        try (MockedStatic<SW360Utils> mockedUtils = Mockito.mockStatic(SW360Utils.class)) {
+            mockedUtils.when(() -> SW360Utils.readConfig(SW360ConfigKeys.LICENSEDB_ENABLED, "false"))
+                    .thenReturn("true");
+
+            LicenseInfoParsingResult res = enrichedParser.getLicenseInfos(cliAttachment, new User(), new Project())
+                    .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result"));
+            assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
+            String licenseText = res.getLicenseInfo().getLicenseNamesWithTexts().iterator().next().getLicenseText();
+            assertThat(licenseText, is("Canonical MIT text from LicenseDB"));
+        }
+    }
+
+    @Test
+    public void testEnrichFromCouchDBPreservesCliXmlWhenNoMatch() throws Exception {
+        String cliXml =
+                "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n" +
+                "<ComponentLicenseInformation component=\"enrichment_test\" creator=\"test\" date=\"01/01/2024\" componentID=\"-1\" >\n" +
+                "<License type=\"global\" name=\"Custom-Internal\" spdxidentifier=\"n/a\" > \n" +
+                "<Content><![CDATA[Custom internal license text.\n" +
+                "]]></Content>\n" +
+                "<Files><![CDATA[src/\n" +
+                "]]></Files>\n" +
+                "</License>\n" +
+                "</ComponentLicenseInformation>";
+
+        LicenseService.Iface mockLicenseClient = Mockito.mock(LicenseService.Iface.class);
+
+        CLIParser enrichedParser = new CLIParser(connector, a -> content, mockLicenseClient);
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(cliXml)).get()
+        );
+
+        try (MockedStatic<SW360Utils> mockedUtils = Mockito.mockStatic(SW360Utils.class)) {
+            mockedUtils.when(() -> SW360Utils.readConfig(SW360ConfigKeys.LICENSEDB_ENABLED, "false"))
+                    .thenReturn("true");
+
+            LicenseInfoParsingResult res = enrichedParser.getLicenseInfos(cliAttachment, new User(), new Project())
+                    .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result"));
+            assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
+            String licenseText = res.getLicenseInfo().getLicenseNamesWithTexts().iterator().next().getLicenseText();
+            assertThat(licenseText, is("Custom internal license text."));
+        }
+    }
+
+    @Test
+    public void testEnrichFromCouchDBNoEnrichmentWhenDisabled() throws Exception {
+        String cliXml =
+                "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n" +
+                "<ComponentLicenseInformation component=\"enrichment_test\" creator=\"test\" date=\"01/01/2024\" componentID=\"-1\" >\n" +
+                "<License type=\"global\" name=\"MIT\" spdxidentifier=\"MIT\" > \n" +
+                "<Content><![CDATA[Original CLIXML text.\n" +
+                "]]></Content>\n" +
+                "<Files><![CDATA[src/\n" +
+                "]]></Files>\n" +
+                "</License>\n" +
+                "</ComponentLicenseInformation>";
+
+        LicenseService.Iface mockLicenseClient = Mockito.mock(LicenseService.Iface.class);
+
+        CLIParser enrichedParser = new CLIParser(connector, a -> content, mockLicenseClient);
+        Attachment cliAttachment = new Attachment("A1", "a.xml");
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(
+                ReaderInputStream.builder().setReader(new StringReader(cliXml)).get()
+        );
+
+        LicenseInfoParsingResult res = enrichedParser.getLicenseInfos(cliAttachment, new User(), new Project())
+                .stream().findFirst().orElseThrow(() -> new RuntimeException("empty result"));
+        assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
+        String licenseText = res.getLicenseInfo().getLicenseNamesWithTexts().iterator().next().getLicenseText();
+        assertThat(licenseText, is("Original CLIXML text."));
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -604,20 +604,19 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
 
     @Operation(
             summary = "Trigger LicenseDB sync.",
-            description = "Synchronise licenses and obligations from LicenseDB into SW360.",
+            description = "Starts an asynchronous sync of licenses and obligations from LicenseDB into SW360.",
             tags = {"Licenses"}
     )
     @PreAuthorize("hasAuthority('ADMIN')")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "LicenseDB sync completed successfully."),
-            @ApiResponse(responseCode = "500", description = "LicenseDB sync failed.")
+            @ApiResponse(responseCode = "202", description = "LicenseDB sync started in background."),
+            @ApiResponse(responseCode = "403", description = "User is not an admin.")
     })
     @PostMapping(value = LICENSES_URL + "/import/LicenseDB")
     public ResponseEntity<RequestSummary> importLicenseDB() throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        RequestSummary requestSummary = licenseService.importLicenseDBInformation(sw360User);
-        HttpStatus status = requestSummary.getRequestStatus() == RequestStatus.SUCCESS ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR;
-        return new ResponseEntity<>(requestSummary, status);
+        RequestSummary requestSummary = licenseService.importLicenseDBInformationAsync(sw360User);
+        return new ResponseEntity<>(requestSummary, HttpStatus.ACCEPTED);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -11,6 +11,8 @@
 package org.eclipse.sw360.rest.resourceserver.license;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +41,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.FileCopyUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.concurrent.CompletableFuture;
 
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
@@ -53,6 +56,7 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhit
 @Service
 @RequiredArgsConstructor
 public class Sw360LicenseService {
+    private static final Logger log = LogManager.getLogger(Sw360LicenseService.class);
     private static final String CONTENT_TYPE = "application/zip";
     LicenseType lType = new LicenseType();
 
@@ -326,6 +330,24 @@ public class Sw360LicenseService {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
             return sw360LicenseClient.importAllLicenseDBLicenses(sw360User);
+        } else {
+            throw new BadRequestClientException("Unable to import LicenseDB licenses. User is not admin");
+        }
+    }
+
+    public RequestSummary importLicenseDBInformationAsync(User sw360User) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, sw360User)) {
+            CompletableFuture.runAsync(() -> {
+                try {
+                    sw360LicenseClient.importAllLicenseDBLicenses(sw360User);
+                } catch (TException e) {
+                    log.error("LicenseDB async sync failed", e);
+                }
+            });
+            return new RequestSummary()
+                    .setRequestStatus(RequestStatus.PROCESSING)
+                    .setMessage("LicenseDB sync started in background");
         } else {
             throw new BadRequestClientException("Unable to import LicenseDB licenses. User is not admin");
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -112,7 +112,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         Mockito.doNothing().when(licenseServiceMock).uploadLicense(any(), any(), anyBoolean(), anyBoolean());
         given(this.licenseServiceMock.deleteLicenseType(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.licenseServiceMock.importOsadlInformation(any())).willReturn(requestSummary);
-        given(this.licenseServiceMock.importLicenseDBInformation(any())).willReturn(requestSummary);
+        given(this.licenseServiceMock.importLicenseDBInformationAsync(any())).willReturn(requestSummary);
         given(this.licenseServiceMock.addLicenseType(any(),any() , any())).willReturn(RequestStatus.SUCCESS);
         given(this.sw360ReportServiceMock.getLicenseBuffer()).willReturn(ByteBuffer.allocate(10000));
         obligation1 = new Obligation();
@@ -432,7 +432,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(post("/api/licenses/import/LicenseDB")
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isAccepted());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds CLIParser CouchDB enrichment and makes the LicenseDB sync trigger asynchronous.

When LicenseDB integration is enabled, CLIParser now prefers license text from CouchDB over CLIXML content. The sync endpoint returns `202 Accepted` immediately and runs the sync in the background.

## Changes

* Added `LicenseService.Iface` to the CLIParser constructor.
* Added SPDX ID match, shortname fallback, and CLIXML preservation.
* Added Guava LoadingCache for on-demand license lookup.
* Enrichment runs only when `licensedb.enabled=true`.
* Made `POST /api/licenses/import/LicenseDB` asynchronous.
* Added four tests for matching, fallback, preservation, and disabled state.

## Suggested Reviewers

@GMishx
@deo002
@Farooq-Fateh-Aftab