### PR TITLE
fix(Project): Display correct license obligation count

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3257,15 +3257,31 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
         int obligationCount = 0;
         int obligationNonOpenCount = 0;
+        Map<String, ObligationStatusInfo> obligationStatusMap = Maps.newHashMap();
         if (!isNullEmptyOrWhitespace(sw360Project.getLinkedObligationId())) {
             ObligationList obligationList = projectService.getObligationData(sw360Project.getLinkedObligationId(), sw360User);
-            if (obligationList != null) {
-                obligationCount = obligationList.getLinkedObligationStatusSize();
-                obligationNonOpenCount = (int) CommonUtils.nullToEmptyMap(obligationList.getLinkedObligationStatus()).values().stream()
-                        .filter(statusInfo -> statusInfo != null && statusInfo.getStatus() != null
-                                && !ObligationStatus.OPEN.equals(statusInfo.getStatus()))
-                        .count();
+            if (obligationList != null && obligationList.getLinkedObligationStatus() != null) {
+                obligationStatusMap = obligationList.getLinkedObligationStatus();
             }
+        } else {
+            // Compute the license obligations from the releases' CLI attachments so the count shows up.
+            List<Release> releases = getReleasesWithAttachments(sw360Project, sw360User);
+            if (!releases.isEmpty()) {
+                final Map<String, String> releaseIdToAcceptedCLI = Maps.newHashMap();
+                obligationStatusMap = CommonUtils.nullToEmptyMap(projectService.setLicenseInfoWithObligations(
+                        Maps.newHashMap(), releaseIdToAcceptedCLI, releases, sw360User));
+            }
+        }
+
+        if (!CommonUtils.isNullOrEmptyMap(obligationStatusMap)) {
+            List<ObligationStatusInfo> licenseObligations = obligationStatusMap.values().stream()
+                    .filter(this::isLicenseObligation)
+                    .toList();
+            obligationCount = licenseObligations.size();
+            obligationNonOpenCount = (int) licenseObligations.stream()
+                    .filter(statusInfo -> statusInfo.getStatus() != null
+                            && !ObligationStatus.OPEN.equals(statusInfo.getStatus()))
+                    .count();
         }
 
         Sw360ProjectService.ProjectEccCounts eccCounts = projectService.getProjectEccCounts(id, sw360User);
@@ -3273,6 +3289,20 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         return new ResponseEntity<>(new ProjectDetailTabCounts(vulnerabilityCount, vulnerabilityRatedCount,
                 obligationCount, obligationNonOpenCount,
                 eccCounts.classifiedCount(), eccCounts.openCount()), HttpStatus.OK);
+    }
+
+    /**
+     * Returns {@code true} if the entry has {@link ObligationLevel#LICENSE_OBLIGATION},
+     * or, for legacy data without a level set, if it carries associated license ids.
+     */
+    private boolean isLicenseObligation(ObligationStatusInfo statusInfo) {
+        if (statusInfo == null) {
+            return false;
+        }
+        if (statusInfo.isSetObligationLevel()) {
+            return ObligationLevel.LICENSE_OBLIGATION.equals(statusInfo.getObligationLevel());
+        }
+        return statusInfo.isSetLicenseIds() && !statusInfo.getLicenseIds().isEmpty();
     }
 
     @Operation(

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -41,6 +41,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ObligationList;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
@@ -955,8 +956,10 @@ public class ProjectTest extends TestIntegrationBase {
         Map<String, ObligationStatusInfo> linkedObligationStatus = new HashMap<>();
         ObligationStatusInfo obligationStatusInfo1 = new ObligationStatusInfo();
         obligationStatusInfo1.setStatus(ObligationStatus.OPEN);
+        obligationStatusInfo1.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
         ObligationStatusInfo obligationStatusInfo2 = new ObligationStatusInfo();
         obligationStatusInfo2.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        obligationStatusInfo2.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
         linkedObligationStatus.put("obligation-1", obligationStatusInfo1);
         linkedObligationStatus.put("obligation-2", obligationStatusInfo2);
         obligationList.setLinkedObligationStatus(linkedObligationStatus);
@@ -992,8 +995,10 @@ public class ProjectTest extends TestIntegrationBase {
         Map<String, ObligationStatusInfo> linkedObligationStatus = new HashMap<>();
         ObligationStatusInfo obligationStatusInfo1 = new ObligationStatusInfo();
         obligationStatusInfo1.setStatus(ObligationStatus.OPEN);
+        obligationStatusInfo1.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
         ObligationStatusInfo obligationStatusInfo2 = new ObligationStatusInfo();
         obligationStatusInfo2.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        obligationStatusInfo2.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
         linkedObligationStatus.put("obligation-1", obligationStatusInfo1);
         linkedObligationStatus.put("obligation-2", obligationStatusInfo2);
         obligationList.setLinkedObligationStatus(linkedObligationStatus);
@@ -1018,6 +1023,143 @@ public class ProjectTest extends TestIntegrationBase {
         assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
         assertEquals(2, responseBody.get("eccClassifiedCount").asInt());
         assertEquals(1, responseBody.get("eccOpenCount").asInt());
+    }
+
+    @Test
+    public void should_get_project_detail_tab_counts_filters_non_license_obligations() throws IOException, TException {
+        project1.setEnableVulnerabilitiesDisplay(true);
+        given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
+        given(this.vulnerabilityServiceMock.getVulnerabilitiesByProjectId(eq(project1.getId()), any()))
+                .willReturn(Collections.emptyList());
+
+        ObligationList obligationList = new ObligationList();
+        Map<String, ObligationStatusInfo> linkedObligationStatus = new HashMap<>();
+
+        ObligationStatusInfo licenseObl1 = new ObligationStatusInfo();
+        licenseObl1.setStatus(ObligationStatus.OPEN);
+        licenseObl1.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
+
+        ObligationStatusInfo licenseObl2 = new ObligationStatusInfo();
+        licenseObl2.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        licenseObl2.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
+
+        ObligationStatusInfo componentObl = new ObligationStatusInfo();
+        componentObl.setStatus(ObligationStatus.OPEN);
+        componentObl.setObligationLevel(ObligationLevel.COMPONENT_OBLIGATION);
+
+        ObligationStatusInfo projectObl = new ObligationStatusInfo();
+        projectObl.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        projectObl.setObligationLevel(ObligationLevel.PROJECT_OBLIGATION);
+
+        ObligationStatusInfo orgObl = new ObligationStatusInfo();
+        orgObl.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        orgObl.setObligationLevel(ObligationLevel.ORGANISATION_OBLIGATION);
+
+        linkedObligationStatus.put("license-obl-1", licenseObl1);
+        linkedObligationStatus.put("license-obl-2", licenseObl2);
+        linkedObligationStatus.put("component-obl-1", componentObl);
+        linkedObligationStatus.put("project-obl-1", projectObl);
+        linkedObligationStatus.put("org-obl-1", orgObl);
+        obligationList.setLinkedObligationStatus(linkedObligationStatus);
+        given(this.projectServiceMock.getObligationData(eq(project1.getLinkedObligationId()), any())).willReturn(obligationList);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api/projects/" + project1.getId() + "/tabCounts",
+                HttpMethod.GET,
+                new HttpEntity<>(null, headers),
+                String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
+        assertEquals(2, responseBody.get("obligationCount").asInt());
+        assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
+    }
+
+    @Test
+    public void should_get_project_detail_tab_counts_for_legacy_license_obligations_without_level() throws IOException, TException {
+        project1.setEnableVulnerabilitiesDisplay(true);
+        given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
+        given(this.vulnerabilityServiceMock.getVulnerabilitiesByProjectId(eq(project1.getId()), any()))
+                .willReturn(Collections.emptyList());
+
+        ObligationList obligationList = new ObligationList();
+        Map<String, ObligationStatusInfo> linkedObligationStatus = new HashMap<>();
+
+        // Legacy license obligation: no obligationLevel, but licenseIds present.
+        ObligationStatusInfo legacyLicenseObl = new ObligationStatusInfo();
+        legacyLicenseObl.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        legacyLicenseObl.setLicenseIds(new HashSet<>(Arrays.asList("Apache-2.0")));
+
+        // Non-license obligation: neither level nor licenseIds.
+        ObligationStatusInfo nonLicenseObl = new ObligationStatusInfo();
+        nonLicenseObl.setStatus(ObligationStatus.OPEN);
+
+        linkedObligationStatus.put("legacy-license", legacyLicenseObl);
+        linkedObligationStatus.put("non-license", nonLicenseObl);
+        obligationList.setLinkedObligationStatus(linkedObligationStatus);
+        given(this.projectServiceMock.getObligationData(eq(project1.getLinkedObligationId()), any())).willReturn(obligationList);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api/projects/" + project1.getId() + "/tabCounts",
+                HttpMethod.GET,
+                new HttpEntity<>(null, headers),
+                String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
+        assertEquals(1, responseBody.get("obligationCount").asInt());
+        assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
+    }
+
+    @Test
+    public void should_get_project_detail_tab_counts_computes_obligations_when_not_linked() throws IOException, TException {
+        project1.setEnableVulnerabilitiesDisplay(true);
+        // Simulate releases with obligations that were just linked: the obligation list
+        // has not been persisted yet, so the project has no linkedObligationId.
+        project1.setLinkedObligationId(null);
+        Map<String, ProjectReleaseRelationship> releaseIdToUsage = new HashMap<>();
+        releaseIdToUsage.put(release1.getId(),
+                new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE));
+        project1.setReleaseIdToUsage(releaseIdToUsage);
+
+        // The release must carry a CLI attachment to be considered for on-demand computation.
+        release1.setAttachments(new HashSet<>(Collections.singletonList(
+                new Attachment().setAttachmentContentId("att-1").setFilename("cli.xml"))));
+
+        given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
+        given(this.vulnerabilityServiceMock.getVulnerabilitiesByProjectId(eq(project1.getId()), any()))
+                .willReturn(Collections.emptyList());
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
+        given(this.projectServiceMock.getProjectEccCounts(eq(project1.getId()), any())).willReturn(
+                new Sw360ProjectService.ProjectEccCounts(0, 0));
+
+        // Obligations computed on-demand from the CLI attachments carry licenseIds but no
+        // obligationLevel, exactly as produced by the backend license info parsing.
+        Map<String, ObligationStatusInfo> computedObligations = new HashMap<>();
+        ObligationStatusInfo computedOpen = new ObligationStatusInfo();
+        computedOpen.setStatus(ObligationStatus.OPEN);
+        computedOpen.setLicenseIds(new HashSet<>(Arrays.asList("Apache-2.0")));
+        ObligationStatusInfo computedFulfilled = new ObligationStatusInfo();
+        computedFulfilled.setStatus(ObligationStatus.ACKNOWLEDGED_OR_FULFILLED);
+        computedFulfilled.setLicenseIds(new HashSet<>(Arrays.asList("MIT")));
+        computedObligations.put("computed-1", computedOpen);
+        computedObligations.put("computed-2", computedFulfilled);
+        given(this.projectServiceMock.setLicenseInfoWithObligations(any(), any(), any(), any()))
+                .willReturn(computedObligations);
+
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api/projects/" + project1.getId() + "/tabCounts",
+                HttpMethod.GET,
+                new HttpEntity<>(null, headers),
+                String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode responseBody = new ObjectMapper().readTree(response.getBody());
+        assertEquals(2, responseBody.get("obligationCount").asInt());
+        assertEquals(1, responseBody.get("obligationNonOpenCount").asInt());
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
Fixes the `/api/projects/{id}/tabCounts` endpoint to display the **correct license obligation count** in the Project detail tab.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4456*)
> * Did you add or update any new dependencies that are required for your change?

Closes https://github.com/eclipse-sw360/sw360/issues/4456

### Suggest Reviewer
> @GMishx 

### How To Test?
1. Open a project that has obligations of **mixed levels** (license + component/project).
2. Call `GET /api/projects/{id}/tabCounts`.
3. Verify `obligationCount` reflects **only** `LICENSE_OBLIGATION` entries.
4. Open a project that has **no** linked obligation list but has releases with CLI attachments.
5. Call `GET /api/projects/{id}/tabCounts`.
6. Verify `obligationCount` is computed correctly and is **non-zero**.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
