### PR TITLE
fix(rest): Send email notifications to both creators and reviewers for clearing request and moderation request changes.

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1602,6 +1602,14 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return recipients;
     }
 
+    private Map<String, String> getRecipients(ClearingRequest cr, User reviewer) {
+        Map<String, String> recipients = getRecipients(cr);
+        if (reviewer != null && CommonUtils.isNotNullEmptyOrWhitespace(reviewer.getEmail())) {
+            recipients.put("reviewer", reviewer.getEmail());
+        }
+        return recipients;
+    }
+
     private String getUserDetails(User user) {
         return new StringBuilder(CommonUtils.nullToEmptyString(user.getUserGroup())).append(MailConstants.DASH).append(SW360Utils.printFullname(user)).toString();
     }
@@ -1694,7 +1702,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     private void sendMailForUpdatedCR(Project project, String projectUrl, ClearingRequest clearingRequest, User user) {
         List<Release> releases = getDirectlyLinkedReleasesInNewState(project);
         String userDetails = getUserDetails(user);
-        mailUtil.sendClearingMail(ClearingRequestEmailTemplate.UPDATED, MailConstants.SUBJECT_FOR_UPDATED_CLEARING_REQUEST, getRecipients(clearingRequest),
+        mailUtil.sendClearingMail(ClearingRequestEmailTemplate.UPDATED, MailConstants.SUBJECT_FOR_UPDATED_CLEARING_REQUEST, getRecipients(clearingRequest, user), true,
                 userDetails, CommonUtils.nullToEmptyString(clearingRequest.getId()), CommonUtils.nullToEmptyString(projectUrl), SW360Utils.printName(project),
                 CommonUtils.getEnumStringOrNull(clearingRequest.getClearingState()), clearingRequest.getRequestedClearingDate(),
                 CommonUtils.nullToEmptyString(clearingRequest.getAgreedClearingDate()), extractReleaseNameForClearingEmail(releases));
@@ -1713,7 +1721,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
         releases = getDirectlyLinkedReleasesInNewState(releases);
         mailUtil.sendClearingMail(ClearingRequestEmailTemplate.PROJECT_UPDATED, MailConstants.SUBJECT_FOR_UPDATED_PROJECT_WITH_CLEARING_REQUEST,
-                getRecipients(clearingRequest), userDetails, SW360Utils.printName(updated), updated.getClearingRequestId(),
+            getRecipients(clearingRequest, user), true, userDetails, SW360Utils.printName(updated), updated.getClearingRequestId(),
                 releaseChangesHtml, // HTML-formatted release changes
                 String.valueOf(updated.getLinkedProjectsSize()), String.valueOf(updated.getReleaseIdToUsageSize()), String.valueOf(totalCount),
                 String.valueOf(approvedCount), CommonUtils.getEnumStringOrNull(clearingRequest.getClearingState()),
@@ -1724,7 +1732,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     private void sendMailForClosedOrRejectedCR(Project project, ClearingRequest clearingRequest, User user, boolean isApproved) {
         mailUtil.sendClearingMail(isApproved ? ClearingRequestEmailTemplate.CLOSED : ClearingRequestEmailTemplate.REJECTED,
                 isApproved ? MailConstants.SUBJECT_FOR_CLOSED_CLEARING_REQUEST : MailConstants.SUBJECT_FOR_REJECTED_CLEARING_REQUEST,
-                getRecipients(clearingRequest), project.getClearingRequestId(), SW360Utils.printName(project), isApproved ? "closed" : "rejected");
+            getRecipients(clearingRequest, user), true, project.getClearingRequestId(), SW360Utils.printName(project), isApproved ? "closed" : "rejected");
     }
 
     private void sendMailNotificationsForNewProject(Project project, String user) {

--- a/backend/common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
@@ -126,15 +126,47 @@ public class MailUtil extends BackendUtils {
     }
 
     public void sendClearingMail(ClearingRequestEmailTemplate template, String subjectNameInPropertiesFile, Map<String, String> recipients, String... textParameters) {
-        MimeMessage messageWithSubjectAndText;
-        messageWithSubjectAndText = makeHtmlMessageWithSubjectAndText(template, subjectNameInPropertiesFile, textParameters);
+        sendClearingMail(template, subjectNameInPropertiesFile, recipients, false, textParameters);
+    }
+
+    public void sendClearingMail(ClearingRequestEmailTemplate template, String subjectNameInPropertiesFile,
+            Map<String, String> recipients, boolean forceRequestingUserMail, String... textParameters) {
+        MimeMessage messageWithSubjectAndText = makeHtmlMessageWithSubjectAndText(template, subjectNameInPropertiesFile, textParameters);
         if (!CommonUtils.isNullOrEmptyMap(recipients)) {
             String requestingUser = recipients.get(ClearingRequest._Fields.REQUESTING_USER.toString());
-            if (isMailWantedBy(requestingUser, SW360Utils.notificationPreferenceKey(SW360Constants.NOTIFICATION_CLASS_CLEARING_REQUEST, ClearingRequest._Fields.REQUESTING_USER.toString()))
-                && CommonUtils.isNotNullEmptyOrWhitespace(requestingUser)) {
-                sendMailWithSubjectAndText(String.join(",", recipients.values()), messageWithSubjectAndText);
-            } else {
-                sendMailWithSubjectAndText(recipients.get(ClearingRequest._Fields.CLEARING_TEAM.toString()), messageWithSubjectAndText);
+            String clearingTeam = recipients.get(ClearingRequest._Fields.CLEARING_TEAM.toString());
+
+            Set<String> resolvedRecipients = Sets.newLinkedHashSet();
+            boolean includeRequestingUser = CommonUtils.isNotNullEmptyOrWhitespace(requestingUser)
+                    && (forceRequestingUserMail
+                    || isMailWantedBy(requestingUser, SW360Utils.notificationPreferenceKey(
+                            SW360Constants.NOTIFICATION_CLASS_CLEARING_REQUEST,
+                            ClearingRequest._Fields.REQUESTING_USER.toString())));
+
+            if (includeRequestingUser) {
+                resolvedRecipients.add(requestingUser);
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(clearingTeam)) {
+                resolvedRecipients.add(clearingTeam);
+            }
+            // include any extra roles (reviewer, commenter, …) unconditionally
+            for (Map.Entry<String, String> entry : recipients.entrySet()) {
+                String roleKey = entry.getKey();
+                String roleEmail = entry.getValue();
+                if (roleKey.equals(ClearingRequest._Fields.REQUESTING_USER.toString())
+                        || roleKey.equals(ClearingRequest._Fields.CLEARING_TEAM.toString())) {
+                    continue;
+                }
+                if (CommonUtils.isNotNullEmptyOrWhitespace(roleEmail)) {
+                    resolvedRecipients.add(roleEmail);
+                }
+            }
+
+            log.info("Resolved clearing mail recipients for template {}: requesterIncluded={}, recipients={}",
+                    template, includeRequestingUser, resolvedRecipients);
+
+            if (!resolvedRecipients.isEmpty()) {
+                sendMailWithSubjectAndText(String.join(",", resolvedRecipients), messageWithSubjectAndText);
             }
         }
     }

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -472,7 +472,7 @@ public class ModerationDatabaseHandler {
         request.setCommentDecisionModerator(moderationDecisionComment);
         request.setReviewer(reviewer);
         repository.update(request);
-        sendMailToUserForDeclinedRequest(request);
+        sendMailToUserForDeclinedRequest(request, reviewer);
     }
 
     public void acceptRequest(ModerationRequest request, String moderationComment, String reviewer) {
@@ -480,7 +480,7 @@ public class ModerationDatabaseHandler {
         if (dbRequest == null) {
             dbHandlerUtil.addChangeLogs(null, request, reviewer, Operation.MODERATION_ACCEPT, null,
                     Lists.newArrayList(), request.getDocumentId(), null);
-            sendMailNotificationsForAcceptedRequest(request);
+            sendMailNotificationsForAcceptedRequest(request, reviewer);
             return;
         }
         ModerationRequest requestBefore = dbRequest.deepCopy();
@@ -497,7 +497,7 @@ public class ModerationDatabaseHandler {
         }
         dbHandlerUtil.addChangeLogs(dbRequest, requestBefore, reviewer, Operation.MODERATION_ACCEPT,
                 null, Lists.newArrayList(), dbRequest.getDocumentId(),null);
-        sendMailNotificationsForAcceptedRequest(request);
+        sendMailNotificationsForAcceptedRequest(request, reviewer);
     }
 
     public RequestStatus createRequest(Component component, User user, Boolean isDeleteRequest) {
@@ -1033,59 +1033,128 @@ public class ModerationDatabaseHandler {
         Map<String, String> recipients = Maps.newHashMap();
         recipients.put(ClearingRequest._Fields.REQUESTING_USER.toString(), cr.getRequestingUser());
         recipients.put(ClearingRequest._Fields.CLEARING_TEAM.toString(), cr.getClearingTeam());
+        // also notify the person who wrote the comment
+        if (user != null && CommonUtils.isNotNullEmptyOrWhitespace(user.getEmail())
+                && !user.getEmail().equals(cr.getRequestingUser())
+                && !user.getEmail().equals(cr.getClearingTeam())) {
+            recipients.put("commenter", user.getEmail());
+        }
         String userDetails = new StringBuilder(CommonUtils.nullToEmptyString(user.getUserGroup())).append(MailConstants.DASH).append(SW360Utils.printFullname(user)).toString();
         mailUtil.sendClearingMail(ClearingRequestEmailTemplate.NEW_COMMENT, MailConstants.SUBJECT_FOR_CLEARING_REQUEST_COMMENT, recipients,
             userDetails, CommonUtils.nullToEmptyString(cr.getId()), SW360Utils.printName(project), CommonUtils.nullToEmptyString(comment.getText()));
     }
 
     private void sendMailNotificationsForNewRequest(ModerationRequest request, String userEmail){
-        mailUtil.sendMail(request.getModerators(), userEmail,
+        String docType = ThriftEnumUtils.enumToString(request.getDocumentType());
+        String docName = request.getDocumentName();
+        Set<String> notified = new HashSet<>();
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(request.getRequestingUser())) {
+            mailUtil.sendMail(request.getRequestingUser(),
                 MailConstants.SUBJECT_FOR_NEW_MODERATION_REQUEST,
                 MailConstants.TEXT_FOR_NEW_MODERATION_REQUEST,
-                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST, ModerationRequest._Fields.MODERATORS.toString(),
-                ThriftEnumUtils.enumToString(request.getDocumentType()),
-                request.getDocumentName());
+                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
+                ModerationRequest._Fields.REQUESTING_USER.toString(),
+                false, docType, docName);
+            notified.add(request.getRequestingUser());
+        }
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(userEmail) && !notified.contains(userEmail)) {
+            mailUtil.sendMail(userEmail,
+                MailConstants.SUBJECT_FOR_NEW_MODERATION_REQUEST,
+                MailConstants.TEXT_FOR_NEW_MODERATION_REQUEST,
+                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
+                ModerationRequest._Fields.MODERATORS.toString(),
+                false, docType, docName);
+        }
+
+        log.info("Moderation NEW mail dispatched: requester={}, actor={}",
+            request.getRequestingUser(), userEmail);
     }
 
     private void sendMailNotificationsForUpdatedRequest(ModerationRequest request, String userEmail){
-        mailUtil.sendMail(request.getModerators(), userEmail,
+        String docType = ThriftEnumUtils.enumToString(request.getDocumentType());
+        String docName = request.getDocumentName();
+        Set<String> notified = new HashSet<>();
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(request.getRequestingUser())) {
+            mailUtil.sendMail(request.getRequestingUser(),
                 MailConstants.SUBJECT_FOR_UPDATE_MODERATION_REQUEST,
                 MailConstants.TEXT_FOR_UPDATE_MODERATION_REQUEST,
-                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST, ModerationRequest._Fields.MODERATORS.toString(),
-                ThriftEnumUtils.enumToString(request.getDocumentType()),
-                request.getDocumentName());
-    }
-
-    private void sendMailToUserForDeclinedRequest(ModerationRequest request){
-        boolean isUserRequest = request.getDocumentType() == DocumentType.USER;
-        if (isUserRequest){
-            mailUtil.sendMail(request.getRequestingUser(),
-                    MailConstants.SUBJECT_FOR_DECLINED_USER_MODERATION_REQUEST,
-                    MailConstants.TEXT_FOR_DECLINED_USER_MODERATION_REQUEST,
-                    SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
-                    ModerationRequest._Fields.REQUESTING_USER.toString(),
-                    false);
-        } else {
-            mailUtil.sendMail(request.getRequestingUser(),
-                    MailConstants.SUBJECT_FOR_DECLINED_MODERATION_REQUEST,
-                    MailConstants.TEXT_FOR_DECLINED_MODERATION_REQUEST,
-                    SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
-                    ModerationRequest._Fields.REQUESTING_USER.toString(),
-                    true,
-                    ThriftEnumUtils.enumToString(request.getDocumentType()),
-                    request.getDocumentName());
+                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
+                ModerationRequest._Fields.REQUESTING_USER.toString(),
+                false, docType, docName);
+            notified.add(request.getRequestingUser());
         }
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(userEmail) && !notified.contains(userEmail)) {
+            mailUtil.sendMail(userEmail,
+                MailConstants.SUBJECT_FOR_UPDATE_MODERATION_REQUEST,
+                MailConstants.TEXT_FOR_UPDATE_MODERATION_REQUEST,
+                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
+                ModerationRequest._Fields.MODERATORS.toString(),
+                false, docType, docName);
+        }
+
+        log.info("Moderation UPDATE mail dispatched: requester={}, actor={}",
+            request.getRequestingUser(), userEmail);
     }
 
-    private void sendMailNotificationsForAcceptedRequest(ModerationRequest request) {
+    private void sendMailToUserForDeclinedRequest(ModerationRequest request, String reviewer){
         boolean isUserRequest = request.getDocumentType() == DocumentType.USER;
-        mailUtil.sendMail(request.getRequestingUser(),
+        String subjectKey = isUserRequest
+            ? MailConstants.SUBJECT_FOR_DECLINED_USER_MODERATION_REQUEST
+            : MailConstants.SUBJECT_FOR_DECLINED_MODERATION_REQUEST;
+        String textKey = isUserRequest
+            ? MailConstants.TEXT_FOR_DECLINED_USER_MODERATION_REQUEST
+            : MailConstants.TEXT_FOR_DECLINED_MODERATION_REQUEST;
+        String[] params = isUserRequest
+            ? new String[]{}
+            : new String[]{ ThriftEnumUtils.enumToString(request.getDocumentType()), request.getDocumentName() };
+
+        Set<String> notified = new HashSet<>();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(request.getRequestingUser())) {
+            mailUtil.sendMail(request.getRequestingUser(), subjectKey, textKey,
+                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
+                ModerationRequest._Fields.REQUESTING_USER.toString(), false, params);
+            notified.add(request.getRequestingUser());
+        }
+
+        if (!isUserRequest && CommonUtils.isNotNullEmptyOrWhitespace(reviewer) && !notified.contains(reviewer)) {
+            mailUtil.sendMail(reviewer, subjectKey, textKey,
+                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
+                ModerationRequest._Fields.MODERATORS.toString(), false, params);
+        }
+
+        log.info("Moderation DECLINED mail dispatched: requester={}, reviewer={}",
+            request.getRequestingUser(), reviewer);
+    }
+
+    private void sendMailNotificationsForAcceptedRequest(ModerationRequest request, String reviewer) {
+        String docType = ThriftEnumUtils.enumToString(request.getDocumentType());
+        String docName = request.getDocumentName();
+        Set<String> notified = new HashSet<>();
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(request.getRequestingUser())) {
+            mailUtil.sendMail(request.getRequestingUser(),
                 MailConstants.SUBJECT_FOR_ACCEPTED_MODERATION_REQUEST,
                 MailConstants.TEXT_FOR_ACCEPTED_MODERATION_REQUEST,
                 SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
                 ModerationRequest._Fields.REQUESTING_USER.toString(),
-                !isUserRequest,
-                ThriftEnumUtils.enumToString(request.getDocumentType()),
-                request.getDocumentName());
+                false, docType, docName);
+            notified.add(request.getRequestingUser());
+        }
+
+        if (CommonUtils.isNotNullEmptyOrWhitespace(reviewer) && !notified.contains(reviewer)) {
+            mailUtil.sendMail(reviewer,
+                MailConstants.SUBJECT_FOR_ACCEPTED_MODERATION_REQUEST,
+                MailConstants.TEXT_FOR_ACCEPTED_MODERATION_REQUEST,
+                SW360Constants.NOTIFICATION_CLASS_MODERATION_REQUEST,
+                ModerationRequest._Fields.MODERATORS.toString(),
+                false, docType, docName);
+        }
+
+        log.info("Moderation ACCEPTED mail dispatched: requester={}, reviewer={}",
+            request.getRequestingUser(), reviewer);
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Before this fix, email notifications for clearing requests and moderation requests were only sent to one side — either the requesting user or the clearing team/moderators, but never both. The reviewer/actor (admin performing accept/decline/update) was never notified at all.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #4464 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
*Prerequisites:**
- At least two users: one as the CR/MR creator, one as admin/reviewer
- One or more Clearing Requests (CR) and Moderation Requests (MR) created by the creator user

**Steps:**

**Clearing Request (CR):**
1. Login as admin
2. Navigate to **Requests** → **Clearing Requests**
3. Open any CR and perform one of these actions:
   - Change state (IN_PROGRESS / ACCEPTED / AWAITING_RESPONSE)
   - Close or Reject the CR
   - Add a comment
4. Check application logs — you should see:

INFO MailUtil - Resolved clearing mail recipients for template <TEMPLATE>: requesterIncluded=true, recipients=[[creator@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [clearingteam@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [admin@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)]
INFO MailUtil - Send asynchronous E-Mail to recipient [[creator@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [clearingteam@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [admin@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)]


**Moderation Request (MR):**
1. Login as admin
2. Navigate to **Requests** → **Moderation Requests**
3. Open any MR and perform one of these actions:
- Accept the request
- Decline the request
4. Check application logs — you should see:

INFO ModerationDatabaseHandler - Moderation ACCEPTED/DECLINED mail dispatched: requester=[creator@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), reviewer=[admin@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
INFO MailUtil - Send asynchronous E-Mail to recipient [[creator@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)]
INFO MailUtil - Send asynchronous E-Mail to recipient [[admin@example.com](vscode-file://vscode-app/snap/code/255/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)]


> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
