### PR TITLE
feat(vendor): Migrate vendor search to nouveau infrastructure

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearchHandler.java
@@ -9,100 +9,86 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.collect.FluentIterable;
-import com.google.gson.Gson;
 import com.ibm.cloud.cloudant.v1.Cloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorSortColumn;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
 /**
- * Lucene search for the Vendor class
+ * Nouveau search handler for Vendors.
+ *
+ * <p>Vendors are globally readable (no per-user access control), therefore this
+ * handler keeps the legacy text based public API ({@link #search}) while
+ * delegating index construction and query routing to the shared
+ * {@link BaseNouveauSearchHandler} DSL infrastructure.</p>
  *
  * @author cedric.bodet@tngtech.com
  * @author johannes.najjar@tngtech.com
  * @author gerrit.grenzebach@tngtech.com
  */
-public class VendorSearchHandler {
+public class VendorSearchHandler extends BaseNouveauSearchHandler<Vendor> {
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-            = new NouveauIndexDesignDocument("vendors",
-            new NouveauIndexFunction(
-                    """
-                    function(doc) {
-                      if(doc.type == 'vendor') {
-                        if (typeof(doc.shortname) == 'string' && doc.shortname.length > 0) {
-                          index('text', 'shortname', doc.shortname, {'store': true});
-                          index('string', 'shortname_sort', doc.shortname);
-                        }
-                        if (typeof(doc.fullname) == 'string' && doc.fullname.length > 0) {
-                          index('text', 'fullname', doc.fullname, {'store': true});
-                          index('string', 'fullname_sort', doc.fullname);
-                        }
-                      }
-                    }
-                    """
-                    ));
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
+
+    private static final List<IndexField> VENDOR_FIELDS = List.of(
+            IndexField.standard("shortname"),
+            IndexField.standard("fullname")
+    );
+
+    private static final BuiltIndexDefinition VENDOR_INDEX_DEFINITION = buildIndexFunction(
+            "vendor",
+            SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN,
+            VENDOR_FIELDS,
+            null,
+            Map.of(),
+            "standard"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Constructor
+    // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
     private final VendorRepository vendorRepository;
 
-    public VendorSearchHandler(Cloudant client, String dbName) throws IOException {
-        // Creates the database connector and adds the lucene search view
-        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
+    public VendorSearchHandler(Cloudant cClient, String dbName) throws IOException {
+        super(Vendor.class, "vendors", VENDOR_INDEX_DEFINITION);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(cClient, dbName);
         // Initialize repository so we have a fallback using the same database and views
         vendorRepository = new VendorRepository(db);
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        connector.addDesignDoc(searchView);
+        setup(connector, db);
     }
+
+    // -------------------------------------------------------------------------
+    //  Public search API
+    // -------------------------------------------------------------------------
 
     /**
-     * Get the query with index names for searching vendors. Current indexes available are 'shortname' and 'fullname'.
-     *
-     * @param searchText Search query from user.
-     * @return Lucene search query with index names.
+     * Paginated search matching vendors whose {@code fullname} or {@code shortname}
+     * starts with the provided text. Falls back to an in-memory repository search
+     * when lucene is unavailable (e.g. in tests).
      */
-    private static @Nonnull String getQueryString(String searchText) {
-        final Function<String, String> addField = input -> input + ": (" +
-                prepareWildcardQuery(searchText) + " )";
-        List<String> typeField = List.of("fullname", "shortname");
-        return "( " + Joiner.on(" OR ").join(
-                FluentIterable.from(typeField).transform(addField)
-        ) + " ) ";
-    }
-
     public Map<PaginationData, List<Vendor>> search(String searchText, PaginationData pageData) {
-        // Query the search view for the provided text
-        String sortColumn = getSortColumnName(pageData);
-        Map<PaginationData, List<Vendor>> luceneResult = connector.searchView(
-                Vendor.class,
-                luceneSearchView.getIndexName(),
-                getQueryString(searchText),
-                pageData,
-                sortColumn,
-                pageData.isAscending());
+        Map<PaginationData, List<Vendor>> luceneResult =
+                baseSearchWithOr(connector, buildFullnameShortnameRestrictions(searchText), pageData);
 
         if (hasResults(luceneResult)) {
             return luceneResult;
@@ -112,13 +98,20 @@ public class VendorSearchHandler {
         return vendorRepository.searchVendorsWithPagination(searchText, pageData);
     }
 
-    public List<String> searchIds(String searchText) {
-        // Query the search view for the provided text
-        return connector.searchIds(Vendor.class, luceneSearchView.getIndexName(),
-                getQueryString(searchText));
+    // -------------------------------------------------------------------------
+    //  Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build the OR'd field restrictions used to match vendors by {@code fullname}
+     * or {@code shortname} against the same search text.
+     */
+    private static Map<String, Set<String>> buildFullnameShortnameRestrictions(String searchText) {
+        return Map.of(
+                Vendor._Fields.FULLNAME.getFieldName(), Collections.singleton(searchText),
+                Vendor._Fields.SHORTNAME.getFieldName(), Collections.singleton(searchText)
+        );
     }
-
-
 
     private static boolean hasResults(Map<PaginationData, List<Vendor>> luceneResult) {
         return luceneResult != null
@@ -126,20 +119,17 @@ public class VendorSearchHandler {
                 && luceneResult.values().stream().anyMatch(list -> list != null && !list.isEmpty());
     }
 
+    // -------------------------------------------------------------------------
+    //  Sort column mapping
+    // -------------------------------------------------------------------------
 
-    /**
-     * Convert sort column number back to sorting column name. This function makes sure to use the string column (with
-     * `_sort` suffix) for text indexes.
-     * @param pageData Pagination Data from the request.
-     * @return Sort column name. Defaults to fullname_sort
-     */
-    private static @Nonnull String getSortColumnName(@Nonnull PaginationData pageData) {
-        return switch (VendorSortColumn.findByValue(pageData.getSortColumnNumber())) {
-            case VendorSortColumn.BY_SHORTNAME -> "shortname_sort";
-            case VendorSortColumn.BY_FULLNAME -> "fullname_sort";
-            case VendorSortColumn.BY_SCORE -> null;
-            case null -> "fullname_sort";
-            default -> "fullname_sort";
+    @Override
+    protected List<String> mapSortColumn(int sortColumnNumber) {
+        return switch (VendorSortColumn.findByValue(sortColumnNumber)) {
+            case VendorSortColumn.BY_FULLNAME -> List.of("fullname_sort", "shortname_sort");
+            case VendorSortColumn.BY_SHORTNAME -> List.of("shortname_sort", "fullname_sort");
+            case VendorSortColumn.BY_SCORE -> List.of(SCORE_SORTING_FIELD);
+            case null, default -> List.of(SCORE_SORTING_FIELD);
         };
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/VendorSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/VendorSearchHandlerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.vendors.VendorSortColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VendorSearchHandlerTest {
+
+    /**
+     * Mirror of {@link VendorSearchHandler#mapSortColumn(int)} so we can test
+     * sorting logic without needing a CouchDB connection.
+     */
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        return switch (VendorSortColumn.findByValue(sortColumnNumber)) {
+            case VendorSortColumn.BY_FULLNAME -> List.of("fullname_sort", "shortname_sort");
+            case VendorSortColumn.BY_SHORTNAME -> List.of("shortname_sort", "fullname_sort");
+            case VendorSortColumn.BY_SCORE -> List.of(SCORE_SORTING_FIELD);
+            case null, default -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+
+    @Test
+    void byFullname_shouldReturnFullnameSortWithShortnameTiebreaker() {
+        List<String> columns = mapSortColumnDirect(VendorSortColumn.BY_FULLNAME.getValue());
+        assertEquals(List.of("fullname_sort", "shortname_sort"), columns);
+        assertFalse(columns.contains(SCORE_SORTING_FIELD));
+    }
+
+    @Test
+    void byShortname_shouldReturnShortnameSortWithFullnameTiebreaker() {
+        List<String> columns = mapSortColumnDirect(VendorSortColumn.BY_SHORTNAME.getValue());
+        assertEquals(List.of("shortname_sort", "fullname_sort"), columns);
+        assertFalse(columns.contains(SCORE_SORTING_FIELD));
+    }
+
+    @Test
+    void byScore_shouldReturnOnlyScoreField() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(VendorSortColumn.BY_SCORE.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToScore() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(999));
+    }
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (VendorSortColumn column : VendorSortColumn.values()) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertNotNull(columns);
+            assertFalse(columns.isEmpty());
+        }
+    }
+
+    @Test
+    void namedColumns_shouldContainBothSortFields() {
+        for (VendorSortColumn column : List.of(VendorSortColumn.BY_FULLNAME, VendorSortColumn.BY_SHORTNAME)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertTrue(columns.contains("fullname_sort"), column + " missing fullname_sort");
+            assertTrue(columns.contains("shortname_sort"), column + " missing shortname_sort");
+        }
+    }
+}
+

--- a/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
+++ b/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
@@ -85,10 +85,6 @@ public class VendorHandler implements VendorService.Iface {
         return vendorSearchHandler.search(searchText, pageData);
     }
 
-    @Override
-    public List<String> searchVendorIds(String searchText) throws TException {
-        return vendorSearchHandler.searchIds(searchText);
-    }
 
 
     @Override

--- a/libraries/datahandler/src/main/thrift/vendors.thrift
+++ b/libraries/datahandler/src/main/thrift/vendors.thrift
@@ -64,10 +64,6 @@ service VendorService {
      **/
     map<PaginationData, list<Vendor>> searchVendors(1: string searchText, 2: PaginationData pageData);
 
-    /**
-     * get set of vendorIds whose fullname or shortname starts with searchText
-     **/
-    list<string> searchVendorIds(1: string searchText);
 
     /**
      * write vendor to database and return id with status summary

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.thrift.TException;
@@ -72,6 +73,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Vendor", description = "Operations related to Vendors on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`score` (default), " +
+        "`fullname` or `shortname`].")
 public class VendorController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String VENDORS_URL = "/vendors";
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)
>
### Summary

Migrates Vendor search to the nouveau `BaseNouveauSearchHandler` pattern,

### Changes

- **`backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearchHandler.java`**
  - Rewritten to extend `BaseNouveauSearchHandler<Vendor>`
  - Replaced legacy inline JS view wiring with `IndexField`-based index definition
  - Added sort mapping via `mapSortColumn(...)`
  - Preserved existing API (`search`, `searchIds`) and repository fallback behavior
- **`backend/common/src/test/java/org/eclipse/sw360/datahandler/db/VendorSearchHandlerTest.java`** *(new)*
  - Added unit tests for sort-column mapping and default/fallback behavior
- **`rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java`**
  - Added class-level OpenAPI `@Tag` description documenting supported pagination sort columns:
    `score` (default), `fullname`, `shortname`


### Suggest Reviewer
> @GMishx .

### How To Test?
- Call `GET /api/vendors?searchText=<text>&sort=score,desc`
- Call `GET /api/vendors?searchText=<text>&sort=fullname,asc`
- Call `GET /api/vendors?searchText=<text>&sort=shortname,asc`
- Verify OpenAPI group "Vendor" shows supported pagination sort columns in tag description.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
