### PR TITLE
feat(obligation): warn when multiple CLI files are accepted for a release 

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3572,6 +3572,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             Map<String, Object> responseBody = new HashMap<>();
             responseBody.put("processedLicenses", processedLicenses);
             responseBody.put("obligationStatusMap", obligationStatusMap);
+            List<String> multipleCLIWarnings = projectService.getReleasesWithMultipleCLIWarnings(releases);
+            if (!multipleCLIWarnings.isEmpty()) {
+                responseBody.put("warnings", multipleCLIWarnings);
+            }
             return new ResponseEntity<>(responseBody, HttpStatus.OK);
         } else {
             obligationStatusMap = projectService.setLicenseInfoWithObligations(obligationStatusMap,
@@ -3589,6 +3593,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
 
             Map<String, Object> responseBody = createPaginationMetadata(pageable, obligationStatusMap);
+            List<String> multipleCLIWarnings = projectService.getReleasesWithMultipleCLIWarnings(releases);
+            if (!multipleCLIWarnings.isEmpty()) {
+                responseBody.put("warnings", multipleCLIWarnings);
+            }
             HalResource<Map<String, Object>> halObligation = new HalResource<>(responseBody);
             return new ResponseEntity<>(halObligation, HttpStatus.OK);
         }
@@ -3669,6 +3677,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
 
         Map<String, Object> responseBody = createPaginationMetadata(pageable, oblData);
+        List<String> multipleCLIWarnings = projectService.getReleasesWithMultipleCLIWarnings(releases);
+        if (!multipleCLIWarnings.isEmpty()) {
+            responseBody.put("warnings", multipleCLIWarnings);
+        }
         HalResource<Map<String, Object>> halObligation = new HalResource<>(responseBody);
         return new ResponseEntity<>(halObligation, HttpStatus.OK);
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3264,7 +3264,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             if (!releases.isEmpty()) {
                 final Map<String, String> releaseIdToAcceptedCLI = Maps.newHashMap();
                 obligationStatusMap = CommonUtils.nullToEmptyMap(projectService.setLicenseInfoWithObligations(
-                        Maps.newHashMap(), releaseIdToAcceptedCLI, releases, sw360User));
+                        Maps.newHashMap(), releaseIdToAcceptedCLI, releases, sw360User, id, new ArrayList<>()));
             }
         }
 
@@ -3558,7 +3558,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     }
 
     @Operation(
-            description = "Get license obligation data of project tab.",
+            description = "Get license obligation data of project tab. Look out for an optional **warnings** field (list of strings) in the response: it appears when a release has multiple CLI files, indicating the first CLI was selected automatically.",
             tags = {"Projects"}
     )
     @ApiResponses(value = {
@@ -3641,8 +3641,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             responseBody.put("obligationStatusMap", obligationStatusMap);
             return new ResponseEntity<>(responseBody, HttpStatus.OK);
         } else {
+            List<String> warnings = new ArrayList<>();
             obligationStatusMap = projectService.setLicenseInfoWithObligations(obligationStatusMap,
-                    releaseIdToAcceptedCLI, releases, sw360User);
+                    releaseIdToAcceptedCLI, releases, sw360User, id, warnings);
             for (Map.Entry<String, ObligationStatusInfo> entry : obligationStatusMap.entrySet()) {
                 ObligationStatusInfo statusInfo = entry.getValue();
                 if(statusInfo.getStatus() == null){
@@ -3656,13 +3657,16 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
 
             Map<String, Object> responseBody = createPaginationMetadata(pageable, obligationStatusMap);
+            if (!warnings.isEmpty()) {
+                responseBody.put("warnings", warnings);
+            }
             HalResource<Map<String, Object>> halObligation = new HalResource<>(responseBody);
             return new ResponseEntity<>(halObligation, HttpStatus.OK);
         }
     }
 
     @Operation(
-            description = "Get obligation data of project tab.",
+            description = "Get obligation data of project tab. Look out for an optional **warnings** field (list of strings) in the response: it appears when a release has multiple CLI files, indicating the first CLI was selected automatically.",
             tags = {"Projects"}
     )
     @ApiResponses(value = {
@@ -3705,10 +3709,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             oblData = projectService.setObligationsFromAdminSection(sw360User, new HashMap(), sw360Project, oblLevel);
         }
 
+        List<String> warnings = new ArrayList<>();
         if (oblLevel.equalsIgnoreCase("License")) {
             filterData = filterObligationsByLevel(obligationStatusMap, null);
             releaseIdToAcceptedCLI.putAll(SW360Utils.getReleaseIdtoAcceptedCLIMappings(filterData));
-            oblData = projectService.setLicenseInfoWithObligations(filterData, releaseIdToAcceptedCLI, releases, sw360User);
+            oblData = projectService.setLicenseInfoWithObligations(filterData, releaseIdToAcceptedCLI, releases, sw360User, id, warnings);
 
             for (Map.Entry<String, ObligationStatusInfo> entry : oblData.entrySet()) {
                 ObligationStatusInfo statusInfo = entry.getValue();
@@ -3736,6 +3741,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
 
         Map<String, Object> responseBody = createPaginationMetadata(pageable, oblData);
+        if (oblLevel.equalsIgnoreCase("License") && !warnings.isEmpty()) {
+            responseBody.put("warnings", warnings);
+        }
         HalResource<Map<String, Object>> halObligation = new HalResource<>(responseBody);
         return new ResponseEntity<>(halObligation, HttpStatus.OK);
     }
@@ -3887,7 +3895,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             obligationStatusMap = CommonUtils.nullToEmptyMap(obligation.getLinkedObligationStatus());
             releaseIdToAcceptedCLI.putAll(SW360Utils.getReleaseIdtoAcceptedCLIMappings(obligationStatusMap));
         } else {
-            obligationStatusMapFromReport = projectService.setLicenseInfoWithObligations(obligationStatusMap, releaseIdToAcceptedCLI, releases, sw360User);
+            obligationStatusMapFromReport = projectService.setLicenseInfoWithObligations(obligationStatusMap, releaseIdToAcceptedCLI, releases, sw360User, id, new ArrayList<>());
         }
 
         if (licenseObligation.size() == 0) {
@@ -4033,7 +4041,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 existingObligationStatusMap,
                 releaseIdToAcceptedCLI,
                 releases,
-                sw360User
+                sw360User,
+                sw360Project.getId(),
+                new ArrayList<>()
         );
 
 
@@ -4943,4 +4953,5 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 .forEach(responseGroups::add);
         return new ArrayList<>(responseGroups);
     }
+
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -808,8 +808,12 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             }
             final String releaseId = release.getId();
 
-            if (approvedCliAttachments.size() == 1) {
-                final Attachment filteredAttachment = approvedCliAttachments.get(0);
+            if (approvedCliAttachments.size() > 1) {
+                log.warn("Release '{}' has {} accepted CLI files. Obligations from all accepted CLIs will be aggregated.",
+                        SW360Utils.printName(release), approvedCliAttachments.size());
+            }
+
+            for (Attachment filteredAttachment : approvedCliAttachments) {
                 final String attachmentContentId = filteredAttachment.getAttachmentContentId();
 
                 if (releaseIdToAcceptedCLI.containsKey(releaseId)
@@ -830,7 +834,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                                 .createLicenseToObligationMapping(licenseResults.get(0), obligationResults.get(0)));
                     }
                 } catch (TException exception) {
-                    log.error(String.format("Error fetchinig Sw360ProjectService.javalicense Information for attachment: %s in release: %s",
+                    log.error(String.format("Error fetching license Information for attachment: %s in release: %s",
                             filteredAttachment.getFilename(), releaseId), exception);
                 }
             }
@@ -862,6 +866,28 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             log.error("Failed to set obligation status for project!", e);
         }
         return obligationStatusMap;
+    }
+
+    public List<String> getReleasesWithMultipleCLIWarnings(List<Release> releases) {
+        List<String> warnings = new ArrayList<>();
+        for (Release release : releases) {
+            List<Attachment> approvedCliAttachments = SW360Utils.getApprovedClxAttachmentForRelease(release);
+            if (approvedCliAttachments.isEmpty()) {
+                approvedCliAttachments = SW360Utils.getClxAttachmentForRelease(release);
+            }
+            if (approvedCliAttachments.size() > 1) {
+                String releaseName = SW360Utils.printName(release);
+                List<String> cliFileNames = approvedCliAttachments.stream()
+                        .map(Attachment::getFilename)
+                        .collect(Collectors.toList());
+                warnings.add(String.format(
+                        "Release '%s' has %d accepted CLI files (%s). "
+                                + "Obligations from all CLI files are aggregated. "
+                                + "Please review and ensure only the correct/latest CLI is accepted.",
+                        releaseName, approvedCliAttachments.size(), String.join(", ", cliFileNames)));
+            }
+        }
+        return warnings;
     }
 
     public Set<Project> searchLinkingProjects(String projectId, User sw360User) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -805,42 +805,80 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
     public Map<String, ObligationStatusInfo> setLicenseInfoWithObligations(
             Map<String, ObligationStatusInfo> obligationStatusMap, Map<String, String> releaseIdToAcceptedCLI,
-            List<Release> releases, User user) {
+            List<Release> releases, User user, String projectId, List<String> warnings) {
 
         final List<LicenseInfoParsingResult> licenseInfoWithObligations = Lists.newArrayList();
         LicenseInfoService.Iface licenseClient = ThriftClients.makeLicenseInfoClient();
 
-        for (Release release : releases) {
-            List<Attachment> approvedCliAttachments = SW360Utils.getApprovedClxAttachmentForRelease(release);
-            if (approvedCliAttachments.isEmpty()) {
-                approvedCliAttachments = SW360Utils.getClxAttachmentForRelease(release);
+        // Pre-load attachment usage once; group by release ID for O(1) lookup per release
+        Map<String, Set<String>> releaseIdToUsedContentIds = new HashMap<>();
+        getLicenseInfoAttachmentUsage(projectId).forEach((contentId, usage) -> {
+            if (usage.getOwner() != null && usage.getOwner().isSetReleaseId()) {
+                releaseIdToUsedContentIds
+                        .computeIfAbsent(usage.getOwner().getReleaseId(), k -> new HashSet<>())
+                        .add(contentId);
             }
+        });
+
+        for (Release release : releases) {
             final String releaseId = release.getId();
 
-            if (approvedCliAttachments.size() == 1) {
-                final Attachment filteredAttachment = approvedCliAttachments.get(0);
-                final String attachmentContentId = filteredAttachment.getAttachmentContentId();
+            // Step 1: use accepted CLIs; step 2: fall back to any CLI if none accepted
+            List<Attachment> cliCandidates = SW360Utils.getApprovedClxAttachmentForRelease(release);
+            if (cliCandidates.isEmpty()) {
+                cliCandidates = SW360Utils.getClxAttachmentForRelease(release);
+            }
+            if (cliCandidates.isEmpty()) {
+                continue;
+            }
+
+            if (cliCandidates.size() > 1) {
+                // Step 3: consult attachment usage to narrow down to the user-selected CLI
+                Set<String> usedContentIds = releaseIdToUsedContentIds.getOrDefault(releaseId, Collections.emptySet());
+                List<Attachment> fromUsage = cliCandidates.stream()
+                        .filter(a -> usedContentIds.contains(a.getAttachmentContentId()))
+                        .collect(Collectors.toList());
+                if (!fromUsage.isEmpty()) {
+                    cliCandidates = fromUsage;
+                }
+            }
+
+            // Step 4: still more than 1 — warn, then try each in order until one has obligations
+            if (cliCandidates.size() > 1) {
+                List<String> fileNames = cliCandidates.stream()
+                        .map(Attachment::getFilename)
+                        .collect(Collectors.toList());
+                warnings.add(String.format(
+                        "Release '%s' has %d CLI files selected in Attachment Usage: [%s]. "
+                                + "This may lead to duplicate or incorrect obligations being displayed. "
+                                + "Please select only one correct CLI file per release in the Attachment Usage.",
+                        SW360Utils.printName(release), cliCandidates.size(), String.join(", ", fileNames)));
+                log.warn("Release '{}' has {} CLI files; trying each in order. Please correct this in Attachment Usage.",
+                        SW360Utils.printName(release), cliCandidates.size());
+            }
+
+            for (Attachment candidate : cliCandidates) {
+                final String candidateContentId = candidate.getAttachmentContentId();
 
                 if (releaseIdToAcceptedCLI.containsKey(releaseId)
-                        && releaseIdToAcceptedCLI.get(releaseId).equals(attachmentContentId)) {
+                        && releaseIdToAcceptedCLI.get(releaseId).equals(candidateContentId)) {
                     releaseIdToAcceptedCLI.remove(releaseId);
                 }
 
                 try {
                     List<LicenseInfoParsingResult> licenseResults = licenseClient.getLicenseInfoForAttachment(release,
-                            attachmentContentId, false, user);
-
+                            candidateContentId, false, user);
                     List<ObligationParsingResult> obligationResults = licenseClient.getObligationsForAttachment(release,
-                            attachmentContentId, user);
-
+                            candidateContentId, user);
                     if (CommonUtils.allAreNotEmpty(licenseResults, obligationResults)
                             && obligationResults.get(0).getObligationsAtProjectSize() > 0) {
                         licenseInfoWithObligations.add(licenseClient
                                 .createLicenseToObligationMapping(licenseResults.get(0), obligationResults.get(0)));
+                        break;
                     }
                 } catch (TException exception) {
-                    log.error(String.format("Error fetchinig Sw360ProjectService.javalicense Information for attachment: %s in release: %s",
-                            filteredAttachment.getFilename(), releaseId), exception);
+                    log.error("Error fetching license information for attachment: {} in release: {}",
+                            candidate.getFilename(), releaseId, exception);
                 }
             }
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -1146,7 +1146,7 @@ public class ProjectTest extends TestIntegrationBase {
         computedFulfilled.setLicenseIds(new HashSet<>(Arrays.asList("MIT")));
         computedObligations.put("computed-1", computedOpen);
         computedObligations.put("computed-2", computedFulfilled);
-        given(this.projectServiceMock.setLicenseInfoWithObligations(any(), any(), any(), any()))
+        given(this.projectServiceMock.setLicenseInfoWithObligations(any(), any(), any(), any(), any(), any()))
                 .willReturn(computedObligations);
 
         HttpHeaders headers = getHeaders(port);
@@ -1281,7 +1281,7 @@ public class ProjectTest extends TestIntegrationBase {
     public void should_get_license_obligations() throws IOException, TException {
         given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
         given(this.projectServiceMock.getObligationData(any(), any())).willReturn(new ObligationList());
-        given(this.projectServiceMock.setLicenseInfoWithObligations(any(), any(), any(), any())).willReturn(new HashMap<>());
+        given(this.projectServiceMock.setLicenseInfoWithObligations(any(), any(), any(), any(), any(), any())).willReturn(new HashMap<>());
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
@@ -1330,7 +1330,7 @@ public class ProjectTest extends TestIntegrationBase {
         given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
 
         // Mock setLicenseInfoWithObligations
-        given(this.projectServiceMock.setLicenseInfoWithObligations(any(), any(), any(), any())).willReturn(new HashMap<>());
+        given(this.projectServiceMock.setLicenseInfoWithObligations(any(), any(), any(), any(), any(), any())).willReturn(new HashMap<>());
 
         // Mock addLinkedObligations
         given(this.projectServiceMock.addLinkedObligations(any(), any(), any())).willReturn(RequestStatus.SUCCESS);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -567,7 +567,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.getLicenseInfoAttachmentUsage(eq(project8.getId()))).willReturn(licenseInfoUsages);
         given(this.projectServiceMock.getObligationData(eq(project8.getLinkedObligationId()), any())).willReturn(obligationLists);
         given(this.projectServiceMock.setObligationsFromAdminSection(any(), any(), any(), any())).willReturn(obligationStatusMapFromAdminSection);
-        given(this.projectServiceMock.setLicenseInfoWithObligations(eq(obligationStatusMap), eq(releaseIdToAcceptedCLI), any(), any())).willReturn(obligationStatusMap);
+        given(this.projectServiceMock.setLicenseInfoWithObligations(eq(obligationStatusMap), eq(releaseIdToAcceptedCLI), any(), any(), any(), any())).willReturn(obligationStatusMap);
         given(this.projectServiceMock.getLicensesFromAttachmentUsage(eq(licenseInfoUsages), any())).willReturn(licensesFromAttachmentUsage);
         given(this.projectServiceMock.getLicenseObligationData(eq(licensesFromAttachmentUsage), any())).willReturn(obligationStatusMap);
         given(this.projectServiceMock.addLinkedObligations(any(), any(), eq(obligationStatusMap))).willReturn(RequestStatus.SUCCESS);


### PR DESCRIPTION

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Summary
Added a warnings field in the license obligations response to notify users when multiple CLI files are accepted for a release.(#4428 )

Closes #4428 

### Suggest Reviewer
>  @GMishx 

### How To Test?

- Create a Component and add a Release (e.g., OpenSSL 3.0.1)
- Upload two CLI files (type: COMPONENT_LICENSE_INFO_XML) as attachments to the release
- Set Check Status = ACCEPTED on both CLI files
- Create a Project and link the release to it
- Navigate to Project → Obligations tab