### PR TITLE
refactor(search): migrate moderation request search to new infra

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -91,8 +91,10 @@ public class ModerationSearchHandler extends BaseNouveauSearchHandler<Moderation
         setup(connector, db);
     }
 
-    public Map<PaginationData, List<ModerationRequest>> search(String text,
-            final Map<String, Set<String>> subQueryRestrictions, PaginationData pageData, User sw360User) {
+    public Map<PaginationData, List<ModerationRequest>> search(
+            final @NonNull Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData, User sw360User
+    ) {
         String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
         String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
         if (!subQueryRestrictions.containsKey(moderatorKey) && !subQueryRestrictions.containsKey(requestingUserKey)) {
@@ -104,20 +106,18 @@ public class ModerationSearchHandler extends BaseNouveauSearchHandler<Moderation
         Map<String, Set<String>> orRestrictions = new java.util.HashMap<>();
         Map<String, Set<String>> andRestrictions = new java.util.HashMap<>();
 
-        if (subQueryRestrictions != null) {
-            for (Map.Entry<String, Set<String>> entry : subQueryRestrictions.entrySet()) {
-                if (entry.getValue() == null || entry.getValue().isEmpty()) {
-                    continue;
-                }
+        for (Map.Entry<String, Set<String>> entry : subQueryRestrictions.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
 
-                String fieldName = entry.getKey();
-                Set<String> values = entry.getValue();
+            String fieldName = entry.getKey();
+            Set<String> values = entry.getValue();
 
-                if (isModeratorOrRequestingUserField(fieldName)) {
-                    orRestrictions.put(fieldName, values);
-                } else {
-                    andRestrictions.put(fieldName, values);
-                }
+            if (isModeratorOrRequestingUserField(fieldName)) {
+                orRestrictions.put(fieldName, values);
+            } else {
+                andRestrictions.put(fieldName, values);
             }
         }
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -9,80 +9,97 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
-import com.google.common.base.Joiner;
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.gson.Gson;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationSortColumn;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.jspecify.annotations.NonNull;
 
-import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
-import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
-public class ModerationSearchHandler {
+public class ModerationSearchHandler extends BaseNouveauSearchHandler<ModerationRequest> {
 
-    private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-        = new NouveauIndexDesignDocument("moderations",
-            new NouveauIndexFunction(
-                "function(doc) {" +
-                OBJ_ARRAY_TO_STRING_INDEX +
-                "    if(!doc.type || doc.type != 'moderation' || !doc.documentId) return;" +
-                "    arrayToStringIndex(doc.moderators, 'moderators');" +
-                "    if(doc.documentName && typeof(doc.documentName) == 'string' && doc.documentName.length > 0) {" +
-                "      index('text', 'documentName', doc.documentName, {'store': true});" +
-                "    }" +
-                "    if(doc.documentType && typeof(doc.documentType) == 'string' && doc.documentType.length > 0) {" +
-                "      index('text', 'documentType', doc.documentType, {'store': true});" +
-                "    }" +
-                "    if(doc.componentType && typeof(doc.componentType) == 'string' && doc.componentType.length > 0) {" +
-                "      index('text', 'componentType', doc.componentType, {'store': true});" +
-                "    }" +
-                "    if(doc.requestingUser && typeof(doc.requestingUser) == 'string' && doc.requestingUser.length > 0) {" +
-                "      index('text', 'requestingUser', doc.requestingUser, {'store': true});" +
-                "    }" +
-                "    if(doc.requestingUserDepartment && typeof(doc.requestingUserDepartment) == 'string' && doc.requestingUserDepartment.length > 0) {" +
-                "      index('text', 'requestingUserDepartment', doc.requestingUserDepartment, {'store': true});" +
-                "    }" +
-                "    if(doc.moderationState && typeof(doc.moderationState) == 'string' && doc.moderationState.length > 0) {" +
-                "      index('text', 'moderationState', doc.moderationState, {'store': true});" +
-                "    }" +
-                "    if(doc.timestamp) {"+
-                "      var dt = new Date(doc.timestamp); "+
-                "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
-                "      index('double', 'timestamp', Number(formattedDt), {'store': true});"+
-                "    }" +
-                "}"));
+    /**
+     * Fields common to all vulnerabilities, grouped by index category.
+     *
+     * <ul>
+     *   <li><b>standard</b>: {@code documentName} - full prefix-search support.</li>
+     *   <li><b>simple</b>: {@code documentType}, {@code componentType}, {@code requestingUser},
+     *   {@code moderationState}, {@code requestingUserDepartment}</li>
+     *   <li><b>date</b>: {@code timestamp} - stored as sortable yyyyMMdd double.</li>
+     * </ul>
+     */
+    private static final List<IndexField> MR_FIELDS = List.of(
+        IndexField.standard("documentName"),
+        IndexField.simple("documentType", "keyword"),
+        IndexField.simple("componentType", "keyword"),
+        IndexField.simple("requestingUser", "email"),
+        IndexField.simple("moderationState", "keyword"),
+        IndexField.simple("requestingUserDepartment", "keyword"),
+        IndexField.date("timestamp")
+    );
+
+    /**
+     * Handler-specific JS: index {@code moderators} as a concatenated text blob
+     */
+    private static final String MR_CUSTOM_JS =
+            "    arrayToStringIndex(doc.moderators, 'moderators');";
+    /**
+     * Analyzer overrides that are not auto-generated from {@link #MR_FIELDS}.
+     * <ul>
+     *   <li>{@code moderators} -> {@code email}</li>
+     * </ul>
+     */
+    private static final Map<String, String> MR_CUSTOM_ANALYZERS = Map.of(
+            "moderators", "email"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Design document
+    // -------------------------------------------------------------------------
+
+    private static final BuiltIndexDefinition MR_INDEX_DEFINITION = buildIndexFunction(
+            "moderation",
+            "",
+            MR_FIELDS,
+            MR_CUSTOM_JS,
+            MR_CUSTOM_ANALYZERS,
+            "standard"
+    );
+
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public ModerationSearchHandler(Cloudant client, String dbName) throws IOException {
+        super(ModerationRequest.class, "moderations", MR_INDEX_DEFINITION);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        connector.addDesignDoc(searchView);
-    }
-
-    public List<ModerationRequest> search(String text, final Map<String, Set<String>> subQueryRestrictions) {
-        return connector.searchViewWithRestrictionsWithAnd(ModerationRequest.class, luceneSearchView.getIndexName(),
-                text, subQueryRestrictions);
+        setup(connector, db);
     }
 
     public Map<PaginationData, List<ModerationRequest>> search(String text,
-            final Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) {
+            final Map<String, Set<String>> subQueryRestrictions, PaginationData pageData, User sw360User) {
+        String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
+        String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
+        if (!subQueryRestrictions.containsKey(moderatorKey) && !subQueryRestrictions.containsKey(requestingUserKey)) {
+            subQueryRestrictions.put(moderatorKey, Collections.singleton(sw360User.getEmail()));
+            subQueryRestrictions.put(requestingUserKey, Collections.singleton(sw360User.getEmail()));
+        }
+
         Map<String, Map<String, Set<String>>> restrictions = new java.util.HashMap<>();
         Map<String, Set<String>> orRestrictions = new java.util.HashMap<>();
         Map<String, Set<String>> andRestrictions = new java.util.HashMap<>();
@@ -111,16 +128,25 @@ public class ModerationSearchHandler {
             restrictions.put("AND", andRestrictions);
         }
 
-        List<String> queryFilters = NouveauLuceneAwareDatabaseConnector.createComplexQuery(
-                ModerationRequest.class, text, restrictions);
-        String finalQuery = Joiner.on(" AND ").join(queryFilters);
-
-        return connector.searchView(ModerationRequest.class, luceneSearchView.getIndexName(), finalQuery,
-                pageData, "timestamp", pageData.isAscending());
+        return complexBaseSearch(connector, restrictions, AND, pageData);
     }
 
     private static boolean isModeratorOrRequestingUserField(String fieldName) {
         return ModerationRequest._Fields.MODERATORS.getFieldName().equals(fieldName)
                 || ModerationRequest._Fields.REQUESTING_USER.getFieldName().equals(fieldName);
+    }
+
+    @Override
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (ModerationSortColumn.findByValue(sortColumnNumber)) {
+            case ModerationSortColumn.BY_DOCUMENT_NAME -> List.of("documentName_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
+            case ModerationSortColumn.BY_DOCUMENT_TYPE -> List.of("documentType_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
+            case ModerationSortColumn.BY_COMPONENT_TYPE -> List.of("componentType_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
+            case ModerationSortColumn.BY_REQUESTING_USER -> List.of("requestingUser_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
+            case ModerationSortColumn.BY_MODERATION_STATE -> List.of("moderationState_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
+            case ModerationSortColumn.BY_REQUESTING_USER_DEPT -> List.of("requestingUserDepartment_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
+            case null, default -> List.of(SCORE_SORTING_FIELD, revDir + "timestamp");
+        };
     }
 }

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -249,13 +249,6 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
-    public List<ModerationRequest> getRequestsByModerator(User user) throws TException {
-        assertUser(user);
-
-        return handler.getRequestsByModerator(user.getEmail());
-    }
-
-    @Override
     public List<ModerationRequest> getRequestsByModeratorWithPaginationNoFilter(User user, PaginationData pageData) throws TException {
         assertUser(user);
 
@@ -263,7 +256,7 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
-    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions,
+    public Map<PaginationData, List<ModerationRequest>> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions,
                                                                          PaginationData pageData, User SW360User) throws TException {
         return handler.searchModerationRequestsByExactValues(subQueryRestrictions, pageData, SW360User);
     }
@@ -374,11 +367,11 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
-    public List<ModerationRequest> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions,
-            PaginationData pageData, User SW360User) throws TException {
-        Map<PaginationData, List<ModerationRequest>> result = modSearchHandler.search(text, subQueryRestrictions,
-                pageData, SW360User);
-        return result.values().iterator().next();
+    public Map<PaginationData, List<ModerationRequest>> refineSearch(
+            Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData, User SW360User
+    ) throws TException {
+        return modSearchHandler.search(subQueryRestrictions, pageData, SW360User);
     }
 
     @Override

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -19,7 +19,6 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RemoveModeratorRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.ClearingRequestSize;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
@@ -264,8 +263,9 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
-    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) throws TException {
-        return handler.searchModerationRequestsByExactValues(subQueryRestrictions, pageData);
+    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions,
+                                                                         PaginationData pageData, User SW360User) throws TException {
+        return handler.searchModerationRequestsByExactValues(subQueryRestrictions, pageData, SW360User);
     }
 
     @Override
@@ -375,9 +375,9 @@ public class ModerationHandler implements ModerationService.Iface {
 
     @Override
     public List<ModerationRequest> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions,
-            PaginationData pageData) throws TException {
+            PaginationData pageData, User SW360User) throws TException {
         Map<PaginationData, List<ModerationRequest>> result = modSearchHandler.search(text, subQueryRestrictions,
-                pageData);
+                pageData, SW360User);
         return result.values().iterator().next();
     }
 

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -138,8 +138,8 @@ public class ModerationDatabaseHandler {
         return repository.getRequestsByModeratorAndRequestingUserWithPaginationNoFilter(moderator, pageData);
     }
 
-    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) {
-        return repository.searchModerationRequestsByExactValues(subQueryRestrictions, pageData);
+    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData, User SW360User) {
+        return repository.searchModerationRequestsByExactValues(subQueryRestrictions, pageData, SW360User);
     }
 
 

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -138,10 +138,9 @@ public class ModerationDatabaseHandler {
         return repository.getRequestsByModeratorAndRequestingUserWithPaginationNoFilter(moderator, pageData);
     }
 
-    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData, User SW360User) {
+    public Map<PaginationData, List<ModerationRequest>> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData, User SW360User) {
         return repository.searchModerationRequestsByExactValues(subQueryRestrictions, pageData, SW360User);
     }
-
 
     public Map<PaginationData, List<ModerationRequest>> getRequestsByModerator(String moderator, PaginationData pageData, boolean open) {
         return repository.getRequestsByModerator(moderator, pageData, open);

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
@@ -36,6 +36,9 @@ import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationSortColumn;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.jetbrains.annotations.NotNull;
 
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.and;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.elemMatch;
@@ -163,22 +166,48 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         return getConnector().getQueryResult(qb, ModerationRequest.class);
     }
 
-    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions, PaginationData pageData) {
-        final int rowsPerPage = pageData.getRowsPerPage();
+    private static @NotNull Map<String, String> getSortSelector(PaginationData pageData) {
         final boolean ascending = pageData.isAscending();
-        final int skip = pageData.getDisplayStart();
+        return switch (ModerationSortColumn.findByValue(pageData.getSortColumnNumber())) {
+            case ModerationSortColumn.BY_DOCUMENT_NAME ->
+                    Collections.singletonMap("documentName", ascending ? "asc" : "desc");
+            case ModerationSortColumn.BY_DOCUMENT_TYPE ->
+                    Collections.singletonMap("documentType", ascending ? "asc" : "desc");
+            case ModerationSortColumn.BY_MODERATION_STATE ->
+                    Collections.singletonMap("moderationState", ascending ? "asc" : "desc");
+            case ModerationSortColumn.BY_COMPONENT_TYPE ->
+                    Collections.singletonMap("componentType", ascending ? "asc" : "desc");
+            case ModerationSortColumn.BY_REQUESTING_USER ->
+                    Collections.singletonMap("requestingUser", ascending ? "asc" : "desc");
+            case ModerationSortColumn.BY_REQUESTING_USER_DEPT ->
+                    Collections.singletonMap("requestingUserDepartment", ascending ? "asc" : "desc");
+            case null, default ->
+                    Collections.singletonMap("timestamp", ascending ? "asc" : "desc"); // Default sort by timestamp
+        };
+    }
+
+    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions,
+                                                                         PaginationData pageData, User sw360User) {
+        String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
+        String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
+        if (!subQueryRestrictions.containsKey(moderatorKey) && !subQueryRestrictions.containsKey(requestingUserKey)) {
+            subQueryRestrictions.put(moderatorKey, Collections.singleton(sw360User.getEmail()));
+            subQueryRestrictions.put(requestingUserKey, Collections.singleton(sw360User.getEmail()));
+        }
+
         final Map<String, Object> typeSelector = eq("type", "moderation");
         final Map<String, Object> restrictionsSelector = getQueryFromRestrictions(subQueryRestrictions);
         final Map<String, Object> finalSelector = and(List.of(typeSelector, restrictionsSelector));
 
-        PostFindOptions qb = getConnector().getQueryBuilder()
+        final Map<String, String> sortSelector = getSortSelector(pageData);
+        PostFindOptions.Builder qb = getConnector()
+                .getQueryBuilder()
                 .selector(finalSelector)
-                .limit(rowsPerPage)
-                .skip(skip)
-                .useIndex(Collections.singletonList(MR_BY_DATE_IDX))
-                .addSort(Collections.singletonMap("timestamp", ascending ? "asc" : "desc"))
-                .build();
-        return getConnector().getQueryResult(qb, ModerationRequest.class);
+                .useIndex(Collections.singletonList(MR_BY_DATE_IDX));
+
+        return getConnector().getQueryResultPaginated(
+                qb, ModerationRequest.class, pageData, sortSelector
+        );
     }
 
     private Map<String, Object> getQueryFromRestrictions(Map<String, Set<String>> subQueryRestrictions) {

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
@@ -149,23 +149,6 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         return makeSummaryFromFullDocs(SummaryType.SHORT, mrs);
     }
 
-    public List<ModerationRequest> getRequestsByModeratorWithPaginationNoFilter(String moderator, PaginationData pageData) {
-        final int rowsPerPage = pageData.getRowsPerPage();
-        final boolean ascending = pageData.isAscending();
-        final int skip = pageData.getDisplayStart();
-        final Map<String, Object> typeSelector = eq("type", "moderation");
-        final Map<String, Object> filterByModeratorSelector = elemMatch("moderators", moderator);
-        final Map<String, Object> finalSelector = and(List.of(typeSelector, filterByModeratorSelector));
-        PostFindOptions qb = getConnector().getQueryBuilder()
-                .selector(finalSelector)
-                .limit(rowsPerPage)
-                .skip(skip)
-                .useIndex(Collections.singletonList(MR_BY_DATE_IDX))
-                .addSort(Collections.singletonMap("timestamp", ascending ? "asc" : "desc"))
-                .build();
-        return getConnector().getQueryResult(qb, ModerationRequest.class);
-    }
-
     private static @NotNull Map<String, String> getSortSelector(PaginationData pageData) {
         final boolean ascending = pageData.isAscending();
         return switch (ModerationSortColumn.findByValue(pageData.getSortColumnNumber())) {
@@ -186,8 +169,10 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         };
     }
 
-    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> subQueryRestrictions,
-                                                                         PaginationData pageData, User sw360User) {
+    public Map<PaginationData, List<ModerationRequest>> searchModerationRequestsByExactValues(
+            Map<String, Set<String>> subQueryRestrictions,
+            PaginationData pageData, User sw360User
+    ) {
         String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
         String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
         if (!subQueryRestrictions.containsKey(moderatorKey) && !subQueryRestrictions.containsKey(requestingUserKey)) {
@@ -205,9 +190,11 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
                 .selector(finalSelector)
                 .useIndex(Collections.singletonList(MR_BY_DATE_IDX));
 
-        return getConnector().getQueryResultPaginated(
+        List<ModerationRequest> moderationRequests = getConnector().getQueryResultPaginated(
                 qb, ModerationRequest.class, pageData, sortSelector
         );
+
+        return Collections.singletonMap(pageData, moderationRequests);
     }
 
     private Map<String, Object> getQueryFromRestrictions(Map<String, Set<String>> subQueryRestrictions) {

--- a/backend/moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
+++ b/backend/moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.sw360.moderation;
 
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -22,6 +23,7 @@ import org.apache.thrift.transport.THttpClient;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Small client for testing a service
@@ -35,8 +37,13 @@ public class TestModerationClient {
         TProtocol protocol = new TCompactProtocol(thriftClient);
         ModerationService.Iface client = new ModerationService.Client(protocol);
 
-        List<ModerationRequest> requestsByModerator = client.getRequestsByModerator(new User().setId("58245y9845").setEmail("cedric.bodet@tngtech.com").setDepartment("BB"));
+        Map<PaginationData, List<ModerationRequest>> requestsByModerator = client.searchModerationRequestsByExactValues(
+                Map.of(),
+                new PaginationData(),
+                new User().setId("58245y9845").setEmail("cedric.bodet@tngtech.com").setDepartment("BB")
+        );
 
-        log.info("Fetched {} moderation requests from moderation service", requestsByModerator.size());
+        log.info("Fetched {} moderation requests from moderation service",
+                requestsByModerator.keySet().iterator().next().getTotalRowCount());
     }
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -535,18 +535,12 @@ public abstract class BaseNouveauSearchHandler<T> {
     private final @NonNull @Unmodifiable Map<PaginationData, List<T>> genericBaseSearch(
             NouveauLuceneAwareDatabaseConnector connector,
             final @NonNull Map<String, Set<String>> subQueryRestrictions,
-            Function<Map<String, String>, String> queryGenerator,
+            Function<Map<String, Set<String>>, String> queryGenerator,
             PaginationData pageData
     ) {
         List<String> sortColumns = getSortColumns(pageData);
-        Map<String, String> simplified = subQueryRestrictions.entrySet()
-                .parallelStream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> SPACE.join(e.getValue())
-                ));
 
-        String query = queryGenerator.apply(simplified);
+        String query = queryGenerator.apply(subQueryRestrictions);
         Map<PaginationData, List<T>> result = connector.searchView(
                 clazz, luceneSearchView.getIndexName(), query, pageData, sortColumns);
         PaginationData respPageData = result.keySet().iterator().next();
@@ -634,19 +628,8 @@ public abstract class BaseNouveauSearchHandler<T> {
             PaginationData pageData
     ) {
         List<String> sortColumns = getSortColumns(pageData);
-        Map<String, Map<String, String>> simplified = complexQueryRestrictions
-                .entrySet()
-                .parallelStream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> e.getValue().entrySet().stream()
-                                .collect(Collectors.toMap(
-                                        Map.Entry::getKey,
-                                        innerEntry -> SPACE.join(innerEntry.getValue())
-                                ))
-                ));
 
-        String query = joiner.join(createComplexQuery(simplified));
+        String query = joiner.join(createComplexQuery(complexQueryRestrictions));
 
         Map<PaginationData, List<T>> result = connector.searchView(
                 clazz, luceneSearchView.getIndexName(), query, pageData, sortColumns);
@@ -684,15 +667,12 @@ public abstract class BaseNouveauSearchHandler<T> {
      *         {@link NouveauLuceneAwareDatabaseConnector#searchView}.
      */
     private @NonNull List<String> buildQueryFromRestrictions(
-            @NonNull Map<String, String> restrictions
+            @NonNull Map<String, Set<String>> restrictions
     ) {
         List<String> parts = new ArrayList<>();
         for (var entry : restrictions.entrySet()) {
             String fieldName = entry.getKey();
-            String filterValue = entry.getValue();
-            if (CommonUtils.isNullEmptyOrWhitespace(filterValue)) {
-                continue;
-            }
+            Set<String> filterValue = entry.getValue();
             parts.add(createFieldQueryRestriction(fieldName, filterValue));
         }
         return parts;
@@ -730,10 +710,10 @@ public abstract class BaseNouveauSearchHandler<T> {
      * @return List of queries
      */
     private @NonNull @Unmodifiable List<String> createComplexQuery(
-            @NonNull Map<String, Map<String, String>> subQueryRestrictions
+            @NonNull Map<String, Map<String, Set<String>>> subQueryRestrictions
     ) {
         List<String> subQueries = new ArrayList<>();
-        for (Map.Entry<String, Map<String, String>> restriction : subQueryRestrictions.entrySet()) {
+        for (Map.Entry<String, Map<String, Set<String>>> restriction : subQueryRestrictions.entrySet()) {
             boolean isPlural = restriction.getValue().size() > 1;
             String query = switch (restriction.getKey()) {
                 case "OR" -> buildQueryFromRestrictionsWithOr(restriction.getValue());
@@ -762,7 +742,7 @@ public abstract class BaseNouveauSearchHandler<T> {
      *         {@link NouveauLuceneAwareDatabaseConnector#searchView}.
      */
     private @NonNull String buildQueryFromRestrictionsWithAnd(
-            @NonNull Map<String, String> restrictions
+            @NonNull Map<String, Set<String>> restrictions
     ) {
         return AND.join(buildQueryFromRestrictions(restrictions));
     }
@@ -777,7 +757,7 @@ public abstract class BaseNouveauSearchHandler<T> {
      *         {@link NouveauLuceneAwareDatabaseConnector#searchView}.
      */
     private @NonNull String buildQueryFromRestrictionsWithOr(
-            @NonNull Map<String, String> restrictions
+            @NonNull Map<String, Set<String>> restrictions
     ) {
         return OR.join(buildQueryFromRestrictions(restrictions));
     }
@@ -796,40 +776,58 @@ public abstract class BaseNouveauSearchHandler<T> {
      * </ol>
      * </p>
      */
-    private String createFieldQueryRestriction(String fieldName, String filterValue) {
-        // Empty-aware: must query the _exact sub-field (the base field is not indexed)
-        if (emptyAwareFields.contains(fieldName)
-                && SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(filterValue)) {
-            return fieldName + "_exact:\"" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "\"";
-        }
-
-        String sanitized = sanitizeLuceneString(filterValue);
-        boolean quoted = NouveauLuceneAwareDatabaseConnector.isValidQuotedPhrase(filterValue);
-        String baseSearch = "(" + fieldName + (quoted ? ":" : ":\"") + sanitized + (quoted ? "" : "\"") + ")";
-
-        if (tieredFields.contains(fieldName)) {
-            if (!quoted) {
-                return "(" + NouveauLuceneAwareDatabaseConnector.buildFieldQuery(
-                        fieldName + "_exact", fieldName + "_ngram", filterValue, true) + ")";
+    private String createFieldQueryRestriction(String fieldName, Set<String> filterValues) {
+        List<String> queries = new ArrayList<>();
+        for (String filterValue : filterValues) {
+            // Empty-aware: must query the _exact sub-field (the base field is not indexed)
+            if (emptyAwareFields.contains(fieldName)
+                    && SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(filterValue)) {
+                queries.add(fieldName + "_exact:\"" + SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN + "\"");
+                continue;
             }
-            // Quoted input -> exact sort-field look-up (keyword field stores lowercased value)
-            return "(" + fieldName + "_sort:" + sanitized.toLowerCase(Locale.ROOT) + ")";
-        }
 
-        if (dateFields.contains(fieldName)) {
-            try {
-                return "(" + fieldName + ":" + NouveauLuceneAwareDatabaseConnector
-                        .formatDateNouveauFormat(filterValue.trim()) + ")";
-            } catch (ParseException e) {
-                return baseSearch;
+            String sanitized = sanitizeLuceneString(filterValue);
+            boolean quoted = NouveauLuceneAwareDatabaseConnector.isValidQuotedPhrase(filterValue);
+            String baseSearch = "(" + fieldName + (quoted ? ":" : ":\"") + sanitized + (quoted ? "" : "\"") + ")";
+
+            if (tieredFields.contains(fieldName)) {
+                if (!quoted) {
+                    queries.add("(" + NouveauLuceneAwareDatabaseConnector.buildFieldQuery(
+                            fieldName + "_exact", fieldName + "_ngram", filterValue, true) + ")");
+                    continue;
+                }
+                // Quoted input -> exact sort-field look-up (keyword field stores lowercased value)
+                queries.add("(" + fieldName + "_sort:" + sanitized.toLowerCase(Locale.ROOT) + ")");
+                continue;
             }
+
+            if (dateFields.contains(fieldName)) {
+                try {
+                    queries.add("(" + fieldName + ":" + NouveauLuceneAwareDatabaseConnector
+                            .formatDateNouveauFormat(filterValue.trim()) + ")");
+                    continue;
+                } catch (ParseException e) {
+                    queries.add(baseSearch);
+                    continue;
+                }
+            }
+
+            if (defaultFields.contains(fieldName)) {
+                queries.add("( " + convertToFreeSearch(filterValue) + " )");
+                continue;
+            }
+            queries.add(baseSearch);
         }
 
-        if (defaultFields.contains(fieldName)) {
-            return "( " + convertToFreeSearch(filterValue) + " )";
+        StringBuilder query = new StringBuilder();
+        if (queries.size() > 1) {
+            query.append("(");
+            query.append(String.join(") OR (", queries));
+            query.append(")");
+        } else {
+            query.append(queries.getFirst());
         }
-
-        return baseSearch;
+        return query.toString();
     }
 
     // -------------------------------------------------------------------------

--- a/libraries/datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/datahandler/src/main/thrift/moderation.thrift
@@ -92,6 +92,17 @@ struct ModerationRequest {
 
 }
 
+enum ModerationSortColumn {
+    BY_SCORE = 1,
+    BY_DOCUMENT_NAME = 2,
+    BY_DOCUMENT_TYPE = 3,
+    BY_COMPONENT_TYPE = 4,
+    BY_REQUESTING_USER = 5,
+    BY_MODERATION_STATE = 6,
+    BY_REQUESTING_USER_DEPT = 7,
+    BY_TIMESTAMP = 8,
+}
+
 service ModerationService {
 
     /**
@@ -338,12 +349,12 @@ service ModerationService {
     /**
      * search moderation requests in database that match subQueryRestrictions
      **/
-    list<ModerationRequest> refineSearch(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: PaginationData pageData);
+    list<ModerationRequest> refineSearch(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: PaginationData pageData, 4: User sw360User);
 
     /**
      * search moderation requests in database that match subQueryRestrictions without lucene search
      **/
-    list<ModerationRequest> searchModerationRequestsByExactValues(1: map<string, set<string>> subQueryRestrictions, 2: PaginationData pageData);
+    list<ModerationRequest> searchModerationRequestsByExactValues(1: map<string, set<string>> subQueryRestrictions, 2: PaginationData pageData, 3: User sw360User);
 
     /**
      * get count of moderation requests by moderation state

--- a/libraries/datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/datahandler/src/main/thrift/moderation.thrift
@@ -255,11 +255,6 @@ service ModerationService {
     oneway void deleteRequestsOnDocument(1: string documentId);
 
     /**
-     * get list of moderation requests where user is one of the moderators
-     **/
-    list<ModerationRequest> getRequestsByModerator(1: User user);
-
-    /**
      * Get list of moderation requests where user is one of the moderator with pagination.
      **/
     list<ModerationRequest> getRequestsByModeratorWithPaginationNoFilter(1: User user, 2: PaginationData pageData);
@@ -349,12 +344,12 @@ service ModerationService {
     /**
      * search moderation requests in database that match subQueryRestrictions
      **/
-    list<ModerationRequest> refineSearch(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: PaginationData pageData, 4: User sw360User);
+    map<PaginationData, list<ModerationRequest>> refineSearch(1: map<string, set<string>> subQueryRestrictions, 2: PaginationData pageData, 3: User sw360User);
 
     /**
      * search moderation requests in database that match subQueryRestrictions without lucene search
      **/
-    list<ModerationRequest> searchModerationRequestsByExactValues(1: map<string, set<string>> subQueryRestrictions, 2: PaginationData pageData, 3: User sw360User);
+    map<PaginationData, list<ModerationRequest>> searchModerationRequestsByExactValues(1: map<string, set<string>> subQueryRestrictions, 2: PaginationData pageData, 3: User sw360User);
 
     /**
      * get count of moderation requests by moderation state

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -27,7 +27,6 @@ import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
-import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
@@ -81,7 +80,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService.isOpenModerationRequest;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -139,13 +137,17 @@ public class ModerationRequestController implements RepresentationModelProcessor
             @RequestParam(value = "requestingUser", required = false) String requestingUser,
             @Parameter(description = "The requesting user's department")
             @RequestParam(value = "requestingUserDepartment", required = false) String requestingUserDepartment,
-            @Parameter(description = "The state of the request")
-            @RequestParam(value = "moderationState", required = false) String moderationState,
-            @Parameter(description = "Date request was created on (YYYY-MM-DD).",
+            @Parameter(
+                    description = "The state of the request.",
+                    schema = @Schema(allowableValues = {"open", "closed", "all"}, defaultValue = "all")
+            )
+            @RequestParam(value = "moderationState", defaultValue = "all") String moderationState,
+            @Parameter(description = "Date request was created on (YYYY-MM-DD)." +
+                    "Supported formats: exact (`=`) as `YYYY-MM-DD` (example: `2026-06-30`) and between as range `[YYYY-MM-DD TO YYYY-MM-DD]` (example: `[2026-06-29 TO 2026-06-30]`). To get a less-than-or-equal (`<=`), use `1970-01-01` as start of range and for greater-than-or-equal (`>=`), use `9999-01-01` as end date (example: `[2026-06-30 TO 9999-01-01]`).",
                     schema = @Schema(type = "string", format = "date"))
             @RequestParam(value = "requestDate", required = false) String requestDate,
-            @Parameter(description = "List requests by lucene search, default false")
-            @RequestParam(value = "luceneSearch", required = false, defaultValue = "false") boolean luceneSearch,
+            @Parameter(description = "List requests by lucene search, default true")
+            @RequestParam(value = "luceneSearch", required = false, defaultValue = "true") boolean luceneSearch,
             @Parameter(description = "Moderators , as a comma separated list.")
             @RequestParam(value = "moderators", required = false) String moderators,
             @Parameter(description = "Fetch all details of the moderation request")
@@ -153,23 +155,17 @@ public class ModerationRequestController implements RepresentationModelProcessor
     ) throws TException, ResourceClassNotFoundException, URISyntaxException, PaginationParameterException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
-        List<ModerationRequest> moderationRequests = new ArrayList<>();
+        Map<PaginationData, List<ModerationRequest>> paginatedMRs = null;
         Map<String, Set<String>> filterMap = getFilterMap(documentType, documentName, requestingUser,
             requestingUserDepartment, moderationState, requestDate, moderators);
 
         if (luceneSearch) {
-            moderationRequests = sw360ModerationRequestService.refineSearch(filterMap, pageable, sw360User);
+            paginatedMRs = sw360ModerationRequestService.refineSearch(filterMap, pageable, sw360User);
         } else {
-            moderationRequests = sw360ModerationRequestService.searchModerationRequestsByExactValues(filterMap, pageable, sw360User);
+            paginatedMRs = sw360ModerationRequestService.searchModerationRequestsByExactValues(filterMap, pageable, sw360User);
         }
 
-        Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData =
-                new HashMap<>();
-        PaginationData paginationData = new PaginationData();
-        paginationData.setTotalRowCount(sw360ModerationRequestService.getTotalCountByModerationStateAndRequestingUser(sw360User,sw360User));
-        modRequestsWithPageData.put(paginationData, moderationRequests);
-
-        return getModerationResponseEntity(pageable, request, allDetails, modRequestsWithPageData);
+        return getModerationResponseEntity(pageable, request, allDetails, paginatedMRs);
     }
 
     /**
@@ -194,10 +190,18 @@ public class ModerationRequestController implements RepresentationModelProcessor
             filterMap.put(ModerationRequest._Fields.REQUESTING_USER_DEPARTMENT.getFieldName(), CommonUtils.splitToSet(requestingUserDepartment));
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(moderationState)) {
-            filterMap.put(ModerationRequest._Fields.MODERATION_STATE.getFieldName(), CommonUtils.splitToSet(moderationState));
+            if ("open".equalsIgnoreCase(moderationState)) {
+                filterMap.put(ModerationRequest._Fields.MODERATION_STATE.getFieldName(), Set.of(
+                        ModerationState.PENDING.name(), ModerationState.INPROGRESS.name()
+                ));
+            } else if ("closed".equalsIgnoreCase(moderationState)) {
+                filterMap.put(ModerationRequest._Fields.MODERATION_STATE.getFieldName(), Set.of(
+                        ModerationState.APPROVED.name(), ModerationState.REJECTED.name()
+                ));
+            }
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(requestDate)) {
-            filterMap.put(ModerationRequest._Fields.TIMESTAMP.getFieldName(), CommonUtils.splitToSet(requestDate));
+            filterMap.put(ModerationRequest._Fields.TIMESTAMP.getFieldName(), Collections.singleton(requestDate));
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(moderators)) {
             filterMap.put(ModerationRequest._Fields.MODERATORS.getFieldName(), CommonUtils.splitToSet(moderators));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.thrift.TException;
@@ -90,6 +91,10 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "ModerationRequests", description = "Operations related to moderation requests on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`score`, " +
+        "`documentName`, `documentType`, `componentType`, `moderationState`, `requestingUser`, " +
+        "`requestDate` or `requestingUserDepartment`].")
 public class ModerationRequestController implements RepresentationModelProcessor<RepositoryLinksResource> {
 
     private static final String REVIEWER = "reviewer";
@@ -153,24 +158,9 @@ public class ModerationRequestController implements RepresentationModelProcessor
             requestingUserDepartment, moderationState, requestDate, moderators);
 
         if (luceneSearch) {
-            String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
-            String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
-            addFilterValue(filterMap, moderatorKey, sw360User.getEmail());
-            addFilterValue(filterMap, requestingUserKey, sw360User.getEmail());
-
-            if (filterMap.containsKey(ModerationRequest._Fields.DOCUMENT_NAME.getFieldName())) {
-                Set<String> values = filterMap.get(ModerationRequest._Fields.DOCUMENT_NAME.getFieldName()).stream()
-                        .map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
-                        .collect(Collectors.toSet());
-                filterMap.put(Project._Fields.NAME.getFieldName(), values);
-            }
-            moderationRequests = sw360ModerationRequestService.refineSearch(filterMap, pageable);
+            moderationRequests = sw360ModerationRequestService.refineSearch(filterMap, pageable, sw360User);
         } else {
-            String moderatorKey = ModerationRequest._Fields.MODERATORS.getFieldName();
-            String requestingUserKey = ModerationRequest._Fields.REQUESTING_USER.getFieldName();
-            addFilterValue(filterMap, moderatorKey, sw360User.getEmail());
-            addFilterValue(filterMap, requestingUserKey, sw360User.getEmail());
-            moderationRequests = sw360ModerationRequestService.searchModerationRequestsByExactValues(filterMap, pageable);
+            moderationRequests = sw360ModerationRequestService.searchModerationRequestsByExactValues(filterMap, pageable, sw360User);
         }
 
         Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData =
@@ -213,13 +203,6 @@ public class ModerationRequestController implements RepresentationModelProcessor
             filterMap.put(ModerationRequest._Fields.MODERATORS.getFieldName(), CommonUtils.splitToSet(moderators));
         }
         return filterMap;
-    }
-
-    private void addFilterValue(Map<String, Set<String>> filterMap, String key, String value) {
-        Set<String> existingValues = filterMap.get(key);
-        Set<String> mutableValues = existingValues == null ? new HashSet<>() : new HashSet<>(existingValues);
-        mutableValues.add(value);
-        filterMap.put(key, mutableValues);
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
@@ -30,15 +30,19 @@ import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationSortColumn;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformationService;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxdocument.SPDXDocumentService;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformationService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
+import org.eclipse.sw360.datahandler.thrift.users.UserSortColumn;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -46,6 +50,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.security.InvalidParameterException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +142,7 @@ public class Sw360ModerationRequestService {
      * @throws TException Exception in case of error.
      */
     public List<ModerationRequest> getRequestsByModerator(User sw360User, Pageable pageable) throws TException {
-        PaginationData pageData = pageableToPaginationData(pageable);
+        PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_TIMESTAMP, false);
         return getThriftModerationClient().getRequestsByModeratorWithPaginationNoFilter(sw360User, pageData);
     }
 
@@ -150,9 +155,10 @@ public class Sw360ModerationRequestService {
      * @return Paginated list of moderation requests.
      * @throws TException Exception in case of error.
      */
-    public List<ModerationRequest> searchModerationRequestsByExactValues(Map<String, Set<String>> filterMap, Pageable pageable) throws TException {
-        PaginationData pageData = pageableToPaginationData(pageable);
-        return getThriftModerationClient().searchModerationRequestsByExactValues(filterMap, pageData);
+    public List<ModerationRequest> searchModerationRequestsByExactValues(
+            Map<String, Set<String>> filterMap, Pageable pageable, User sw360User) throws TException {
+        PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_TIMESTAMP, false);
+        return getThriftModerationClient().searchModerationRequestsByExactValues(filterMap, pageData, sw360User);
     }
 
     /**
@@ -165,7 +171,7 @@ public class Sw360ModerationRequestService {
     public Map<PaginationData, List<ModerationRequest>> getRequestsByRequestingUser(
             User sw360User, Pageable pageable
     ) throws TException {
-        PaginationData pageData = pageableToPaginationData(pageable);
+        PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_TIMESTAMP, false);
         ModerationService.Iface client = getThriftModerationClient();
 
         List<ModerationRequest> moderationList = client.
@@ -215,12 +221,38 @@ public class Sw360ModerationRequestService {
      * @param pageable Pageable from request
      * @return Converted PaginationData
      */
-    private static @NotNull PaginationData pageableToPaginationData(@NotNull Pageable pageable) {
-        PaginationData pageData = new PaginationData();
-        pageData.setRowsPerPage(pageable.getPageSize());
-        pageData.setDisplayStart((int) pageable.getOffset());
-        pageData.setSortColumnNumber(-1);
-        return pageData;
+    private static @NotNull PaginationData pageableToPaginationData(
+            @NotNull Pageable pageable, ModerationSortColumn defaultSort, Boolean defaultAscending
+    ) {
+        ModerationSortColumn column = ModerationSortColumn.BY_TIMESTAMP;
+        boolean ascending = true;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            column = switch (property) {
+                case "documentName" -> ModerationSortColumn.BY_DOCUMENT_NAME;
+                case "documentType" -> ModerationSortColumn.BY_DOCUMENT_TYPE;
+                case "componentType" -> ModerationSortColumn.BY_COMPONENT_TYPE;
+                case "moderationState" -> ModerationSortColumn.BY_MODERATION_STATE;
+                case "requestingUser" -> ModerationSortColumn.BY_REQUESTING_USER;
+                case "requestingUserDepartment" -> ModerationSortColumn.BY_REQUESTING_USER_DEPT;
+                case "score" -> ModerationSortColumn.BY_SCORE;
+                case "requestDate" -> ModerationSortColumn.BY_TIMESTAMP;
+                default -> column;
+            };
+            ascending = order.isAscending();
+        } else {
+            if (defaultSort != null) {
+                column = defaultSort;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
+        }
+
+        return new PaginationData().setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize()).setSortColumnNumber(column.getValue()).setAscending(ascending);
     }
 
     /**
@@ -236,7 +268,7 @@ public class Sw360ModerationRequestService {
      */
     public Map<PaginationData, List<ModerationRequest>> getRequestsByState(User sw360user, Pageable pageable,
                                                                            boolean open, boolean allDetails) throws TException {
-        PaginationData pageData = pageableToPaginationData(pageable);
+        PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_TIMESTAMP, false);
         ModerationService.Iface client = getThriftModerationClient();
         Map<PaginationData, List<ModerationRequest>> moderationData;
         if (allDetails) {
@@ -532,8 +564,8 @@ public class Sw360ModerationRequestService {
      * @return List<ModerationRequest> the list of moderation requests
      * @throws TException if Thrift communication fails
      */
-    public List<ModerationRequest> refineSearch(Map<String, Set<String>> filterMap, Pageable pageable) throws TException {
-        PaginationData pageData = pageableToPaginationData(pageable);
-        return getThriftModerationClient().refineSearch(null, filterMap, pageData);
+    public List<ModerationRequest> refineSearch(Map<String, Set<String>> filterMap, Pageable pageable, User sw360User) throws TException {
+        PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_SCORE, false);
+        return getThriftModerationClient().refineSearch(null, filterMap, pageData, sw360User);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
@@ -25,7 +25,6 @@ import org.eclipse.sw360.datahandler.thrift.RemoveModeratorRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
-import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -33,13 +32,10 @@ import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationSortColumn;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformationService;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxdocument.SPDXDocumentService;
 import org.eclipse.sw360.datahandler.thrift.spdx.spdxpackageinfo.PackageInformationService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.datahandler.thrift.users.UserService;
-import org.eclipse.sw360.datahandler.thrift.users.UserSortColumn;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -50,7 +46,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.security.InvalidParameterException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,15 +80,12 @@ public class Sw360ModerationRequestService {
         return ThriftClients.makeSPDXClient();
     }
 
-    private DocumentCreationInformationService.Iface getThriftDocumentCreationInfo()  throws TTransportException {
+    private DocumentCreationInformationService.Iface getThriftDocumentCreationInfo() {
         return ThriftClients.makeSPDXDocumentInfoClient();
     }
 
-    private PackageInformationService.Iface getThriftPackageInfo()  throws TTransportException {
+    private PackageInformationService.Iface getThriftPackageInfo() {
         return ThriftClients.makeSPDXPackageInfoClient();
-    }
-    private UserService.Iface getThriftUserClient() throws TTransportException {
-        return ThriftClients.makeUserClient();
     }
 
     /**
@@ -131,21 +123,6 @@ public class Sw360ModerationRequestService {
         return moderationRequest;
     }
 
-
-    /**
-     * Get paginated list of moderation requests where user is one of the
-     * moderators.
-     *
-     * @param sw360User Moderator
-     * @param pageable  Pageable information from request
-     * @return Paginated list of moderation requests.
-     * @throws TException Exception in case of error.
-     */
-    public List<ModerationRequest> getRequestsByModerator(User sw360User, Pageable pageable) throws TException {
-        PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_TIMESTAMP, false);
-        return getThriftModerationClient().getRequestsByModeratorWithPaginationNoFilter(sw360User, pageData);
-    }
-
     /**
      * Get paginated list of moderation requests based on search parameters provided by users
      * without lucene search
@@ -155,7 +132,7 @@ public class Sw360ModerationRequestService {
      * @return Paginated list of moderation requests.
      * @throws TException Exception in case of error.
      */
-    public List<ModerationRequest> searchModerationRequestsByExactValues(
+    public Map<PaginationData, List<ModerationRequest>> searchModerationRequestsByExactValues(
             Map<String, Set<String>> filterMap, Pageable pageable, User sw360User) throws TException {
         PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_TIMESTAMP, false);
         return getThriftModerationClient().searchModerationRequestsByExactValues(filterMap, pageData, sw360User);
@@ -182,37 +159,6 @@ public class Sw360ModerationRequestService {
         Map<PaginationData, List<ModerationRequest>> result = new HashMap<>();
         result.put(pageData, moderationList);
         return result;
-    }
-
-    /**
-     * Get total count of moderation requests with user as a moderator.
-     *
-     * @param sw360User Moderator
-     * @return Count of moderation requests
-     * @throws TException Throws exception in case of error
-     */
-    public long getTotalCountOfRequests(User sw360User) throws TException {
-        Map<String, Long> countInfo = getThriftModerationClient().getCountByModerationState(sw360User);
-        long totalCount = 0;
-        totalCount += countInfo.getOrDefault("OPEN", 0L);
-        totalCount += countInfo.getOrDefault("CLOSED", 0L);
-        return totalCount;
-    }
-
-    /**
-     * Get total count of moderation requests with user as a moderator and specific requesting user.
-     *
-     * @param moderator Moderator
-     * @param requestingUser Requesting user
-     * @return Count of moderation requests
-     * @throws TException Throws exception in case of error
-     */
-    public long getTotalCountByModerationStateAndRequestingUser(User moderator, User requestingUser) throws TException {
-        Map<String, Long> countInfo = getThriftModerationClient().getCountByModerationStateAndRequestingUser(moderator, requestingUser);
-        long totalCount = 0L;
-        totalCount += countInfo.getOrDefault("OPEN", 0L);
-        totalCount += countInfo.getOrDefault("CLOSED", 0L);
-        return totalCount;
     }
 
     /**
@@ -393,25 +339,6 @@ public class Sw360ModerationRequestService {
         return new User(request.getId(), request.getModerators().toString());
     }
 
-    public User getUserByEmail(String email) {
-        try {
-            UserService.Iface sw360UserClient = getThriftUserClient();
-            return sw360UserClient.getByEmail(email);
-        } catch (TException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public User getUserByEmailOrExternalId(org.eclipse.sw360.datahandler.thrift.users.UserService.Iface userClient,
-            String userIdentifier, String string) {
-        try {
-            UserService.Iface sw360UserClient = getThriftUserClient();
-            return sw360UserClient.getByEmailOrExternalId(userIdentifier, userIdentifier);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     /**
      * Set moderation state of the moderation request to REJECTED
      *
@@ -507,7 +434,7 @@ public class Sw360ModerationRequestService {
 
     public RequestStatus deleteModerationRequestInfo(@NotNull User sw360User, @NotNull String id,
 			@NotNull ModerationRequest moderationRequest)
-            throws TTransportException, TException {
+            throws TException {
         RequestStatus requestStatus = null;
         Set<String> moderators = moderationRequest.getModerators();
         String requestingUser = moderationRequest.getRequestingUser();
@@ -564,8 +491,10 @@ public class Sw360ModerationRequestService {
      * @return List<ModerationRequest> the list of moderation requests
      * @throws TException if Thrift communication fails
      */
-    public List<ModerationRequest> refineSearch(Map<String, Set<String>> filterMap, Pageable pageable, User sw360User) throws TException {
+    public Map<PaginationData, List<ModerationRequest>> refineSearch(
+            Map<String, Set<String>> filterMap, Pageable pageable, User sw360User
+    ) throws TException {
         PaginationData pageData = pageableToPaginationData(pageable, ModerationSortColumn.BY_SCORE, false);
-        return getThriftModerationClient().refineSearch(null, filterMap, pageData, sw360User);
+        return getThriftModerationClient().refineSearch(filterMap, pageData, sw360User);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
@@ -31,8 +31,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -438,8 +441,12 @@ public class ModerationRequestTest extends TestIntegrationBase {
 
     @Test
     public void should_list_moderation_requests_empty_page() throws IOException, TException {
-        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(java.util.List.of());
-        given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(0L);
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(0).setDisplayStart(0).setTotalRowCount(0),
+                        List.of()
+                )
+        );
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);
@@ -454,17 +461,22 @@ public class ModerationRequestTest extends TestIntegrationBase {
         assertTrue(response.getBody() != null && response.getBody().contains("_embedded"));
     }
 
-        @Test
-        public void should_search_moderation_requests_with_exact_filters() throws IOException, TException {
+    @Test
+    public void should_search_moderation_requests_with_exact_filters() throws IOException, TException {
         ModerationRequest mrSearch = new ModerationRequest(openMr);
         mrSearch.setId("MR-S1");
         given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any()))
-            .willReturn(new java.util.ArrayList<>(java.util.List.of(mrSearch)));
+            .willReturn(
+                    Collections.singletonMap(
+                            new PaginationData().setRowsPerPage(10).setDisplayStart(0).setTotalRowCount(1),
+                            new ArrayList<>(List.of(mrSearch))
+                    )
+            );
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
-            "http://localhost:" + port + "/api/moderationrequest?type=RELEASE&documentName=Release%201&requestingUser=admin@sw360.org&requestingUserDepartment=DEPT&moderationState=INPROGRESS&requestDate=2026-01-01&moderators=admin@sw360.org&page=0&page_entries=10",
+            "http://localhost:" + port + "/api/moderationrequest?type=RELEASE&documentName=Release%201&requestingUser=admin@sw360.org&requestingUserDepartment=DEPT&moderationState=INPROGRESS&requestDate=2026-01-01&moderators=admin@sw360.org&page=0&page_entries=10&luceneSearch=false",
             HttpMethod.GET,
             request,
             String.class
@@ -472,14 +484,19 @@ public class ModerationRequestTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertTrue(response.getBody() != null && response.getBody().contains("MR-S1"));
-        }
+    }
 
-        @Test
-        public void should_search_moderation_requests_with_lucene() throws IOException, TException {
+    @Test
+    public void should_search_moderation_requests_with_lucene() throws IOException, TException {
         ModerationRequest mrSearch = new ModerationRequest(openMr);
         mrSearch.setId("MR-L1");
         given(moderationServiceMock.refineSearch(any(), any(), any()))
-            .willReturn(new java.util.ArrayList<>(java.util.List.of(mrSearch)));
+            .willReturn(
+                    Collections.singletonMap(
+                            new PaginationData().setRowsPerPage(10).setDisplayStart(0).setTotalRowCount(1),
+                            new ArrayList<>(List.of(mrSearch))
+                    )
+            );
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);
@@ -492,7 +509,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertTrue(response.getBody() != null && response.getBody().contains("MR-L1"));
-        }
+    }
 
     @Test
     public void should_error_on_invalid_state() throws IOException, TException {
@@ -561,13 +578,17 @@ public class ModerationRequestTest extends TestIntegrationBase {
         mr2.setId("MR-3");
         java.util.List<ModerationRequest> list = new java.util.ArrayList<>(java.util.List.of(mr1, mr2));
 
-        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(list);
-        given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(2L);
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(20).setDisplayStart(0).setTotalRowCount(list.size()),
+                        list
+                )
+        );
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
-                "http://localhost:" + port + "/api/moderationrequest?allDetails=true&page=0&page_entries=20",
+                "http://localhost:" + port + "/api/moderationrequest?allDetails=true&page=0&page_entries=20&luceneSearch=false",
                 HttpMethod.GET,
                 request,
                 String.class
@@ -601,13 +622,17 @@ public class ModerationRequestTest extends TestIntegrationBase {
         dupMr.setDocumentCreationInfoAdditions(new org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformation().setId("DC1"));
         dupMr.setDocumentCreationInfoDeletions(new org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformation().setId("DC1"));
 
-        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(new java.util.ArrayList<>(java.util.List.of(dupMr)));
-        given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(1L);
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(
+                Collections.singletonMap(
+                        new PaginationData().setRowsPerPage(10).setDisplayStart(0).setTotalRowCount(1),
+                        new ArrayList<>(List.of(dupMr))
+                )
+        );
 
         HttpHeaders headers = getHeaders(port);
         HttpEntity<Void> request = new HttpEntity<>(headers);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
-                "http://localhost:" + port + "/api/moderationrequest?allDetails=true&page=0&page_entries=20",
+                "http://localhost:" + port + "/api/moderationrequest?allDetails=true&page=0&page_entries=20&luceneSearch=false",
                 HttpMethod.GET,
                 request,
                 String.class

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ModerationRequestTest.java
@@ -438,7 +438,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
 
     @Test
     public void should_list_moderation_requests_empty_page() throws IOException, TException {
-        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any())).willReturn(java.util.List.of());
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(java.util.List.of());
         given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(0L);
 
         HttpHeaders headers = getHeaders(port);
@@ -458,7 +458,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         public void should_search_moderation_requests_with_exact_filters() throws IOException, TException {
         ModerationRequest mrSearch = new ModerationRequest(openMr);
         mrSearch.setId("MR-S1");
-        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any()))
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any()))
             .willReturn(new java.util.ArrayList<>(java.util.List.of(mrSearch)));
 
         HttpHeaders headers = getHeaders(port);
@@ -478,7 +478,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         public void should_search_moderation_requests_with_lucene() throws IOException, TException {
         ModerationRequest mrSearch = new ModerationRequest(openMr);
         mrSearch.setId("MR-L1");
-        given(moderationServiceMock.refineSearch(any(), any()))
+        given(moderationServiceMock.refineSearch(any(), any(), any()))
             .willReturn(new java.util.ArrayList<>(java.util.List.of(mrSearch)));
 
         HttpHeaders headers = getHeaders(port);
@@ -561,7 +561,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         mr2.setId("MR-3");
         java.util.List<ModerationRequest> list = new java.util.ArrayList<>(java.util.List.of(mr1, mr2));
 
-        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any())).willReturn(list);
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(list);
         given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(2L);
 
         HttpHeaders headers = getHeaders(port);
@@ -601,7 +601,7 @@ public class ModerationRequestTest extends TestIntegrationBase {
         dupMr.setDocumentCreationInfoAdditions(new org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformation().setId("DC1"));
         dupMr.setDocumentCreationInfoDeletions(new org.eclipse.sw360.datahandler.thrift.spdx.documentcreationinformation.DocumentCreationInformation().setId("DC1"));
 
-        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any())).willReturn(new java.util.ArrayList<>(java.util.List.of(dupMr)));
+        given(moderationServiceMock.searchModerationRequestsByExactValues(any(), any(), any())).willReturn(new java.util.ArrayList<>(java.util.List.of(dupMr)));
         given(moderationServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn(1L);
 
         HttpHeaders headers = getHeaders(port);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
@@ -172,14 +172,23 @@ public class ModerationRequestSpecTest extends TestRestDocsSpecBase {
         given(this.releaseServiceMock.getReleaseForUserById(eq(moderationRequest.getDocumentId()), any())).willReturn(releaseAdditions);
         given(this.userServiceMock.getUserByEmail(moderationRequest.getRequestingUser())).willReturn(new User("test.admin@sw360.org", "DEPT").setId("12345"));
         given(this.userServiceMock.getUserByEmailOrExternalId(testUserId)).willReturn(user);
-        given(this.moderationRequestServiceMock.getTotalCountByModerationStateAndRequestingUser(any(), any())).willReturn((long) moderationRequests.size());
         given(this.moderationRequestServiceMock.getModerationRequestById(eq(moderationRequest.getId()))).willReturn(moderationRequest);
         given(this.moderationRequestServiceMock.getRequestsByState(any(), any(), eq(false), anyBoolean())).willReturn(requestsByState);
         given(this.moderationRequestServiceMock.acceptRequest(eq(moderationRequest), eq("Changes looks good."), any())).willReturn(ModerationState.APPROVED);
         given(this.moderationRequestServiceMock.assignRequest(eq(moderationRequest), any())).willReturn(ModerationState.INPROGRESS);
         given(this.moderationRequestServiceMock.getRequestsByRequestingUser(any(), any())).willReturn(requestsByState);
-                given(this.moderationRequestServiceMock.searchModerationRequestsByExactValues(anyMap(), any(), any())).willReturn(new ArrayList<>(moderationRequests));
-                given(this.moderationRequestServiceMock.refineSearch(anyMap(), any(), any())).willReturn(new ArrayList<>(moderationRequests));
+                given(this.moderationRequestServiceMock.searchModerationRequestsByExactValues(anyMap(), any(), any())).willReturn(
+                        Collections.singletonMap(
+                                new PaginationData().setRowsPerPage(moderationRequests.size()).setDisplayStart(0).setTotalRowCount(moderationRequests.size()),
+                                new ArrayList<>(moderationRequests)
+                        )
+                );
+                given(this.moderationRequestServiceMock.refineSearch(anyMap(), any(), any())).willReturn(
+                        Collections.singletonMap(
+                                new PaginationData().setRowsPerPage(moderationRequests.size()).setDisplayStart(0).setTotalRowCount(moderationRequests.size()),
+                                new ArrayList<>(moderationRequests)
+                        )
+                );
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ModerationRequestSpecTest.java
@@ -178,8 +178,8 @@ public class ModerationRequestSpecTest extends TestRestDocsSpecBase {
         given(this.moderationRequestServiceMock.acceptRequest(eq(moderationRequest), eq("Changes looks good."), any())).willReturn(ModerationState.APPROVED);
         given(this.moderationRequestServiceMock.assignRequest(eq(moderationRequest), any())).willReturn(ModerationState.INPROGRESS);
         given(this.moderationRequestServiceMock.getRequestsByRequestingUser(any(), any())).willReturn(requestsByState);
-                given(this.moderationRequestServiceMock.searchModerationRequestsByExactValues(anyMap(), any())).willReturn(new ArrayList<>(moderationRequests));
-                given(this.moderationRequestServiceMock.refineSearch(anyMap(), any())).willReturn(new ArrayList<>(moderationRequests));
+                given(this.moderationRequestServiceMock.searchModerationRequestsByExactValues(anyMap(), any(), any())).willReturn(new ArrayList<>(moderationRequests));
+                given(this.moderationRequestServiceMock.refineSearch(anyMap(), any(), any())).willReturn(new ArrayList<>(moderationRequests));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Description
- Moved moderation request search to new infra.
- Add sort functionality.

### How To Test?
Make a curl request to the ```GET /moderationrequest``` endpoint and ensure only relevant results are found.
```
curl -X 'GET' \
  'http://localhost:8080/resource/api/moderationrequest?page=0&page_entries=10&sort=name%2Cdesc&type=RELEASE&luceneSearch=true' \
  -H 'accept: application/vnd.hal+json' \
  -H 'Authorization: Basic abc'
```

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
