### PR TITLE
fix(projects): handle private sub-projects

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1425,8 +1425,12 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 for (String projectId : linkedProjects.keySet()) {
                     if (visitedProjectIds.contains(projectId)) continue;
 
-                    Project linkedProject = getProjectById(projectId, user);
-                    releaseIdToProjects(linkedProject, user, visitedProjectIds, releaseIdToProjects);
+                    try {
+                        Project linkedProject = getProjectById(projectId, user);
+                        releaseIdToProjects(linkedProject, user, visitedProjectIds, releaseIdToProjects);
+                    } catch (SW360Exception e) {
+                        log.warn("Could not get linked project with ID: {}", projectId, e);
+                    }
                 }
         }
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -704,7 +704,13 @@ public class RestControllerHelper<T> {
 
     public void addEmbeddedProject(HalResource<Project> halProject, Set<String> projectIds, Sw360ProjectService sw360ProjectService, User user) throws TException {
         for (String projectId : projectIds) {
-            final Project project = sw360ProjectService.getProjectForUserById(projectId, user);
+            final Project project;
+            try {
+                project = sw360ProjectService.getProjectForUserById(projectId, user);
+            } catch (ResourceNotFoundException | AccessDeniedException e) {
+                LOGGER.warn("Could not access/find project with id {}, for user {}", projectId, user.getEmail());
+                continue;
+            }
             addEmbeddedProject(halProject, project, false);
         }
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3261,7 +3261,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             ObligationList obligationList = projectService.getObligationData(sw360Project.getLinkedObligationId(), sw360User);
             if (obligationList != null) {
                 obligationCount = obligationList.getLinkedObligationStatusSize();
-                obligationNonOpenCount = (int) obligationList.getLinkedObligationStatus().values().stream()
+                obligationNonOpenCount = (int) CommonUtils.nullToEmptyMap(obligationList.getLinkedObligationStatus()).values().stream()
                         .filter(statusInfo -> statusInfo != null && statusInfo.getStatus() != null
                                 && !ObligationStatus.OPEN.equals(statusInfo.getStatus()))
                         .count();


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

If a Project contains a sub-project which is not visible to current user following endpoints throw 500 exceptions:
* `/projects/{id}/tabCounts`
* `/projects/{id}/licenseClearing`
* `/projects/{id}/linkedProjects`

This PR handles the cases and NPE.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. Login as User1 and create 2 Projects, PublicProject and a PrivateProject.
    - PublicProject has visibility set to EVERYONE
    - PrivateProject has visibility set to PRIVATE
2. Make link the PrivateProject as a sub-project of PublicProject.
3. Login as User2 which should not have visibility for PrivateProject.
4. Open the PublicProject with the new sw360-frontend Project.
5. The page should load with warning that there are linked Projects not visible to current user. The page uses all the mentioned endpoints.