### PR TITLE
fix(project): fix releases list in obligation page.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -843,11 +843,11 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         try {
             LicenseObligationsStatusInfo licenseObligation = licenseClient.getProjectObligationStatus(
                     obligationStatusMap, licenseInfoWithObligations, releaseIdToAcceptedCLI);
-            Map<String, String> releaseIdToAcceptedCli = new HashMap<String, String>();
             obligationStatusMap = licenseObligation.getObligationStatusMap();
             for (Map.Entry<String, ObligationStatusInfo> entry : obligationStatusMap.entrySet()) {
                 ObligationStatusInfo details = entry.getValue();
                 if (details.getReleaseIdToAcceptedCLI() == null && details.getReleases()!=null) {
+                    Map<String, String> releaseIdToAcceptedCli = new HashMap<>();
                     Set<Release> releaseData = details.getReleases();
                     for (Release rel : releaseData) {
                         String releaseId = rel.getId();


### PR DESCRIPTION
Issue: If a user goes to the Obligations tab of a Project, each and every Obligation shows each and every Linked Release irrespective if the Obligation is coming from the Release or not. There should only be the Release which has that Obligation.

Description: fix releases list in obligation page. Now obligations are shown as per releases.
