### PR TITLE
feat(project): add filters

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -22,10 +22,12 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
@@ -59,7 +61,9 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
             "softwarePlatforms_sort", "keyword",
             "operatingSystems_sort", "keyword",
             "vendorNames_sort", "keyword",
-            "mainLicenseIds_sort", "keyword"
+            "mainLicenseIds_sort", "keyword",
+            "externalIds_sort", "keyword",
+            "id", "keyword"
     );
 
     /**
@@ -72,7 +76,9 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
             "    arrayToStringIndex(doc.softwarePlatforms, 'softwarePlatforms');" +
             "    arrayToStringIndex(doc.operatingSystems, 'operatingSystems');" +
             "    arrayToStringIndex(doc.vendorNames, 'vendorNames');" +
-            "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');";
+            "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');" +
+            "    arrayToStringIndex(doc.externalIds, 'externalIds');" +
+            INDEX_ID_FIELD;
 
     private static final BuiltIndexDefinition COMPONENT_INDEX_DEFINITION = buildIndexFunction(
             "component",
@@ -88,6 +94,13 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
     // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
+
+    private static final List<Component._Fields> QUICK_FILTER_FIELDS = List.of(
+            Component._Fields.ID,
+            Component._Fields.NAME,
+            Component._Fields.DESCRIPTION,
+            Component._Fields.EXTERNAL_IDS
+    );
 
     public ComponentSearchHandler(Cloudant cClient, String dbName) throws IOException {
         super(Component.class, "components", COMPONENT_INDEX_DEFINITION);
@@ -112,6 +125,27 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
 
         componentList = componentList.stream().filter(component ->
                 makePermission(component, user).isActionAllowed(RequestedAction.READ))
+                .toList();
+
+        return Collections.singletonMap(respPageData, componentList);
+    }
+
+    /**
+     * Search Components with id, name, description or externalIds fields.
+     */
+    public Map<PaginationData, List<Component>> searchFilteredComponents(
+            String searchText, User user, PaginationData pageData
+    ) {
+        Map<String, Set<String>> subQueryRestrictions = new HashMap<>();
+        for (Component._Fields field : QUICK_FILTER_FIELDS) {
+            subQueryRestrictions.put(field.getFieldName(), Collections.singleton(searchText));
+        }
+        Map<PaginationData, List<Component>> resultComponentList = baseSearchWithOr(connector, subQueryRestrictions, pageData);
+        PaginationData respPageData = resultComponentList.keySet().iterator().next();
+        List<Component> componentList = resultComponentList.values().iterator().next();
+
+        componentList = componentList.stream().filter(component ->
+                        makePermission(component, user).isActionAllowed(RequestedAction.READ))
                 .toList();
 
         return Collections.singletonMap(respPageData, componentList);

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
 import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
@@ -76,7 +77,8 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
             "          index('text', 'attachmentCreatedBy', doc.attachments[i].createdBy);" +
             "        }" +
             "      }" +
-            "    }";
+            "    }" +
+            INDEX_ID_FIELD;
 
     /**
      * Analyzer overrides that are not auto-generated from {@link #PROJECT_FIELDS}.
@@ -87,7 +89,8 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
      */
     private static final Map<String, String> PROJECT_CUSTOM_ANALYZERS = Map.of(
             "attachmentCreatedBy", "email",
-            "additionalData_sort", "keyword"
+            "additionalData_sort", "keyword",
+            "id", "keyword"
     );
 
     // -------------------------------------------------------------------------
@@ -110,6 +113,7 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     private static final List<Project._Fields> QUICK_FILTER_FIELDS = List.of(
+            Project._Fields.ID,
             Project._Fields.NAME,
             Project._Fields.DESCRIPTION,
             Project._Fields.TAG,

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -22,10 +22,12 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
@@ -44,6 +46,7 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
     // -------------------------------------------------------------------------
 
     private static final List<IndexField> RELEASE_FIELDS = List.of(
+            IndexField.string("id"),
             IndexField.standard("name"),
             IndexField.standard("version"),
             IndexField.simple("clearingState", "keyword"),
@@ -61,7 +64,9 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
             "    arrayToStringIndex(doc.languages, 'languages');" +
             "    arrayToStringIndex(doc.operatingSystems, 'operatingSystems');" +
             "    arrayToStringIndex(doc.softwarePlatforms, 'softwarePlatforms');" +
-            "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');";
+            "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');" +
+            "    arrayToStringIndex(doc.externalIds, 'externalIds');" +
+            INDEX_ID_FIELD;
 
     /**
      * Analyzer overrides for fields created by {@code arrayToStringIndex}.
@@ -72,7 +77,9 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
             "languages_sort", "keyword",
             "operatingSystems_sort", "keyword",
             "softwarePlatforms_sort", "keyword",
-            "mainLicenseIds_sort", "keyword"
+            "mainLicenseIds_sort", "keyword",
+            "externalIds_sort", "keyword",
+            "id", "keyword"
     );
 
     private static final BuiltIndexDefinition RELEASE_INDEX_DEFINITION = buildIndexFunction(
@@ -89,6 +96,13 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
     // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
+
+    private static final List<Release._Fields> QUICK_FILTER_FIELDS = List.of(
+            Release._Fields.ID,
+            Release._Fields.NAME,
+            Release._Fields.VERSION,
+            Release._Fields.EXTERNAL_IDS
+    );
 
     public ReleaseSearchHandler(Cloudant cClient, String dbName) throws IOException {
         super(Release.class, "releases", RELEASE_INDEX_DEFINITION);
@@ -107,6 +121,28 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
     public Map<PaginationData, List<Release>> searchAccessibleReleases(
             final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
         Map<PaginationData, List<Release>> resultReleaseList = baseSearch(connector, subQueryRestrictions, pageData);
+
+        PaginationData respPageData = resultReleaseList.keySet().iterator().next();
+        List<Release> releaseList = resultReleaseList.values().iterator().next();
+
+        releaseList = releaseList.stream().filter(release ->
+                makePermission(release, user).isActionAllowed(RequestedAction.READ))
+                .toList();
+
+        return Collections.singletonMap(respPageData, releaseList);
+    }
+
+    /**
+     * Search Releases with id, name, description or externalIds fields.
+     */
+    public Map<PaginationData, List<Release>> searchFilteredReleases(
+            final String searchText, User user, PaginationData pageData
+    ) {
+        Map<String, Set<String>> subQueryRestrictions = new HashMap<>();
+        for (Release._Fields field : QUICK_FILTER_FIELDS) {
+            subQueryRestrictions.put(field.getFieldName(), Collections.singleton(searchText));
+        }
+        Map<PaginationData, List<Release>> resultReleaseList = baseSearchWithOr(connector, subQueryRestrictions, pageData);
 
         PaginationData respPageData = resultReleaseList.keySet().iterator().next();
         List<Release> releaseList = resultReleaseList.values().iterator().next();

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -162,6 +162,14 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
+    public Map<PaginationData, List<Release>> searchFilteredReleases(String searchText, User user, PaginationData pageData) throws TException {
+        if (searchText == null) {
+            searchText = "";
+        }
+        return releaseSearchHandler.searchFilteredReleases(searchText, user, pageData);
+    }
+
+    @Override
     public List<Release> searchReleaseByNamePrefix(String name) throws TException {
         return handler.searchReleaseByNamePrefix(name);
     }

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -129,6 +129,14 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
+    public Map<PaginationData, List<Component>> searchFilteredComponents(String searchText, User user, PaginationData pageData) {
+        if (searchText == null) {
+            searchText = "";
+        }
+        return componentSearchHandler.searchFilteredComponents(searchText, user, pageData);
+    }
+
+    @Override
     public List<Component> refineSearchWithAccessibility(String text, Map<String,Set<String>> subQueryRestrictions, User user) throws TException {
         return componentSearchHandler.searchWithAccessibility(text, subQueryRestrictions, user);
     }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -261,7 +261,7 @@ public abstract class BaseNouveauSearchHandler<T> {
 
         /** String fields index with no extra work. */
         public static IndexField string(String fieldName) {
-            return new IndexField(fieldName, Category.STRING, null, 0, 0);
+            return new IndexField(fieldName, Category.STRING, "keyword", 0, 0);
         }
 
         /** Text index of entire CouchDB Object for generic search. */

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
@@ -109,4 +109,13 @@ public class SearchUtils {
               }
             }
             """;
+
+    /**
+     * This function indexes {@code doc._id} as a string field with name {@code id}.
+     */
+    public static final String INDEX_ID_FIELD = """
+            if(doc._id && typeof(doc._id) == 'string' && doc._id.length > 0) {
+              index('string', 'id', doc._id);
+            }
+            """;
 }

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -582,6 +582,12 @@ service ComponentService {
     map<PaginationData, list<Component>> refineSearchAccessibleComponents(1: map<string, set<string>> subQueryRestrictions, 2: User user, 3: PaginationData pageData);
 
     /**
+     * search Components in database that match searchText in
+     * name, description or externalIds fields.
+     **/
+    map<PaginationData, list<Component>> searchFilteredComponents(1: string searchText, 2: User user, 3: PaginationData pageData) throws (1: SW360Exception exp);
+
+    /**
      * search components with the accessibility in database that match subQueryRestrictions
      **/
     list<Component> refineSearchWithAccessibility(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: User user);

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -603,6 +603,12 @@ service ComponentService {
     map<PaginationData, list<Release>> refineSearchAccessibleReleases(1: map<string, set<string>> subQueryRestrictions, 2: User user, 3: PaginationData pageData);
 
     /**
+     * search Releases in database that match searchText in
+     * name, version or externalIds fields.
+     */
+    map<PaginationData, list<Release>> searchFilteredReleases(1: string searchText, 2: User user, 3: PaginationData pageData);
+
+    /**
      *  list accessible releases with pagination for ECC page
      */
     map<PaginationData, list<Release>> getAccessibleReleasesWithPagination(1: User user, 2: PaginationData pageData);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
@@ -106,6 +107,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Components", description = "Operations related to Components on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`score` (default), " +
+        "`createdOn`, `name`, `vendorNames`, `mainLicenseIds` or `type`].")
 public class ComponentController implements RepresentationModelProcessor<RepositoryLinksResource> {
 
     public static final String COMPONENTS_URL = "/components";
@@ -171,6 +175,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             @RequestParam(value = "fields", required = false) List<String> fields,
             @Parameter(description = "Flag to get components with all details.")
             @RequestParam(value = "allDetails", required = false) boolean allDetails,
+            @Parameter(description = "A generic filter which searches [id, name, description and externalIds]." +
+                    " Note that is field should be used exclusive of other filters.")
+            @RequestParam(value = "searchText", required = false) String searchText,
             @Parameter(description = "Use lucenesearch to filter the components.")
             @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
             HttpServletRequest request
@@ -186,7 +193,14 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             Set<String> values = Collections.singleton(name);
             filterMap.put(Component._Fields.NAME.getFieldName(), values);
         }
-        if (luceneSearch) {
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) && !filterMap.isEmpty()) {
+            throw new BadRequestClientException("Use either only \"searchText\" or other filters, not both.");
+        }
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
+            paginatedComponents = componentService.searchFilteredComponents(searchText, sw360User, pageable);
+        } else if (luceneSearch) {
             paginatedComponents = componentService.refineSearch(filterMap, sw360User, pageable);
         } else {
             if (filterMap.isEmpty()) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -418,6 +418,12 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         return sw360ComponentClient.refineSearchAccessibleComponents(filterMap, sw360User, pageData);
     }
 
+    public Map<PaginationData, List<Component>> searchFilteredComponents(String searchText, User sw360User, Pageable pageable) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        PaginationData pageData = pageableToPaginationData(pageable, ComponentSortColumn.BY_SCORE, true);
+        return sw360ComponentClient.searchFilteredComponents(searchText, sw360User, pageData);
+    }
+
     public Map<PaginationData, List<Component>> searchComponentByExactValues(Map<String, Set<String>> filterMap, User sw360User, Pageable pageable) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         PaginationData pageData = pageableToPaginationData(pageable);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -288,7 +288,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "additionalData", required = false) String additionalData,
             @Parameter(description = "Filter by attachment author email (createdBy field of attachments)")
             @RequestParam(value = "attachmentAuthor", required = false) String attachmentAuthor,
-            @Parameter(description = "A generic filter which searches [name, description, tag and projectResponsible]." +
+            @Parameter(description = "A generic filter which searches [id, name, description, tag and projectResponsible]." +
                     " Note that is field should be used exclusive of other filters.")
             @RequestParam(value = "searchText", required = false) String searchText,
             @Parameter(description = "List project by lucene search, default true")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -119,6 +120,9 @@ import com.google.common.collect.ImmutableMap;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Releases", description = "Operations related to Releases on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`createdOn` (default), " +
+        "`name`, `version`, `clearingState`, `mainlineState` or `score`].")
 public class ReleaseController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String RELEASES_URL = "/releases";
     private static final int MAX_BATCH_SUMMARY_IDS = 200;
@@ -194,6 +198,9 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
             @Parameter(description = "fetch releases that are in NEW state and have a SRC/SRS attachment")
             @RequestParam(value = "isNewClearingWithSourceAvailable", required = false) boolean isNewClearingWithSourceAvailable,
+            @Parameter(description = "A generic filter which searches [id, name, version and externalIds]." +
+                    " Note that is field should be used exclusive of other filters.")
+            @RequestParam(value = "searchText", required = false) String searchText,
             @Parameter(description = "allDetails of the release")
             @RequestParam(value = "allDetails", required = false) boolean allDetails,
             HttpServletRequest request
@@ -202,7 +209,14 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Map<PaginationData, List<Release>> paginatedReleases = null;
 
-        if (luceneSearch && CommonUtils.isNotNullEmptyOrWhitespace(name)) {
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) &&
+                (CommonUtils.isNotNullEmptyOrWhitespace(name) || CommonUtils.isNotNullEmptyOrWhitespace(sha1))) {
+            throw new BadRequestClientException("Use either only \"searchText\" or other filters, not both.");
+        }
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
+            paginatedReleases = releaseService.searchFilteredReleases(searchText, sw360User, pageable);
+        } else if (luceneSearch && CommonUtils.isNotNullEmptyOrWhitespace(name)) {
             paginatedReleases = releaseService.refineSearch(name, sw360User, pageable);
         } else {
             if (sha1 != null && !sha1.isEmpty()) {
@@ -1898,7 +1912,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         if (subscribers == null) {
             subscribers = new HashSet<>();
         }
-        
+
         if (subscribers.contains(user.getEmail())) {
             releaseService.unsubscribeRelease(user, releaseId);
             return new ResponseEntity<>("Release has been unsubscribed", HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -1359,6 +1359,15 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return sw360ComponentClient.refineSearchAccessibleReleases(filterMap, sw360User, pageData);
     }
 
+    /*
+     * Use lucene search for searching releases based on name, version or externalIds
+     */
+    public Map<PaginationData, List<Release>> searchFilteredReleases(String searchText, User sw360User, Pageable pageable) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        PaginationData pageData = pageableToPaginationData(pageable, ReleaseSortColumn.BY_SCORE, true);
+        return sw360ComponentClient.searchFilteredReleases(searchText, sw360User, pageData);
+    }
+
     /**
      * Multi-field paginated search for releases using the nouveau search infrastructure.
      */

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
@@ -28,7 +29,6 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
-import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
@@ -44,7 +44,6 @@ import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestExceptionHandler;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -86,6 +85,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Users", description = "Operations related to Users on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`givenname` (default), " +
+        "`lastname`, `email`, `deactivated`, `department`, `primaryRoles` or `score`].")
 public class UserController implements RepresentationModelProcessor<RepositoryLinksResource> {
     private static final Logger log = LogManager.getLogger(UserController.class);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
@@ -93,6 +94,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Vulnerabilities", description = "Operations related to Vulnerabilities on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`lastUpdateDate` (default), " +
+        "`externalId`, `title`, `cvss`, or `publishDate`].")
 public class VulnerabilityController implements RepresentationModelProcessor<RepositoryLinksResource> {
     private static final Logger log = LogManager.getLogger(VulnerabilityController.class);
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Add new search field called `searchText` to `/projects`, `/components` and `/releases` which helps search in a bunch of different fields, including `id` which gives exact match.

This field is helpful for UI pop-up searches.