### PR TITLE
feat(backend): require X-SW360-Internal-Token for backend WAR access

### DIFF
--- a/.github/instructions/sw360_backend.instructions.md
+++ b/.github/instructions/sw360_backend.instructions.md
@@ -460,6 +460,21 @@ errorCode = 400  → Bad request
 
 ## Security & Authentication
 
+### Backend WAR internal auth
+
+Backend Spring Boot WARs are not meant for direct end-user access. When
+`backend.internal.auth.enabled=true` (or env `SW360_BACKEND_INTERNAL_AUTH_ENABLED`),
+every backend HTTP request must include header `X-SW360-Internal-Token` matching
+`backend.internal.token` / env `SW360_BACKEND_INTERNAL_TOKEN`.
+
+- `BackendRestClients.shared()` attaches the header for resource-server and
+  cross-backend `*Clients` calls.
+- `BackendInternalAuthFilter` (auto-configured from `backend-common`) rejects
+  other callers with HTTP 401, including `/health`.
+- Default in shipped properties is `enabled=false` so local installs keep working;
+  enable and set a strong per-deployment token in production (`/etc/sw360/sw360.properties`
+  or Docker env/secrets). Never commit a real production token.
+
 ### Authentication Methods
 
 SW360 supports two authentication methods:

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,10 @@ ENV SW360_CORS_ALLOWED_ORIGIN="*"
 ENV SW360_THRIFT_SERVER_URL="http://localhost:8080"
 ENV SW360_BASE_URL="http://localhost:8080"
 ENV SW360_FRONTEND_URL="http://localhost:3000"
+# Backend WAR gate: set SW360_BACKEND_INTERNAL_AUTH_ENABLED=true and a strong
+# SW360_BACKEND_INTERNAL_TOKEN (e.g. from Docker secrets) in production.
+ENV SW360_BACKEND_INTERNAL_AUTH_ENABLED="false"
+ENV SW360_BACKEND_INTERNAL_TOKEN=""
 
 # Install dependencies for entrypoint
 RUN apt-get update -qq \

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -158,6 +158,14 @@ Leave host/port empty to disable email service.
     Set this to `false` in production - clients should authenticate via
     OAuth2/JWT or API token. Set to `true` only for local development or
     integration testing where Basic auth is needed for convenience.
+* `SW360_BACKEND_INTERNAL_AUTH_ENABLED`: When `true`, every backend WAR
+    (`/users`, `/projects`, `/health`, …) requires the
+    `X-SW360-Internal-Token` header. Resource-server and backend `*Clients`
+    send it automatically via `BackendRestClients`. Direct calls without the
+    token receive `401`. Default: `false` (local/dev). Set `true` in production.
+* `SW360_BACKEND_INTERNAL_TOKEN`: Shared secret for backend WAR access.
+    **Do not commit a real value.** Prefer Docker secrets / private env.
+    Must match on all SW360 nodes. Required when internal auth is enabled.
 * `JWT_SECRETKEY`: Password used by the Authorization Server to open
     `/etc/sw360/jwt-keystore.jks` (default: `sw360SecretKey`).
     **Change this in production** and keep it identical on every SW360 node
@@ -187,6 +195,8 @@ Backend runtime consumes these secret values:
 * `EMAIL_PROPERTIES_USERNAME`
 * `EMAIL_PROPERTIES_PASSWORD`
 * `JWT_KEYSTORE` (binary JKS payload)
+* `SW360_BACKEND_INTERNAL_TOKEN` (recommended when
+  `SW360_BACKEND_INTERNAL_AUTH_ENABLED=true`)
 
 `REST_APITOKEN_HASH_SALT` must be OpenBSD bcrypt salt format:
 `$2a$<cost>$<22-char-salt>`.

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -75,5 +75,21 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/backend/common/src/main/java/org/eclipse/sw360/common/security/BackendInternalAuthAutoConfiguration.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/security/BackendInternalAuthAutoConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Shivamrut<gshivamrut@gmail.com>, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.common.security;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+
+/**
+ * Registers {@link BackendInternalAuthFilter} for every backend Spring Boot WAR that
+ * depends on backend-common (via Spring Boot auto-configuration).
+ */
+@AutoConfiguration
+public class BackendInternalAuthAutoConfiguration {
+
+    @Bean
+    public FilterRegistrationBean<BackendInternalAuthFilter> backendInternalAuthFilter() {
+        FilterRegistrationBean<BackendInternalAuthFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new BackendInternalAuthFilter());
+        registration.addUrlPatterns("/*");
+        registration.setName("backendInternalAuthFilter");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+}

--- a/backend/common/src/main/java/org/eclipse/sw360/common/security/BackendInternalAuthFilter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/common/security/BackendInternalAuthFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Shivamrut<gshivamrut@gmail.com>, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.common.security;
+
+import java.io.IOException;
+
+import org.eclipse.sw360.datahandler.rest.BackendInternalAuth;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Rejects direct access to backend WARs unless {@link BackendInternalAuth} is satisfied.
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class BackendInternalAuthFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!BackendInternalAuth.isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String provided = request.getHeader(BackendInternalAuth.HEADER_NAME);
+        if (BackendInternalAuth.matches(provided)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("text/plain;charset=UTF-8");
+        response.getWriter().write("Unauthorized: missing or invalid " + BackendInternalAuth.HEADER_NAME);
+    }
+}

--- a/backend/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/backend/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.eclipse.sw360.common.security.BackendInternalAuthAutoConfiguration

--- a/backend/common/src/main/resources/sw360.properties
+++ b/backend/common/src/main/resources/sw360.properties
@@ -10,6 +10,13 @@
 # common property file for the backend services
 backend.url= http://localhost:8080
 
+# Backend internal auth: when enabled, backends require X-SW360-Internal-Token.
+# Leave disabled for local open access; enable in production and set a strong token
+# via /etc/sw360/sw360.properties or env SW360_BACKEND_INTERNAL_TOKEN
+# (never commit a real production token).
+backend.internal.auth.enabled=false
+#backend.internal.token=
+
 # settings for the mail utility:
 # if host is not set, e-mailing is disabled
 MailUtil_host=

--- a/backend/common/src/test/java/org/eclipse/sw360/common/security/BackendInternalAuthFilterTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/common/security/BackendInternalAuthFilterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Shivamrut<gshivamrut@gmail.com>, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.common.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.eclipse.sw360.datahandler.rest.BackendInternalAuth;
+import org.junit.Test;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class BackendInternalAuthFilterTest {
+
+    @Test
+    public void headerNameIsStable() {
+        assertEquals("X-SW360-Internal-Token", BackendInternalAuth.HEADER_NAME);
+    }
+
+    @Test
+    public void whenAuthDisabled_requestPassesThrough() throws Exception {
+        if (BackendInternalAuth.isEnabled()) {
+            return;
+        }
+
+        BackendInternalAuthFilter filter = new BackendInternalAuthFilter();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test
+    public void whenAuthEnabledAndHeaderMissing_returnsUnauthorized() throws Exception {
+        if (!BackendInternalAuth.isEnabled()) {
+            return;
+        }
+
+        BackendInternalAuthFilter filter = new BackendInternalAuthFilter();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        when(request.getHeader(BackendInternalAuth.HEADER_NAME)).thenReturn(null);
+        when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain, never()).doFilter(any(), any());
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/build-configuration/resources/sw360.properties
+++ b/build-configuration/resources/sw360.properties
@@ -11,3 +11,7 @@
 # N.B this is the default build property file, defined in module build-configuration
 
 backend.url= http://localhost:8080
+
+# Backend internal auth (see BackendInternalAuth). Disabled by default for local/dev.
+backend.internal.auth.enabled=false
+#backend.internal.token=

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/rest/BackendInternalAuth.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/rest/BackendInternalAuth.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Shivamrut<gshivamrut@gmail.com>, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.rest;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Properties;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+
+/**
+ * Shared secret for SW360 backend WAR HTTP access.
+ *
+ * <p>When enabled, every backend request must carry {@link #HEADER_NAME} matching the
+ * configured token. Resource-server and backend {@code *Clients} attach it via
+ * {@link BackendRestClients}. The real token must be set per deployment (properties or
+ * env); do not commit production secrets.
+ */
+public final class BackendInternalAuth {
+
+    private static final Logger log = LogManager.getLogger(BackendInternalAuth.class);
+
+    public static final String HEADER_NAME = "X-SW360-Internal-Token";
+
+    public static final String PROP_ENABLED = "backend.internal.auth.enabled";
+    public static final String PROP_TOKEN = "backend.internal.token";
+
+    public static final String ENV_ENABLED = "SW360_BACKEND_INTERNAL_AUTH_ENABLED";
+    public static final String ENV_TOKEN = "SW360_BACKEND_INTERNAL_TOKEN";
+
+    private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+
+    private static final boolean ENABLED;
+    private static final String TOKEN;
+
+    static {
+        Properties props = CommonUtils.loadProperties(BackendInternalAuth.class, PROPERTIES_FILE_PATH);
+        ENABLED = parseEnabled(firstNonBlank(System.getenv(ENV_ENABLED), props.getProperty(PROP_ENABLED, "false")));
+        TOKEN = nullToEmpty(firstNonBlank(System.getenv(ENV_TOKEN), props.getProperty(PROP_TOKEN, "")));
+
+        if (ENABLED && TOKEN.isEmpty()) {
+            log.error("{} is true but no token is configured ({} or env {}). "
+                    + "All backend HTTP requests will be rejected until a token is set.",
+                    PROP_ENABLED, PROP_TOKEN, ENV_TOKEN);
+        } else if (ENABLED) {
+            log.info("Backend internal auth is enabled (header {}).", HEADER_NAME);
+        } else {
+            log.info("Backend internal auth is disabled ({}=false).", PROP_ENABLED);
+        }
+    }
+
+    private BackendInternalAuth() {}
+
+    public static boolean isEnabled() {
+        return ENABLED;
+    }
+
+    /**
+     * Configured token for outbound clients. Empty when unset. Never log this value.
+     */
+    public static String getToken() {
+        return TOKEN;
+    }
+
+    /**
+     * Whether {@link BackendRestClients} should send {@link #HEADER_NAME}.
+     */
+    public static boolean shouldAttachHeader() {
+        return ENABLED && !TOKEN.isEmpty();
+    }
+
+    /**
+     * Constant-time compare of the request header to the configured token.
+     */
+    public static boolean matches(String providedHeaderValue) {
+        if (!ENABLED) {
+            return true;
+        }
+        if (TOKEN.isEmpty() || providedHeaderValue == null) {
+            return false;
+        }
+        byte[] expected = TOKEN.getBytes(StandardCharsets.UTF_8);
+        byte[] actual = providedHeaderValue.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(expected, actual);
+    }
+
+    private static boolean parseEnabled(String value) {
+        return Boolean.parseBoolean(nullToEmpty(value).trim());
+    }
+
+    private static String firstNonBlank(String primary, String fallback) {
+        if (primary != null && !primary.isBlank()) {
+            return primary.trim();
+        }
+        if (fallback != null && !fallback.isBlank()) {
+            return fallback.trim();
+        }
+        return "";
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/rest/BackendRestClients.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/rest/BackendRestClients.java
@@ -98,10 +98,13 @@ public final class BackendRestClients {
         if (sharedRestClient == null) {
             synchronized (BackendRestClients.class) {
                 if (sharedRestClient == null) {
-                    sharedRestClient = RestClient.builder()
+                    RestClient.Builder builder = RestClient.builder()
                             .baseUrl(BACKEND_URL)
-                            .requestFactory(new HttpComponentsClientHttpRequestFactory(HTTP_CLIENT))
-                            .build();
+                            .requestFactory(new HttpComponentsClientHttpRequestFactory(HTTP_CLIENT));
+                    if (BackendInternalAuth.shouldAttachHeader()) {
+                        builder.defaultHeader(BackendInternalAuth.HEADER_NAME, BackendInternalAuth.getToken());
+                    }
+                    sharedRestClient = builder.build();
                 }
             }
         }

--- a/libraries/datahandler/src/main/resources/sw360.properties
+++ b/libraries/datahandler/src/main/resources/sw360.properties
@@ -30,6 +30,12 @@
 ## URL for connecting the backend
 #backend.url= http://127.0.0.1:8080
 
+## Require X-SW360-Internal-Token on backend WARs (default: false).
+## Set a per-deployment secret via backend.internal.token or env
+## SW360_BACKEND_INTERNAL_TOKEN. Env SW360_BACKEND_INTERNAL_AUTH_ENABLED overrides enabled.
+#backend.internal.auth.enabled=false
+#backend.internal.token=
+
 ## Proxy URL for connecting the backend. If set all requests to
 ## the backend are routed through the proxy.
 ##  Example: http://localhost:3128

--- a/scripts/docker-config/etc_sw360/sw360.properties.template
+++ b/scripts/docker-config/etc_sw360/sw360.properties.template
@@ -21,6 +21,12 @@ rest.apitoken.hash.salt=$REST_APITOKEN_HASH_SALT
 # where the Thrift should connect
 backend.url=http://127.0.0.1:8080
 
+# Backend internal auth (header X-SW360-Internal-Token). Prefer setting
+# SW360_BACKEND_INTERNAL_TOKEN via Docker secrets / env; leave enabled=false
+# until a token is configured.
+backend.internal.auth.enabled=$SW360_BACKEND_INTERNAL_AUTH_ENABLED
+backend.internal.token=$SW360_BACKEND_INTERNAL_TOKEN
+
 org.eclipse.sw360.licensinfo.projectclearing.templatemapping=Default:templateReport
 enable.sw360.change.log=false
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

Closes a security gap where backend Spring Boot WARs on Tomcat were reachable without authentication. End users and anyone who can hit Tomcat could call backends directly (e.g. `GET /components/api/components`) with no login. Only `/resource/...` (resource-server) enforced JWT/Basic; the backends themselves did not.

When enabled, every backend WAR requires a shared secret header. External clients keep using resource-server only; resource-server and backend `*Clients` attach the header automatically. Direct calls without a valid token get `401`.

## Problem

Anyone who could reach Tomcat could call backends directly, for example:

```http
GET http://localhost:8080/components/api/components
```

No login. Resource-server (`/resource/...`) had auth; backends did not.

That meant network exposure of Tomcat (or a misconfigured proxy) was enough to read/mutate backend data without going through the public API security model.

## Fix

When enabled, backends require a secret header:

```http
X-SW360-Internal-Token: <your-secret>
```

Intended traffic path:

```text
You / browser  →  only /resource/...  (JWT / Basic)
                      │
                      ▼
              resource-server adds X-SW360-Internal-Token
                      │
                      ▼
              backend WARs (/components, /users, /health, …)
```

Direct `curl` to `/components/...` (or any backend WAR) **without** the header → **401**.

Business responses are unchanged when the caller is authorized; this only gates access.

## What changed

- **`BackendInternalAuth`** (`libraries/datahandler`) — shared config + constant-time token check
  - Header: `X-SW360-Internal-Token`
  - Properties: `backend.internal.auth.enabled`, `backend.internal.token`
  - Env overrides: `SW360_BACKEND_INTERNAL_AUTH_ENABLED`, `SW360_BACKEND_INTERNAL_TOKEN`
  - Fail-closed if enabled with an empty token
- **`BackendInternalAuthFilter` + auto-config** (`backend/common`) — registered via Spring Boot `AutoConfiguration.imports` for all backends that depend on `backend-common` (including `/health`)
- **`BackendRestClients.shared()`** — attaches the header when auth is enabled and a token is set (resource-server + backend↔backend via `*Clients`)
- Sample `sw360.properties`, Docker/`README_DOCKER.md`, and backend instructions updated
- Unit coverage for the filter

**Default:** `backend.internal.auth.enabled=false` (local/dev convenience). Production should enable it and set a per-deployment secret (not committed to git).

## How to turn it on (local / screenshot verification)

1. Edit `/etc/sw360/sw360.properties` (or set env vars):

```properties
backend.internal.auth.enabled=true
backend.internal.token=test-secret-123
```

Equivalent env:

```bash
export SW360_BACKEND_INTERNAL_AUTH_ENABLED=true
export SW360_BACKEND_INTERNAL_TOKEN=test-secret-123
```

2. Rebuild and redeploy so WARs include the filter (old WARs ignore the props):

```bash
mvn package -P deploy -DskipTests -Dbase.deploy.dir=/opt/apache-tomcat-11.0.4
# then restart Tomcat
```

3. Confirm catalina logs contain:

```text
Backend internal auth is enabled (header X-SW360-Internal-Token).
```

4. Verify with:

```bash
# Reject without token → 401
curl -i http://127.0.0.1:8080/health/api/health

# Reject wrong token → 401
curl -i -H 'X-SW360-Internal-Token: wrong' http://127.0.0.1:8080/health/api/health

# Accept good token → 200
curl -i -H 'X-SW360-Internal-Token: test-secret-123' http://127.0.0.1:8080/health/api/health

# Same pattern on another WAR
curl -i http://127.0.0.1:8080/users/api/users
curl -i -H 'X-SW360-Internal-Token: test-secret-123' http://127.0.0.1:8080/users/api/users
```

Expected: **401** without/wrong token; **200** with the configured secret.

> **Screenshots:** verification screenshots (401 without token / 200 with token) will be attached in a follow-up PR comment.

## How to test (reviewers)

- With auth **disabled** (default): backends behave as before (no header required).
- With auth **enabled** + token set: exercise the curls above; also hit `/resource/...` as a normal user and confirm resource-server → backend calls still succeed (clients attach the header).
- Optional: wrong token must never succeed; empty token with `enabled=true` must fail closed.

### Checklist

Must:
- [x] Related changes documented in PR description
- [ ] Screenshots attached in a PR comment