### PR TITLE
fix(rest): improve the code of filter getFilteredReleases by componet type and clearing state

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -2022,30 +2022,28 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     }
 
     public List<Release> getFilteredReleases(Set<String> releaseIds, User sw360User, List<ClearingState> clearingState, List<ComponentType> componentType, Sw360ReleaseService releaseService) throws TException {
-        List<Release> releases = releaseIds.stream().map(relId -> wrapTException(() -> {
-            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-            return sw360Release;
-        }))
+        ComponentService.Iface componentClient = ThriftClients.makeComponentClient();
+        List<Release> releases = componentClient.getAccessibleReleasesById(releaseIds, sw360User);
+        releaseService.setComponentDependentFieldsInRelease(releases, sw360User);
+        return releases.stream()
         .filter(Objects::nonNull)
         .filter(release -> {
-        // Filter by componentType if provided
-        if (componentType != null && !componentType.isEmpty()) {
-            ComponentType releaseType = release.getComponentType();
-            if (releaseType == null || componentType.stream().noneMatch(input -> input == releaseType)) {
-                return false;
-            }
-        }
         // Filter by clearingState if provided
-        if (clearingState != null && !clearingState.isEmpty()) {
-            ClearingState releaseState = release.getClearingState();
-            if (releaseState == null || clearingState.stream().noneMatch(input -> input == releaseState)) {
-                return false;
+        if (componentType != null && !componentType.isEmpty()) {
+                ComponentType releaseType = release.getComponentType();
+                if (releaseType == null || componentType.stream().noneMatch(input -> input == releaseType)) {
+                    return false;
+                }
             }
-        }
-        return true;
+            // Filter by clearingState if provided
+            if (clearingState != null && !clearingState.isEmpty()) {
+                ClearingState releaseState = release.getClearingState();
+                if (releaseState == null || clearingState.stream().noneMatch(input -> input == releaseState)) {
+                    return false;
+                }
+            }
+            return true;
         }).collect(Collectors.toList());
-        return releases;
     }
 
     /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -2022,30 +2022,28 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     }
 
     public List<Release> getFilteredReleases(Set<String> releaseIds, User sw360User, List<ClearingState> clearingState, List<ComponentType> componentType, Sw360ReleaseService releaseService) throws TException {
-        List<Release> releases = releaseIds.stream().map(relId -> wrapTException(() -> {
-            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-            return sw360Release;
-        }))
+        ComponentService.Iface componentClient = ThriftClients.makeComponentClient();
+        List<Release> releases = componentClient.getAccessibleReleasesById(releaseIds, sw360User);
+        releaseService.setComponentDependentFieldsInRelease(releases, sw360User);
+        return releases.stream()
         .filter(Objects::nonNull)
         .filter(release -> {
         // Filter by componentType if provided
         if (componentType != null && !componentType.isEmpty()) {
-            ComponentType releaseType = release.getComponentType();
-            if (releaseType == null || componentType.stream().noneMatch(input -> input == releaseType)) {
-                return false;
+                ComponentType releaseType = release.getComponentType();
+                if (releaseType == null || componentType.stream().noneMatch(input -> input == releaseType)) {
+                    return false;
+                }
             }
-        }
-        // Filter by clearingState if provided
-        if (clearingState != null && !clearingState.isEmpty()) {
-            ClearingState releaseState = release.getClearingState();
-            if (releaseState == null || clearingState.stream().noneMatch(input -> input == releaseState)) {
-                return false;
+            // Filter by clearingState if provided
+            if (clearingState != null && !clearingState.isEmpty()) {
+                ClearingState releaseState = release.getClearingState();
+                if (releaseState == null || clearingState.stream().noneMatch(input -> input == releaseState)) {
+                    return false;
+                }
             }
-        }
-        return true;
+            return true;
         }).collect(Collectors.toList());
-        return releases;
     }
 
     /**


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Refactored release validation to eliminate N+1 backend calls by switching to bulk release fetch and in-memory lookup.


> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
