### PR TITLE
feat(clearingRequest): Add new params and date filters for advanced filter

### DIFF
--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingRequestRepository.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingRequestRepository.java
@@ -18,9 +18,12 @@ import java.util.Set;
 import java.util.Collections;
 import java.util.ArrayList;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestPriority;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -33,6 +36,8 @@ import com.ibm.cloud.cloudant.v1.model.PostFindOptions;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.eq;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.and;
 import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.or;
+import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.gte;
+import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant.lte;
 
 /**
  * CRUD access for the ClearingRequest class
@@ -40,6 +45,8 @@ import static org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorClou
  * @author abdul.mannankapti@siemens.com
  */
 public class ClearingRequestRepository extends DatabaseRepositoryCloudantClient<ClearingRequest> {
+    private static final Logger log = LogManager.getLogger(ClearingRequestRepository.class);
+
     private static final String ALL = "function(doc) { if (doc.type == 'clearingRequest') emit(null, doc._id) }";
 
     private static final String BY_PROJECT_ID = "function(doc) { " +
@@ -114,7 +121,13 @@ public class ClearingRequestRepository extends DatabaseRepositoryCloudantClient<
                 ClearingRequest._Fields.CLEARING_TEAM.getFieldName(),
                 ClearingRequest._Fields.PROJECT_BU.getFieldName(),
                 ClearingRequest._Fields.CLEARING_STATE.getFieldName(),
-                ClearingRequest._Fields.TIMESTAMP.getFieldName()
+                ClearingRequest._Fields.TIMESTAMP.getFieldName(),
+                ClearingRequest._Fields.PRIORITY.getFieldName(),
+                ClearingRequest._Fields.CLEARING_TYPE.getFieldName(),
+                ClearingRequest._Fields.REQUESTED_CLEARING_DATE.getFieldName(),
+                ClearingRequest._Fields.AGREED_CLEARING_DATE.getFieldName(),
+                ClearingRequest._Fields.MODIFIED_ON.getFieldName(),
+                ClearingRequest._Fields.TIMESTAMP_OF_DECISION.getFieldName()
         }, db);
     }
 
@@ -148,61 +161,74 @@ public class ClearingRequestRepository extends DatabaseRepositoryCloudantClient<
     /**
      * Get recent clearing requests with pagination filtered by user access
      * @param user User email
-     * @param businessUnit User's business unit
+     * @param businessUnits Business units the user belongs to (primary and secondary)
      * @param pageData Pagination data
      * @return Map containing pagination data as key and list of clearing requests as value
      */
     public Map<PaginationData, List<ClearingRequest>> getRecentClearingRequestsWithPagination(
-            String user, String businessUnit, PaginationData pageData) {
+            String user, Set<String> businessUnits, PaginationData pageData) {
         Map<PaginationData, List<ClearingRequest>> result = Maps.newHashMap();
-        
+
         final Map<String, Object> typeSelector = eq("type", "clearingRequest");
-        final Map<String, Object> userOrBuSelector = or(List.of(
-                eq(ClearingRequest._Fields.REQUESTING_USER.getFieldName(), user),
-                eq(ClearingRequest._Fields.CLEARING_TEAM.getFieldName(), user),
-                eq(ClearingRequest._Fields.PROJECT_BU.getFieldName(), businessUnit)
-        ));
+        final Map<String, Object> userOrBuSelector = getVisibilitySelector(user, businessUnits);
         final Map<String, Object> finalSelector = and(List.of(typeSelector, userOrBuSelector));
-        
+
         final Map<String, String> sortSelector = Collections.singletonMap(
-                ClearingRequest._Fields.TIMESTAMP.getFieldName(), 
+                ClearingRequest._Fields.TIMESTAMP.getFieldName(),
                 pageData.isAscending() ? "asc" : "desc"
         );
-        
+
         PostFindOptions.Builder qb = getConnector().getQueryBuilder()
                 .selector(finalSelector)
                 .useIndex(Collections.singletonList(CLEARING_REQUEST_BY_ALL_IDX));
-        
+
         List<ClearingRequest> clearingRequests = getConnector().getQueryResultPaginated(
                 qb, ClearingRequest.class, pageData, sortSelector
         );
-        
+
         result.put(pageData, clearingRequests);
         return result;
     }
 
     /**
+     * Builds the mandatory visibility clause: a clearing request is visible when the user
+     * raised it, is its clearing team, or when it belongs to one of the user's business
+     * units. Secondary departments are included so that filtering by a secondary BA-BL
+     * returns results, matching the behaviour of the legacy clearing request page.
+     * @param user User email
+     * @param businessUnits Business units the user belongs to (primary and secondary)
+     * @return Visibility selector
+     */
+    private static Map<String, Object> getVisibilitySelector(String user, Set<String> businessUnits) {
+        List<Map<String, Object>> visibleConditions = new ArrayList<>();
+        visibleConditions.add(eq(ClearingRequest._Fields.REQUESTING_USER.getFieldName(), user));
+        visibleConditions.add(eq(ClearingRequest._Fields.CLEARING_TEAM.getFieldName(), user));
+        CommonUtils.nullToEmptySet(businessUnits).stream()
+                .filter(CommonUtils::isNotNullEmptyOrWhitespace)
+                .distinct()
+                .forEach(bu -> visibleConditions.add(
+                        eq(ClearingRequest._Fields.PROJECT_BU.getFieldName(), bu)));
+        return or(visibleConditions);
+    }
+
+    /**
      * Search clearing requests by filters with pagination filtered by user access
      * @param user User email
-     * @param businessUnit User's business unit
+     * @param businessUnits Business units the user belongs to (primary and secondary)
      * @param filterMap Map of field names to sets of values to match against
      * @param pageData Pagination data
      * @return Map containing pagination data as key and list of clearing requests as value
      */
     public Map<PaginationData, List<ClearingRequest>> searchClearingRequestsByFilters(
-            String user, String businessUnit, Map<String, Set<String>> filterMap, PaginationData pageData) {
-        
+            String user, Set<String> businessUnits, Map<String, Set<String>> filterMap, PaginationData pageData) {
+
         final Map<String, Object> typeSelector = eq("type", "clearingRequest");
-        final Map<String, Object> userOrBuSelector = or(List.of(
-                eq(ClearingRequest._Fields.REQUESTING_USER.getFieldName(), user),
-                eq(ClearingRequest._Fields.CLEARING_TEAM.getFieldName(), user),
-                eq(ClearingRequest._Fields.PROJECT_BU.getFieldName(), businessUnit)
-        ));
+        final Map<String, Object> userOrBuSelector = getVisibilitySelector(user, businessUnits);
         final Map<String, Object> restrictionsSelector = getQueryFromRestrictions(filterMap);
         final Map<String, Object> finalSelector = and(List.of(typeSelector, userOrBuSelector, restrictionsSelector));
 
         final Map<String, String> sortSelector = Collections.singletonMap(
-                ClearingRequest._Fields.TIMESTAMP.getFieldName(), 
+                ClearingRequest._Fields.TIMESTAMP.getFieldName(),
                 pageData.isAscending() ? "asc" : "desc"
         );
 
@@ -220,14 +246,29 @@ public class ClearingRequestRepository extends DatabaseRepositoryCloudantClient<
     private Map<String, Object> getQueryFromRestrictions(Map<String, Set<String>> subQueryRestrictions) {
         List<Map<String, Object>> andConditions = new ArrayList<>();
 
+        // Date-range filters (e.g. "Last 7 days") are signalled via sentinel keys instead of
+        // the standard field name, since the generic filterMap only supports eq/or matching.
+        String dateField = getSingleValue(subQueryRestrictions, SW360Constants.CLEARING_REQUEST_DATE_FIELD_KEY);
+        if (dateField != null) {
+            String from = getSingleValue(subQueryRestrictions, SW360Constants.CLEARING_REQUEST_DATE_FROM_KEY);
+            String to = getSingleValue(subQueryRestrictions, SW360Constants.CLEARING_REQUEST_DATE_TO_KEY);
+            addDateRangeConditions(andConditions, dateField, from, to);
+        }
+
         for (Map.Entry<String, Set<String>> entry : subQueryRestrictions.entrySet()) {
             String field = entry.getKey();
             Set<String> values = entry.getValue();
 
+            if (SW360Constants.CLEARING_REQUEST_DATE_FIELD_KEY.equals(field)
+                    || SW360Constants.CLEARING_REQUEST_DATE_FROM_KEY.equals(field)
+                    || SW360Constants.CLEARING_REQUEST_DATE_TO_KEY.equals(field)) {
+                continue;
+            }
+
             if (values == null || values.isEmpty()) {
                 continue;
             }
-            
+
             List<String> nonEmptyValues = values.stream()
                     .filter(v -> v != null && !v.isEmpty())
                     .toList();
@@ -248,5 +289,62 @@ public class ClearingRequestRepository extends DatabaseRepositoryCloudantClient<
         }
 
         return and(andConditions);
+    }
+
+    /**
+     * Appends $gte / $lte selectors for the given ClearingRequest date field, choosing the
+     * numeric or the lexicographic comparison depending on how the field is persisted.
+     * @param andConditions Condition list to append to
+     * @param dateField Name of the ClearingRequest field to filter on
+     * @param from Inclusive lower bound, or {@code null} for an open lower bound
+     * @param to Inclusive upper bound, or {@code null} for an open upper bound
+     * @throws IllegalArgumentException if the field is not a supported date field or a bound
+     *         cannot be parsed. Failing loudly is intentional: silently dropping the range
+     *         would return documents outside the caller's requested window.
+     */
+    private void addDateRangeConditions(List<Map<String, Object>> andConditions, String dateField,
+                                        String from, String to) {
+        if (from == null && to == null) {
+            return;
+        }
+        if (SW360Constants.CLEARING_REQUEST_EPOCH_DATE_FIELDS.contains(dateField)) {
+            if (from != null) {
+                andConditions.add(gte(dateField, parseEpochBound(from, dateField)));
+            }
+            if (to != null) {
+                andConditions.add(lte(dateField, parseEpochBound(to, dateField)));
+            }
+        } else if (SW360Constants.CLEARING_REQUEST_ISO_DATE_FIELDS.contains(dateField)) {
+            if (from != null) {
+                andConditions.add(gte(dateField, from));
+            }
+            if (to != null) {
+                andConditions.add(lte(dateField, to));
+            }
+        } else {
+            log.error("Unsupported clearing request date range field: {}", dateField);
+            throw new IllegalArgumentException(
+                    "Unsupported clearing request date range field: " + dateField);
+        }
+    }
+
+    private static long parseEpochBound(String value, String dateField) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            log.error("Invalid epoch millis bound '{}' for clearing request date field: {}", value, dateField, e);
+            throw new IllegalArgumentException(
+                    "Invalid epoch millis bound '" + value + "' for clearing request date field: " + dateField, e);
+        }
+    }
+
+    private static String getSingleValue(Map<String, Set<String>> filterMap, String key) {
+        Set<String> values = filterMap.get(key);
+        if (values == null) {
+            return null;
+        }
+        return values.stream()
+                .filter(v -> v != null && !v.isEmpty())
+                .findFirst().orElse(null);
     }
 }

--- a/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -173,13 +173,30 @@ public class ModerationDatabaseHandler {
 
     public Map<PaginationData, List<ClearingRequest>> getRecentClearingRequestsWithPagination(User user, PaginationData pageData) {
         return clearingRequestRepository.getRecentClearingRequestsWithPagination(
-                user.getEmail(), user.getDepartment(), pageData);
+                user.getEmail(), getUserBusinessUnits(user), pageData);
     }
 
     public Map<PaginationData, List<ClearingRequest>> searchClearingRequestsByFilters(
             User user, Map<String, Set<String>> filterMap, PaginationData pageData) {
         return clearingRequestRepository.searchClearingRequestsByFilters(
-                user.getEmail(), user.getDepartment(), filterMap, pageData);
+                user.getEmail(), getUserBusinessUnits(user), filterMap, pageData);
+    }
+
+    /**
+     * Collects every business unit a user belongs to: the primary department plus all
+     * secondary departments. Clearing requests of any of them are visible to the user.
+     * @param user User to collect the business units for
+     * @return Business units of the user, never null
+     */
+    private static Set<String> getUserBusinessUnits(User user) {
+        Set<String> businessUnits = new HashSet<>();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(user.getDepartment())) {
+            businessUnits.add(user.getDepartment());
+        }
+        if (!CommonUtils.isNullOrEmptyMap(user.getSecondaryDepartmentsAndRoles())) {
+            businessUnits.addAll(user.getSecondaryDepartmentsAndRoles().keySet());
+        }
+        return businessUnits;
     }
 
     public Integer getOpenCriticalCrCountByGroup(String group) {

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseConnectorCloudant.java
@@ -79,9 +79,11 @@ public class DatabaseConnectorCloudant {
     private static final String OPERATOR_EXISTS = "$exists";
     private static final String OPERATOR_ELEM_MATCH = "$elemMatch";
     private static final String OPERATOR_REGEX = "$regex";
+    private static final String OPERATOR_GTE = "$gte";
+    private static final String OPERATOR_LTE = "$lte";
     private static final Set<String> OPERATORS = Set.of(
             OPERATOR_EQ, OPERATOR_IN, OPERATOR_ALL, OPERATOR_AND, OPERATOR_OR,
-            OPERATOR_EXISTS, OPERATOR_ELEM_MATCH
+            OPERATOR_EXISTS, OPERATOR_ELEM_MATCH, OPERATOR_GTE, OPERATOR_LTE
     );
 
     public DatabaseConnectorCloudant(Cloudant client, String dbName) {
@@ -985,6 +987,60 @@ public class DatabaseConnectorCloudant {
         field = replaceFirstSymbol(field);
         return Collections.singletonMap(field,
                 Collections.singletonMap(OPERATOR_EQ, value));
+    }
+
+    /**
+     * Generates a $gte (greater-than-or-equal) selector for given field with given value.
+     * Useful for numeric/timestamp range queries, e.g. "createdOn is on or after X".
+     * @param field Field name
+     * @param value Numeric value (e.g. epoch millis) to compare against
+     * @return New selector
+     */
+    public static @NotNull Map<String, Object> gte(String field, long value) {
+        field = replaceFirstSymbol(field);
+        return Collections.singletonMap(field,
+                Collections.singletonMap(OPERATOR_GTE, value));
+    }
+
+    /**
+     * Generates a $lte (less-than-or-equal) selector for given field with given value.
+     * Useful for numeric/timestamp range queries, e.g. "createdOn is on or before X".
+     * @param field Field name
+     * @param value Numeric value (e.g. epoch millis) to compare against
+     * @return New selector
+     */
+    public static @NotNull Map<String, Object> lte(String field, long value) {
+        field = replaceFirstSymbol(field);
+        return Collections.singletonMap(field,
+                Collections.singletonMap(OPERATOR_LTE, value));
+    }
+
+    /**
+     * Generates a $gte (greater-than-or-equal) selector for given field with given value.
+     * Useful for lexicographic range queries on zero-padded date strings,
+     * e.g. "requestedClearingDate is on or after 2026-08-01".
+     * @param field Field name
+     * @param value String value (e.g. an ISO {@code yyyy-MM-dd} date) to compare against
+     * @return New selector
+     */
+    public static @NotNull Map<String, Object> gte(String field, String value) {
+        field = replaceFirstSymbol(field);
+        return Collections.singletonMap(field,
+                Collections.singletonMap(OPERATOR_GTE, value));
+    }
+
+    /**
+     * Generates a $lte (less-than-or-equal) selector for given field with given value.
+     * Useful for lexicographic range queries on zero-padded date strings,
+     * e.g. "requestedClearingDate is on or before 2026-08-31".
+     * @param field Field name
+     * @param value String value (e.g. an ISO {@code yyyy-MM-dd} date) to compare against
+     * @return New selector
+     */
+    public static @NotNull Map<String, Object> lte(String field, String value) {
+        field = replaceFirstSymbol(field);
+        return Collections.singletonMap(field,
+                Collections.singletonMap(OPERATOR_LTE, value));
     }
 
     /**

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -82,6 +82,38 @@ public class SW360Constants {
     public static final String TYPE_PROJECT_OBLIGATION = "obligationList";
     public static final String TYPE_MODERATION = "moderation";
     public static final String TYPE_CLEARING = "clearing";
+
+    /**
+     * Sentinel filter-map keys used by ClearingRequest date-range search (e.g. "Last 7 days").
+     * The generic filterMap mechanism (Map&lt;String, Set&lt;String&gt;&gt;) only supports
+     * equality/OR matching per field, so these dedicated keys signal the repository layer
+     * to build a $gte / $lte range selector on the ClearingRequest field named by
+     * {@link #CLEARING_REQUEST_DATE_FIELD_KEY} instead of an $eq/$or one.
+     * Shared between the REST controller (producer) and the backend repository (consumer)
+     * since those two modules don't share a direct Java dependency (they only talk via Thrift).
+     */
+    public static final String CLEARING_REQUEST_DATE_FIELD_KEY = "crDateField";
+    public static final String CLEARING_REQUEST_DATE_FROM_KEY = "crDateFrom";
+    public static final String CLEARING_REQUEST_DATE_TO_KEY = "crDateTo";
+
+    /**
+     * ClearingRequest date fields stored as epoch milliseconds (Thrift {@code i64}).
+     * Range bounds for these fields are transported as the decimal string form of the
+     * epoch millis and must be compared numerically.
+     */
+    public static final Set<String> CLEARING_REQUEST_EPOCH_DATE_FIELDS = Set.of(
+            ClearingRequest._Fields.TIMESTAMP.getFieldName(),
+            ClearingRequest._Fields.MODIFIED_ON.getFieldName(),
+            ClearingRequest._Fields.TIMESTAMP_OF_DECISION.getFieldName());
+
+    /**
+     * ClearingRequest date fields stored as ISO {@code yyyy-MM-dd} strings.
+     * Since the format is zero-padded and fixed width, lexicographic comparison is
+     * equivalent to chronological comparison.
+     */
+    public static final Set<String> CLEARING_REQUEST_ISO_DATE_FIELDS = Set.of(
+            ClearingRequest._Fields.REQUESTED_CLEARING_DATE.getFieldName(),
+            ClearingRequest._Fields.AGREED_CLEARING_DATE.getFieldName());
     public static final String TYPE_SEARCHRESULT = "searchResult";
     public static final String TYPE_CHANGELOG = "changeLog";
     public static final String TYPE_VULNERABILITYDTO = "vulDTO";

--- a/rest/resource-server/src/docs/asciidoc/clearingRequests.adoc
+++ b/rest/resource-server/src/docs/asciidoc/clearingRequests.adoc
@@ -77,6 +77,91 @@ include::{snippets}/should_document_get_clearingrequests_by_state/curl-request.a
 include::{snippets}/should_document_get_clearingrequests_by_state/http-response.adoc[]
 
 
+[[resources-clearingRequest-by-date-range]]
+==== List all clearingRequest by date range
+
+A `GET` request will list all the Clearing Requests visible to the user whose selected date
+field falls inside the given range.
+
+`dateField` selects which date is filtered on and accepts `createdOn`, `requestedClearingDate`,
+`agreedClearingDate`, `modifiedOn` or `closedOn`. It defaults to `createdOn`.
+
+The range is given either as an explicit inclusive `fromDate` / `toDate` pair in ISO
+`yyyy-MM-dd` format, or as a relative `days` value. The two forms cannot be combined.
+
+|===
+|`days` |Resulting range
+
+|`0`
+|Today only
+
+|`< 0`
+|The last N days, up to and including today
+
+|`> 0`
+|Today up to and including the next N days
+|===
+
+A range in the future is rejected with `400 Bad Request` for `createdOn`, `modifiedOn` and
+`closedOn`, since those dates can never lie in the future.
+
+===== Request parameter
+include::{snippets}/should_document_get_clearingrequests_by_date_range/query-parameters.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_clearingrequests_by_date_range/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_clearingrequests_by_date_range/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_clearingrequests_by_date_range/http-response.adoc[]
+
+
+[[resources-clearingRequest-by-relative-date-range]]
+==== List all clearingRequest by relative date range
+
+A `GET` request using the `days` parameter will list all the Clearing Requests visible to the
+user whose selected date field falls inside a range relative to today.
+
+===== Request parameter
+include::{snippets}/should_document_get_clearingrequests_by_relative_date_range/query-parameters.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_clearingrequests_by_relative_date_range/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_clearingrequests_by_relative_date_range/http-response.adoc[]
+
+
+[[resources-clearingRequest-by-group]]
+==== List all clearingRequest by BA-BL / group
+
+A `GET` request with the `group` parameter will list all the Clearing Requests visible to the
+user whose project business unit matches the given BA-BL / group.
+
+The match is **exact**: filtering by `SHS AT` returns clearing requests of `SHS AT` only, and
+not those of nested units such as `SHS AT COR`. The selectable values can be retrieved from
+the project groups endpoint (`GET /api/projects/groups`), since a clearing request inherits
+its business unit from the project it was raised for.
+
+A clearing request is visible to a user when the user raised it, is its clearing team, or
+when it belongs to the user's primary department or to any of the user's secondary
+departments.
+
+===== Request parameter
+include::{snippets}/should_document_get_clearingrequests_by_group/query-parameters.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_clearingrequests_by_group/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_clearingrequests_by_group/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_clearingrequests_by_group/http-response.adoc[]
+
+
 [[resources-comments-list]]
 ==== Listing comments for a clearing request
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -13,7 +13,10 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -188,17 +191,40 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             @RequestParam(value = "projectId", required = false) String projectId,
             @Parameter(description = "Status of the clearing request (comma-separated for multiple values, e.g., 'NEW,ACCEPTED,IN_PROGRESS')")
             @RequestParam(value = "status", required = false) Set<ClearingRequestState> status,
+            @Parameter(description = "Priority of the clearing request (comma-separated for multiple values, e.g., 'LOW,HIGH')")
+            @RequestParam(value = "priority", required = false) Set<ClearingRequestPriority> priority,
+            @Parameter(description = "Type of the clearing request. Possible values are: DEEP, HIGH")
+            @RequestParam(value = "clearingType", required = false) String clearingType,
             @Parameter(description = "Requesting user email to filter")
             @RequestParam(value = "createdBy", required = false) String createdBy,
+            @Parameter(description = "BA-BL / group of the project the clearing request belongs to. "
+                    + "Matched exactly against the project business unit. "
+                    + "The selectable values are available from /api/projects/groups.")
+            @RequestParam(value = "group", required = false) String group,
             @Parameter(description = "Date clearing request was created on (timestamp).")
             @RequestParam(value = "createdOn", required = false) String createdOn,
+            @Parameter(description = "Date field to apply the date range filter on. Defaults to 'createdOn' when a range is given.",
+                    schema = @Schema(allowableValues = {"createdOn", "requestedClearingDate", "agreedClearingDate", "modifiedOn", "closedOn"}))
+            @RequestParam(value = "dateField", required = false) String dateField,
+            @Parameter(description = "Inclusive start of the date range in ISO format (yyyy-MM-dd). Cannot be combined with 'days'.",
+                    example = "2026-08-01")
+            @RequestParam(value = "fromDate", required = false) String fromDate,
+            @Parameter(description = "Inclusive end of the date range in ISO format (yyyy-MM-dd). Cannot be combined with 'days'.",
+                    example = "2026-08-31")
+            @RequestParam(value = "toDate", required = false) String toDate,
+            @Parameter(description = "Relative date range in days: 0 = today, negative = the last N days up to today, "
+                    + "positive = today up to the next N days. Cannot be combined with 'fromDate'/'toDate'. "
+                    + "Positive values are only valid for 'requestedClearingDate' and 'agreedClearingDate'.",
+                    example = "-30")
+            @RequestParam(value = "days", required = false) Integer days,
             HttpServletRequest request
     ) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
 
         Map<PaginationData, List<ClearingRequest>> paginatedClearingRequests = null;
-        Map<String, Set<String>> filterMap = getFilterMapForClearingRequests(projectId, status, createdBy, createdOn);
+        Map<String, Set<String>> filterMap = getFilterMapForClearingRequests(projectId, status, priority, clearingType,
+                createdBy, group, createdOn, dateField, fromDate, toDate, days);
 
         try {
             if (filterMap.isEmpty()) {
@@ -227,9 +253,7 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
             HttpStatus status1 = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
             return new ResponseEntity<>(resources, status1);
 
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException e) {
             throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
@@ -237,7 +261,8 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
     }
 
     private Map<String, Set<String>> getFilterMapForClearingRequests(
-            String projectId, Set<ClearingRequestState> status, String createdBy, String createdOn) {
+            String projectId, Set<ClearingRequestState> status, Set<ClearingRequestPriority> priority, String clearingType,
+            String createdBy, String group, String createdOn, String dateField, String fromDate, String toDate, Integer days) {
         Map<String, Set<String>> filterMap = new HashMap<>();
 
         if (CommonUtils.isNotNullEmptyOrWhitespace(projectId)) {
@@ -249,14 +274,170 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
                     .collect(Collectors.toSet());
             filterMap.put(ClearingRequest._Fields.CLEARING_STATE.getFieldName(), statusValues);
         }
+        if (priority != null && !priority.isEmpty()) {
+            Set<String> priorityValues = priority.stream()
+                    .map(ClearingRequestPriority::toString)
+                    .collect(Collectors.toSet());
+            filterMap.put(ClearingRequest._Fields.PRIORITY.getFieldName(), priorityValues);
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(clearingType)) {
+            String normalizedClearingType = clearingType.trim().toUpperCase();
+            try {
+                ClearingRequestType.valueOf(normalizedClearingType);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestClientException(
+                        "Invalid value for clearingType: " + clearingType + ". Allowed values are " + Arrays.toString(ClearingRequestType.values()));
+            }
+            filterMap.put(ClearingRequest._Fields.CLEARING_TYPE.getFieldName(), Collections.singleton(normalizedClearingType));
+        }
         if (CommonUtils.isNotNullEmptyOrWhitespace(createdBy)) {
             filterMap.put(ClearingRequest._Fields.REQUESTING_USER.getFieldName(), Collections.singleton(createdBy));
+        }
+        if (CommonUtils.isNotNullEmptyOrWhitespace(group)) {
+            filterMap.put(ClearingRequest._Fields.PROJECT_BU.getFieldName(), Collections.singleton(group.trim()));
         }
         if (CommonUtils.isNotNullEmptyOrWhitespace(createdOn)) {
             filterMap.put(ClearingRequest._Fields.TIMESTAMP.getFieldName(), Collections.singleton(createdOn));
         }
 
+        addDateRangeFilter(filterMap, dateField, fromDate, toDate, days);
         return filterMap;
+    }
+
+    /**
+     * Date fields of a {@link ClearingRequest} that can be filtered on by a date range,
+     * mapping the API parameter value to the underlying document field.
+     */
+    private enum ClearingRequestDateField {
+        CREATED_ON("createdOn", ClearingRequest._Fields.TIMESTAMP, false, false),
+        REQUESTED_CLEARING_DATE("requestedClearingDate", ClearingRequest._Fields.REQUESTED_CLEARING_DATE, true, true),
+        AGREED_CLEARING_DATE("agreedClearingDate", ClearingRequest._Fields.AGREED_CLEARING_DATE, true, true),
+        MODIFIED_ON("modifiedOn", ClearingRequest._Fields.MODIFIED_ON, false, false),
+        CLOSED_ON("closedOn", ClearingRequest._Fields.TIMESTAMP_OF_DECISION, false, false);
+
+        private final String parameterValue;
+        private final ClearingRequest._Fields field;
+
+        /** Whether the field is persisted as an ISO {@code yyyy-MM-dd} string rather than epoch millis. */
+        private final boolean isoDateString;
+
+        /** Whether the field may legitimately hold a date in the future. */
+        private final boolean futureAllowed;
+
+        ClearingRequestDateField(String parameterValue, ClearingRequest._Fields field,
+                                 boolean isoDateString, boolean futureAllowed) {
+            this.parameterValue = parameterValue;
+            this.field = field;
+            this.isoDateString = isoDateString;
+            this.futureAllowed = futureAllowed;
+        }
+
+        private static ClearingRequestDateField from(String value) {
+            return Arrays.stream(values())
+                    .filter(f -> f.parameterValue.equalsIgnoreCase(value.trim()))
+                    .findFirst()
+                    .orElseThrow(() -> new BadRequestClientException("Invalid value for dateField: " + value
+                            + ". Allowed values are " + allowedValues() + "."));
+        }
+
+        private static String allowedValues() {
+            return Arrays.stream(values()).map(f -> f.parameterValue).collect(Collectors.joining(", "));
+        }
+    }
+
+    /**
+     * Validates the date range parameters and, if a range was requested, writes the resolved
+     * inclusive bounds into the filter map using the sentinel keys understood by
+     * {@code ClearingRequestRepository}.
+     * @param filterMap Filter map to populate
+     * @param dateFieldParam Date field to filter on, defaults to {@code createdOn}
+     * @param fromDate Inclusive lower bound as ISO {@code yyyy-MM-dd}, may be null
+     * @param toDate Inclusive upper bound as ISO {@code yyyy-MM-dd}, may be null
+     * @param days Relative range in days, may be null. Mutually exclusive with fromDate/toDate
+     */
+    private void addDateRangeFilter(Map<String, Set<String>> filterMap, String dateFieldParam,
+                                    String fromDate, String toDate, Integer days) {
+        boolean hasExplicitRange = CommonUtils.isNotNullEmptyOrWhitespace(fromDate)
+                || CommonUtils.isNotNullEmptyOrWhitespace(toDate);
+        if (days != null && hasExplicitRange) {
+            throw new BadRequestClientException(
+                    "The 'days' parameter cannot be combined with 'fromDate' or 'toDate'.");
+        }
+        if (days == null && !hasExplicitRange) {
+            // dateField without a range is a no-op, nothing to filter on.
+            return;
+        }
+
+        ClearingRequestDateField dateField = CommonUtils.isNotNullEmptyOrWhitespace(dateFieldParam)
+                ? ClearingRequestDateField.from(dateFieldParam)
+                : ClearingRequestDateField.CREATED_ON;
+
+        LocalDate today = LocalDate.now();
+        LocalDate from;
+        LocalDate to;
+        if (days != null) {
+            if (days > 0 && !dateField.futureAllowed) {
+                throw new BadRequestClientException("A future date range is not allowed for dateField '"
+                        + dateField.parameterValue + "'. Use a value of 'days' that is less than or equal to 0.");
+            }
+            from = days < 0 ? today.plusDays(days) : today;
+            to = days > 0 ? today.plusDays(days) : today;
+        } else {
+            from = parseIsoDate(fromDate, "fromDate");
+            to = parseIsoDate(toDate, "toDate");
+            if (from != null && to != null && from.isAfter(to)) {
+                throw new BadRequestClientException("'fromDate' must not be after 'toDate'.");
+            }
+            if (!dateField.futureAllowed && ((from != null && from.isAfter(today)) || (to != null && to.isAfter(today)))) {
+                throw new BadRequestClientException("A future date range is not allowed for dateField '"
+                        + dateField.parameterValue + "'.");
+            }
+        }
+
+        filterMap.put(SW360Constants.CLEARING_REQUEST_DATE_FIELD_KEY,
+                Collections.singleton(dateField.field.getFieldName()));
+        if (from != null) {
+            filterMap.put(SW360Constants.CLEARING_REQUEST_DATE_FROM_KEY,
+                    Collections.singleton(formatLowerBound(from, dateField)));
+        }
+        if (to != null) {
+            filterMap.put(SW360Constants.CLEARING_REQUEST_DATE_TO_KEY,
+                    Collections.singleton(formatUpperBound(to, dateField)));
+        }
+    }
+
+    private LocalDate parseIsoDate(String value, String parameterName) {
+        if (!CommonUtils.isNotNullEmptyOrWhitespace(value)) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value.trim(), DateTimeFormatter.ISO_LOCAL_DATE);
+        } catch (DateTimeParseException e) {
+            throw new BadRequestClientException(
+                    "Invalid value for " + parameterName + ": " + value + ". Expected format is yyyy-MM-dd.");
+        }
+    }
+
+    /**
+     * Renders the inclusive lower bound: the ISO date itself for string fields,
+     * or the epoch millis at the very start of that day for timestamp fields.
+     */
+    private String formatLowerBound(LocalDate date, ClearingRequestDateField dateField) {
+        if (dateField.isoDateString) {
+            return date.format(DateTimeFormatter.ISO_LOCAL_DATE);
+        }
+        return String.valueOf(date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+    }
+
+    /**
+     * Renders the inclusive upper bound: the ISO date itself for string fields,
+     * or the epoch millis at the very end of that day for timestamp fields.
+     */
+    private String formatUpperBound(LocalDate date, ClearingRequestDateField dateField) {
+        if (dateField.isoDateString) {
+            return date.format(DateTimeFormatter.ISO_LOCAL_DATE);
+        }
+        return String.valueOf(date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli() - 1);
     }
 
     @Operation(

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ClearingRequestTest.java
@@ -14,6 +14,7 @@ package org.eclipse.sw360.rest.resourceserver.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
@@ -22,6 +23,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -32,9 +34,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,6 +47,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 
 public class ClearingRequestTest extends TestIntegrationBase {
 
@@ -134,6 +140,151 @@ public class ClearingRequestTest extends TestIntegrationBase {
         // Embedded details
         assertTrue(body.contains("sw360:project"));
         assertTrue(body.contains("openRelease"));
+    }
+
+    @Test
+    public void should_filter_clearing_requests_by_iso_date_range() throws IOException, TException {
+        org.eclipse.sw360.datahandler.thrift.PaginationData paginationData = new org.eclipse.sw360.datahandler.thrift.PaginationData();
+        paginationData.setTotalRowCount(1);
+        paginationData.setRowsPerPage(20);
+        paginationData.setDisplayStart(0);
+        given(clearingServiceMock.searchClearingRequestsByFilters(any(), any(), any())).willReturn(
+                java.util.Collections.singletonMap(paginationData, List.of(cr))
+        );
+
+        HttpHeaders headers = getHeaders(port);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port
+                        + "/api/clearingrequests?dateField=requestedClearingDate&fromDate=2026-08-01&toDate=2026-08-31",
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Set<String>>> filterCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(clearingServiceMock).searchClearingRequestsByFilters(any(), filterCaptor.capture(), any());
+        Map<String, Set<String>> filterMap = filterCaptor.getValue();
+
+        assertEquals(Set.of("requestedClearingDate"), filterMap.get(SW360Constants.CLEARING_REQUEST_DATE_FIELD_KEY));
+        // ISO date fields keep their yyyy-MM-dd form, they are compared lexicographically.
+        assertEquals(Set.of("2026-08-01"), filterMap.get(SW360Constants.CLEARING_REQUEST_DATE_FROM_KEY));
+        assertEquals(Set.of("2026-08-31"), filterMap.get(SW360Constants.CLEARING_REQUEST_DATE_TO_KEY));
+    }
+
+    @Test
+    public void should_filter_clearing_requests_by_relative_days() throws IOException, TException {
+        org.eclipse.sw360.datahandler.thrift.PaginationData paginationData = new org.eclipse.sw360.datahandler.thrift.PaginationData();
+        paginationData.setTotalRowCount(1);
+        paginationData.setRowsPerPage(20);
+        paginationData.setDisplayStart(0);
+        given(clearingServiceMock.searchClearingRequestsByFilters(any(), any(), any())).willReturn(
+                java.util.Collections.singletonMap(paginationData, List.of(cr))
+        );
+
+        HttpHeaders headers = getHeaders(port);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api/clearingrequests?dateField=createdOn&days=-7",
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Set<String>>> filterCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(clearingServiceMock).searchClearingRequestsByFilters(any(), filterCaptor.capture(), any());
+        Map<String, Set<String>> filterMap = filterCaptor.getValue();
+
+        assertEquals(Set.of("timestamp"), filterMap.get(SW360Constants.CLEARING_REQUEST_DATE_FIELD_KEY));
+
+        ZoneId zone = ZoneId.systemDefault();
+        LocalDate today = LocalDate.now();
+        long expectedFrom = today.minusDays(7).atStartOfDay(zone).toInstant().toEpochMilli();
+        long expectedTo = today.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli() - 1;
+        assertEquals(Set.of(String.valueOf(expectedFrom)), filterMap.get(SW360Constants.CLEARING_REQUEST_DATE_FROM_KEY));
+        assertEquals(Set.of(String.valueOf(expectedTo)), filterMap.get(SW360Constants.CLEARING_REQUEST_DATE_TO_KEY));
+    }
+
+    @Test
+    public void should_filter_clearing_requests_by_group() throws IOException, TException {
+        org.eclipse.sw360.datahandler.thrift.PaginationData paginationData = new org.eclipse.sw360.datahandler.thrift.PaginationData();
+        paginationData.setTotalRowCount(1);
+        paginationData.setRowsPerPage(20);
+        paginationData.setDisplayStart(0);
+        given(clearingServiceMock.searchClearingRequestsByFilters(any(), any(), any())).willReturn(
+                java.util.Collections.singletonMap(paginationData, List.of(cr))
+        );
+
+        HttpHeaders headers = getHeaders(port);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                java.net.URI.create("http://localhost:" + port + "/api/clearingrequests?group=SHS%20AT"),
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Set<String>>> filterCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(clearingServiceMock).searchClearingRequestsByFilters(any(), filterCaptor.capture(), any());
+        Map<String, Set<String>> filterMap = filterCaptor.getValue();
+
+        // The group is matched exactly against the project business unit.
+        assertEquals(Set.of("SHS AT"), filterMap.get(ClearingRequest._Fields.PROJECT_BU.getFieldName()));
+    }
+
+    @Test
+    public void should_reject_unknown_date_field() throws IOException {
+        assertBadRequestForQuery("dateField=notADateField&days=-7");
+    }
+
+    @Test
+    public void should_reject_days_combined_with_explicit_range() throws IOException {
+        assertBadRequestForQuery("dateField=createdOn&days=-7&fromDate=2026-08-01");
+    }
+
+    @Test
+    public void should_reject_malformed_date() throws IOException {
+        assertBadRequestForQuery("dateField=createdOn&fromDate=01-08-2026");
+    }
+
+    @Test
+    public void should_reject_from_date_after_to_date() throws IOException {
+        assertBadRequestForQuery("dateField=createdOn&fromDate=2026-08-31&toDate=2026-08-01");
+    }
+
+    @Test
+    public void should_reject_future_range_on_created_on() throws IOException {
+        assertBadRequestForQuery("dateField=createdOn&days=30");
+    }
+
+    @Test
+    public void should_reject_future_range_on_modified_on() throws IOException {
+        assertBadRequestForQuery("dateField=modifiedOn&days=30");
+    }
+
+    @Test
+    public void should_reject_future_range_on_closed_on() throws IOException {
+        assertBadRequestForQuery("dateField=closedOn&days=30");
+    }
+
+    private void assertBadRequestForQuery(String query) throws IOException {
+        HttpEntity<Void> request = new HttpEntity<>(getHeaders(port));
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api/clearingrequests?" + query,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(), "Expected 400 for query: " + query);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ClearingRequestSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ClearingRequestSpecTest.java
@@ -352,6 +352,164 @@ public class ClearingRequestSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_document_get_clearingrequests_by_date_range() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("dateField", "requestedClearingDate")
+                .queryParam("fromDate", "2020-09-01")
+                .queryParam("toDate", "2020-09-30")
+                .queryParam("page", "0")
+                .queryParam("page_entries", "2")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("dateField").description("The date field to filter on. Possible values are: "
+                                        + "createdOn, requestedClearingDate, agreedClearingDate, modifiedOn, closedOn. Defaults to createdOn."),
+                                parameterWithName("fromDate").description("Inclusive start of the date range in ISO format (yyyy-MM-dd)."),
+                                parameterWithName("toDate").description("Inclusive end of the date range in ISO format (yyyy-MM-dd)."),
+                                parameterWithName("page").description("The page number for pagination."),
+                                parameterWithName("page_entries").description("The number of clearing requests per page.")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]id").description("The id of the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]agreedClearingDate").description("The agreed clearing date of the request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]clearingState").description("The clearing state of request. Possible values are:  " + Arrays.asList(ClearingRequestState.values())),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]clearingTeam").description("The clearing team email id."),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]projectBU").description("The Business Unit / Group of the Project, for which clearing request is created"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]projectId").description("The id of the Project, for which clearing request is created"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]requestedClearingDate").description("The requested clearing date of releases"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]requestingUser").description("The user who created the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]priority").description("The priority of clearing request. Possible values are:  " + Arrays.asList(ClearingRequestPriority.values())),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.totalRelease").description("Total number of releases associated with the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.openRelease").description("Number of open releases associated with the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.createdOn").description("The date when the clearing request was created"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.requestingUser").description("The user who created the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests").description("An array of <<resources-clearingRequest, ClearingRequests>>"),
+                                subsectionWithPath("_links").description("Link to <<resources-clearingRequest, ClearingRequest resource>>"),
+                                fieldWithPath("page").description("Additional paging information for the clearing requests."),
+                                fieldWithPath("page.size").description("Number of Clearing requests per page."),
+                                fieldWithPath("page.totalElements").description("Total number of clearing requests available."),
+                                fieldWithPath("page.totalPages").description("Total number of pages available."),
+                                fieldWithPath("page.number").description("Current page number.")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_clearingrequests_by_group() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("group", "DEPT")
+                .queryParam("page", "0")
+                .queryParam("page_entries", "2")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("group").description("The BA-BL / group of the project the clearing request "
+                                        + "belongs to. Matched exactly against the project business unit. The selectable values "
+                                        + "are available from GET /api/projects/groups."),
+                                parameterWithName("page").description("The page number for pagination."),
+                                parameterWithName("page_entries").description("The number of clearing requests per page.")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]id").description("The id of the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]agreedClearingDate").description("The agreed clearing date of the request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]clearingState").description("The clearing state of request. Possible values are:  " + Arrays.asList(ClearingRequestState.values())),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]clearingTeam").description("The clearing team email id."),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]projectBU").description("The Business Unit / Group of the Project, for which clearing request is created"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]projectId").description("The id of the Project, for which clearing request is created"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]requestedClearingDate").description("The requested clearing date of releases"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]requestingUser").description("The user who created the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]priority").description("The priority of clearing request. Possible values are:  " + Arrays.asList(ClearingRequestPriority.values())),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.totalRelease").description("Total number of releases associated with the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.openRelease").description("Number of open releases associated with the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.createdOn").description("The date when the clearing request was created"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests.[]_embedded.requestingUser").description("The user who created the clearing request"),
+                                subsectionWithPath("_embedded.sw360:clearingRequests").description("An array of <<resources-clearingRequest, ClearingRequests>>"),
+                                subsectionWithPath("_links").description("Link to <<resources-clearingRequest, ClearingRequest resource>>"),
+                                fieldWithPath("page").description("Additional paging information for the clearing requests."),
+                                fieldWithPath("page.size").description("Number of Clearing requests per page."),
+                                fieldWithPath("page.totalElements").description("Total number of clearing requests available."),
+                                fieldWithPath("page.totalPages").description("Total number of pages available."),
+                                fieldWithPath("page.number").description("Current page number.")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_clearingrequests_by_relative_date_range() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("dateField", "createdOn")
+                .queryParam("days", "-30")
+                .queryParam("page", "0")
+                .queryParam("page_entries", "2")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("dateField").description("The date field to filter on. Possible values are: "
+                                        + "createdOn, requestedClearingDate, agreedClearingDate, modifiedOn, closedOn. Defaults to createdOn."),
+                                parameterWithName("days").description("Relative date range in days: 0 = today, negative = the last N days up to today, "
+                                        + "positive = today up to the next N days. Positive values are only valid for requestedClearingDate and agreedClearingDate."),
+                                parameterWithName("page").description("The page number for pagination."),
+                                parameterWithName("page_entries").description("The number of clearing requests per page.")
+                        )));
+    }
+
+    @Test
+    public void should_reject_invalid_date_field() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("dateField", "notADateField")
+                .queryParam("days", "-7")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void should_reject_days_combined_with_explicit_range() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("dateField", "createdOn")
+                .queryParam("days", "-7")
+                .queryParam("fromDate", "2020-09-01")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void should_reject_malformed_date() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("dateField", "createdOn")
+                .queryParam("fromDate", "01-09-2020")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void should_reject_from_date_after_to_date() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("dateField", "createdOn")
+                .queryParam("fromDate", "2020-09-30")
+                .queryParam("toDate", "2020-09-01")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void should_reject_future_range_on_created_on() throws Exception {
+        mockMvc.perform(get("/api/clearingrequests")
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))
+                .queryParam("dateField", "createdOn")
+                .queryParam("days", "30")
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     public void should_document_get_comments_by_clearing_request_id() throws Exception {
         mockMvc.perform(get("/api/clearingrequest/" + clearingRequest.getId() +"/comments")
                         .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword))


### PR DESCRIPTION
Adds server-side date and BA-BL/group filtering to `GET /api/clearingrequests`, so the new
UI can reproduce the Advanced Filter panel of the old Liferay clearing request page. The
legacy page filtered client-side with DataTables; since the REST endpoint paginates in the
database, the filters have to be pushed into the query.

* `dateField` (`createdOn`, `requestedClearingDate`, `agreedClearingDate`, `modifiedOn`,
  `closedOn`) combined with either explicit `fromDate`/`toDate` bounds or a relative
  `days` value (`0` = today, negative = last N days, positive = next N days). Replaces
  `createdOnPeriod`, which only supported 7/30/90 days. Invalid combinations return `400`.
* `group` matches the project business unit exactly, as the old page did. Values come from
  the existing `/api/projects/groups`.
* Fixes a related gap: the paginated query only considered the user's primary department,
  so filtering by a secondary BA-BL would have returned nothing. Visibility now covers
  secondary departments too, matching the legacy page.

Implemented with CouchDB Mango selectors, which the endpoint already used. No Thrift
changes, no migration, no new dependencies.

Closes #4437 

### How To Test?

```bash
curl -H "Authorization: Bearer <token>" \
  "http://localhost:8080/api/clearingrequests?dateField=createdOn&days=-30"
curl -H "Authorization: Bearer <token>" \
  "http://localhost:8080/api/clearingrequests?group=sw360"