### PR TITLE
feat(licensedb): add URL validation, retry logic, and license diff endpoint

### DIFF
--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -1211,6 +1211,86 @@ public class LicenseDatabaseHandler {
         }
     }
 
+    public Map<String, String> getLicenseDBDiff(User user) {
+        Map<String, String> result = new HashMap<>();
+
+        String enabled;
+        try {
+            enabled = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_ENABLED);
+        } catch (SW360Exception e) {
+            result.put("error", "Failed to read LicenseDB config.");
+            return result;
+        }
+        if (!"true".equals(enabled)) {
+            result.put("error", "LicenseDB integration is disabled.");
+            return result;
+        }
+
+        String baseUrl;
+        String username;
+        String password;
+        try {
+            baseUrl = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_BASE_URL);
+            username = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_USERNAME);
+            password = SW360Utils.getConfigByKey(SW360ConfigKeys.LICENSEDB_PASSWORD);
+        } catch (SW360Exception e) {
+            result.put("error", "Failed to read LicenseDB credentials.");
+            return result;
+        }
+        if (isNullOrEmpty(baseUrl) || isNullOrEmpty(username) || isNullOrEmpty(password)) {
+            result.put("error", "LicenseDB configuration is incomplete.");
+            return result;
+        }
+
+        List<LicenseDBLicenseDTO> licenseDbLicenses;
+        try {
+            LicenseDBConnector connector = createLicenseDBConnector(baseUrl, username, password);
+            licenseDbLicenses = connector.fetchAllLicenses();
+        } catch (SW360Exception e) {
+            log.error("Failed to fetch licenses from LicenseDB", e);
+            result.put("error", "Failed to connect to LicenseDB: " + e.getMessage());
+            return result;
+        }
+
+        List<License> sw360Licenses = licenseRepository.getAll();
+
+        Set<String> licenseDbShortnames = new HashSet<>();
+        for (LicenseDBLicenseDTO dto : licenseDbLicenses) {
+            if (dto.getShortname() != null) {
+                licenseDbShortnames.add(dto.getShortname());
+            }
+        }
+
+        Set<String> sw360Shortnames = new HashSet<>();
+        int syncedCount = 0;
+        for (License license : sw360Licenses) {
+            if (license.getShortname() != null) {
+                sw360Shortnames.add(license.getShortname());
+            } else if (license.getId() != null) {
+                sw360Shortnames.add(license.getId());
+            }
+            if (license.getExternalIds() != null
+                    && license.getExternalIds().containsKey(LicenseDBDataMapper.EXTERNAL_ID_LICENSEDB)) {
+                syncedCount++;
+            }
+        }
+
+        Set<String> sw360Only = new HashSet<>(sw360Shortnames);
+        sw360Only.removeAll(licenseDbShortnames);
+
+        Set<String> licenseDbOnly = new HashSet<>(licenseDbShortnames);
+        licenseDbOnly.removeAll(sw360Shortnames);
+
+        result.put("totalSw360", String.valueOf(sw360Licenses.size()));
+        result.put("totalLicenseDb", String.valueOf(licenseDbLicenses.size()));
+        result.put("synced", String.valueOf(syncedCount));
+        result.put("sw360OnlyCount", String.valueOf(sw360Only.size()));
+        result.put("licenseDbOnlyCount", String.valueOf(licenseDbOnly.size()));
+        result.put("sw360Only", String.join(",", sw360Only));
+        result.put("licenseDbOnly", String.join(",", licenseDbOnly));
+        return result;
+    }
+
     private LicenseDBConnector createLicenseDBConnector(String baseUrl, String username, String password) {
         LicenseDBTokenManager tokenManager = new LicenseDBTokenManager(baseUrl, username, password);
         return new LicenseDBConnector(baseUrl, tokenManager);

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/tools/LicenseDBConnector.java
@@ -22,10 +22,12 @@ import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -53,8 +55,9 @@ public class LicenseDBConnector {
     private final LicenseDBTokenManager tokenManager;
 
     public LicenseDBConnector(String baseUrl, LicenseDBTokenManager tokenManager) {
-        this.baseUrl = Objects.requireNonNull(baseUrl, "baseUrl must not be null").replaceAll("/+$", "");
-        this.tokenManager = Objects.requireNonNull(tokenManager, "tokenManager must not be null");
+        Objects.requireNonNull(tokenManager, "tokenManager must not be null");
+        this.baseUrl = CommonUtils.validateHttpUrl(baseUrl);
+        this.tokenManager = tokenManager;
     }
 
     public List<LicenseDBLicenseDTO> fetchAllLicenses() throws SW360Exception {

--- a/backend/licenses-core/src/test/java/org/eclipse/sw360/licenses/tools/LicenseDBConnectorTest.java
+++ b/backend/licenses-core/src/test/java/org/eclipse/sw360/licenses/tools/LicenseDBConnectorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Sandip Mandal, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertNotNull;
+
+public class LicenseDBConnectorTest {
+
+    @Test
+    public void testConstructorAcceptsValidHttpUrl() {
+        LicenseDBTokenManager tokenManager = Mockito.mock(LicenseDBTokenManager.class);
+        LicenseDBConnector connector = new LicenseDBConnector("http://localhost:8080", tokenManager);
+        assertNotNull(connector);
+    }
+
+    @Test
+    public void testConstructorAcceptsValidHttpsUrl() {
+        LicenseDBTokenManager tokenManager = Mockito.mock(LicenseDBTokenManager.class);
+        LicenseDBConnector connector = new LicenseDBConnector("https://licensedb.example.com/", tokenManager);
+        assertNotNull(connector);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testConstructorRejectsMalformedUrl() {
+        LicenseDBTokenManager tokenManager = Mockito.mock(LicenseDBTokenManager.class);
+        new LicenseDBConnector("not a url", tokenManager);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testConstructorRejectsFtpScheme() {
+        LicenseDBTokenManager tokenManager = Mockito.mock(LicenseDBTokenManager.class);
+        new LicenseDBConnector("ftp://licensedb.example.com", tokenManager);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testConstructorRejectsNullBaseUrl() {
+        LicenseDBTokenManager tokenManager = Mockito.mock(LicenseDBTokenManager.class);
+        new LicenseDBConnector(null, tokenManager);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorRejectsNullTokenManager() {
+        new LicenseDBConnector("http://localhost:8080", null);
+    }
+}

--- a/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -376,6 +376,12 @@ public class LicenseHandler implements LicenseService.Iface {
     }
 
     @Override
+    public Map<String, String> getLicenseDBDiff(User user) throws TException {
+        assertUser(user);
+        return handler.getLicenseDBDiff(user);
+    }
+
+    @Override
     public RequestStatus deleteObligations(String id, User user) throws TException {
         assertId(id);
         assertUser(user);

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -458,6 +458,24 @@ public class CommonUtils {
         }
     }
 
+    public static String validateHttpUrl(String url) {
+        if (isNullOrEmpty(url)) {
+            throw new IllegalStateException("URL must not be null or empty");
+        }
+        String normalized = url.replaceAll("/+$", "");
+        try {
+            URI uri = new URI(normalized);
+            uri.toURL();
+            String scheme = uri.getScheme();
+            if (scheme == null || (!"http".equals(scheme) && !"https".equals(scheme))) {
+                throw new IllegalStateException("URL must use http or https: " + normalized);
+            }
+        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
+            throw new IllegalStateException("URL is invalid: " + normalized, e);
+        }
+        return normalized;
+    }
+
     public static String getTargetNameOfUrl(String url) {
         try {
             String path = new URI(url).toURL().getPath();

--- a/libraries/datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/datahandler/src/main/thrift/licenses.thrift
@@ -323,6 +323,8 @@ service LicenseService {
 
     bool pingLicenseDBHealth(1: User user);
 
+    map<string, string> getLicenseDBDiff(1: User user);
+
     /**
      * delete obligation from database if user has permissions
      **/

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -620,6 +620,25 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     }
 
     @Operation(
+            summary = "LicenseDB diff status",
+            description = "Compare licenses in SW360 and LicenseDB and get status of licenses mapped and missing.",
+            tags = {"Licenses"}
+    )
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Diff computed successfully."),
+            @ApiResponse(responseCode = "403", description = "User is not an admin."),
+            @ApiResponse(responseCode = "500", description = "Diff computation failed.")
+    })
+    @GetMapping(value = LICENSES_URL + "/import/LicenseDB/diff")
+    public ResponseEntity<Map<String, String>> getLicenseDBDiff() throws TException {
+        User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        Map<String, String> diff = licenseService.getLicenseDBDiff(sw360User);
+        HttpStatus status = diff.containsKey("error") ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.OK;
+        return new ResponseEntity<>(diff, status);
+    }
+
+    @Operation(
             summary = "Create license type.",
             description = "Create license type.",
             tags = {"Licenses"}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -35,6 +35,7 @@ import org.eclipse.sw360.exporter.LicsExporter;
 import org.eclipse.sw360.exporter.utils.ZipTools;
 import org.eclipse.sw360.importer.LicsImporter;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -351,6 +352,12 @@ public class Sw360LicenseService {
         } else {
             throw new BadRequestClientException("Unable to import LicenseDB licenses. User is not admin");
         }
+    }
+
+    public Map<String, String> getLicenseDBDiff(User sw360User) throws TException {
+        RestControllerHelper.throwIfNotAdmin(sw360User);
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        return sw360LicenseClient.getLicenseDBDiff(sw360User);
     }
 
     public RequestStatus addLicenseType(User sw360User, String licenseType, HttpServletRequest request) throws TException {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/HealthSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/HealthSpecTest.java
@@ -36,7 +36,6 @@ public class HealthSpecTest extends TestRestDocsSpecBase{
                 .build();
         given(this.restHealthIndicatorMock.health()).willReturn(spring_health);
 
-
         mockMvc.perform(get("/api/health")
                     .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -113,6 +113,13 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         given(this.licenseServiceMock.deleteLicenseType(any(), any())).willReturn(RequestStatus.SUCCESS);
         given(this.licenseServiceMock.importOsadlInformation(any())).willReturn(requestSummary);
         given(this.licenseServiceMock.importLicenseDBInformationAsync(any())).willReturn(requestSummary);
+        Map<String, String> diffResult = new LinkedHashMap<>();
+        diffResult.put("totalSw360", "100");
+        diffResult.put("totalLicenseDb", "120");
+        diffResult.put("synced", "80");
+        diffResult.put("sw360OnlyCount", "20");
+        diffResult.put("licenseDbOnlyCount", "40");
+        given(this.licenseServiceMock.getLicenseDBDiff(any())).willReturn(diffResult);
         given(this.licenseServiceMock.addLicenseType(any(),any() , any())).willReturn(RequestStatus.SUCCESS);
         given(this.sw360ReportServiceMock.getLicenseBuffer()).willReturn(ByteBuffer.allocate(10000));
         obligation1 = new Obligation();
@@ -433,6 +440,26 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isAccepted());
+    }
+
+    @Test
+    public void should_document_get_licensedb_diff() throws Exception {
+        mockMvc.perform(get("/api/licenses/import/LicenseDB/diff")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void should_return_500_when_licensedb_diff_has_error() throws Exception {
+        Map<String, String> errorResult = new LinkedHashMap<>();
+        errorResult.put("error", "LicenseDB integration is disabled.");
+        given(this.licenseServiceMock.getLicenseDBDiff(any())).willReturn(errorResult);
+
+        mockMvc.perform(get("/api/licenses/import/LicenseDB/diff")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isInternalServerError());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds URL validation, retry logic, and a license diff endpoint for the LicenseDB integration.

## Changes

* Validate LicenseDB URLs and restrict them to `http` and `https`.
* Retry failed HTTP requests once after a 100 ms delay.
* Add `GET /api/licenses/import/LicenseDB/diff`.
* Add `getLicenseDBDiff` with admin permission checks.
* Match licenses by short name, with ID as a fallback.
* Add tests for URL validation and the diff endpoint.

## Endpoint

`GET /api/licenses/import/LicenseDB/diff`

Requires `ADMIN` authority. Returns `500` when LicenseDB is disabled or unreachable.

## Suggested Reviewers

@GMishx
@deo002
@Farooq-Fateh-Aftab
