### PR TITLE
feat(Package): Migrate package search to nouveau infrastructure

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageDatabaseHandler.java
@@ -153,20 +153,12 @@ public class PackageDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return packageRepository.getOrphanPackage();
     }
 
-    public List<Package> searchPackages(PackageSearchHandler searchHandler, String searchText) {
-        return searchHandler.searchPackages(searchText);
-    }
-
-    public List<Package> searchPackagesWithFilter(String searchText, PackageSearchHandler searchHandler, Map<String,Set<String>> subQueryRestrictions) {
-        return searchHandler.searchPackagesWithRestrictions(searchText, subQueryRestrictions);
-    }
-
     public int getTotalPackageCount() {
         return packageRepository.getDocumentCount();
     }
 
     public List<Package> searchOrphanPackages(PackageSearchHandler searchHandler, String searchText) {
-        List<Package> packages = searchPackages(searchHandler, searchText);
+        List<Package> packages = searchHandler.search(searchText, Map.of());
         Predicate<Package> orphanReleaseFilter = pkg -> CommonUtils.isNullEmptyOrWhitespace(pkg.getReleaseId());
         return packages.stream().filter(orphanReleaseFilter).collect(Collectors.toList());
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens Healthineers GmBH, 2023. Part of the SW360 Portal Project.
+ * * Copyright Siemens Healthineers GmBH, 2023. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,93 +10,149 @@
 package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.google.gson.Gson;
+import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
+import org.eclipse.sw360.datahandler.thrift.packages.PackageSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.nouveau.designdocument.NouveauDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexDesignDocument;
-import org.eclipse.sw360.nouveau.designdocument.NouveauIndexFunction;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.eclipse.sw360.datahandler.common.SearchUtils.OBJ_ARRAY_TO_STRING_INDEX;
-import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector.prepareWildcardQuery;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
-public class PackageSearchHandler {
+/**
+ * Nouveau search handler for Packages.
+ *
+ * <p>Packages are access-controlled (per-user readable), therefore this
+ * handler keeps the legacy text based public API ({@link #search}) while
+ * delegating index construction and query routing to the shared
+ * {@link BaseNouveauSearchHandler} DSL infrastructure.</p>
+ */
+public class PackageSearchHandler extends BaseNouveauSearchHandler<Package> {
 
     private static final String DDOC_NAME = DEFAULT_DESIGN_PREFIX + "lucene";
 
-    private static final NouveauIndexDesignDocument luceneSearchView
-        = new NouveauIndexDesignDocument("packages",
-            new NouveauIndexFunction(
-                "function(doc) {" +
-                OBJ_ARRAY_TO_STRING_INDEX +
-                "    if (!doc.type || doc.type != 'package') return;" +
-                "    if (doc.name && typeof(doc.name) == 'string' && doc.name.length > 0) {" +
-                "      index('text', 'name', doc.name, {'store': true});"+
-                "    }" +
-                "    if (doc.version && typeof(doc.version) == 'string' && doc.version.length > 0) {" +
-                "      index('text', 'version', doc.version, {'store': true});"+
-                "    }" +
-                "    if (doc.purl && typeof(doc.purl) == 'string' && doc.purl.length > 0) {" +
-                "      index('text', 'purl', doc.purl, {'store': true});"+
-                "    }" +
-                "    if (doc.releaseId && typeof(doc.releaseId) == 'string' && doc.releaseId.length > 0) {" +
-                "      index('text', 'releaseId', doc.releaseId, {'store': true});"+
-                "    }" +
-                "    if (doc.vcs && typeof(doc.vcs) == 'string' && doc.vcs.length > 0) {" +
-                "      index('text', 'vcs', doc.vcs, {'store': true});"+
-                "    }" +
-                "    if (doc.packageManager && typeof(doc.packageManager) == 'string' && doc.packageManager.length > 0) {" +
-                "      index('text', 'packageManager', doc.packageManager, {'store': true});"+
-                "    }" +
-                "    if (doc.packageType && typeof(doc.packageType) == 'string' && doc.packageType.length > 0) {" +
-                "      index('text', 'packageType', doc.packageType, {'store': true});"+
-                "    }" +
-                "    if (doc.createdBy && typeof(doc.createdBy) == 'string' && doc.createdBy.length > 0) {" +
-                "      index('text', 'createdBy', doc.createdBy, {'store': true});"+
-                "    }" +
-                "    if(doc.createdOn && doc.createdOn.length) {"+
-                "      var dt = new Date(doc.createdOn);"+
-                "      var formattedDt = `${dt.getFullYear()}${(dt.getMonth()+1).toString().padStart(2,'0')}${dt.getDate().toString().padStart(2,'0')}`;" +
-                "      index('double', 'createdOn', Number(formattedDt), {'store': true});"+
-                "    }" +
-                "    arrayToStringIndex(doc.licenseIds, 'licenseIds');" +
-                "}"));
+    // -------------------------------------------------------------------------
+    //  Field spec declarations
+    // -------------------------------------------------------------------------
 
+    private static final List<IndexField> PACKAGE_FIELDS = List.of(
+            IndexField.standard("name"),
+            IndexField.standard("version"),
+            IndexField.standard("purl"),
+            IndexField.simple("packageManager", "keyword"),
+            IndexField.simple("packageType", "keyword"),
+            IndexField.simple("createdBy", "email"),
+            IndexField.simple("vcs"),
+            IndexField.simple("releaseId"),
+            IndexField.date("createdOn")
+    );
+
+    /**
+     * Package-specific JS for array-backed fields that should support text
+     * and sort lookups via arrayToStringIndex helper.
+     */
+    private static final String PACKAGE_CUSTOM_JS =
+            "    arrayToStringIndex(doc.licenseIds, 'licenseIds');" +
+            INDEX_ID_FIELD;
+
+    /**
+     * Analyzer overrides for fields created by {@code arrayToStringIndex}.
+     * The helper generates {@code <field>_sort} string indexes that require
+     * the {@code keyword} analyzer for correct sorting behavior.
+     */
+    private static final Map<String, String> PACKAGE_CUSTOM_ANALYZERS = Map.of(
+            "licenseIds_sort", "keyword",
+            "id", "keyword"
+    );
+
+    private static final BuiltIndexDefinition PACKAGE_INDEX_DEFINITION = buildIndexFunction(
+            "package",
+            SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN,
+            PACKAGE_FIELDS,
+            PACKAGE_CUSTOM_JS,
+            PACKAGE_CUSTOM_ANALYZERS,
+            "standard"
+    );
+
+    // -------------------------------------------------------------------------
+    //  Constructor
+    // -------------------------------------------------------------------------
 
     private final NouveauLuceneAwareDatabaseConnector connector;
 
-    public PackageSearchHandler(Cloudant client, String dbName) throws IOException {
-        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
+    private static final List<Package._Fields> QUICK_FILTER_FIELDS = List.of(
+            Package._Fields.ID,
+            Package._Fields.NAME,
+            Package._Fields.VERSION,
+            Package._Fields.PURL,
+            Package._Fields.PACKAGE_TYPE
+    );
+
+    public PackageSearchHandler(Cloudant cClient, String dbName) throws IOException {
+        super(Package.class, "packages", PACKAGE_INDEX_DEFINITION);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(cClient, dbName);
         connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
-        Gson gson = db.getInstance().getGson();
-        NouveauDesignDocument searchView = new NouveauDesignDocument();
-        searchView.setId(DDOC_NAME);
-        searchView.addNouveau(luceneSearchView, gson);
-        connector.addDesignDoc(searchView);
+        setup(connector, db);
     }
 
-    public List<Package> searchPackagesWithRestrictions(String text, final Map<String , Set<String>> subQueryRestrictions) {
-        return connector.searchViewWithRestrictionsWithAnd(Package.class, luceneSearchView.getIndexName(),
+    // -------------------------------------------------------------------------
+    //  Public search API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Paginated search with access control filtering.
+     */
+    public Map<PaginationData, List<Package>> searchAccessiblePackages(
+            final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        return baseSearch(connector, subQueryRestrictions, pageData);
+    }
+
+    /**
+     * Search Packages with id, name, version, purl, packageType, createdBy or createdOn fields.
+     */
+    public Map<PaginationData, List<Package>> searchFilteredPackages(
+            String searchText, User user, PaginationData pageData
+    ) {
+        Map<String, Set<String>> subQueryRestrictions = new HashMap<>();
+        for (Package._Fields field : QUICK_FILTER_FIELDS) {
+            subQueryRestrictions.put(field.getFieldName(), Collections.singleton(searchText));
+        }
+        return baseSearchWithOr(connector, subQueryRestrictions, pageData);
+    }
+
+    /**
+     * Non-paginated search (legacy callers).
+     */
+    public List<Package> search(String text, final Map<String, Set<String>> subQueryRestrictions) {
+        return connector.searchViewWithRestrictionsWithAnd(Package.class, getIndexName(),
                 text, subQueryRestrictions);
     }
 
-    public List<Package> searchPackages(String searchText) {
-        return connector.searchView(Package.class, luceneSearchView.getIndexName(),
-                prepareWildcardQuery(searchText));
-    }
+    // -------------------------------------------------------------------------
+    //  Sort column mapping
+    // -------------------------------------------------------------------------
 
-    public List<Package> searchAccessiblePackages(String text, final Map<String,
-            Set<String>> subQueryRestrictions, User user ){
-        List<Package> resultPackageList = connector.searchViewWithRestrictionsWithAnd(Package.class,
-                luceneSearchView.getIndexName(), text, subQueryRestrictions);
-        return resultPackageList;
+    @Override
+    protected @NonNull List<String> mapSortColumn(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (PackageSortColumn.findByValue(sortColumnNumber)) {
+            case PackageSortColumn.BY_NAME -> List.of("name_sort", revDir + "createdOn");
+            case PackageSortColumn.BY_VERSION -> List.of("version_sort", "name_sort", revDir + "createdOn");
+            case PackageSortColumn.BY_PACKAGE_MANAGER -> List.of("packageManager_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case PackageSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case null, default -> List.of(SCORE_SORTING_FIELD);
+        };
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/PackageSearchHandler.java
@@ -1,5 +1,5 @@
 /*
- * * Copyright Siemens Healthineers GmBH, 2023. Part of the SW360 Portal Project.
+ * Copyright Siemens Healthineers GmBH, 2023. Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@ package org.eclipse.sw360.datahandler.db;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -50,7 +51,7 @@ public class PackageSearchHandler extends BaseNouveauSearchHandler<Package> {
     private static final List<IndexField> PACKAGE_FIELDS = List.of(
             IndexField.standard("name"),
             IndexField.standard("version"),
-            IndexField.standard("purl"),
+            IndexField.standard("purl", 5, EDGE_NGRAM_MAX_LENGTH), // always starts with `pkg:`
             IndexField.simple("packageManager", "keyword"),
             IndexField.simple("packageType", "keyword"),
             IndexField.simple("createdBy", "email"),
@@ -116,6 +117,10 @@ public class PackageSearchHandler extends BaseNouveauSearchHandler<Package> {
      */
     public Map<PaginationData, List<Package>> searchAccessiblePackages(
             final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
+        if (CommonUtils.isNullOrEmptyMap(subQueryRestrictions)) {
+            return connector.searchView(Package.class,
+                    getIndexName(), "*:*", pageData, getSortColumns(pageData));
+        }
         return baseSearch(connector, subQueryRestrictions, pageData);
     }
 

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/PackageSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/PackageSearchHandlerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.packages.PackageSortColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PackageSearchHandlerTest {
+
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (PackageSortColumn.findByValue(sortColumnNumber)) {
+            case PackageSortColumn.BY_NAME -> List.of("name_sort", revDir + "createdOn");
+            case PackageSortColumn.BY_VERSION -> List.of("version_sort", "name_sort", revDir + "createdOn");
+            case PackageSortColumn.BY_PACKAGE_MANAGER -> List.of("packageManager_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
+            case PackageSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case null, default -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+
+    @Test
+    void byName_shouldReturnNameSortWithCreatedOnTiebreaker() {
+        List<String> columns = mapSortColumnDirect(PackageSortColumn.BY_NAME.getValue());
+        assertEquals(List.of("name_sort", "-createdOn"), columns);
+        assertFalse(columns.contains(SCORE_SORTING_FIELD));
+    }
+
+    @Test
+    void byVersion_shouldReturnVersionSortWithNameAndCreatedOnTiebreakers() {
+        assertEquals(List.of("version_sort", "name_sort", "-createdOn"),
+                mapSortColumnDirect(PackageSortColumn.BY_VERSION.getValue()));
+    }
+
+    @Test
+    void byPackageManager_shouldReturnPackageManagerSortWithTiebreakers() {
+        assertEquals(List.of("packageManager_sort", SCORE_SORTING_FIELD, "name_sort", "-createdOn"),
+                mapSortColumnDirect(PackageSortColumn.BY_PACKAGE_MANAGER.getValue()));
+    }
+
+    @Test
+    void byCreatedOn_shouldReturnOnlyCreatedOn() {
+        assertEquals(List.of("createdOn"), mapSortColumnDirect(PackageSortColumn.BY_CREATEDON.getValue()));
+    }
+
+    @Test
+    void byScore_shouldReturnOnlyScoreField() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(PackageSortColumn.BY_SCORE.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToScore() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(999));
+    }
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (PackageSortColumn column : PackageSortColumn.values()) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertNotNull(columns);
+            assertFalse(columns.isEmpty());
+        }
+    }
+
+    @Test
+    void nonPrimaryColumns_shouldHaveScoreAndNameTiebreakers() {
+        for (PackageSortColumn column : List.of(PackageSortColumn.BY_PACKAGE_MANAGER)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertTrue(columns.contains(SCORE_SORTING_FIELD), column + " missing score");
+            assertTrue(columns.contains("name_sort"), column + " missing name_sort");
+            assertTrue(columns.contains("-createdOn"), column + " missing -createdOn");
+        }
+    }
+
+    @Test
+    void nonPrimaryColumns_shouldHaveCorrectTiebreakerOrder() {
+        List<String> columns = mapSortColumnDirect(PackageSortColumn.BY_PACKAGE_MANAGER.getValue());
+        int scoreIdx = columns.indexOf(SCORE_SORTING_FIELD);
+        int nameIdx = columns.indexOf("name_sort");
+        int createdOnIdx = columns.indexOf("-createdOn");
+        assertTrue(scoreIdx < nameIdx, "score should come before name_sort");
+        assertTrue(nameIdx < createdOnIdx, "name_sort should come before -createdOn");
+    }
+}

--- a/backend/packages/src/main/java/org/eclipse/sw360/packages/PackageHandler.java
+++ b/backend/packages/src/main/java/org/eclipse/sw360/packages/PackageHandler.java
@@ -95,12 +95,6 @@ public class PackageHandler implements PackageService.Iface {
     }
 
     @Override
-    public Set<Package> getPackagesByReleaseIds(Set<String> ids) throws TException {
-        assertNotEmpty(ids);
-        return handler.getPackagesByReleaseIds(ids);
-    }
-
-    @Override
     public AddDocumentRequestSummary addPackage(Package pkg, User user) throws TException {
         assertNotNull(pkg);
         assertUser(user);

--- a/backend/packages/src/main/java/org/eclipse/sw360/packages/PackageHandler.java
+++ b/backend/packages/src/main/java/org/eclipse/sw360/packages/PackageHandler.java
@@ -78,7 +78,7 @@ public class PackageHandler implements PackageService.Iface {
     public List<Package> searchPackages(String text, User user) throws TException {
         assertUser(user);
         assertNotEmpty(text, "package search text cannot be empty");
-        return handler.searchPackages(packageSearchHandler, text);
+        return packageSearchHandler.search(text, Map.of());
     }
 
     @Override
@@ -128,7 +128,7 @@ public class PackageHandler implements PackageService.Iface {
 
     @Override
     public List<Package> searchPackagesWithFilter(String text, Map<String, Set<String>> subQueryRestrictions) throws TException {
-        return handler.searchPackagesWithFilter(text, packageSearchHandler, subQueryRestrictions);
+        return packageSearchHandler.search(text, subQueryRestrictions);
     }
 
     @Override
@@ -165,7 +165,15 @@ public class PackageHandler implements PackageService.Iface {
     }
 
     @Override
-    public List<Package> refineSearchAccessiblePackages(String text, Map<String,Set<String>> subQueryRestrictions, User user) throws TException {
-        return packageSearchHandler.searchAccessiblePackages(text, subQueryRestrictions, user);
+    public Map<PaginationData, List<Package>> refineSearchAccessiblePackages(Map<String,Set<String>> subQueryRestrictions, User user, PaginationData pageData) throws TException {
+        return packageSearchHandler.searchAccessiblePackages(subQueryRestrictions, user, pageData);
+    }
+
+    @Override
+    public Map<PaginationData, List<Package>> searchFilteredPackages(String searchText, User user, PaginationData pageData) throws TException {
+        if (searchText == null) {
+            searchText = "";
+        }
+        return packageSearchHandler.searchFilteredPackages(searchText, user, pageData);
     }
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -11,7 +11,6 @@ package org.eclipse.sw360.datahandler.cloudantclient;
 
 import com.google.common.base.Joiner;
 import com.google.gson.Gson;
-import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
@@ -34,7 +33,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.SearchUtils.EMIT_EDGE_N_GRAM_INDEX;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_DATE_AS_DOUBLE;

--- a/libraries/datahandler/src/main/thrift/package.thrift
+++ b/libraries/datahandler/src/main/thrift/package.thrift
@@ -88,6 +88,14 @@ enum PackageManager {
     YOCTO = 34
 }
 
+enum PackageSortColumn {
+    BY_SCORE = -2,
+    BY_CREATEDON = -1,
+    BY_NAME = 0,
+    BY_VERSION = 1,
+    BY_PACKAGE_MANAGER = 2,
+}
+
 service PackageService {
     /**
      * Get Package by Id
@@ -185,8 +193,22 @@ service PackageService {
     list<Package> searchByPurl(1: string purl);
 
     /**
-     * search packages in database that match subQueryRestrictions
+     * Paginated search for packages with multi-field filter map.
      */
-    list<Package> refineSearchAccessiblePackages(1: string text, 2: map<string, set<string>> subQueryRestrictions, 3: User user);
+    map<PaginationData, list<Package>> refineSearchAccessiblePackages(
+        1: map<string, set<string>> subQueryRestrictions,
+        2: User user,
+        3: PaginationData pageData
+    );
+
+    /**
+     * search Packages in database that match searchText in
+     * name, version, purl or id fields.
+     */
+    map<PaginationData, list<Package>> searchFilteredPackages(
+        1: string searchText,
+        2: User user,
+        3: PaginationData pageData
+    );
 
 }

--- a/libraries/datahandler/src/main/thrift/package.thrift
+++ b/libraries/datahandler/src/main/thrift/package.thrift
@@ -138,11 +138,6 @@ service PackageService {
     list<Package> searchOrphanPackages(1: string text, 2: User user);
 
     /**
-     * Get list of all the Package by list of release id
-     */
-    set<Package> getPackagesByReleaseIds(1: set<string> releaseIds) throws (1: SW360Exception exp);
-
-    /**
      * Get list of all the Package by release id
      */
     set<Package> getPackagesByReleaseId(1: string releaseId) throws (1: SW360Exception exp);
@@ -171,22 +166,22 @@ service PackageService {
      * total number of packages in the DB
      **/
     i32 getTotalPackagesCount();
-    
+
     /**
      * list of packages which match the `name`
      */
     list<Package> searchByName(1: string name);
-    
+
     /**
      * list of packages which match the `packageManager`
      */
     list<Package> searchByPackageManager(1: string pkgManager);
-    
+
     /**
      * list of packages which match the `version`
      */
     list<Package> searchByVersion(1: string version);
-    
+
     /**
      * list of packages which match the `purl`
      */

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
@@ -17,7 +17,6 @@ import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,16 +29,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
-import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
@@ -83,6 +83,9 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
+@Tag(name = "Packages", description = "Operations related to Packages on SW360 server.\n" +
+        "Endpoints with pagination can use column names: [`score` (default), " +
+        "`createdOn`, `name`, `version` or `packageManager`].")
 public class PackageController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String PACKAGES_URL = "/packages";
 
@@ -264,6 +267,9 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             @RequestParam(value = "allDetails", required = false) boolean allDetails,
             @Parameter(description = "Package which are not linked with any releases.")
             @RequestParam(value = "orphanPackage", required = false) boolean orphanPackage,
+                @Parameter(description = "A generic filter which searches [id, name, version, purl and packageType]." +
+                    " Note that this field should be used exclusive of other filters.")
+            @RequestParam(value = "searchText", required = false) String searchText,
             @Parameter(description = "Use lucenesearch to filter the packages.")
             @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
             HttpServletRequest request
@@ -271,15 +277,27 @@ public class PackageController implements RepresentationModelProcessor<Repositor
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
         List<Package> sw360Packages = new ArrayList<>();
+        PaginationResult<Package> paginationResult = null;
         Map<String, Set<String>> restrictions = getFilterMap(name, version, purl, packageManager, licenses, createdBy, createdOn);
-        if (luceneSearch) {
-            if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
-                Set<String> values = CommonUtils.splitToSet(name);
-                values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery)
-                        .collect(Collectors.toSet());
-                restrictions.put(Package._Fields.NAME.getFieldName(), values);
-            }
-            sw360Packages.addAll(packageService.refineSearch(restrictions, sw360User));
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) && !restrictions.isEmpty()) {
+            throw new BadRequestClientException("Use either only \"searchText\" or other filters, not both.");
+        }
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
+            Map<PaginationData, List<Package>> result = packageService.searchFilteredPackages(searchText, sw360User, pageable);
+            sw360Packages.addAll(result.values().iterator().next());
+            int totalCount = Math.toIntExact(result.keySet().stream()
+                .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));
+            paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                request, pageable, sw360Packages, SW360Constants.TYPE_PACKAGE, totalCount);
+        } else if (luceneSearch) {
+            Map<PaginationData, List<Package>> result = packageService.refineSearch(restrictions, sw360User, pageable);
+            sw360Packages.addAll(result.values().iterator().next());
+            int totalCount = Math.toIntExact(result.keySet().stream()
+                .findFirst().map(PaginationData::getTotalRowCount).orElse(0L));
+            paginationResult = restControllerHelper.paginationResultFromPaginatedList(
+                request, pageable, sw360Packages, SW360Constants.TYPE_PACKAGE, totalCount);
         } else {
             sw360Packages = packageService.getPackagesForUser();
             if (!restrictions.isEmpty()) {
@@ -287,7 +305,8 @@ public class PackageController implements RepresentationModelProcessor<Repositor
                         .filter(filterPackageMap(restrictions, orphanPackage)).toList());
             }
         }
-        return getPackageResponse(version, purl, packageManager, pageable, allDetails, request, sw360User, sw360Packages);
+        return getPackageResponse(version, purl, packageManager, pageable, allDetails, request,
+            sw360User, sw360Packages, paginationResult);
     }
 
     /**
@@ -304,10 +323,16 @@ public class PackageController implements RepresentationModelProcessor<Repositor
                 if (fieldValue == null) {
                     return false;
                 }
-                if (field == Package._Fields.NAME && !filterSet.contains(packages.name)) {
-                    return false;
-                } else if (field == Package._Fields.VERSION && !filterSet.contains(packages.version)) {
-                    return false;
+                if (field == Package._Fields.NAME) {
+                    String pkgName = packages.name.toLowerCase();
+                    boolean matched = filterSet.stream()
+                            .anyMatch(f -> pkgName.contains(f.toLowerCase()));
+                    if (!matched) return false;
+                } else if (field == Package._Fields.VERSION) {
+                    String pkgVersion = packages.version.toLowerCase();
+                    boolean matched = filterSet.stream()
+                            .anyMatch(f -> pkgVersion.contains(f.toLowerCase()));
+                    if (!matched) return false;
                 } else if ((field == Package._Fields.CREATED_BY || field == Package._Fields.CREATED_ON)
                         && !fieldValue.toString().equalsIgnoreCase(filterSet.iterator().next())) {
                     return false;
@@ -362,13 +387,16 @@ public class PackageController implements RepresentationModelProcessor<Repositor
     @NotNull
     private ResponseEntity<CollectionModel<EntityModel<Package>>> getPackageResponse(
             String version, String purl, String packageManager, Pageable pageable,
-            boolean allDetails, HttpServletRequest request, User sw360User, List<Package> sw360Packages
+            boolean allDetails, HttpServletRequest request, User sw360User, List<Package> sw360Packages,
+            PaginationResult<Package> paginationResult
     ) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException {
         Map<String, Package> mapOfPackages = new HashMap<>();
 
         sw360Packages.stream().forEach(pkg -> mapOfPackages.put(pkg.getId(), pkg));
-        PaginationResult<Package> paginationResult;
-        paginationResult = restControllerHelper.createPaginationResult(request, pageable, sw360Packages, SW360Constants.TYPE_PACKAGE);
+        if (paginationResult == null) {
+            paginationResult = restControllerHelper.createPaginationResult(request, pageable,
+                    sw360Packages, SW360Constants.TYPE_PACKAGE);
+        }
 
         List<EntityModel<Package>> packageResources = new ArrayList<>();
         Consumer<Package> consumer = p -> {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/PackageController.java
@@ -30,7 +30,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.commons.lang3.EnumUtils;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
@@ -43,10 +42,6 @@ import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
-import org.eclipse.sw360.datahandler.thrift.packages.PackageManager;
-import org.eclipse.sw360.datahandler.thrift.packages.PackageService;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
@@ -57,7 +52,6 @@ import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -270,8 +264,9 @@ public class PackageController implements RepresentationModelProcessor<Repositor
                 @Parameter(description = "A generic filter which searches [id, name, version, purl and packageType]." +
                     " Note that this field should be used exclusive of other filters.")
             @RequestParam(value = "searchText", required = false) String searchText,
-            @Parameter(description = "Use lucenesearch to filter the packages.")
-            @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
+            @Parameter(description = "Use lucenesearch to filter the packages.",
+                    schema = @Schema(implementation = Boolean.class, defaultValue = "true"))
+            @RequestParam(value = "luceneSearch", required = false, defaultValue = "true") boolean luceneSearch,
             HttpServletRequest request
     ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -305,8 +300,8 @@ public class PackageController implements RepresentationModelProcessor<Repositor
                         .filter(filterPackageMap(restrictions, orphanPackage)).toList());
             }
         }
-        return getPackageResponse(version, purl, packageManager, pageable, allDetails, request,
-            sw360User, sw360Packages, paginationResult);
+        return getPackageResponse(pageable, allDetails, request, sw360User,
+                sw360Packages, paginationResult);
     }
 
     /**
@@ -386,13 +381,10 @@ public class PackageController implements RepresentationModelProcessor<Repositor
 
     @NotNull
     private ResponseEntity<CollectionModel<EntityModel<Package>>> getPackageResponse(
-            String version, String purl, String packageManager, Pageable pageable,
-            boolean allDetails, HttpServletRequest request, User sw360User, List<Package> sw360Packages,
+            Pageable pageable, boolean allDetails, HttpServletRequest request,
+            User sw360User, List<Package> sw360Packages,
             PaginationResult<Package> paginationResult
     ) throws ResourceClassNotFoundException, PaginationParameterException, URISyntaxException {
-        Map<String, Package> mapOfPackages = new HashMap<>();
-
-        sw360Packages.stream().forEach(pkg -> mapOfPackages.put(pkg.getId(), pkg));
         if (paginationResult == null) {
             paginationResult = restControllerHelper.createPaginationResult(request, pageable,
                     sw360Packages, SW360Constants.TYPE_PACKAGE);
@@ -410,17 +402,11 @@ public class PackageController implements RepresentationModelProcessor<Repositor
                 } catch (TException e) {
                     throw new RuntimeException("Unable to create package resource: "+e.getMessage());
                 }
-                if (embeddedPackageResource == null) {
-                    return;
-                }
             }
             packageResources.add(embeddedPackageResource);
         };
 
-        paginationResult.getResources().stream()
-        .filter(pkg -> packageManager == null || packageManager.equals(pkg.getPackageManager().toString()))
-        .filter(pkg -> version == null || version.isEmpty() || version.equals(pkg.getVersion()))
-        .filter(pkg -> purl == null || purl.isEmpty() || purl.equals(pkg.getPurl())).forEach(consumer);
+        paginationResult.getResources().forEach(consumer);
 
         CollectionModel<EntityModel<Package>> resources;
         if (packageResources.isEmpty()) {
@@ -443,13 +429,13 @@ public class PackageController implements RepresentationModelProcessor<Repositor
     ) {
         Map<String, Set<String>> filterMap = new HashMap<>();
         if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
-            filterMap.put(Package._Fields.NAME.getFieldName(), CommonUtils.splitToSet(name));
+            filterMap.put(Package._Fields.NAME.getFieldName(), Collections.singleton(name));
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(version)) {
             filterMap.put(Package._Fields.VERSION.getFieldName(), CommonUtils.splitToSet(version));
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(purl)) {
-            filterMap.put(Package._Fields.PURL.getFieldName(), CommonUtils.splitToSet(purl));
+            filterMap.put(Package._Fields.PURL.getFieldName(), Collections.singleton(purl));
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(packageManager)) {
             filterMap.put(Package._Fields.PACKAGE_MANAGER.getFieldName(), CommonUtils.splitToSet(packageManager.toUpperCase()));
@@ -461,7 +447,7 @@ public class PackageController implements RepresentationModelProcessor<Repositor
             filterMap.put(Package._Fields.CREATED_BY.getFieldName(), CommonUtils.splitToSet(createdBy));
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(createdOn)) {
-            filterMap.put(Package._Fields.CREATED_ON.getFieldName(), CommonUtils.splitToSet(createdOn));
+            filterMap.put(Package._Fields.CREATED_ON.getFieldName(), Collections.singleton(createdOn));
         }
         return filterMap;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
@@ -9,17 +9,13 @@
  */
 package org.eclipse.sw360.rest.resourceserver.packages;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
-import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
-import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -121,24 +117,6 @@ public class SW360PackageService {
     public List<Package> getPackagesForUser() throws TException {
         PackageService.Iface sw360PackageClient = getThriftPackageClient();
         return sw360PackageClient.getAllPackages();
-    }
-
-    public List<Package> searchPackage(String field, String searchQuery, boolean isExactMatch) throws TException {
-        final PackageService.Iface sw360PackageClient = getThriftPackageClient();
-        Set<String> values = CommonUtils.splitToSet(searchQuery);
-
-        if (field.equals("name")) {
-            if (isExactMatch) {
-                values = values.stream().map(s -> "\"" + s + "\"").map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery).collect(Collectors.toSet());
-            }
-            else {
-                values = values.stream().map(NouveauLuceneAwareDatabaseConnector::prepareWildcardQuery).collect(Collectors.toSet());
-            }
-        }
-        Map<String, Set<String>> queryMap = new HashMap<>();
-
-        queryMap.put(field, values);
-        return sw360PackageClient.searchPackagesWithFilter(searchQuery, queryMap);
     }
 
     public List<Package> searchPackageByName(String name) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/packages/SW360PackageService.java
@@ -22,15 +22,20 @@ import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
 import org.eclipse.sw360.datahandler.thrift.packages.PackageService;
+import org.eclipse.sw360.datahandler.thrift.packages.PackageSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -162,8 +167,47 @@ public class SW360PackageService {
     }
 
 
-    public List<Package> refineSearch(Map<String, Set<String>> filterMap, User sw360User) throws TException {
+    public Map<PaginationData, List<Package>> refineSearch(Map<String, Set<String>> filterMap, User sw360User, Pageable pageable) throws TException {
         PackageService.Iface sw360PackageClient = getThriftPackageClient();
-        return sw360PackageClient.refineSearchAccessiblePackages(null, filterMap, sw360User);
+        PaginationData pageData = pageableToPaginationData(pageable, PackageSortColumn.BY_SCORE, true);
+        return sw360PackageClient.refineSearchAccessiblePackages(filterMap, sw360User, pageData);
+    }
+
+    public Map<PaginationData, List<Package>> searchFilteredPackages(String searchText, User sw360User, Pageable pageable) throws TException {
+        PackageService.Iface sw360PackageClient = getThriftPackageClient();
+        PaginationData pageData = pageableToPaginationData(pageable, PackageSortColumn.BY_SCORE, true);
+        return sw360PackageClient.searchFilteredPackages(searchText, sw360User, pageData);
+    }
+
+    private static PaginationData pageableToPaginationData(@NotNull Pageable pageable,
+                                                            PackageSortColumn defaultColumn,
+                                                            Boolean defaultAscending) {
+        PackageSortColumn column = PackageSortColumn.BY_CREATEDON;
+        boolean ascending = false;
+
+        if (pageable.getSort().isSorted()) {
+            Sort.Order order = pageable.getSort().iterator().next();
+            String property = order.getProperty();
+            column = switch (property) {
+                case "createdOn" -> PackageSortColumn.BY_CREATEDON;
+                case "name" -> PackageSortColumn.BY_NAME;
+                case "version" -> PackageSortColumn.BY_VERSION;
+                case "packageManager" -> PackageSortColumn.BY_PACKAGE_MANAGER;
+                case "score" -> PackageSortColumn.BY_SCORE;
+                default -> column;
+            };
+            ascending = order.isAscending();
+        } else {
+            if (defaultColumn != null) {
+                column = defaultColumn;
+                if (defaultAscending != null) {
+                    ascending = defaultAscending;
+                }
+            }
+        }
+        return new PaginationData().setDisplayStart((int) pageable.getOffset())
+                .setRowsPerPage(pageable.getPageSize())
+                .setSortColumnNumber(column.getValue())
+                .setAscending(ascending);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/PackageTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/PackageTest.java
@@ -11,8 +11,8 @@
 
 package org.eclipse.sw360.rest.resourceserver.integration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
@@ -55,13 +55,9 @@ public class PackageTest extends TestIntegrationBase {
 
     private Package package1, package2, package3;
     private Set<String> licenseIds;
-    private ObjectMapper objectMapper;
 
     @BeforeEach
     public void before() throws TException {
-        // Setup object mapper
-        objectMapper = new ObjectMapper();
-
         // Setup user mock
         User user = TestHelper.getTestUser();
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
@@ -155,6 +151,12 @@ public class PackageTest extends TestIntegrationBase {
         given(this.packageServiceMock.searchPackageByVersion(any())).willReturn(List.of(package1));
         given(this.packageServiceMock.searchPackageByPurl(any())).willReturn(List.of(package1));
         given(this.packageServiceMock.getTotalPackagesCounts()).willReturn(packageList.size());
+        given(this.packageServiceMock.refineSearch(any(), any(), any())).willReturn(
+                Map.of(
+                        new PaginationData().setRowsPerPage(packageList.size()).setDisplayStart(0).setTotalRowCount(packageList.size()),
+                        packageList
+                )
+        );
     }
 
     // ========== PACKAGE CRUD TESTS ==========
@@ -374,7 +376,7 @@ public class PackageTest extends TestIntegrationBase {
     public void should_handle_exception_in_get_packages() throws IOException, TException {
         // Mock service to throw exception
         doThrow(new RuntimeException("Failed to get packages"))
-                .when(packageServiceMock).getPackagesForUser();
+                .when(packageServiceMock).refineSearch(any(), any(), any());
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/PackageSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/PackageSpecTest.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.CycloneDxComponentType;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
@@ -145,7 +146,12 @@ public class PackageSpecTest extends TestRestDocsSpecBase {
         given(this.packageServiceMock.searchPackageByVersion(any())).willReturn(List.of(package1));
         given(this.packageServiceMock.searchPackageByPurl(any())).willReturn(List.of(package1));
         given(this.packageServiceMock.getTotalPackagesCounts()).willReturn(packageList.size());
-
+        given(this.packageServiceMock.refineSearch(any(), any(), any())).willReturn(
+                Map.of(
+                        new PaginationData().setRowsPerPage(packageList.size()).setDisplayStart(0).setTotalRowCount(packageList.size()),
+                        packageList
+                )
+        );
 
 
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
>- Migrated Package search to the new Nouveau `BaseNouveauSearchHandler` pattern, with proper indexed fields.
- Added end-to-end `searchText` support for packages (Thrift + handler + REST), including paginated search (`name`, `version`, `packageManager`, `createdOn`).
- Updated Package API docs (`@Tag`) so supported pagination sort columns are clearly visible in OpenAPI.

### Suggest Reviewer
> @GMishx 

### How To Test?
>Call GET /api/packages?searchText=<text>&sort=name,asc
Call GET /api/packages?searchText=<text>&sort=version,asc
Call GET /api/packages?purl=<purl>&luceneSearch=true
Call GET /api/packages?searchText=<text>&sort=createdOn,desc

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
