### PR TITLE
Vulnerability Search Rework

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
@@ -11,10 +11,14 @@ package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.gson.Gson;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilitySortColumn;
 import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
@@ -30,67 +34,79 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
 /**
  * Lucene search for the Vulnerability class
  */
-public class VulnerabilitySearchHandler {
+public class VulnerabilitySearchHandler extends BaseNouveauSearchHandler<Vulnerability> {
 
-    private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
 
-    private static final String CVE_REFERENCES_TO_TEXT = """
-            function cveRefsToTextIndex(references, indexName) {
-              for (ref in references) {
-                if (typeof(references[ref]) == 'object' && references[ref]['type'] == 'cveReference') {
-                  let refString = 'CVE-' + references[ref]['year'] + '-' + references[ref]['number'];
-                  index('text', indexName, refString, {'store': true});
-                }
-              }
+    /**
+     * Fields common to all vulnerabilities, grouped by index category.
+     *
+     * <ul>
+     *   <li><b>standard</b>: {@code title} - full prefix-search support.</li>
+     *   <li><b>simple</b>: {@code externalId}</li>
+     *   <li><b>date</b>: {@code lastUpdateDate}, {@code publishDate} - stored as sortable yyyyMMdd double.</li>
+     *   <li><b>double</b>: {@code cvss} - index for numbers</li>
+     * </ul>
+     */
+    private static final List<IndexField> VULNERABILITY_FIELDS = List.of(
+            IndexField.standard("title"),
+            IndexField.simple("externalId"),
+            IndexField.date("lastUpdateDate"),
+            IndexField.date("publishDate"),
+            IndexField.doubleField("cvss")
+    );
+
+    /**
+     * Handler-specific JS: index {@code cveReferences} index the cve references.
+     */
+    private static final String CVE_REFERENCES_CUSTOM_JS = """
+          for (var i in doc.cveReferences) {
+            if (typeof(doc.cveReferences[i]) == 'object' && doc.cveReferences[i]['type'] == 'cveReference') {
+              let refString = 'CVE-' + doc.cveReferences[i]['year'] + '-' + doc.cveReferences[i]['number'];
+              index('string', 'cveReferences', refString);
             }
-            """;
+          }
+          """;
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-            = new NouveauIndexDesignDocument("vulnerabilities",
-            new NouveauIndexFunction(
-                    "function(doc) {" +
-                            CVE_REFERENCES_TO_TEXT +
-                            "  if(doc.type == 'vulnerability') {" +
-                            "    if (typeof(doc.externalId) == 'string' && doc.externalId.length > 0) {" +
-                            "      index('text', 'externalId', doc.externalId, {'store': true});" +
-                            "      index('string', 'externalId_sort', doc.externalId);" +
-                            "    }" +
-                            "    if (typeof(doc.title) == 'string' && doc.title.length > 0) {" +
-                            "      index('text', 'title', doc.title, {'store': true});" +
-                            "      index('string', 'title_sort', doc.title);" +
-                            "    }" +
-                            "    if(doc.lastUpdateDate && doc.lastUpdateDate.length) {"+
-                            "      var dt = new Date(doc.lastUpdateDate);"+
-                            "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
-                            "      index('double', 'lastUpdateDate', Number(formattedDt));"+
-                            "    }" +
-                            "    if(doc.publishDate && doc.publishDate.length) {"+
-                            "      var dt = new Date(doc.publishDate);"+
-                            "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
-                            "      index('double', 'publishDate', Number(formattedDt));"+
-                            "    }" +
-                            "    if(doc.cvss && typeof(doc.cvss) == 'number') {"+
-                            "      index('double', 'cvss', doc.cvss);"+
-                            "    }" +
-                            "    cveRefsToTextIndex(doc.cveReferences, 'cveReferences');" +
-                            "  }" +
-                            "}"));
+    /**
+     * Analyzer overrides that are not auto-generated from {@link #VULNERABILITY_FIELDS}.
+     * <ul>
+     *   <li>{@code cveReferences} -> {@code keyword}</li>
+     * </ul>
+     */
+    private static final Map<String, String> CVE_REFERENCES_CUSTOM_ANALYZERS = Map.of(
+            "cveReferences", "keyword"
+    );
+
+
+    // -------------------------------------------------------------------------
+    //  Design document
+    // -------------------------------------------------------------------------
+
+    private static final BuiltIndexDefinition VULNERABILITY_INDEX_DEFINITION = buildIndexFunction(
+            "vulnerability",
+            "",
+            VULNERABILITY_FIELDS,
+            CVE_REFERENCES_CUSTOM_JS,
+            CVE_REFERENCES_CUSTOM_ANALYZERS,
+            "standard"
+    );
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public VulnerabilitySearchHandler(Cloudant client) throws IOException {
         // Creates the database connector and adds the lucene search view
+        super(Vulnerability.class, "vulnerabilities", VULNERABILITY_INDEX_DEFINITION);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, "sw360vm");
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, "sw360vm", db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        connector.addDesignDoc(searchView);
+        setup(connector, db);
     }
 
     public Map<PaginationData, List<Vulnerability>> search(String searchText, String cveId, PaginationData pageData) {
@@ -102,28 +118,18 @@ public class VulnerabilitySearchHandler {
         if (CommonUtils.isNotNullEmptyOrWhitespace(cveId)) {
             subQueryRestrictions.put(Vulnerability._Fields.CVE_REFERENCES.getFieldName(), Collections.singleton(cveId));
         }
-
-        String sortColumn = getSortColumnName(pageData);
-
-        return connector.searchViewWithRestrictionsWithOr(Vulnerability.class,
-                luceneSearchView.getIndexName(), null, subQueryRestrictions,
-                pageData, sortColumn, pageData.isAscending());
+        return baseSearchWithOr(connector, subQueryRestrictions, pageData);
     }
 
-    /**
-     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
-     * `_sort` suffix) for text indexes.
-     * @param pageData Pagination Data from the request.
-     * @return Sort column name. Defaults to lastUpdateDate
-     */
-    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
-        return switch (VulnerabilitySortColumn.findByValue(pageData.getSortColumnNumber())) {
-            case VulnerabilitySortColumn.BY_EXTERNALID -> "externalId_sort";
-            case VulnerabilitySortColumn.BY_TITLE -> "title_sort";
-            case VulnerabilitySortColumn.BY_WEIGHTING -> "cvss";
-            case VulnerabilitySortColumn.BY_PUBLISHDATE -> "publishDate";
-            case null -> "lastUpdateDate";
-            default -> "lastUpdateDate";
+    @Override
+    protected List<String> mapSortColumn(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (VulnerabilitySortColumn.findByValue(sortColumnNumber)) {
+            case VulnerabilitySortColumn.BY_EXTERNALID -> List.of("externalId_sort", revDir + "lastUpdateDate");
+            case VulnerabilitySortColumn.BY_TITLE -> List.of("title_sort", revDir + "lastUpdateDate");
+            case VulnerabilitySortColumn.BY_WEIGHTING -> List.of("cvss", SCORE_SORTING_FIELD);
+            case VulnerabilitySortColumn.BY_PUBLISHDATE -> List.of("publishDate");
+            case null, default -> List.of(revDir + "lastUpdateDate");
         };
     }
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.sw360.datahandler.cloudantclient;
 
+import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.eclipse.sw360.datahandler.common.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_DATE_AS_DOUBLE;
@@ -87,6 +89,9 @@ public abstract class BaseNouveauSearchHandler<T> {
      * are short and index bloat should be minimized.
      */
     public static final int EDGE_NGRAM_SHORT_MAX_LENGTH = 10;
+
+    private static final Joiner AND = Joiner.on(" AND ");
+    private static final Joiner OR = Joiner.on(" OR ");
 
     /**
      * Built index definition that bundles the generated index function with derived
@@ -522,12 +527,14 @@ public abstract class BaseNouveauSearchHandler<T> {
      *
      * @param connector            Nouveau Aware DB Connector to use.
      * @param subQueryRestrictions Map of field names to their accepted values.
+     * @param queryGenerator The query generator function to use for joining the query
      * @param pageData             Pagination information.
      * @return Paginated search results.
      */
-    protected final @NonNull @Unmodifiable Map<PaginationData, List<T>> baseSearch(
+    private final @NonNull @Unmodifiable Map<PaginationData, List<T>> genericBaseSearch(
             NouveauLuceneAwareDatabaseConnector connector,
             final @NonNull Map<String, Set<String>> subQueryRestrictions,
+            Function<Map<String, String>, String> queryGenerator,
             PaginationData pageData
     ) {
         List<String> sortColumns = getSortColumns(pageData);
@@ -536,12 +543,50 @@ public abstract class BaseNouveauSearchHandler<T> {
             simplified.put(restriction.getKey(), String.join(" ", restriction.getValue()));
         }
 
-        String query = buildQueryFromRestrictions(simplified);
+        String query = queryGenerator.apply(simplified);
         Map<PaginationData, List<T>> result = connector.searchView(
                 clazz, luceneSearchView.getIndexName(), query, pageData, sortColumns);
         PaginationData respPageData = result.keySet().iterator().next();
         List<T> items = result.values().iterator().next();
         return Collections.singletonMap(respPageData, items);
+    }
+
+    /**
+     * Perform a AND'd base search for a given type with the provided field restrictions and pagination.
+     *
+     * <p>Query routing is metadata-driven from the {@link BuiltIndexDefinition} passed to
+     * the constructor.</p>
+     *
+     * @param connector            Nouveau Aware DB Connector to use.
+     * @param subQueryRestrictions Map of field names to their accepted values.
+     * @param pageData             Pagination information.
+     * @return Paginated search results.
+     */
+    protected final @NonNull @Unmodifiable Map<PaginationData, List<T>> baseSearch(
+            NouveauLuceneAwareDatabaseConnector connector,
+            final @NonNull Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData
+    ) {
+        return genericBaseSearch(connector, subQueryRestrictions, this::buildQueryFromRestrictionsWithAnd, pageData);
+    }
+
+    /**
+     * Perform a OR'd base search for a given type with the provided field restrictions and pagination.
+     *
+     * <p>Query routing is metadata-driven from the {@link BuiltIndexDefinition} passed to
+     * the constructor.</p>
+     *
+     * @param connector            Nouveau Aware DB Connector to use.
+     * @param subQueryRestrictions Map of field names to their accepted values.
+     * @param pageData             Pagination information.
+     * @return Paginated search results.
+     */
+    protected final @NonNull @Unmodifiable Map<PaginationData, List<T>> baseSearchWithOr(
+            NouveauLuceneAwareDatabaseConnector connector,
+            final @NonNull Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData
+    ) {
+        return genericBaseSearch(connector, subQueryRestrictions, this::buildQueryFromRestrictionsWithOr, pageData);
     }
 
     /**
@@ -563,15 +608,16 @@ public abstract class BaseNouveauSearchHandler<T> {
     // -------------------------------------------------------------------------
 
     /**
-     * Build a Lucene query string from a simplified restriction map, using registered
-     * field metadata for per-field routing.
+     * Build a Lucene query parts which can be joined based on condition
+     * to from the final query.
      *
      * @param restrictions Map of {@code fieldName -> filterValue} (multi-value sets should
      *                     already be joined into a single string by the caller).
-     * @return A Lucene query string that can be passed directly to
+     * @return A list of Lucene query parts which needs to be joined before
+     *         they can be passed directly to
      *         {@link NouveauLuceneAwareDatabaseConnector#searchView}.
      */
-    private @NonNull String buildQueryFromRestrictions(
+    private @NonNull List<String> buildQueryFromRestrictions(
             @NonNull Map<String, String> restrictions
     ) {
         List<String> parts = new ArrayList<>();
@@ -583,7 +629,37 @@ public abstract class BaseNouveauSearchHandler<T> {
             }
             parts.add(createFieldQueryRestriction(fieldName, filterValue));
         }
-        return String.join(" AND ", parts);
+        return parts;
+    }
+
+    /**
+     * Build a Lucene query using AND joiner from a simplified restriction map, using registered
+     * field metadata for per-field routing.
+     *
+     * @param restrictions Map of {@code fieldName -> filterValue} (multi-value sets should
+     *                     already be joined into a single string by the caller).
+     * @return A Lucene query string that can be passed directly to
+     *         {@link NouveauLuceneAwareDatabaseConnector#searchView}.
+     */
+    private @NonNull String buildQueryFromRestrictionsWithAnd(
+            @NonNull Map<String, String> restrictions
+    ) {
+        return AND.join(buildQueryFromRestrictions(restrictions));
+    }
+
+    /**
+     * Build a Lucene query string from a simplified restriction map OR'd, using registered
+     * field metadata for per-field routing.
+     *
+     * @param restrictions Map of {@code fieldName -> filterValue} (multi-value sets should
+     *                     already be joined into a single string by the caller).
+     * @return A Lucene query string that can be passed directly to
+     *         {@link NouveauLuceneAwareDatabaseConnector#searchView}.
+     */
+    private @NonNull String buildQueryFromRestrictionsWithOr(
+            @NonNull Map<String, String> restrictions
+    ) {
+        return OR.join(buildQueryFromRestrictions(restrictions));
     }
 
     /**

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -609,20 +609,20 @@ public abstract class BaseNouveauSearchHandler<T> {
 
         String sanitized = sanitizeLuceneString(filterValue);
         boolean quoted = NouveauLuceneAwareDatabaseConnector.isValidQuotedPhrase(filterValue);
-        String baseSearch = "+(" + fieldName + (quoted ? ":" : ":\"") + sanitized + (quoted ? "" : "\"") + ")";
+        String baseSearch = "(" + fieldName + (quoted ? ":" : ":\"") + sanitized + (quoted ? "" : "\"") + ")";
 
         if (tieredFields.contains(fieldName)) {
             if (!quoted) {
-                return "+(" + NouveauLuceneAwareDatabaseConnector.buildFieldQuery(
+                return "(" + NouveauLuceneAwareDatabaseConnector.buildFieldQuery(
                         fieldName + "_exact", fieldName + "_ngram", filterValue, true) + ")";
             }
             // Quoted input -> exact sort-field look-up (keyword field stores lowercased value)
-            return "+(" + fieldName + "_sort:" + sanitized.toLowerCase(Locale.ROOT) + ")";
+            return "(" + fieldName + "_sort:" + sanitized.toLowerCase(Locale.ROOT) + ")";
         }
 
         if (dateFields.contains(fieldName)) {
             try {
-                return "+(" + fieldName + ":" + NouveauLuceneAwareDatabaseConnector
+                return "(" + fieldName + ":" + NouveauLuceneAwareDatabaseConnector
                         .formatDateNouveauFormat(filterValue.trim()) + ")";
             } catch (ParseException e) {
                 return baseSearch;
@@ -630,7 +630,7 @@ public abstract class BaseNouveauSearchHandler<T> {
         }
 
         if (defaultFields.contains(fieldName)) {
-            return "+( " + convertToFreeSearch(filterValue) + " )";
+            return "( " + convertToFreeSearch(filterValue) + " )";
         }
 
         return baseSearch;


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Changes
- Remove redundant plus sign from ```createFieldQueryRestriction```. It was not compatible with ```OR``` queries.
- Migrate vulnerablity search to new infra.

### How To Test?
Make curl requests to the api with some search parameters and ensure they are returning relevant results.
```
curl 'http://localhost:8080/resource/api/vulnerabilities?luceneSearch=true&cveId=CVE-2020-12345&search=vul%202&page=0&page_entries=10&sort=' \
  -H 'Accept: application/*' \
  -H 'Authorization: Basic xyz' 
```

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
