### PR TITLE
feat(search): structure for complex queries

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -177,7 +178,7 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
     // -------------------------------------------------------------------------
 
     @Override
-    protected List<String> mapSortColumn(int sortColumnNumber) {
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
         String revDir = "-";
         return switch (ComponentSortColumn.findByValue(sortColumnNumber)) {
             case ComponentSortColumn.BY_NAME -> List.of("name_sort", revDir + "createdOn");

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
-import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
 public class ObligationSearchHandler extends BaseNouveauSearchHandler<Obligation> {
@@ -84,15 +82,31 @@ public class ObligationSearchHandler extends BaseNouveauSearchHandler<Obligation
     public Map<PaginationData, List<Obligation>> searchWithPagination(
             String searchText, ObligationLevel obligationLevel, PaginationData pageData
     ) {
-        Map<String, Set<String>> subQueryRestrictions = new HashMap<>();
+        Map<String, Map<String, Set<String>>> restrictions = new HashMap<>();
+
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
-            subQueryRestrictions.put(Obligation._Fields.TITLE.getFieldName(), Collections.singleton(searchText));
-            subQueryRestrictions.put(Obligation._Fields.TEXT.getFieldName(), Collections.singleton(searchText));
+            Map<String, Set<String>> textFilter = new HashMap<>();
+
+            textFilter.put(
+                    Obligation._Fields.TITLE.getFieldName(),
+                    Collections.singleton(searchText));
+            textFilter.put(
+                    Obligation._Fields.TEXT.getFieldName(),
+                    Collections.singleton(searchText));
+
+            restrictions.put("OR", textFilter);
         }
         if (obligationLevel != null) {
-            subQueryRestrictions.put(Obligation._Fields.OBLIGATION_LEVEL.getFieldName(), Collections.singleton(obligationLevel.toString()));
+            Map<String, Set<String>> levelFilter = new HashMap<>();
+            levelFilter.put(
+                    Obligation._Fields.OBLIGATION_LEVEL.getFieldName(),
+                    Collections.singleton(obligationLevel.toString())
+            );
+
+            restrictions.put("AND", levelFilter);
         }
-        return baseSearchWithOr(connector, subQueryRestrictions, pageData);
+
+        return complexBaseSearch(connector, restrictions, AND, pageData);
     }
 
     @Override

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationSortColumn;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -110,7 +111,7 @@ public class ObligationSearchHandler extends BaseNouveauSearchHandler<Obligation
     }
 
     @Override
-    protected List<String> mapSortColumn(int sortColumnNumber) {
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
         return switch (ObligationSortColumn.findByValue(sortColumnNumber)) {
             case ObligationSortColumn.BY_TITLE -> List.of("title_sort", SCORE_SORTING_FIELD, "text_sort");
             case ObligationSortColumn.BY_TEXT -> List.of("text_sort", SCORE_SORTING_FIELD, "title_sort");

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -204,7 +205,7 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
     // -------------------------------------------------------------------------
 
     @Override
-    protected List<String> mapSortColumn(int sortColumnNumber) {
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
         String revDir = "-";
         return switch (ProjectSortColumn.findByValue(sortColumnNumber)) {
             case ProjectSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -167,7 +168,7 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
     // -------------------------------------------------------------------------
 
     @Override
-    protected List<String> mapSortColumn(int sortColumnNumber) {
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
         String revDir = "-";
         return switch (ReleaseSortColumn.findByValue(sortColumnNumber)) {
             case ReleaseSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/UserSearchHandler.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseCo
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserSortColumn;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -140,7 +141,7 @@ public class UserSearchHandler extends BaseNouveauSearchHandler<User> {
      * Similar to ProjectSearchHandler pattern.
      */
     @Override
-    protected List<String> mapSortColumn(int sortColumnNumber) {
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
         return switch (UserSortColumn.findByValue(sortColumnNumber)) {
             case UserSortColumn.BY_GIVENNAME -> List.of("givenname_sort", "lastname_sort", "email_sort");
             case UserSortColumn.BY_LASTNAME -> List.of("lastname_sort", "givenname_sort", "email_sort");
@@ -154,4 +155,3 @@ public class UserSearchHandler extends BaseNouveauSearchHandler<User> {
     }
 
 }
-

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VendorSearchHandler.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseCo
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorSortColumn;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -124,7 +125,7 @@ public class VendorSearchHandler extends BaseNouveauSearchHandler<Vendor> {
     // -------------------------------------------------------------------------
 
     @Override
-    protected List<String> mapSortColumn(int sortColumnNumber) {
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
         return switch (VendorSortColumn.findByValue(sortColumnNumber)) {
             case VendorSortColumn.BY_FULLNAME -> List.of("fullname_sort", "shortname_sort");
             case VendorSortColumn.BY_SHORTNAME -> List.of("shortname_sort", "fullname_sort");

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
@@ -10,22 +10,15 @@
 package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.gson.Gson;
 import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
-import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
-import org.eclipse.sw360.datahandler.thrift.projects.Project;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilitySortColumn;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
+import org.jspecify.annotations.NonNull;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
 /**
@@ -122,7 +114,7 @@ public class VulnerabilitySearchHandler extends BaseNouveauSearchHandler<Vulnera
     }
 
     @Override
-    protected List<String> mapSortColumn(int sortColumnNumber) {
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
         String revDir = "-";
         return switch (VulnerabilitySortColumn.findByValue(sortColumnNumber)) {
             case VulnerabilitySortColumn.BY_EXTERNALID -> List.of("externalId_sort", revDir + "lastUpdateDate");

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -874,5 +874,5 @@ public abstract class BaseNouveauSearchHandler<T> {
      * }</pre>
      * </p>
      */
-    protected abstract List<String> mapSortColumn(int sortColumnNumber);
+    protected abstract @NonNull @Unmodifiable List<String> mapSortColumn(int sortColumnNumber);
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -35,6 +34,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_DATE_AS_DOUBLE;
@@ -90,8 +90,9 @@ public abstract class BaseNouveauSearchHandler<T> {
      */
     public static final int EDGE_NGRAM_SHORT_MAX_LENGTH = 10;
 
-    private static final Joiner AND = Joiner.on(" AND ");
-    private static final Joiner OR = Joiner.on(" OR ");
+    protected static final Joiner AND = Joiner.on(" AND ");
+    protected static final Joiner OR = Joiner.on(" OR ");
+    protected static final Joiner SPACE = Joiner.on(" ");
 
     /**
      * Built index definition that bundles the generated index function with derived
@@ -538,10 +539,12 @@ public abstract class BaseNouveauSearchHandler<T> {
             PaginationData pageData
     ) {
         List<String> sortColumns = getSortColumns(pageData);
-        Map<String, String> simplified = new HashMap<>();
-        for (var restriction : subQueryRestrictions.entrySet()) {
-            simplified.put(restriction.getKey(), String.join(" ", restriction.getValue()));
-        }
+        Map<String, String> simplified = subQueryRestrictions.entrySet()
+                .parallelStream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> SPACE.join(e.getValue())
+                ));
 
         String query = queryGenerator.apply(simplified);
         Map<PaginationData, List<T>> result = connector.searchView(
@@ -590,6 +593,69 @@ public abstract class BaseNouveauSearchHandler<T> {
     }
 
     /**
+     * Perform a complex search with the provided field restrictions and
+     * pagination. The function helps generate results where query needs to
+     * contain {@code AND} or {@code OR} joiners.
+     *
+     * <p>
+     * Provide the restrictions in format
+     * <pre>
+     * {@code
+     * {
+     *   "OR": {
+     *     "field1": "val1",
+     *     "field2": "val1"
+     *   },
+     *   "AND": {
+     *     "field3": "val2",
+     *     "field4": "val3"
+     *   }
+     * }
+     * }
+     * </pre>
+     * </p>
+     *
+     * <p>
+     * If the {@code joiner} is {@code AND}, then final query sent to Nouveau
+     * will be:
+     * {@code (field1:"val1" OR field2:"val1") AND (field3:"val2" AND field4:"val3")}
+     * </p>
+     *
+     * @param connector Nouveau Aware DB Connector to use.
+     * @param complexQueryRestrictions Complex map of field names to their accepted values.
+     * @param joiner    How to join the query parts?
+     * @param pageData  Pagination information.
+     * @return Paginated search results.
+     */
+    protected final @NonNull @Unmodifiable Map<PaginationData, List<T>> complexBaseSearch(
+            @NonNull NouveauLuceneAwareDatabaseConnector connector,
+            final @NonNull Map<String, Map<String, Set<String>>> complexQueryRestrictions,
+            final @NonNull Joiner joiner,
+            PaginationData pageData
+    ) {
+        List<String> sortColumns = getSortColumns(pageData);
+        Map<String, Map<String, String>> simplified = complexQueryRestrictions
+                .entrySet()
+                .parallelStream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().entrySet().stream()
+                                .collect(Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        innerEntry -> SPACE.join(innerEntry.getValue())
+                                ))
+                ));
+
+        String query = joiner.join(createComplexQuery(simplified));
+
+        Map<PaginationData, List<T>> result = connector.searchView(
+                clazz, luceneSearchView.getIndexName(), query, pageData, sortColumns);
+        PaginationData respPageData = result.keySet().iterator().next();
+        List<T> items = result.values().iterator().next();
+        return Collections.singletonMap(respPageData, items);
+    }
+
+    /**
      * Simple text search (no pagination) - sanitises the input before forwarding to the connector.
      */
     public final List<T> search(
@@ -630,6 +696,60 @@ public abstract class BaseNouveauSearchHandler<T> {
             parts.add(createFieldQueryRestriction(fieldName, filterValue));
         }
         return parts;
+    }
+
+    /**
+     * Create query for complex scenarios based on "OR" or "AND" keys for Nouveau queries.
+     * For example input like bellow:<br />
+     * <pre>
+     * {@code
+     * {
+     *   "OR": {
+     *     "field1": "val1",
+     *     "field2": "val1"
+     *   },
+     *   "AND": {
+     *     "field3": "val2"
+     *   }
+     * }
+     * }
+     * </pre>
+     * You will get the output:
+     * <pre>
+     * {@code
+     * List<String> query = [
+     *   "(( field1:"val1" ) OR ( field2:"val1" ))",
+     *   "( field3:"val2" )"
+     * ]
+     * }
+     * </pre>
+     * This can later be joined using another joiner like and to get final query:
+     * {@code (( field1:"val1" ) OR ( field2:"val1" )) AND
+     *  ( field3:"val2" )}
+     * @param subQueryRestrictions Restrictions with joiner. See description for example.
+     * @return List of queries
+     */
+    private @NonNull @Unmodifiable List<String> createComplexQuery(
+            @NonNull Map<String, Map<String, String>> subQueryRestrictions
+    ) {
+        List<String> subQueries = new ArrayList<>();
+        for (Map.Entry<String, Map<String, String>> restriction : subQueryRestrictions.entrySet()) {
+            boolean isPlural = restriction.getValue().size() > 1;
+            String query = switch (restriction.getKey()) {
+                case "OR" -> buildQueryFromRestrictionsWithOr(restriction.getValue());
+                case "AND" -> buildQueryFromRestrictionsWithAnd(restriction.getValue());
+                default -> null;
+            };
+            if (query == null) {
+                continue;
+            }
+            if (isPlural) {
+                subQueries.add("(" + query + ")");
+            } else {
+                subQueries.add(query);
+            }
+        }
+        return subQueries;
     }
 
     /**

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -896,6 +896,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
      * @return List of queries
      * @param <T> Class for which filtering
      */
+    @Deprecated
     public static <T> @NotNull List<String> createComplexQuery(
             Class<T> type, String text,
             @NotNull Map<String, Map<String, Set<String>>> subQueryRestrictions
@@ -985,6 +986,7 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
         return "( " + OR.join(queryParts) + " ) ";
     }
 
+    @Deprecated
     public static @NotNull String prepareWildcardQuery(@NotNull String query) {
         // Note: Nouveau does NOT support leading wildcards (*term), only trailing (term*)
         //


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

1. Provide structure to perform complex Nouveau queries which can contain fields which are OR'd or AND'd together.
2. Revert the search behavior of ObligationSearchHandler to the Complex queries as before.