### PR TITLE
feat(archival): restore archived entities from a bundle

### DIFF
--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
@@ -16,10 +16,13 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
 import org.eclipse.sw360.datahandler.services.archival.ArchivePreview;
 import org.eclipse.sw360.datahandler.services.archival.ArchiveRequest;
+import org.eclipse.sw360.datahandler.services.archival.RestorePreview;
+import org.eclipse.sw360.datahandler.services.archival.RestoreResult;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
@@ -41,9 +45,11 @@ import java.util.Map;
 public class ArchivalController {
 
     private final ArchivalHandler handler;
+    private final RestoreHandler restoreHandler;
 
-    public ArchivalController(ArchivalHandler handler) {
+    public ArchivalController(ArchivalHandler handler, RestoreHandler restoreHandler) {
         this.handler = handler;
+        this.restoreHandler = restoreHandler;
     }
 
     @PostMapping("/archive")
@@ -77,6 +83,34 @@ public class ArchivalController {
             @RequestHeader(value = "X-User-Group", required = false) String userGroup) throws SW360Exception {
         User user = requireAdmin(email, department, userGroup);
         return ResponseEntity.ok(handler.preview(req, user));
+    }
+
+    @PostMapping(value = "/restore/preview", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<RestorePreview> restorePreview(
+            @RequestParam("bundle") MultipartFile bundle,
+            @RequestHeader("X-User-Email") String email,
+            @RequestHeader(value = "X-User-Department", required = false) String department,
+            @RequestHeader(value = "X-User-Group", required = false) String userGroup) throws SW360Exception {
+        User user = requireAdmin(email, department, userGroup);
+        try {
+            return ResponseEntity.ok(restoreHandler.preview(bundle.getInputStream(), user));
+        } catch (IOException e) {
+            throw new SW360Exception("could not read the uploaded bundle: " + e.getMessage());
+        }
+    }
+
+    @PostMapping(value = "/restore", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<RestoreResult> restore(
+            @RequestParam("bundle") MultipartFile bundle,
+            @RequestHeader("X-User-Email") String email,
+            @RequestHeader(value = "X-User-Department", required = false) String department,
+            @RequestHeader(value = "X-User-Group", required = false) String userGroup) throws SW360Exception {
+        User user = requireAdmin(email, department, userGroup);
+        try {
+            return ResponseEntity.ok(restoreHandler.restore(bundle.getInputStream(), user));
+        } catch (IOException e) {
+            throw new SW360Exception("could not read the uploaded bundle: " + e.getMessage());
+        }
     }
 
     /**

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/RestoreHandler.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/RestoreHandler.java
@@ -80,6 +80,15 @@ public class RestoreHandler {
         this.db = db;
     }
 
+    /** Test seam: inject the live-entity and attachment connectors directly. */
+    RestoreHandler(ArchivalDatabaseHandler db,
+                   DatabaseConnectorCloudant entityDb,
+                   DatabaseConnectorCloudant attachmentDb) {
+        this.db = db;
+        this.entityDb = entityDb;
+        this.attachmentDb = attachmentDb;
+    }
+
     /**
      * Dry run: reports, per entity, whether it would be restored or skipped
      * (already present), without changing anything.
@@ -157,6 +166,10 @@ public class RestoreHandler {
 
     private RestoreResult.Outcome restoreOne(RestoredEntity re) throws Exception {
         ManifestEntry me = re.entry();
+        if (!re.checksumMatches()) {
+            throw new SW360Exception("bundle entry " + me.getEntityId()
+                    + " failed checksum verification (corrupt or tampered bundle)");
+        }
         byte[] document = re.primaryDocument();
         if (document == null) {
             throw new SW360Exception("bundle entry " + me.getEntityId() + " has no entity document");

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/RestoreHandler.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/RestoreHandler.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.archival.bundle.BundleReader;
+import org.eclipse.sw360.archival.bundle.RestoredEntity;
+import org.eclipse.sw360.archival.bundle.ThriftJson;
+import org.eclipse.sw360.archival.db.ArchivalDatabaseHandler;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.packages.Package;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalStatus;
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+import org.eclipse.sw360.datahandler.services.archival.ManifestEntry;
+import org.eclipse.sw360.datahandler.services.archival.RestorePreview;
+import org.eclipse.sw360.datahandler.services.archival.RestoreResult;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Restores entities from a previously produced archival bundle.
+ *
+ * <p>Restore is upload driven: the caller supplies the TAR.GZ they downloaded at
+ * archive time. The decision for each entity is presence based — if it already
+ * exists in the live database it is skipped, otherwise it is re-inserted with its
+ * original id and a stripped revision. Entities are inserted in dependency order
+ * (releases before the components/projects/packages that reference them).
+ */
+@Service
+public class RestoreHandler {
+
+    private static final Logger log = LogManager.getLogger(RestoreHandler.class);
+
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private final ArchivalDatabaseHandler db;
+    private DatabaseConnectorCloudant entityDb;
+    private DatabaseConnectorCloudant attachmentDb;
+
+    public RestoreHandler() throws IOException {
+        this.db = new ArchivalDatabaseHandler(
+                DatabaseSettings.getConfiguredClient(),
+                ArchivalConstants.COUCH_DB_ARCHIVAL);
+    }
+
+    RestoreHandler(ArchivalDatabaseHandler db) {
+        this.db = db;
+    }
+
+    /**
+     * Dry run: reports, per entity, whether it would be restored or skipped
+     * (already present), without changing anything.
+     */
+    public RestorePreview preview(InputStream bundle, User user) throws SW360Exception {
+        BundleReader.Bundle read = readBundle(bundle);
+
+        List<RestorePreview.Entry> entries = new ArrayList<>();
+        for (RestoredEntity re : read.entities()) {
+            ManifestEntry me = re.entry();
+            RestorePreview.Entry e = new RestorePreview.Entry();
+            e.setEntityId(me.getEntityId());
+            e.setEntityName(me.getEntityName());
+            e.setEntityType(me.getEntityType());
+            e.setAttachmentCount(me.getAttachmentCount());
+            e.setConflict(entityExists(me.getEntityId()));
+            entries.add(e);
+        }
+
+        RestorePreview preview = new RestorePreview();
+        preview.setBundleId(read.manifest().getBundleId());
+        preview.setEntries(entries);
+        return preview;
+    }
+
+    /**
+     * Re-inserts the bundle's entities into the live database in dependency order,
+     * skipping any that already exist, and flips the matching archival records to
+     * RESTORED.
+     */
+    public RestoreResult restore(InputStream bundle, User user) throws SW360Exception {
+        BundleReader.Bundle read = readBundle(bundle);
+
+        List<RestoredEntity> ordered = new ArrayList<>(read.entities());
+        ordered.sort(Comparator.comparingInt(re -> insertPriority(re.entry().getEntityType())));
+
+        List<RestoreResult.Entry> results = new ArrayList<>();
+        Set<String> restoredIds = new HashSet<>();
+        int restored = 0;
+        int skipped = 0;
+        int failed = 0;
+
+        for (RestoredEntity re : ordered) {
+            ManifestEntry me = re.entry();
+            RestoreResult.Entry res = new RestoreResult.Entry();
+            res.setEntityId(me.getEntityId());
+            res.setEntityType(me.getEntityType());
+            try {
+                RestoreResult.Outcome outcome = restoreOne(re);
+                res.setOutcome(outcome);
+                switch (outcome) {
+                    case RESTORED -> { restored++; restoredIds.add(me.getEntityId()); }
+                    case SKIPPED -> { skipped++; res.setReason("already exists in the live database"); }
+                    case FAILED -> failed++;
+                }
+            } catch (Exception e) {
+                log.error("restore failed for {} {}", me.getEntityType(), me.getEntityId(), e);
+                res.setOutcome(RestoreResult.Outcome.FAILED);
+                res.setReason(describe(e));
+                failed++;
+            }
+            results.add(res);
+        }
+
+        markRecordsRestored(read.manifest().getBundleId(), restoredIds, user);
+
+        RestoreResult result = new RestoreResult();
+        result.setBundleId(read.manifest().getBundleId());
+        result.setEntries(results);
+        result.setRestoredCount(restored);
+        result.setSkippedCount(skipped);
+        result.setFailedCount(failed);
+        return result;
+    }
+
+    private RestoreResult.Outcome restoreOne(RestoredEntity re) throws Exception {
+        ManifestEntry me = re.entry();
+        byte[] document = re.primaryDocument();
+        if (document == null) {
+            throw new SW360Exception("bundle entry " + me.getEntityId() + " has no entity document");
+        }
+        Object entity = deserializeStrippingRevision(me.getEntityType(), document);
+        // add() preserves the pre-set id and returns false when the id already
+        // exists, which is exactly the presence-based skip we want.
+        boolean added = entityDb().add(entity);
+        if (!added) {
+            return RestoreResult.Outcome.SKIPPED;
+        }
+        restoreAttachmentContent(re);
+        return RestoreResult.Outcome.RESTORED;
+    }
+
+    /**
+     * Re-creates the AttachmentContent documents and their binary blobs for a
+     * restored entity, preserving the original attachment content ids so the
+     * entity's attachment references resolve. Content already present is left
+     * untouched (add returns false), which also dedupes shared attachments.
+     */
+    private void restoreAttachmentContent(RestoredEntity re) {
+        for (Map.Entry<String, byte[]> att : re.attachmentContent().entrySet()) {
+            String attachmentContentId = att.getKey();
+            byte[] binary = att.getValue();
+            try {
+                AttachmentMetadata meta = readMeta(re.attachmentMeta().get(attachmentContentId));
+                String filename = meta != null && meta.getFilename() != null
+                        ? meta.getFilename() : attachmentContentId;
+                String contentType = meta != null && meta.getContentType() != null
+                        ? meta.getContentType() : "application/octet-stream";
+
+                AttachmentContent content = new AttachmentContent()
+                        .setId(attachmentContentId)
+                        .setFilename(filename)
+                        .setContentType(contentType);
+
+                // add() creates the doc with the preserved id (and a placeholder
+                // blob); createAttachment then puts the real bytes under the same
+                // name, replacing the placeholder. Skip if it already exists.
+                if (attachmentDb().add(content)) {
+                    attachmentDb().createAttachment(attachmentContentId, filename,
+                            new ByteArrayInputStream(binary), contentType);
+                }
+            } catch (Exception e) {
+                log.warn("could not restore attachment content {} for {}: {}",
+                        attachmentContentId, re.entry().getEntityId(), describe(e));
+            }
+        }
+    }
+
+    private static AttachmentMetadata readMeta(byte[] metaJson) {
+        if (metaJson == null) {
+            return null;
+        }
+        try {
+            return JSON.readValue(metaJson, AttachmentMetadata.class);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static Object deserializeStrippingRevision(ArchivalEntityType type, byte[] json) throws IOException {
+        return switch (type) {
+            case PROJECT -> {
+                Project p = ThriftJson.fromJson(json, Project.class);
+                p.unsetRevision();
+                yield p;
+            }
+            case COMPONENT -> {
+                Component c = ThriftJson.fromJson(json, Component.class);
+                c.unsetRevision();
+                yield c;
+            }
+            case RELEASE -> {
+                Release r = ThriftJson.fromJson(json, Release.class);
+                r.unsetRevision();
+                yield r;
+            }
+            case PACKAGE -> {
+                Package pkg = ThriftJson.fromJson(json, Package.class);
+                pkg.unsetRevision();
+                yield pkg;
+            }
+        };
+    }
+
+    /** Releases first, then components, then projects, then packages. */
+    private static int insertPriority(ArchivalEntityType type) {
+        return switch (type) {
+            case RELEASE -> 0;
+            case COMPONENT -> 1;
+            case PROJECT -> 2;
+            case PACKAGE -> 3;
+        };
+    }
+
+    private void markRecordsRestored(String bundleId, Set<String> restoredIds, User user) {
+        if (restoredIds.isEmpty()) {
+            return;
+        }
+        Instant now = Instant.now();
+        for (ArchivalRecord r : db.getAll()) {
+            if (!bundleId.equals(r.getBundleId()) || !restoredIds.contains(r.getEntityId())) {
+                continue;
+            }
+            r.setStatus(ArchivalStatus.RESTORED);
+            r.setRestoredBy(user.getEmail());
+            r.setRestoredAt(now);
+            if (!db.update(r)) {
+                log.warn("archival record {} could not be flipped to RESTORED", r.getId());
+            }
+        }
+    }
+
+    private boolean entityExists(String id) {
+        return entityDb().contains(id);
+    }
+
+    private synchronized DatabaseConnectorCloudant entityDb() {
+        if (entityDb == null) {
+            entityDb = new DatabaseConnectorCloudant(
+                    DatabaseSettings.getConfiguredClient(),
+                    DatabaseSettings.COUCH_DB_DATABASE);
+        }
+        return entityDb;
+    }
+
+    private synchronized DatabaseConnectorCloudant attachmentDb() {
+        if (attachmentDb == null) {
+            attachmentDb = new DatabaseConnectorCloudant(
+                    DatabaseSettings.getConfiguredClient(),
+                    DatabaseSettings.COUCH_DB_ATTACHMENTS);
+        }
+        return attachmentDb;
+    }
+
+    private BundleReader.Bundle readBundle(InputStream bundle) throws SW360Exception {
+        try {
+            return BundleReader.read(bundle);
+        } catch (IOException e) {
+            throw new SW360Exception("could not read the uploaded bundle: " + describe(e));
+        }
+    }
+
+    private static String describe(Throwable e) {
+        String message = e.getMessage();
+        return CommonUtils.isNullEmptyOrWhitespace(message) ? e.getClass().getName() : message;
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/BundleReader.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/BundleReader.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.eclipse.sw360.datahandler.services.archival.ArchiveManifest;
+import org.eclipse.sw360.datahandler.services.archival.ManifestEntry;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reads a TAR.GZ bundle produced by {@link ArchiveBuilder} back into memory: the
+ * manifest plus one {@link RestoredEntity} per manifest entry. The inverse of the
+ * builder's layout ({folder}/{id}/{type}.json and .../attachments/{attId}.bin).
+ */
+public final class BundleReader {
+
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private static final int COPY_BUFFER = 64 * 1024;
+    private static final long MAX_UNCOMPRESSED_BYTES = 4L * 1024 * 1024 * 1024; // 4 GiB guard
+
+    private BundleReader() {}
+
+    public static final class Bundle {
+        private final ArchiveManifest manifest;
+        private final List<RestoredEntity> entities;
+
+        Bundle(ArchiveManifest manifest, List<RestoredEntity> entities) {
+            this.manifest = manifest;
+            this.entities = entities;
+        }
+
+        public ArchiveManifest manifest() { return manifest; }
+        public List<RestoredEntity> entities() { return entities; }
+    }
+
+    public static Bundle read(InputStream rawIn) throws IOException {
+        Map<String, byte[]> files = new HashMap<>();
+
+        long total = 0;
+        try (GzipCompressorInputStream gz = new GzipCompressorInputStream(rawIn);
+             TarArchiveInputStream tar = new TarArchiveInputStream(gz)) {
+            TarArchiveEntry entry;
+            while ((entry = tar.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                byte[] body = readAll(tar);
+                total += body.length;
+                if (total > MAX_UNCOMPRESSED_BYTES) {
+                    throw new IOException("bundle exceeds the maximum uncompressed size");
+                }
+                files.put(entry.getName(), body);
+            }
+        }
+
+        byte[] manifestBytes = files.get("manifest.json");
+        if (manifestBytes == null) {
+            throw new IOException("bundle is missing manifest.json");
+        }
+        ArchiveManifest manifest = JSON.readValue(manifestBytes, ArchiveManifest.class);
+
+        List<RestoredEntity> entities = new ArrayList<>();
+        if (manifest.getEntries() != null) {
+            for (ManifestEntry me : manifest.getEntries()) {
+                entities.add(assemble(me, files));
+            }
+        }
+        return new Bundle(manifest, entities);
+    }
+
+    private static RestoredEntity assemble(ManifestEntry me, Map<String, byte[]> files) {
+        String folder = me.getPath();               // e.g. "projects/<id>/"
+        String attachmentsPrefix = folder + "attachments/";
+
+        Map<String, byte[]> documents = new LinkedHashMap<>();
+        Map<String, byte[]> attachmentContent = new HashMap<>();
+        Map<String, byte[]> attachmentMeta = new HashMap<>();
+
+        for (Map.Entry<String, byte[]> f : files.entrySet()) {
+            String path = f.getKey();
+            if (!path.startsWith(folder)) {
+                continue;
+            }
+            if (path.startsWith(attachmentsPrefix)) {
+                String name = path.substring(attachmentsPrefix.length());
+                if (name.endsWith(".meta.json")) {
+                    attachmentMeta.put(name.substring(0, name.length() - ".meta.json".length()), f.getValue());
+                } else if (name.endsWith(".bin")) {
+                    attachmentContent.put(name.substring(0, name.length() - ".bin".length()), f.getValue());
+                }
+            } else {
+                documents.put(path.substring(folder.length()), f.getValue());
+            }
+        }
+        return new RestoredEntity(me, documents, attachmentContent, attachmentMeta);
+    }
+
+    private static byte[] readAll(InputStream in) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[COPY_BUFFER];
+        int n;
+        while ((n = in.read(buf)) > 0) {
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/BundleReader.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/BundleReader.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,8 @@ public final class BundleReader {
     }
 
     public static Bundle read(InputStream rawIn) throws IOException {
-        Map<String, byte[]> files = new HashMap<>();
+        // LinkedHashMap keeps the tar order, which the per-entity checksum depends on.
+        Map<String, byte[]> files = new LinkedHashMap<>();
 
         long total = 0;
         try (GzipCompressorInputStream gz = new GzipCompressorInputStream(rawIn);
@@ -96,8 +96,8 @@ public final class BundleReader {
         String attachmentsPrefix = folder + "attachments/";
 
         Map<String, byte[]> documents = new LinkedHashMap<>();
-        Map<String, byte[]> attachmentContent = new HashMap<>();
-        Map<String, byte[]> attachmentMeta = new HashMap<>();
+        Map<String, byte[]> attachmentContent = new LinkedHashMap<>();
+        Map<String, byte[]> attachmentMeta = new LinkedHashMap<>();
 
         for (Map.Entry<String, byte[]> f : files.entrySet()) {
             String path = f.getKey();

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/RestoredEntity.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/RestoredEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import java.util.Map;
+
+import org.eclipse.sw360.datahandler.services.archival.ManifestEntry;
+
+/**
+ * One entity read back out of a bundle. The inverse of {@link CollectedEntity}:
+ * documents are filename -> raw bytes (e.g. project.json), attachmentContent and
+ * attachmentMeta are keyed by attachment id.
+ */
+public final class RestoredEntity {
+
+    private final ManifestEntry entry;
+    private final Map<String, byte[]> documents;
+    private final Map<String, byte[]> attachmentContent;
+    private final Map<String, byte[]> attachmentMeta;
+
+    public RestoredEntity(ManifestEntry entry,
+                          Map<String, byte[]> documents,
+                          Map<String, byte[]> attachmentContent,
+                          Map<String, byte[]> attachmentMeta) {
+        this.entry = entry;
+        this.documents = documents;
+        this.attachmentContent = attachmentContent;
+        this.attachmentMeta = attachmentMeta;
+    }
+
+    public ManifestEntry entry() { return entry; }
+    public Map<String, byte[]> documents() { return documents; }
+    public Map<String, byte[]> attachmentContent() { return attachmentContent; }
+    public Map<String, byte[]> attachmentMeta() { return attachmentMeta; }
+
+    /** The primary entity document (e.g. project.json), or null if missing. */
+    public byte[] primaryDocument() {
+        return switch (entry.getEntityType()) {
+            case PROJECT -> documents.get("project.json");
+            case COMPONENT -> documents.get("component.json");
+            case RELEASE -> documents.get("release.json");
+            case PACKAGE -> documents.get("package.json");
+        };
+    }
+}

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/RestoredEntity.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/RestoredEntity.java
@@ -9,6 +9,9 @@
  */
 package org.eclipse.sw360.archival.bundle;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.Map;
 
 import org.eclipse.sw360.datahandler.services.archival.ManifestEntry;
@@ -48,5 +51,39 @@ public final class RestoredEntity {
             case RELEASE -> documents.get("release.json");
             case PACKAGE -> documents.get("package.json");
         };
+    }
+
+    /**
+     * Recomputes the entity's sha256 in the same order ArchiveBuilder hashed it
+     * (documents, then each attachment's binary followed by its metadata). Relies
+     * on BundleReader preserving the bundle's tar order.
+     */
+    public String computeChecksum() {
+        MessageDigest hash = sha256();
+        for (byte[] doc : documents.values()) {
+            hash.update(doc);
+        }
+        for (Map.Entry<String, byte[]> att : attachmentContent.entrySet()) {
+            hash.update(att.getValue());
+            byte[] meta = attachmentMeta.get(att.getKey());
+            if (meta != null) {
+                hash.update(meta);
+            }
+        }
+        return "sha256:" + HexFormat.of().formatHex(hash.digest());
+    }
+
+    /** True if the recomputed checksum matches the manifest entry's. */
+    public boolean checksumMatches() {
+        String expected = entry.getChecksum();
+        return expected == null || expected.equals(computeChecksum());
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
     }
 }

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ThriftJson.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/bundle/ThriftJson.java
@@ -12,7 +12,9 @@ package org.eclipse.sw360.archival.bundle;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
@@ -34,10 +36,24 @@ public final class ThriftJson {
             .registerModule(new SimpleModule()
                     .setMixInAnnotation(Object.class, ThriftMixin.class));
 
+    private static final ObjectReader READER = MAPPER
+            .reader()
+            .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
     private ThriftJson() {}
 
     public static byte[] toJsonBytes(Object thriftObject) throws IOException {
         return MAPPER.writeValueAsBytes(thriftObject);
+    }
+
+    /**
+     * Reads bytes written by {@link #toJsonBytes} back into a Thrift struct. The
+     * same field-based mapper is used so the JSON produced on archive round-trips
+     * cleanly on restore. Unknown properties are ignored so a bundle written by an
+     * older SW360 still restores when new fields have appeared.
+     */
+    public static <T> T fromJson(byte[] json, Class<T> type) throws IOException {
+        return READER.readValue(json, type);
     }
 
     /**

--- a/backend/archival/src/main/resources/application.yml
+++ b/backend/archival/src/main/resources/application.yml
@@ -11,6 +11,12 @@ spring:
     name: sw360-archival
   jackson:
     default-property-inclusion: non_null
+  servlet:
+    multipart:
+      # Restore uploads the archived TAR.GZ bundle, which can be large because it
+      # carries attachment content. Raise the defaults well above the 1 MB cap.
+      max-file-size: 2GB
+      max-request-size: 2GB
 
 server:
   servlet:

--- a/backend/archival/src/test/java/org/eclipse/sw360/archival/RestoreHandlerTest.java
+++ b/backend/archival/src/test/java/org/eclipse/sw360/archival/RestoreHandlerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival;
+
+import org.eclipse.sw360.archival.bundle.ArchiveBuilder;
+import org.eclipse.sw360.archival.bundle.CollectedEntity;
+import org.eclipse.sw360.archival.db.ArchivalDatabaseHandler;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalStatus;
+import org.eclipse.sw360.datahandler.services.archival.RestorePreview;
+import org.eclipse.sw360.datahandler.services.archival.RestoreResult;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RestoreHandlerTest {
+
+    private final User user = new User().setEmail("taanvi@example.com");
+
+    @Test
+    void restore_reinsertsNewEntity_andFlipsMatchingRecord() throws Exception {
+        FakeDb db = new FakeDb();
+        db.seed(record("bundle-1", "proj-1", ArchivalStatus.ARCHIVED));
+
+        DatabaseConnectorCloudant entityDb = mock(DatabaseConnectorCloudant.class);
+        DatabaseConnectorCloudant attachmentDb = mock(DatabaseConnectorCloudant.class);
+        when(entityDb.add(any())).thenReturn(true); // not present -> inserted
+
+        RestoreHandler handler = new RestoreHandler(db, entityDb, attachmentDb);
+        byte[] bundle = bundle("bundle-1", project("proj-1", "Empty Alpha"));
+
+        RestoreResult result = handler.restore(new ByteArrayInputStream(bundle), user);
+
+        assertEquals(1, result.getRestoredCount());
+        assertEquals(0, result.getSkippedCount());
+        assertEquals(0, result.getFailedCount());
+        assertEquals(RestoreResult.Outcome.RESTORED, result.getEntries().get(0).getOutcome());
+
+        // the entity was re-inserted, and its archival record was flipped to RESTORED
+        verify(entityDb, times(1)).add(any(Project.class));
+        ArchivalRecord flipped = db.byId.get("rec-proj-1");
+        assertEquals(ArchivalStatus.RESTORED, flipped.getStatus());
+        assertEquals("taanvi@example.com", flipped.getRestoredBy());
+    }
+
+    @Test
+    void restore_skipsEntityThatAlreadyExists_andLeavesRecordUntouched() throws Exception {
+        FakeDb db = new FakeDb();
+        db.seed(record("bundle-1", "proj-1", ArchivalStatus.ARCHIVED));
+
+        DatabaseConnectorCloudant entityDb = mock(DatabaseConnectorCloudant.class);
+        DatabaseConnectorCloudant attachmentDb = mock(DatabaseConnectorCloudant.class);
+        when(entityDb.add(any())).thenReturn(false); // already present -> skipped
+
+        RestoreHandler handler = new RestoreHandler(db, entityDb, attachmentDb);
+        byte[] bundle = bundle("bundle-1", project("proj-1", "Empty Alpha"));
+
+        RestoreResult result = handler.restore(new ByteArrayInputStream(bundle), user);
+
+        assertEquals(0, result.getRestoredCount());
+        assertEquals(1, result.getSkippedCount());
+        assertEquals(RestoreResult.Outcome.SKIPPED, result.getEntries().get(0).getOutcome());
+
+        // a skipped entity must not upload attachment content, nor flip the record
+        verify(attachmentDb, never()).createAttachment(anyString(), anyString(), any(), anyString());
+        assertEquals(ArchivalStatus.ARCHIVED, db.byId.get("rec-proj-1").getStatus());
+    }
+
+    @Test
+    void restore_insertsReleasesBeforeProjects() throws Exception {
+        FakeDb db = new FakeDb();
+        DatabaseConnectorCloudant entityDb = mock(DatabaseConnectorCloudant.class);
+        DatabaseConnectorCloudant attachmentDb = mock(DatabaseConnectorCloudant.class);
+        when(entityDb.add(any())).thenReturn(true);
+
+        RestoreHandler handler = new RestoreHandler(db, entityDb, attachmentDb);
+        // deliberately list the project first so ordering has to reorder it
+        byte[] bundle = bundle("bundle-1",
+                project("proj-1", "Web Stack"),
+                release("rel-1", "Flask"));
+
+        handler.restore(new ByteArrayInputStream(bundle), user);
+
+        ArgumentCaptor<Object> inserted = ArgumentCaptor.forClass(Object.class);
+        verify(entityDb, times(2)).add(inserted.capture());
+        List<Object> order = inserted.getAllValues();
+        assertInstanceOf(Release.class, order.get(0), "releases restore before projects");
+        assertInstanceOf(Project.class, order.get(1));
+    }
+
+    @Test
+    void preview_reportsConflictOnlyForEntitiesAlreadyPresent() throws Exception {
+        FakeDb db = new FakeDb();
+        DatabaseConnectorCloudant entityDb = mock(DatabaseConnectorCloudant.class);
+        DatabaseConnectorCloudant attachmentDb = mock(DatabaseConnectorCloudant.class);
+        when(entityDb.contains("proj-1")).thenReturn(true);  // present -> conflict
+        when(entityDb.contains("rel-1")).thenReturn(false);  // absent  -> restorable
+
+        RestoreHandler handler = new RestoreHandler(db, entityDb, attachmentDb);
+        byte[] bundle = bundle("bundle-1",
+                project("proj-1", "Web Stack"),
+                release("rel-1", "Flask"));
+
+        RestorePreview preview = handler.preview(new ByteArrayInputStream(bundle), user);
+
+        Map<String, Boolean> conflictById = new HashMap<>();
+        for (RestorePreview.Entry e : preview.getEntries()) {
+            conflictById.put(e.getEntityId(), e.isConflict());
+        }
+        assertTrue(conflictById.get("proj-1"), "present entity is a conflict");
+        assertTrue(!conflictById.get("rel-1"), "absent entity is not a conflict");
+    }
+
+    @Test
+    void restore_withNoMatchingRecords_stillRestoresWithoutError() throws Exception {
+        FakeDb db = new FakeDb(); // empty registry: bundle came from another instance
+        DatabaseConnectorCloudant entityDb = mock(DatabaseConnectorCloudant.class);
+        DatabaseConnectorCloudant attachmentDb = mock(DatabaseConnectorCloudant.class);
+        when(entityDb.add(any())).thenReturn(true);
+
+        RestoreHandler handler = new RestoreHandler(db, entityDb, attachmentDb);
+        byte[] bundle = bundle("bundle-1", project("proj-1", "Orphan"));
+
+        RestoreResult result = handler.restore(new ByteArrayInputStream(bundle), user);
+
+        assertEquals(1, result.getRestoredCount());
+        assertTrue(db.updated.isEmpty(), "no records to flip when the registry has none");
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private static byte[] bundle(String bundleId, CollectedEntity... entities) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new ArchiveBuilder(bundleId, "taanvi@example.com", "20.1.0", "test")
+                .writeTo(out, List.of(entities));
+        return out.toByteArray();
+    }
+
+    private static CollectedEntity project(String id, String name) {
+        return entity(id, name, ArchivalEntityType.PROJECT, "project.json");
+    }
+
+    private static CollectedEntity release(String id, String name) {
+        return entity(id, name, ArchivalEntityType.RELEASE, "release.json");
+    }
+
+    private static CollectedEntity entity(String id, String name, ArchivalEntityType type, String docName) {
+        Map<String, byte[]> docs = new HashMap<>();
+        docs.put(docName, ("{\"id\":\"" + id + "\",\"name\":\"" + name + "\"}")
+                .getBytes(StandardCharsets.UTF_8));
+        return new CollectedEntity(id, name, "1.0", type, docs, List.of());
+    }
+
+    private static ArchivalRecord record(String bundleId, String entityId, ArchivalStatus status) {
+        ArchivalRecord r = new ArchivalRecord();
+        r.setId("rec-" + entityId);
+        r.setBundleId(bundleId);
+        r.setEntityId(entityId);
+        r.setStatus(status);
+        return r;
+    }
+
+    /** In-memory stand-in for ArchivalDatabaseHandler (the real one needs Cloudant). */
+    static class FakeDb extends ArchivalDatabaseHandler {
+        final Map<String, ArchivalRecord> byId = new HashMap<>();
+        final List<ArchivalRecord> updated = new ArrayList<>();
+
+        FakeDb() {
+            super((org.eclipse.sw360.archival.db.ArchivalRepository) null);
+        }
+
+        void seed(ArchivalRecord r) {
+            byId.put(r.getId(), r);
+        }
+
+        @Override
+        public List<ArchivalRecord> getAll() {
+            return new ArrayList<>(byId.values());
+        }
+
+        @Override
+        public boolean update(ArchivalRecord r) {
+            if (!byId.containsKey(r.getId())) {
+                return false;
+            }
+            updated.add(r);
+            byId.put(r.getId(), r);
+            return true;
+        }
+    }
+}

--- a/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/BundleReaderTest.java
+++ b/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/BundleReaderTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -54,6 +55,32 @@ class BundleReaderTest {
         assertArrayEquals(releaseJson, re.primaryDocument());
         assertArrayEquals(sourceZip, re.attachmentContent().get("att-1"));
         assertNotNull(re.attachmentMeta().get("att-1"));
+
+        // the recomputed checksum must match the one ArchiveBuilder wrote into the manifest
+        assertTrue(re.checksumMatches(), "recomputed checksum matches the manifest entry");
+    }
+
+    @Test
+    void checksumCatchesTamperedContent() throws Exception {
+        byte[] releaseJson = "{\"name\":\"x\"}".getBytes(StandardCharsets.UTF_8);
+        Map<String, byte[]> docs = new LinkedHashMap<>();
+        docs.put("release.json", releaseJson);
+
+        CollectedEntity release = new CollectedEntity(
+                "rel-1", "x", "1.0", ArchivalEntityType.RELEASE, docs, List.of());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new ArchiveBuilder("b", "u", "20.1.0", "c").writeTo(out, List.of(release));
+
+        BundleReader.Bundle bundle = BundleReader.read(new ByteArrayInputStream(out.toByteArray()));
+        RestoredEntity good = bundle.entities().get(0);
+        assertTrue(good.checksumMatches(), "untampered entity verifies");
+
+        // Same manifest entry, but different document bytes -> checksum must fail.
+        Map<String, byte[]> tampered = new LinkedHashMap<>();
+        tampered.put("release.json", "{\"name\":\"EVIL\"}".getBytes(StandardCharsets.UTF_8));
+        RestoredEntity bad = new RestoredEntity(good.entry(), tampered, Map.of(), Map.of());
+        assertFalse(bad.checksumMatches(), "tampered content fails checksum");
     }
 
     @Test

--- a/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/BundleReaderTest.java
+++ b/backend/archival/src/test/java/org/eclipse/sw360/archival/bundle/BundleReaderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Taanvi Khevaria, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.archival.bundle;
+
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
+import org.eclipse.sw360.datahandler.services.archival.AttachmentMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BundleReaderTest {
+
+    @Test
+    void readsBackWhatArchiveBuilderWrote() throws Exception {
+        byte[] sourceZip = "fake-source-zip-bytes".getBytes(StandardCharsets.UTF_8);
+        byte[] releaseJson = "{\"name\":\"Apache Commons IO\",\"version\":\"2.11.0\"}"
+                .getBytes(StandardCharsets.UTF_8);
+
+        Map<String, byte[]> docs = new LinkedHashMap<>();
+        docs.put("release.json", releaseJson);
+
+        CollectedEntity release = new CollectedEntity(
+                "rel-abc-123", "Apache Commons IO", "2.11.0", ArchivalEntityType.RELEASE,
+                docs, List.of(new ByteArrayAttachmentSource(meta("att-1", "source.zip"), sourceZip)));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new ArchiveBuilder("bundle-1", "taanvi@example.com", "20.0.0", "test").writeTo(out, List.of(release));
+
+        BundleReader.Bundle bundle = BundleReader.read(new ByteArrayInputStream(out.toByteArray()));
+
+        assertEquals("bundle-1", bundle.manifest().getBundleId());
+        assertEquals(1, bundle.entities().size());
+
+        RestoredEntity re = bundle.entities().get(0);
+        assertEquals("rel-abc-123", re.entry().getEntityId());
+        assertEquals(ArchivalEntityType.RELEASE, re.entry().getEntityType());
+        assertArrayEquals(releaseJson, re.primaryDocument());
+        assertArrayEquals(sourceZip, re.attachmentContent().get("att-1"));
+        assertNotNull(re.attachmentMeta().get("att-1"));
+    }
+
+    @Test
+    void rejectsBundleWithoutManifest() throws Exception {
+        // an empty gzip/tar stream has no manifest.json
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (var gz = new org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream(out);
+             var tar = new org.apache.commons.compress.archivers.tar.TarArchiveOutputStream(gz)) {
+            tar.finish();
+        }
+        boolean threw = false;
+        try {
+            BundleReader.read(new ByteArrayInputStream(out.toByteArray()));
+        } catch (java.io.IOException e) {
+            threw = e.getMessage().contains("manifest.json");
+        }
+        assertTrue(threw, "reading a bundle with no manifest should fail");
+    }
+
+    private static AttachmentMetadata meta(String id, String filename) {
+        AttachmentMetadata m = new AttachmentMetadata();
+        m.setAttachmentId(id);
+        m.setFilename(filename);
+        return m;
+    }
+}


### PR DESCRIPTION
## Summary
Adds restore for the archival service: an admin uploads a previously downloaded TAR.GZ and the entities it contains are re-inserted into the live database.

## Changes
- **BundleReader** - unpacks the TAR.GZ back into the manifest + one entry per entity (documents + attachments); the inverse of ArchiveBuilder.
- **RestoreHandler** - presence-driven restore: entities already present are skipped, others are re-inserted with their original id and stripped revision, in dependency order (releases before components/projects/packages). Attachment content is recreated with its original id and binary blob. Archival records flip to RESTORED (restoredBy/restoredAt).
- **Endpoints** - POST /restore and POST /restore/preview (multipart upload).
- Bundle round-trip test.

## Testing
Verified end-to-end against a live CouchDB: project + release restore with id preservation, dependency ordering, keep-alive/shared-release skip, idempotent re-runs, record flip, and attachment content (recreated + downloadable, byte-for-byte). Unit tests cover the bundle round-trip.