### PR TITLE
feat(license): nouveau search migration for licenses endpoint

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/LicenseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/LicenseSearchHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import com.ibm.cloud.cloudant.v1.Cloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseSortColumn;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
+
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+
+public class LicenseSearchHandler extends BaseNouveauSearchHandler<License> {
+
+    private static final List<IndexField> LICENSE_FIELDS = List.of(
+            IndexField.standard("fullname"),
+            IndexField.standard("shortname")
+    );
+
+    private static final Map<String, String> LICENSE_CUSTOM_ANALYZERS = Map.of(
+            "id", "keyword"
+    );
+
+    private static final String LICENSE_CUSTOM_JS = INDEX_ID_FIELD;
+
+    private static final BuiltIndexDefinition LICENSE_INDEX_DEFINITION = buildIndexFunction(
+            "license",
+            "",
+            LICENSE_FIELDS,
+            LICENSE_CUSTOM_JS,
+            LICENSE_CUSTOM_ANALYZERS,
+            "standard"
+    );
+
+    private final NouveauLuceneAwareDatabaseConnector connector;
+
+    public LicenseSearchHandler(Cloudant cClient, String dbName) throws IOException {
+        super(License.class, "licenses", LICENSE_INDEX_DEFINITION);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(cClient, dbName);
+        connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
+        setup(connector, db);
+    }
+
+    public Map<PaginationData, List<License>> searchWithPagination(String searchText, PaginationData pageData) {
+        if (isNullEmptyOrWhitespace(searchText)) {
+            return connector.searchView(License.class, getIndexName(), "*:*", pageData, getSortColumns(pageData));
+        }
+
+        Map<String, Set<String>> subQueryRestrictions = Map.of(
+                License._Fields.FULLNAME.getFieldName(), Collections.singleton(searchText.trim()),
+                License._Fields.SHORTNAME.getFieldName(), Collections.singleton(searchText.trim())
+        );
+        return baseSearchWithOr(connector, subQueryRestrictions, pageData);
+    }
+
+    @Override
+    protected List<String> mapSortColumn(int sortColumnNumber) {
+        return switch (LicenseSortColumn.findByValue(sortColumnNumber)) {
+            case LicenseSortColumn.BY_FULLNAME  -> List.of("fullname_sort", SCORE_SORTING_FIELD, "id_sort");
+            case LicenseSortColumn.BY_SHORTNAME -> List.of("shortname_sort", SCORE_SORTING_FIELD, "fullname_sort");
+            case null, default                  -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+}

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/LicenseSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/LicenseSearchHandlerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseSortColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LicenseSearchHandlerTest {
+
+    private static final String MATCH_ALL_QUERY = "*:*";
+
+    /**
+     * Mirror of {@code LicenseSearchHandler.mapSortColumn()} for unit-level
+     * testing without requiring a CouchDB connection.
+     */
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        return switch (LicenseSortColumn.findByValue(sortColumnNumber)) {
+            case LicenseSortColumn.BY_FULLNAME  -> List.of("fullname_sort", SCORE_SORTING_FIELD, "id_sort");
+            case LicenseSortColumn.BY_SHORTNAME -> List.of("shortname_sort", SCORE_SORTING_FIELD, "fullname_sort");
+            case null, default                  -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+
+    /**
+     * Mirrors the branch contract in LicenseSearchHandler.searchWithPagination:
+     * blank input uses a match-all query, non-blank input is trimmed.
+     */
+    private static String resolveQueryForPagination(String searchText) {
+        return isBlank(searchText) ? MATCH_ALL_QUERY : searchText.trim();
+    }
+
+    private static boolean isMatchAllSearch(String searchText) {
+        return MATCH_ALL_QUERY.equals(resolveQueryForPagination(searchText));
+    }
+
+    private static boolean isBlank(String value) {
+        return Optional.ofNullable(value).map(String::trim).orElse("").isEmpty();
+    }
+
+    @Test
+    void byFullName_shouldUseFullNameScoreIdOrder() {
+        assertEquals(
+                List.of("fullname_sort", SCORE_SORTING_FIELD, "id_sort"),
+                mapSortColumnDirect(LicenseSortColumn.BY_FULLNAME.getValue())
+        );
+    }
+
+    @Test
+    void byShortName_shouldUseShortNameScoreFullNameOrder() {
+        assertEquals(
+                List.of("shortname_sort", SCORE_SORTING_FIELD, "fullname_sort"),
+                mapSortColumnDirect(LicenseSortColumn.BY_SHORTNAME.getValue())
+        );
+    }
+
+    @Test
+    void byScore_shouldUseOnlyScoreField() {
+        assertEquals(
+                List.of(SCORE_SORTING_FIELD),
+                mapSortColumnDirect(LicenseSortColumn.BY_SCORE.getValue())
+        );
+    }
+
+    @Test
+    void unknownSort_shouldDefaultToScoreField() {
+        assertEquals(
+                List.of(SCORE_SORTING_FIELD),
+                mapSortColumnDirect(Integer.MAX_VALUE)
+        );
+    }
+
+    @Test
+    void allSortColumns_shouldProduceNonEmptySortDefinitions() {
+        for (LicenseSortColumn column : LicenseSortColumn.values()) {
+            List<String> sortColumns = mapSortColumnDirect(column.getValue());
+            assertNotNull(sortColumns);
+            assertFalse(sortColumns.isEmpty(), "Expected non-empty sort list for " + column);
+        }
+    }
+
+    @Test
+    void searchWithPagination_shouldUseMatchAllQuery_whenSearchTextBlank() {
+        assertTrue(isMatchAllSearch(null));
+        assertTrue(isMatchAllSearch(""));
+        assertTrue(isMatchAllSearch("   \t\n  "));
+        assertEquals(MATCH_ALL_QUERY, resolveQueryForPagination("   "));
+    }
+
+    @Test
+    void searchWithPagination_shouldTrimInput_whenSearchTextProvided() {
+        assertFalse(isMatchAllSearch("license"));
+        assertFalse(isMatchAllSearch("  license  "));
+        assertEquals("license", resolveQueryForPagination("  license  "));
+        assertEquals("Apache 2.0", resolveQueryForPagination("  Apache 2.0  "));
+    }
+}

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -52,7 +52,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.net.MalformedURLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.*;
@@ -104,7 +103,7 @@ public class LicenseDatabaseHandler {
     private String obligationText;
     private final Logger log = LogManager.getLogger(LicenseDatabaseHandler.class);
 
-    public LicenseDatabaseHandler(Cloudant client, String dbName) throws MalformedURLException {
+    public LicenseDatabaseHandler(Cloudant client, String dbName) {
         // Create the connector
         db = new DatabaseConnectorCloudant(client, dbName);
         DatabaseConnectorCloudant dbChangelogs = new DatabaseConnectorCloudant(client, DatabaseSettings.COUCH_DB_CHANGE_LOGS);
@@ -147,7 +146,7 @@ public class LicenseDatabaseHandler {
 
     }
 
-    private List<License> convertToLicenseSummary(List<License> licenses) {
+    public List<License> convertToLicenseSummary(List<License> licenses) {
         final List<LicenseType> licenseTypes = licenseTypeRepository.getAll();
         putLicenseTypesInLicenses(licenses, licenseTypes);
         /*Note that risks are not set here*/
@@ -1414,18 +1413,6 @@ public class LicenseDatabaseHandler {
 
     public List<LicenseType> searchByLicenseType(String licenseType) {
         return licenseTypeRepository.searchByLicenseType(licenseType);
-    }
-
-    /**
-     * Search license by shortname or name.
-     * @param searchText String to search.
-     * @return List of licenses.
-     */
-    public List<License> searchLicense(String searchText) {
-        Set<License> results = new HashSet<>();
-        results.addAll(licenseRepository.searchByName(searchText));
-        results.addAll(licenseRepository.searchByShortName(searchText));
-        return convertToLicenseSummary(results.stream().toList());
     }
 
     /**

--- a/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -15,6 +15,7 @@ import com.ibm.cloud.cloudant.v1.Cloudant;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.db.LicenseSearchHandler;
 import org.eclipse.sw360.datahandler.db.ObligationSearchHandler;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -31,10 +32,12 @@ import org.eclipse.sw360.datahandler.db.ObligationElementSearchHandler;
 import org.apache.thrift.TException;
 import java.nio.ByteBuffer;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.io.IOException;
+
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
 
@@ -48,15 +51,18 @@ public class LicenseHandler implements LicenseService.Iface {
     LicenseDatabaseHandler handler;
     ObligationElementSearchHandler searchHandler;
     ObligationSearchHandler obligationSearchHandler;
+    LicenseSearchHandler licenseSearchHandler;
 
     LicenseHandler() throws IOException {
         handler = new LicenseDatabaseHandler(DatabaseSettings.getConfiguredClient(), DatabaseSettings.COUCH_DB_DATABASE);
         searchHandler = new ObligationElementSearchHandler(DatabaseSettings.getConfiguredClient(), DatabaseSettings.COUCH_DB_DATABASE);
         obligationSearchHandler = new ObligationSearchHandler(DatabaseSettings.getConfiguredClient(), DatabaseSettings.COUCH_DB_DATABASE);
+        licenseSearchHandler = new LicenseSearchHandler(DatabaseSettings.getConfiguredClient(), DatabaseSettings.COUCH_DB_DATABASE);
     }
 
     LicenseHandler(Cloudant client, String dbName) throws IOException {
         handler = new LicenseDatabaseHandler(client, dbName);
+        licenseSearchHandler = new LicenseSearchHandler(client, dbName);
     }
 
     /////////////////////
@@ -398,11 +404,10 @@ public class LicenseHandler implements LicenseService.Iface {
     }
 
     @Override
-    public List<License> searchLicense(String searchText) {
-        if (CommonUtils.isNullEmptyOrWhitespace(searchText)) {
-            return handler.getLicenseSummary();
-        }
-        return handler.searchLicense(searchText);
+    public Map<PaginationData, List<License>> searchLicenseWithPagination(String searchText, PaginationData pageData) {
+        Map<PaginationData, List<License>> result = licenseSearchHandler.searchWithPagination(searchText, pageData);
+        Map.Entry<PaginationData, List<License>> page = result.entrySet().iterator().next();
+        return Collections.singletonMap(page.getKey(), handler.convertToLicenseSummary(page.getValue()));
     }
 
     @Override

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/NouveauLuceneAwareDatabaseConnector.java
@@ -119,26 +119,39 @@ public class NouveauLuceneAwareDatabaseConnector extends LuceneAwareCouchDbConne
     public boolean addDesignDoc(@NotNull NouveauDesignDocument designDocument)
             throws RuntimeException {
         NouveauDesignDocument documentFromDb = this.getNouveauDesignDocument(designDocument.getId());
-        if (documentFromDb == null) {
+        if (documentFromDb == null || (documentFromDb.getNouveau() == null && designDocument.getNouveau() != null)) {
+            // New design document or existing doc has no nouveau section yet.
+            // No merge checks required.
             return putNouveauDesignDocument(designDocument);
         }
 
-        AtomicBoolean indexMissMatched = new AtomicBoolean(false);
+        AtomicBoolean requiresUpdate = new AtomicBoolean(false);
         if (!designDocument.equals(documentFromDb)) {
             designDocument.setRev(documentFromDb.getRev());
-            if (documentFromDb.getNouveau() != null) {
+            if (designDocument.getNouveau() != null) {
+                // Adding a brand-new index key must persist the design doc.
+                designDocument.getNouveau().asMap().forEach((key, value) -> {
+                    if (!documentFromDb.getNouveau().has(key)) {
+                        requiresUpdate.set(true);
+                    }
+                });
+
                 // Add missing indexes from existing DDOC as to not overwrite them
                 // Check if any index definition exists but does not match
                 documentFromDb.getNouveau().asMap().forEach((key, value) -> {
                     if (! designDocument.getNouveau().has(key)) {
                         designDocument.getNouveau().add(key, value);
                     } else if (!designDocument.getNouveau().get(key).equals(value)) {
-                        indexMissMatched.set(true);
+                        requiresUpdate.set(true);
                     }
                 });
+            } else {
+                // Incoming design document has no nouveau section while DB has one.
+                // Do not overwrite existing indexes.
+                return true;
             }
-            if (!indexMissMatched.get()) {
-                // No miss-match found
+            if (!requiresUpdate.get()) {
+                // No changes required.
                 return true;
             }
             return putNouveauDesignDocument(designDocument);

--- a/libraries/datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/datahandler/src/main/thrift/licenses.thrift
@@ -49,6 +49,13 @@ enum ObligationElementStatus {
     UNDEFINED = 2
 }
 
+enum LicenseSortColumn {
+    BY_SCORE    = -2,
+    BY_FULLNAME =  0,
+    BY_SHORTNAME =  1,
+    BY_LICENSE_TYPE = 2
+}
+
 enum ObligationSortColumn {
     BY_SCORE = -2,
     BY_TITLE = 0,
@@ -391,9 +398,9 @@ service LicenseService {
     list<LicenseType> searchByLicenseType(1: string licenseType);
 
     /**
-     * Search licenses by shortname or fullname
+     * Search licenses by shortname or fullname with pagination.
      */
-    list<License> searchLicense(1: string searchText);
+    map<PaginationData, list<License>> searchLicenseWithPagination(1: string searchText, 2: PaginationData pageData);
 
     /**
      * Search obligations by title or text with pagination

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/LicenseController.java
@@ -37,6 +37,7 @@ import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundExceptio
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
@@ -82,6 +83,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @BasePathAwareController
@@ -90,6 +93,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Licenses", description = "Operations related to Licenses on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`score` (default for search), " +
+        "`fullName` (default for listing), `shortName`].")
 public class LicenseController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String LICENSES_URL = "/licenses";
     public static final String LICENSE_TYPES_URL = "/licenseTypes";
@@ -121,15 +127,20 @@ public class LicenseController implements RepresentationModelProcessor<Repositor
     ) throws TException, ResourceClassNotFoundException, PaginationParameterException, URISyntaxException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
-        List<License> sw360Licenses;
-
+        Map<PaginationData, List<License>> paginatedLicenses;
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
-            sw360Licenses = licenseService.searchLicenses(searchText);
+            paginatedLicenses = licenseService.searchLicenses(searchText.trim(), pageable);
         } else {
-            sw360Licenses = licenseService.getLicenses();
+            paginatedLicenses = licenseService.getLicensesWithPagination(pageable);
         }
 
-        PaginationResult<License> paginationResult = restControllerHelper.createPaginationResult(request, pageable, sw360Licenses, SW360Constants.TYPE_LICENSE);
+        Map.Entry<PaginationData, List<License>> licensePage = paginatedLicenses.entrySet().iterator().next();
+        List<License> sw360Licenses = new ArrayList<>(licensePage.getValue());
+        int totalCount = Math.toIntExact(licensePage.getKey().getTotalRowCount());
+
+        PaginationResult<License> paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                request, pageable, sw360Licenses, SW360Constants.TYPE_LICENSE, totalCount);
+
         List<EntityModel<License>> licenseResources = new ArrayList<>();
         paginationResult.getResources()
                 .forEach(license -> {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/license/Sw360LicenseService.java
@@ -20,10 +20,12 @@ import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
+import org.eclipse.sw360.datahandler.thrift.licenses.LicenseSortColumn;
 import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
@@ -37,6 +39,8 @@ import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -47,6 +51,7 @@ import java.util.*;
 import java.util.zip.ZipOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 
@@ -54,11 +59,16 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhit
 @RequiredArgsConstructor
 public class Sw360LicenseService {
     private static final String CONTENT_TYPE = "application/zip";
-    LicenseType lType = new LicenseType();
 
     public List<License> getLicenses() throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
         return sw360LicenseClient.getLicenseSummary();
+    }
+
+    public Map<PaginationData, List<License>> getLicensesWithPagination(Pageable pageable) throws TException {
+        LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        PaginationData pageData = pageableToPaginationData(pageable, LicenseSortColumn.BY_FULLNAME, true);
+        return sw360LicenseClient.searchLicenseWithPagination("", pageData);
     }
 
     public License getLicenseById(String licenseId) throws TException {
@@ -92,7 +102,7 @@ public class Sw360LicenseService {
     public void deleteAllLicenseInfo(User user) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
         if (PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user)) {
-            RequestSummary deleteLicenseStatus = sw360LicenseClient.deleteAllLicenseInformation(user);
+            sw360LicenseClient.deleteAllLicenseInformation(user);
         } else {
             throw new BadRequestClientException("Unable to delete license. User is not admin");
         }
@@ -324,6 +334,7 @@ public class Sw360LicenseService {
 
     public RequestStatus addLicenseType(User sw360User, String licenseType, HttpServletRequest request) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
+        LicenseType lType = new LicenseType();
         if (StringUtils.isNotEmpty(licenseType)) {
             lType.setLicenseType(licenseType);
         } else {
@@ -407,16 +418,40 @@ public class Sw360LicenseService {
         }
     }
 
-    /**
-     * Search licenses for given text in fullname or shortname.
-     * @param searchText String to search.
-     * @return Sorted list of licenses.
-     * @throws TException If Thrift had issues.
-     */
-    public List<License> searchLicenses(String searchText) throws TException {
+    public Map<PaginationData, List<License>> searchLicenses(String searchText, Pageable pageable) throws TException {
         LicenseService.Iface sw360LicenseClient = getThriftLicenseClient();
-        List<License> licenses = sw360LicenseClient.searchLicense(searchText);
-        licenses.sort(Comparator.comparing(License::getFullname, String.CASE_INSENSITIVE_ORDER));
-        return licenses;
+        PaginationData pageData = pageableToPaginationData(pageable, LicenseSortColumn.BY_SCORE, false);
+        return sw360LicenseClient.searchLicenseWithPagination(searchText, pageData);
+    }
+
+    private static PaginationData pageableToPaginationData(@NotNull Pageable pageable,
+            LicenseSortColumn defaultColumn, Boolean defaultAscending) {
+        LicenseSortColumn column = LicenseSortColumn.BY_FULLNAME;
+        boolean ascending = true;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            column = switch (property) {
+                case "fullName" -> LicenseSortColumn.BY_FULLNAME;
+                case "shortName" -> LicenseSortColumn.BY_SHORTNAME;
+                case "score" -> LicenseSortColumn.BY_SCORE;
+                default -> column;
+            };
+            ascending = order.isAscending();
+        } else {
+            if (defaultColumn != null) {
+                column = defaultColumn;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
+        }
+
+        return new PaginationData()
+                .setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize())
+                .setSortColumnNumber(column.getValue())
+                .setAscending(ascending);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/LicenseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/LicenseTest.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
@@ -52,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -144,7 +146,15 @@ public class LicenseTest extends TestIntegrationBase {
         licenseList.add(license1);
         licenseList.add(license2);
 
+        PaginationData paginationData = new PaginationData()
+                .setDisplayStart(0)
+                .setRowsPerPage(5)
+                .setTotalRowCount(licenseList.size());
+        Map<PaginationData, List<License>> paginatedLicenseMap = Collections.singletonMap(paginationData, licenseList);
+
         given(this.licenseServiceMock.getLicenses()).willReturn(licenseList);
+        given(this.licenseServiceMock.getLicensesWithPagination(any())).willReturn(paginatedLicenseMap);
+        given(this.licenseServiceMock.searchLicenses(anyString(), any())).willReturn(paginatedLicenseMap);
         given(this.licenseServiceMock.getLicenseById(eq(license1.getId()))).willReturn(license1);
         given(this.licenseServiceMock.getLicenseById(eq(license2.getId()))).willReturn(license2);
         given(this.licenseServiceMock.createLicense(any(), any())).willReturn(license3);
@@ -468,7 +478,7 @@ public class LicenseTest extends TestIntegrationBase {
     public void should_handle_exception_in_get_licenses() throws IOException, TException {
         // Mock service to throw exception
         doThrow(new RuntimeException("Failed to get licenses"))
-                .when(licenseServiceMock).getLicenses();
+                .when(licenseServiceMock).getLicensesWithPagination(any());
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
@@ -84,6 +85,12 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         licenseList.add(license);
         licenseList.add(license2);
 
+        PaginationData paginationData = new PaginationData()
+                .setDisplayStart(0)
+                .setRowsPerPage(5)
+                .setTotalRowCount(licenseList.size());
+        Map<PaginationData, List<License>> paginatedLicenseMap = Collections.singletonMap(paginationData, licenseList);
+
         license3 = new License();
         license3.setId("Apache-3.0");
         license3.setShortname("Apache 3.0");
@@ -97,6 +104,8 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         licensetype.setType("xyz");
 
         given(this.licenseServiceMock.getLicenses()).willReturn(licenseList);
+        given(this.licenseServiceMock.getLicensesWithPagination(any())).willReturn(paginatedLicenseMap);
+        given(this.licenseServiceMock.searchLicenses(anyString(), any())).willReturn(paginatedLicenseMap);
         given(this.licenseServiceMock.getLicenseById(eq(license.getId()))).willReturn(license);
         given(this.licenseServiceMock.createLicense(any(), any())).willReturn(license3);
         given(this.licenseServiceMock.updateLicense(any(),any())).willReturn(RequestStatus.SUCCESS);


### PR DESCRIPTION
Description: Migrates the /api/licenses endpoint from the legacy CouchDB view-based search to CouchDB Nouveau (Lucene-backed) search, adding proper server-side pagination and sort support.

### Files Changed

| File | Change |
|------|--------|
| LicenseSearchHandler.java | New Nouveau license search handler. Defines license index schema and sort mapping, adds OR-based quick search by fullname/id/shortname, and adds searchWithPagination with match-all query for blank search text. |
| LicenseSearchHandlerTest.java | Unit test file for license Nouveau search behavior. Covers sort-column mapping plus the new pagination branch contract: blank search maps to match-all and non-blank search is trimmed. |
| LicenseDatabaseHandler.java | Removed LicenseSearchHandler dependency and removed DB-layer search/pagination orchestration methods. Keeps DB/repository responsibilities; exposes convertToLicenseSummary for handler-level orchestration. |
| LicenseHandler.java | Now owns LicenseSearchHandler and routes searchLicenseWithPagination through it, then converts results to license summaries. Removes legacy non-paginated searchLicense path. |
| licenses.thrift | Contains LicenseSortColumn enum and paginated searchLicenseWithPagination method. Legacy non-paginated searchLicense method removed. |
| NouveauLuceneAwareDatabaseConnector.java | addDesignDoc updated so a newly introduced index key is persisted into an existing design doc instead of being skipped. This is a shared Nouveau infrastructure fix, not license-only logic. |
| Sw360LicenseService.java | Provides getLicensesWithPagination and paginated searchLicenses(searchText, pageable). pageableToPaginationData aligned to ProjectService style and maps sort properties including licenseType and score. |
| LicenseController.java | Listing endpoint routes blank search to paginated list API and non-blank search to paginated quick-search API; OpenAPI tag text documents supported sort columns for paginated endpoints. |
