### PR TITLE
feat(User): user search nouveau migration

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
@@ -10,18 +10,14 @@
 package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserSortColumn;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,128 +25,131 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
-import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareFuzzyQuery;
-import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
-public class UserSearchHandler {
+public class UserSearchHandler extends BaseNouveauSearchHandler<User> {
 
-    private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-        = new NouveauIndexDesignDocument("users",
-            new NouveauIndexFunction("function(doc) {" +
-                "  if (doc.type == 'user') { " +
-                "    if (doc.givenname && typeof(doc.givenname) == 'string' && doc.givenname.length > 0) {" +
-                "      index('text', 'givenname', doc.givenname, {'store': true});" +
-                "    }" +
-                "    if (doc.lastname && typeof(doc.lastname) == 'string' && doc.lastname.length > 0) {" +
-                "      index('text', 'lastname', doc.lastname, {'store': true});" +
-                "    }" +
-                "    if (doc.email && typeof(doc.email) == 'string' && doc.email.length > 0) {" +
-                "      index('text', 'email', doc.email, {'store': true});" +
-                "    }" +
-                "  }" +
-                "}"));
+    /**
+     * Fields indexed for user search, grouped by index category.
+     *
+     * <ul>
+     *   <li><b>standard</b>: {@code givenname}, {@code lastname} - full prefix-search support.</li>
+     *   <li><b>simple</b>: {@code email} (email analyzer), {@code department} (keyword),
+     *       {@code userGroup} (keyword)</li>
+     *   <li><b>date</b>: {@code createdOn} - stored as sortable yyyyMMdd double.</li>
+     * </ul>
+     */
+    private static final List<IndexField> USER_FIELDS = List.of(
+            IndexField.standard("givenname"),
+            IndexField.standard("lastname"),
+            IndexField.simple("email", "email"),
+            IndexField.simple("department", "keyword"),
+            IndexField.simple("userGroup", "keyword"),
+            IndexField.date("createdOn")
+    );
 
-    private static final NouveauIndexDesignDocument luceneUserSearchView
-        = new NouveauIndexDesignDocument("usersearch",
-            new NouveauIndexFunction("function(doc) {" +
-                OBJ_ARRAY_TO_STRING_INDEX +
-                "    if (!doc.type || doc.type != 'user') return;" +
-                "    if (doc.givenname && typeof(doc.givenname) == 'string' && doc.givenname.length > 0) {" +
-                "      index('text', 'givenname', doc.givenname, {'store': true});" +
-                "      index('string', 'givenname_sort', doc.givenname);" +
-                "    }" +
-                "    if (doc.lastname && typeof(doc.lastname) == 'string' && doc.lastname.length > 0) {" +
-                "      index('text', 'lastname', doc.lastname, {'store': true});" +
-                "      index('string', 'lastname_sort', doc.lastname);" +
-                "    }" +
-                "    if (doc.email && typeof(doc.email) == 'string' && doc.email.length > 0) {" +
-                "      index('text', 'email', doc.email, {'store': true});" +
-                "      index('string', 'email_sort', doc.email);" +
-                "    }" +
-                "    if (doc.userGroup && typeof(doc.userGroup) == 'string' && doc.userGroup.length > 0) {" +
-                "      index('text', 'userGroup', doc.userGroup, {'store': true});" +
-                "    }" +
-                "    if (doc.department && typeof(doc.department) == 'string' && doc.department.length > 0) {" +
-                "      index('text', 'department', doc.department, {'store': true});" +
-                "      index('string', 'department_sort', doc.department);" +
-                "    }" +
-                "    if (doc.deactivated && typeof(doc.deactivated) == 'boolean') {" +
-                "      index('double', 'deactivated', doc.deactivated ? 0 : 1);" +
-                "    }" +
-                "    arrayToStringIndex(doc.primaryRoles, 'primaryroles');" +
-                "}"));
+    /**
+     * Custom JS: index {@code primaryRoles} as a concatenated text blob.
+     */
+    private static final String USER_CUSTOM_JS =
+            "    arrayToStringIndex(doc.primaryRoles, 'primaryroles');";
+
+    /**
+     * Analyzer overrides that are not auto-generated from {@link #USER_FIELDS}.
+     * <ul>
+     *   <li>{@code primaryroles_sort} -> {@code keyword} (created by {@code arrayToStringIndex})</li>
+     * </ul>
+     */
+    private static final Map<String, String> USER_CUSTOM_ANALYZERS = Map.of(
+            "primaryroles_sort", "keyword"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Design document
+    // -------------------------------------------------------------------------
+
+    private static final BuiltIndexDefinition USER_INDEX_DEFINITION = buildIndexFunction(
+            "user",
+            "",  // No empty-aware token needed for users
+            USER_FIELDS,
+            USER_CUSTOM_JS,
+            USER_CUSTOM_ANALYZERS,
+            "standard"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Constructor
+    // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public UserSearchHandler(Cloudant client, String dbName) throws IOException {
+        super(User.class, "users", USER_INDEX_DEFINITION);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
-        // Creates the database connector and adds the lucene search view
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        searchView.addNouveau(luceneUserSearchView, gson);
-        connector.addDesignDoc(searchView);
+        setup(connector, db);
     }
 
-    private String cleanUp(String searchText) {
-        // Lucene seems to split email addresses at an '@' when indexing
-        // so in this case we only search for the username in front of the '@'
-        return searchText.split("@")[0];
-    }
+    // -------------------------------------------------------------------------
+    //  Public search API (matching ProjectSearchHandler pattern)
+    // -------------------------------------------------------------------------
 
-    public List<User> searchByNameAndEmail(String searchText) {
-        // Query the search view for the provided text
-        if(searchText == null) {
-            searchText = "";
-        }
-        String queryString = prepareFuzzyQuery(cleanUp(searchText));
-        return connector.searchAndSortByScore(User.class, luceneSearchView.getIndexName(), queryString);
-    }
-
-    public Map<PaginationData, List<User>> search(String text, final Map<String, Set<String>> subQueryRestrictions, @Nonnull PaginationData pageData) {
-        String sortColumn = getSortColumnName(pageData);
-        return connector.searchViewWithRestrictionsWithAnd(User.class,
-                luceneUserSearchView.getIndexName(), text, subQueryRestrictions,
-                pageData, sortColumn, pageData.isAscending());
+    /**
+     * Search with pagination and filter restrictions (primary method)
+     */
+    public Map<PaginationData, List<User>> search(final Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) {
+        return baseSearch(connector, subQueryRestrictions, pageData);
     }
 
     /**
-     * Search users by a free-text term matched against givenname, lastname, or email using.
+     * Search users by a free-text term matched against givenname, lastname, or email (OR logic).
      */
-    public Map<PaginationData, List<User>> searchByNameOrEmail(String searchText, @Nonnull PaginationData pageData) {
+    public Map<PaginationData, List<User>> searchByNameOrEmail(String searchText, PaginationData pageData) {
         Map<String, Set<String>> subQueryRestrictions = new HashMap<>();
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             subQueryRestrictions.put(User._Fields.GIVENNAME.getFieldName(), Collections.singleton(searchText));
             subQueryRestrictions.put(User._Fields.LASTNAME.getFieldName(), Collections.singleton(searchText));
             subQueryRestrictions.put(User._Fields.EMAIL.getFieldName(), Collections.singleton(searchText));
         }
-        String sortColumn = getSortColumnName(pageData);
-        return connector.searchViewWithRestrictionsWithOr(User.class,
-                luceneUserSearchView.getIndexName(), null, subQueryRestrictions,
-                pageData, sortColumn, pageData.isAscending());
+        return baseSearchWithOr(connector, subQueryRestrictions, pageData);
     }
 
     /**
-     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
-     * `_sort` suffix) for text indexes.
-     * @param pageData Pagination Data from the request.
-     * @return Sort column name. Defaults to givenname_sort
+     * Simple free-text search (non-paginated) matching givenname, lastname, or email.
+     * Returns users sorted by relevance score.
      */
-    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
-        return switch (UserSortColumn.findByValue(pageData.getSortColumnNumber())) {
-            case UserSortColumn.BY_LASTNAME -> "lastname_sort";
-            case UserSortColumn.BY_EMAIL -> "email_sort";
-            case UserSortColumn.BY_STATUS -> "deactivated";
-            case UserSortColumn.BY_DEPARTMENT -> "department_sort";
-            case UserSortColumn.BY_ROLE -> "primaryroles_sort";
-            case UserSortColumn.BY_SCORE -> null;
-            case null -> "givenname_sort";
-            default -> "givenname_sort";
+    public List<User> searchByNameAndEmail(String searchText) {
+        if (searchText == null || searchText.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return connector.searchAndSortByScore(User.class, getIndexName(), searchText);
+    }
+
+    // -------------------------------------------------------------------------
+    //  Sort column mapping
+    // -------------------------------------------------------------------------
+
+    /**
+     * Map sort column number to Lucene sort field names with tie-breaking.
+     * Similar to ProjectSearchHandler pattern.
+     */
+    @Override
+    protected List<String> mapSortColumn(int sortColumnNumber) {
+        return switch (UserSortColumn.findByValue(sortColumnNumber)) {
+            case UserSortColumn.BY_GIVENNAME -> List.of("givenname_sort", "lastname_sort", "email_sort");
+            case UserSortColumn.BY_LASTNAME -> List.of("lastname_sort", "givenname_sort", "email_sort");
+            case UserSortColumn.BY_EMAIL -> List.of("email_sort", "givenname_sort", "lastname_sort");
+            case UserSortColumn.BY_DEPARTMENT -> List.of("department_sort", SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort");
+            case UserSortColumn.BY_STATUS -> List.of(SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort");
+            case UserSortColumn.BY_ROLE -> List.of("primaryroles_sort", SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort");
+            // Default sort by scoring
+            case null, default -> List.of(SCORE_SORTING_FIELD);
         };
     }
+
 }
+

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/UserSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/UserSearchHandlerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.users.UserSortColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserSearchHandlerTest {
+
+    /**
+     * Mirror of UserSearchHandler.mapSortColumn() for unit-level testing without
+     * requiring a CouchDB connection.
+     */
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        return switch (UserSortColumn.findByValue(sortColumnNumber)) {
+            case UserSortColumn.BY_GIVENNAME  -> List.of("givenname_sort", "lastname_sort", "email_sort");
+            case UserSortColumn.BY_LASTNAME   -> List.of("lastname_sort", "givenname_sort", "email_sort");
+            case UserSortColumn.BY_EMAIL      -> List.of("email_sort", "givenname_sort", "lastname_sort");
+            case UserSortColumn.BY_DEPARTMENT -> List.of("department_sort", SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort");
+            case UserSortColumn.BY_STATUS     -> List.of(SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort");
+            case UserSortColumn.BY_ROLE       -> List.of("primaryroles_sort", SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort");
+            case UserSortColumn.BY_SCORE      -> List.of(SCORE_SORTING_FIELD);
+            case null, default               -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    //  Name columns
+    // -------------------------------------------------------------------------
+
+    @Test
+    void byGivenName_shouldReturnGivenNameFirst() {
+        List<String> cols = mapSortColumnDirect(UserSortColumn.BY_GIVENNAME.getValue());
+        assertEquals(List.of("givenname_sort", "lastname_sort", "email_sort"), cols);
+        assertFalse(cols.contains(SCORE_SORTING_FIELD));
+    }
+
+    @Test
+    void byLastName_shouldReturnLastNameFirst() {
+        List<String> cols = mapSortColumnDirect(UserSortColumn.BY_LASTNAME.getValue());
+        assertEquals(List.of("lastname_sort", "givenname_sort", "email_sort"), cols);
+        assertFalse(cols.contains(SCORE_SORTING_FIELD));
+    }
+
+    @Test
+    void byEmail_shouldReturnEmailFirst() {
+        List<String> cols = mapSortColumnDirect(UserSortColumn.BY_EMAIL.getValue());
+        assertEquals(List.of("email_sort", "givenname_sort", "lastname_sort"), cols);
+        assertFalse(cols.contains(SCORE_SORTING_FIELD));
+    }
+
+    // -------------------------------------------------------------------------
+    //  Categorical columns (department, status, role)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void byDepartment_shouldReturnDepartmentWithScoreAndNameTiebreakers() {
+        List<String> cols = mapSortColumnDirect(UserSortColumn.BY_DEPARTMENT.getValue());
+        assertEquals(List.of("department_sort", SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort"), cols);
+    }
+
+    @Test
+    void byStatus_shouldReturnScoreFirstWithNameTiebreakers() {
+        List<String> cols = mapSortColumnDirect(UserSortColumn.BY_STATUS.getValue());
+        assertEquals(List.of(SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort"), cols);
+    }
+
+    @Test
+    void byRole_shouldReturnPrimaryRolesSortWithScoreAndNameTiebreakers() {
+        List<String> cols = mapSortColumnDirect(UserSortColumn.BY_ROLE.getValue());
+        assertEquals(List.of("primaryroles_sort", SCORE_SORTING_FIELD, "givenname_sort", "lastname_sort"), cols);
+    }
+
+    // -------------------------------------------------------------------------
+    //  Score / default
+    // -------------------------------------------------------------------------
+
+    @Test
+    void byScore_shouldReturnOnlyScoreField() {
+        assertEquals(List.of(SCORE_SORTING_FIELD),
+                mapSortColumnDirect(UserSortColumn.BY_SCORE.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToScore() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(999));
+    }
+
+    // -------------------------------------------------------------------------
+    //  Completeness
+    // -------------------------------------------------------------------------
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (UserSortColumn column : UserSortColumn.values()) {
+            List<String> cols = mapSortColumnDirect(column.getValue());
+            assertNotNull(cols);
+            assertFalse(cols.isEmpty(), "Expected non-empty list for " + column);
+        }
+    }
+
+    @Test
+    void categoricalColumns_shouldHaveScoreAndGivenNameTiebreakers() {
+        for (UserSortColumn column : List.of(
+                UserSortColumn.BY_DEPARTMENT,
+                UserSortColumn.BY_STATUS,
+                UserSortColumn.BY_ROLE)) {
+            List<String> cols = mapSortColumnDirect(column.getValue());
+            assertTrue(cols.contains(SCORE_SORTING_FIELD), column + " missing score");
+            assertTrue(cols.contains("givenname_sort"), column + " missing givenname_sort");
+            assertTrue(cols.contains("lastname_sort"), column + " missing lastname_sort");
+        }
+    }
+
+    @Test
+    void categoricalColumns_shouldHaveCorrectTiebreakerOrder() {
+        // BY_STATUS uses score as primary sort, so it is excluded from this ordering check.
+        for (UserSortColumn column : List.of(
+                UserSortColumn.BY_DEPARTMENT,
+                UserSortColumn.BY_ROLE)) {
+            List<String> cols = mapSortColumnDirect(column.getValue());
+            int scoreIdx     = cols.indexOf(SCORE_SORTING_FIELD);
+            int givenNameIdx = cols.indexOf("givenname_sort");
+            int lastNameIdx  = cols.indexOf("lastname_sort");
+            assertTrue(scoreIdx > 0,              column + ": score should not be primary");
+            assertTrue(givenNameIdx > scoreIdx,   column + ": givenname_sort should follow score");
+            assertTrue(lastNameIdx > givenNameIdx, column + ": lastname_sort should be last");
+        }
+    }
+
+    @Test
+    void nameColumns_shouldNotContainScore() {
+        for (UserSortColumn column : List.of(
+                UserSortColumn.BY_GIVENNAME,
+                UserSortColumn.BY_LASTNAME,
+                UserSortColumn.BY_EMAIL)) {
+            List<String> cols = mapSortColumnDirect(column.getValue());
+            assertFalse(cols.contains(SCORE_SORTING_FIELD),
+                    column + " should not contain score field");
+        }
+    }
+
+    @Test
+    void nameColumns_shouldAlwaysHaveThreeElements() {
+        for (UserSortColumn column : List.of(
+                UserSortColumn.BY_GIVENNAME,
+                UserSortColumn.BY_LASTNAME,
+                UserSortColumn.BY_EMAIL)) {
+            assertEquals(3, mapSortColumnDirect(column.getValue()).size(),
+                    column + " should have exactly 3 sort columns");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    //  n-gram constants (BaseNouveauSearchHandler)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void edgeNgramConstants_shouldHaveExpectedValues() {
+        int max      = org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler.EDGE_NGRAM_MAX_LENGTH;
+        int shortMax = org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler.EDGE_NGRAM_SHORT_MAX_LENGTH;
+        assertEquals(50, max);
+        assertEquals(10, shortMax);
+    }
+}

--- a/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/UserHandler.java
@@ -345,4 +345,10 @@ public class UserHandler implements UserService.Iface {
     public Set<String> getUserSecondaryDepartments() throws TException {
         return db.getUserSecondaryDepartments();
     }
+
+    @Override
+    public Map<PaginationData, List<User>> refineSearchAccessibleUsers(Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData)
+            throws TException {
+        return db.refineSearchAccessibleUsers(subQueryRestrictions, pageData);
+    }
 }

--- a/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -150,7 +150,7 @@ public class UserDatabaseHandler {
                 && (subQueryRestrictions == null || subQueryRestrictions.isEmpty())) {
             return userSearchHandler.searchByNameOrEmail(text, pageData);
         }
-        return userSearchHandler.search(text, subQueryRestrictions, pageData);
+        return userSearchHandler.search(subQueryRestrictions, pageData);
     }
 
     public Map<PaginationData, List<User>> searchUsersByExactValues(Map<String,Set<String>> subQueryRestrictions, PaginationData pageData) throws TException {
@@ -448,5 +448,9 @@ public class UserDatabaseHandler {
 
     public Set<String> getUserSecondaryDepartments() {
         return repository.getUserSecondaryDepartments();
+    }
+
+    public Map<PaginationData, List<User>> refineSearchAccessibleUsers(Map<String,Set<String>> subQueryRestrictions, PaginationData pageData) {
+        return userSearchHandler.search(subQueryRestrictions, pageData);
     }
 }

--- a/libraries/datahandler/src/main/thrift/users.thrift
+++ b/libraries/datahandler/src/main/thrift/users.thrift
@@ -186,6 +186,13 @@ service UserService {
 
     /**
      * search users in database that match subQueryRestrictions
+     * Gets the users with Lucene/Nouveau search.
+     * Search text should be included in the subQueryRestrictions map.
+     **/
+    map<PaginationData, list<User>> refineSearchAccessibleUsers(1: map<string, set<string>> subQueryRestrictions, 2: User user, 3: PaginationData pageData);
+
+    /**
+     * search users in database that match subQueryRestrictions
      * Gets the users with mango query and pagination.
      **/
     map<PaginationData, list<User>> searchUsersByExactValues(1: map<string, set<string>> subQueryRestrictions, 2: PaginationData pageData) throws (1: SW360Exception exp);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -56,7 +56,9 @@ import org.eclipse.sw360.datahandler.thrift.spdx.spdxdocument.SPDXDocument;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformation;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentController;
 import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
@@ -1815,6 +1817,31 @@ public class RestControllerHelper<T> {
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(attachmentAuthor)) {
             filterMap.put(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY, Collections.singleton(attachmentAuthor));
+        }
+        return filterMap;
+    }
+
+    public static Map<String, Set<String>> getFilterMapForUser(
+            String givenName, String lastName, String email, String department,
+            UserGroup usergroup
+    ) {
+        Map<String, Set<String>> filterMap = new HashMap<>();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(givenName)) {
+            filterMap.put(User._Fields.GIVENNAME.getFieldName(), CommonUtils.splitToSet(givenName));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(lastName)) {
+            filterMap.put(User._Fields.LASTNAME.getFieldName(), CommonUtils.splitToSet(lastName));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(email)) {
+            filterMap.put(User._Fields.EMAIL.getFieldName(), CommonUtils.splitToSet(email));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(department)) {
+            Set<String> values = CommonUtils.splitToSet(department);
+            filterMap.put(User._Fields.DEPARTMENT.getFieldName(), values);
+        }
+        if (usergroup != null) {
+            Set<String> values = CommonUtils.splitToSet(usergroup.toString());
+            filterMap.put(User._Fields.USER_GROUP.getFieldName(), values);
         }
         return filterMap;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -172,7 +172,7 @@ public class Sw360UserService {
 
     public Map<PaginationData, List<User>> searchUsersByNameOrEmail(String searchTerm, Pageable pageable) throws TException {
         UserService.Iface sw360UserClient = getThriftUserClient();
-        PaginationData pageData = pageableToPaginationData(pageable);
+        PaginationData pageData = pageableToPaginationData(pageable, UserSortColumn.BY_SCORE, true);
         return sw360UserClient.refineSearch(searchTerm, Collections.emptyMap(), pageData);
     }
 
@@ -293,6 +293,11 @@ public class Sw360UserService {
      * @return a PaginationData object representing the pagination information
      */
     private static PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
+        return pageableToPaginationData(pageable, UserSortColumn.BY_GIVENNAME, true);
+    }
+
+    private static PaginationData pageableToPaginationData(@NotNull Pageable pageable,
+            UserSortColumn defaultColumn, Boolean defaultAscending) {
         UserSortColumn column = UserSortColumn.BY_GIVENNAME;
         boolean ascending = true;
 
@@ -306,9 +311,16 @@ public class Sw360UserService {
                 case "department" -> UserSortColumn.BY_DEPARTMENT;
                 case "primaryRoles" -> UserSortColumn.BY_ROLE;
                 case "score" -> UserSortColumn.BY_SCORE;
-                default -> column; // Default to BY_GIVENNAME if no match
+                default -> column;
             };
             ascending = order.isAscending();
+        } else {
+            if (defaultColumn != null) {
+                column = defaultColumn;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
         }
         return new PaginationData().setDisplayStart((int) pageable.getOffset())
                 .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
@@ -412,4 +424,15 @@ public class Sw360UserService {
         formerEmailAddresses.add(thriftUser.getEmail());
         return formerEmailAddresses;
     }
+
+    /**
+     * Refine search with Lucene/Nouveau using filters and user context.
+     * This method is for pageable Lucene searches with access control.
+     */
+    public Map<PaginationData, List<User>> refineSearch(Map<String, Set<String>> filterMap, User user, Pageable pageable) throws TException {
+        UserService.Iface sw360UserClient = getThriftUserClient();
+        PaginationData pageData = pageableToPaginationData(pageable, UserSortColumn.BY_SCORE, true);
+        return sw360UserClient.refineSearchAccessibleUsers(filterMap, user, pageData);
+    }
 }
+

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -132,7 +132,7 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             @Parameter(description = "Role of the users")
             @RequestParam(value = "usergroup", required = false) UserGroup usergroup,
             @Parameter(description = "luceneSearch parameter to filter the users.")
-            @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
+            @RequestParam(value = "luceneSearch", required = false, defaultValue = "true") boolean luceneSearch,
             @Parameter(description = "Search term to filter users by first name, last name, or email. Uses full-text Nouveau/Lucene search.")
             @RequestParam(value = "searchText", required = false) String searchText
     ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
@@ -143,16 +143,14 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             paginatedUsers = userService.searchUsersByNameOrEmail(searchText.trim(), pageable);
         } else {
-            Map<String, Set<String>> filterMap = getFilterMap(givenname, lastname, email, department,
-                    usergroup, luceneSearch);
-            if (luceneSearch) {
-                paginatedUsers = userService.refineSearch(filterMap, pageable);
+            Map<String, Set<String>> filterMap = RestControllerHelper.getFilterMapForUser(
+                    givenname, lastname, email, department, usergroup);
+            if (luceneSearch && !filterMap.isEmpty()) {
+                paginatedUsers = userService.refineSearch(filterMap, user, pageable);
+            } else if (filterMap.isEmpty()) {
+                paginatedUsers = userService.getUsersWithPagination(pageable);
             } else {
-                if (filterMap.isEmpty()) {
-                    paginatedUsers = userService.getUsersWithPagination(pageable);
-                } else {
-                    paginatedUsers = userService.searchUsersByExactValues(filterMap, pageable);
-                }
+                paginatedUsers = userService.searchUsersByExactValues(filterMap, pageable);
             }
         }
         PaginationResult<User> paginationResult = null;
@@ -478,52 +476,5 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             case "secondary" -> new ResponseEntity<>(userService.getExistingSecondaryDepartments(), HttpStatus.OK);
             default -> new ResponseEntity<>("Type must be: primary or secondary", HttpStatus.BAD_REQUEST);
         };
-    }
-
-    /**
-     * Create a map of filters with the field name in the key and expected value in the value (as set).
-     * @return Filter map from the user's request.
-     */
-    private @NonNull Map<String, Set<String>> getFilterMap(
-            String givenName, String lastName, String email, String department,
-            UserGroup usergroup, boolean luceneSearch
-    ) {
-        Map<String, Set<String>> filterMap = new HashMap<>();
-        if (CommonUtils.isNotNullEmptyOrWhitespace(givenName)) {
-            Set<String> values = CommonUtils.splitToSet(givenName);
-            if (luceneSearch) {
-                values = values.stream()
-                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
-                        .collect(Collectors.toSet());
-            }
-            filterMap.put(User._Fields.GIVENNAME.getFieldName(), values);
-        }
-        if (CommonUtils.isNotNullEmptyOrWhitespace(email)) {
-            Set<String> values = CommonUtils.splitToSet(email);
-            if (luceneSearch) {
-                values = values.stream()
-                        .map(NouveauLuceneAwareDatabaseConnector::prepareFuzzyQuery)
-                        .collect(Collectors.toSet());
-            }
-            filterMap.put(User._Fields.EMAIL.getFieldName(), values);
-        }
-        if (CommonUtils.isNotNullEmptyOrWhitespace(department)) {
-            Set<String> values = CommonUtils.splitToSet(department);
-            filterMap.put(User._Fields.DEPARTMENT.getFieldName(), values);
-        }
-        if (usergroup != null) {
-            Set<String> values = CommonUtils.splitToSet(usergroup.toString());
-            filterMap.put(User._Fields.USER_GROUP.getFieldName(), values);
-        }
-        if (CommonUtils.isNotNullEmptyOrWhitespace(lastName)) {
-            Set<String> values = CommonUtils.splitToSet(lastName);
-            if (luceneSearch) {
-                values = values.stream()
-                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
-                        .collect(Collectors.toSet());
-            }
-            filterMap.put(User._Fields.LASTNAME.getFieldName(), values);
-        }
-        return filterMap;
     }
 }


### PR DESCRIPTION
Summary
Migrates the /api/users endpoint search to the Nouveau/Lucene architecture already used by components, projects, and other entities. Before this change, user type-ahead (moderators, contributors, etc.) and advanced search used CouchDB views or exact-value queries. This adds a proper Lucene index for users with prefix/n-gram support, relevance scoring, and filter-based search.

Changes
New Thrift method (users.thrift)
Added refineSearchAccessibleUsers(subQueryRestrictions, user, pageData) to keep the new filter-based Lucene path separate from the existing refineSearch used by free-text search and legacy callers.

New UserSearchHandler (common)
Implements BaseNouveauSearchHandler<User> with:

- givenname / lastname as STANDARD fields (edge n-gram for prefix search)
- email with the Lucene email analyzer
- department, userGroup as keyword fields
- createdOn as sortable date double
- primaryRoles via custom JS (arrayToStringIndex) since it is a Thrift set<UserGroup> (JSON array)
- Sort column mapping for all UserSortColumn values

New baseSearchOr in BaseNouveauSearchHandler (datahandler)
OR-joining counterpart to baseSearch. Uses the same metadata-driven createFieldQueryRestriction so STANDARD/tiered fields (_exact/_ngram sub-fields) are queried correctly. The existing searchViewWithRestrictionsWithOr was not suitable because it only handles a fixed set of known field names.

UserController — two search paths

- searchText=<term> → searchByNameOrEmail() → baseSearchOr() (OR across givenname/lastname/email)
- luceneSearch=true + field params → refineSearchAccessibleUsers() → baseSearch() (AND across filters)
- luceneSearch=false + searchText → quoted phrase for exact matching