### PR TITLE
feat(projects): create new quick filter field

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -109,6 +109,13 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
+    private static final List<Project._Fields> QUICK_FILTER_FIELDS = List.of(
+            Project._Fields.NAME,
+            Project._Fields.DESCRIPTION,
+            Project._Fields.TAG,
+            Project._Fields.PROJECT_RESPONSIBLE
+    );
+
     public ProjectSearchHandler(Cloudant client, String dbName) throws IOException {
         super(Project.class, "projects", PROJECT_INDEX_DEFINITION);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
@@ -122,6 +129,20 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
 
     public Map<PaginationData, List<Project>> search(final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
         Map<PaginationData, List<Project>> resultProjectList = baseSearch(connector, subQueryRestrictions, pageData);
+        PaginationData respPageData = resultProjectList.keySet().iterator().next();
+        List<Project> projectList = resultProjectList.values().iterator().next();
+
+        projectList = projectList.stream().filter(ProjectPermissions.isVisible(user)).toList();
+
+        return Collections.singletonMap(respPageData, projectList);
+    }
+
+    public Map<PaginationData, List<Project>> searchFilteredProjects(final String searchText, User user, PaginationData pageData) {
+        Map<String, Set<String>> subQueryRestrictions = new HashMap<>();
+        for (Project._Fields field : QUICK_FILTER_FIELDS) {
+            subQueryRestrictions.put(field.getFieldName(), Collections.singleton(searchText));
+        }
+        Map<PaginationData, List<Project>> resultProjectList = baseSearchWithOr(connector, subQueryRestrictions, pageData);
         PaginationData respPageData = resultProjectList.keySet().iterator().next();
         List<Project> projectList = resultProjectList.values().iterator().next();
 

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -105,6 +105,19 @@ public class ProjectHandler implements ProjectService.Iface {
     }
 
     @Override
+    public Map<PaginationData, List<Project>> searchFilteredProjects(
+            String searchText, User user, PaginationData pageData
+    ) throws TException {
+        assertUser(user);
+
+        if (searchText == null) {
+            searchText = "";
+        }
+
+        return searchHandler.searchFilteredProjects(searchText, user, pageData);
+    }
+
+    @Override
     public List<Project> getMyProjects(User user, Map<String, Boolean> userRoles) throws TException {
         assertNotNull(user);
         assertNotEmpty(user.getEmail());

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -388,6 +388,12 @@ service ProjectService {
     list<Project> refineSearch(1: string text, 2: map<string,set<string>>  subQueryRestrictions, 3: User user);
 
     /**
+     * search projects in database that match searchText in
+     * name, description, tag or projectResponsible fields.
+     **/
+    map<PaginationData, list<Project>> searchFilteredProjects(1: string searchText, 2: User user, 3: PaginationData pageData) throws (1: SW360Exception exp);
+
+    /**
      * returns a list of projects which match `text` and the
      * `subQueryRestrictions` and are visible to the `user`. The request is pageable
      */

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -288,6 +288,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "additionalData", required = false) String additionalData,
             @Parameter(description = "Filter by attachment author email (createdBy field of attachments)")
             @RequestParam(value = "attachmentAuthor", required = false) String attachmentAuthor,
+            @Parameter(description = "A generic filter which searches [name, description, tag and projectResponsible]." +
+                    " Note that is field should be used exclusive of other filters.")
+            @RequestParam(value = "searchText", required = false) String searchText,
             @Parameter(description = "List project by lucene search, default true")
             @RequestParam(value = "luceneSearch", required = false, defaultValue = "true") boolean luceneSearch,
             HttpServletRequest request
@@ -303,7 +306,13 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             filterMap.put(Project._Fields.NAME.getFieldName(), values);
         }
 
-        if (luceneSearch && !filterMap.isEmpty()) {
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) && !filterMap.isEmpty()) {
+            throw new BadRequestClientException("Use either only \"searchText\" or other filters, not both.");
+        }
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
+            paginatedProjects = projectService.searchFilteredProjects(searchText, sw360User, pageable);
+        } else if (luceneSearch && !filterMap.isEmpty()) {
             paginatedProjects = projectService.refineSearch(filterMap, sw360User, pageable);
         } else {
             if (filterMap.isEmpty()) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -173,6 +173,14 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return sw360ProjectClient.searchAccessibleProjectByExactValues(filterMap, sw360User, pageData);
     }
 
+    public Map<PaginationData, List<Project>> searchFilteredProjects(
+            String searchText, User sw360User, Pageable pageable
+    ) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        PaginationData pageData = pageableToPaginationData(pageable, ProjectSortColumn.BY_SCORE, true);
+        return sw360ProjectClient.searchFilteredProjects(searchText, sw360User, pageData);
+    }
+
     public Project getProjectForUserById(String projectId, User sw360User) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         try {


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Allow Projects to be searched by `name, description, tag or projectResponsible` fields and a search text. This will be helpful in searches like Link Project pop-up.

This makes it possible to use `/projects?searchText=some+value+in+name+or+tag`