### PR TITLE
feat(release): search releases in a component for merging

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -24,11 +24,13 @@ import org.jspecify.annotations.NonNull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
+import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_VERSION_SEGMENTS;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 
@@ -44,9 +46,9 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
     // -------------------------------------------------------------------------
 
     private static final List<IndexField> RELEASE_FIELDS = List.of(
-            IndexField.string("id"),
             IndexField.standard("name"),
             IndexField.standard("version"),
+            IndexField.simple("componentId", "keyword"),
             IndexField.simple("clearingState", "keyword"),
             IndexField.simple("mainlineState", "keyword"),
             IndexField.simple("createdBy", "email"),
@@ -64,6 +66,7 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
             "    arrayToStringIndex(doc.softwarePlatforms, 'softwarePlatforms');" +
             "    arrayToStringIndex(doc.mainLicenseIds, 'mainLicenseIds');" +
             "    arrayToStringIndex(doc.externalIds, 'externalIds');" +
+            INDEX_VERSION_SEGMENTS +
             INDEX_ID_FIELD;
 
     /**
@@ -150,6 +153,27 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
                 .toList();
 
         return Collections.singletonMap(respPageData, releaseList);
+    }
+
+    public Map<PaginationData, List<Release>> searchAccessibleReleasesFromComponent(
+            String componentId, String searchText, User user, PaginationData pageData
+    ) {
+        Map<String, Set<String>> andRestrictions = new HashMap<>();
+        andRestrictions.put(Release._Fields.COMPONENT_ID.getFieldName(), Collections.singleton(componentId));
+
+        if (searchText == null || searchText.isBlank()) {
+            return baseSearch(connector, andRestrictions, pageData);
+        }
+
+        Map<String, Set<String>> orRestrictions = new HashMap<>();
+        orRestrictions.put(Release._Fields.ID.getFieldName(), Collections.singleton(searchText));
+        orRestrictions.put(Release._Fields.VERSION.getFieldName(), Collections.singleton(searchText));
+
+        Map<String, Map<String, Set<String>>> complexRestrictions = new LinkedHashMap<>();
+        complexRestrictions.put("OR", orRestrictions);
+        complexRestrictions.put("AND", andRestrictions);
+
+        return complexBaseSearch(connector, complexRestrictions, AND, pageData);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.datahandler.db;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -161,7 +162,7 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
         Map<String, Set<String>> andRestrictions = new HashMap<>();
         andRestrictions.put(Release._Fields.COMPONENT_ID.getFieldName(), Collections.singleton(componentId));
 
-        if (searchText == null || searchText.isBlank()) {
+        if (CommonUtils.isNullEmptyOrWhitespace(searchText)) {
             return baseSearch(connector, andRestrictions, pageData);
         }
 

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -147,6 +147,14 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
+    public Map<PaginationData, List<Release>> searchAccessibleReleasesFromComponent(
+            String componentId, String searchText, User user, PaginationData pageData) throws TException {
+        assertUser(user);
+        assertId(componentId);
+        return releaseSearchHandler.searchAccessibleReleasesFromComponent(componentId, searchText, user, pageData);
+    }
+
+    @Override
     public Map<PaginationData, List<Release>> refineSearchAccessibleReleases(Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) throws TException {
         return releaseSearchHandler.searchAccessibleReleases(subQueryRestrictions, user, pageData);
     }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
@@ -111,6 +111,26 @@ public class SearchUtils {
             """;
 
     /**
+     * Emits edge n-grams for each non-alphanumeric-delimited segment of {@code doc.version}.
+     * This allows partial infix searches to match version strings like {@code 2.4.1_conflict}
+     * when the user searches for {@code conf}, which the standard whitespace-splitting ngram
+     * function cannot support because the whole value has no whitespace.
+     *
+     * <p>Example: {@code 2.4.1_conflict} splits into {@code ["2","4","1","conflict"]};
+     * the segment {@code conflict} generates ngrams {@code co, con, conf, …, conflict}.</p>
+     */
+    public static final String INDEX_VERSION_SEGMENTS = """
+            if (doc.version && typeof(doc.version) == 'string') {
+              var vParts = doc.version.toLowerCase().split(/[^a-z0-9]+/);
+              for (var vi = 0; vi < vParts.length; vi++) {
+                if (vParts[vi].length >= 2) {
+                  emitEdgeNGrams('version_ngram', vParts[vi], 2, 50);
+                }
+              }
+            }
+            """;
+
+    /**
      * This function indexes {@code doc._id} as a string field with name {@code id}.
      */
     public static final String INDEX_ID_FIELD = """

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.sw360.datahandler.common;
 
+import static org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler.EDGE_NGRAM_MAX_LENGTH;
+
 public class SearchUtils {
 
     /*
@@ -124,11 +126,11 @@ public class SearchUtils {
               var vParts = doc.version.toLowerCase().split(/[^a-z0-9]+/);
               for (var vi = 0; vi < vParts.length; vi++) {
                 if (vParts[vi].length >= 2) {
-                  emitEdgeNGrams('version_ngram', vParts[vi], 2, 50);
+                  emitEdgeNGrams('version_ngram', vParts[vi], 2, %d);
                 }
               }
             }
-            """;
+            """.formatted(EDGE_NGRAM_MAX_LENGTH);
 
     /**
      * This function indexes {@code doc._id} as a string field with name {@code id}.

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -886,6 +886,11 @@ service ComponentService {
     map<PaginationData, list<Release>> getReleasesFromComponentIdWithPagination(1: string id, 2: User user, 3: PaginationData pageData);
 
     /**
+     * get component-scoped releases using Nouveau search over release id/version
+     **/
+    map<PaginationData, list<Release>> searchAccessibleReleasesFromComponent(1: string componentId, 2: string searchText, 3: User user, 4: PaginationData pageData);
+
+    /**
      * get components belonging to linked releases of the release specified by releaseId
      **/
     set <Component> getUsingComponentsForRelease(1: string releaseId );

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
@@ -613,23 +614,24 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
             @Parameter(description = "Release search text.")
-            @RequestParam(value = "name", required = false) String name,
-            @Parameter(description = "Use Nouveau/Lucene search for releases.")
-            @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
+            @RequestParam(value = "searchText", required = false) String searchText,
+            @Parameter(description = "Use lucene search for releases. Default true")
+            @RequestParam(value = "luceneSearch", required = false, defaultValue = "true") boolean luceneSearch,
             HttpServletRequest request
     ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
         Map<PaginationData, List<ReleaseLink>> paginatedReleaseLinks;
-        if (luceneSearch && CommonUtils.isNotNullEmptyOrWhitespace(name)) {
+        if (luceneSearch && CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             paginatedReleaseLinks =
-                    componentService.searchReleaseLinksByComponentWithLucene(id, name, sw360User, pageable);
+                    componentService.searchReleaseLinksByComponentWithLucene(id, searchText, sw360User, pageable);
         } else {
             paginatedReleaseLinks = componentService.getReleaseLinksByComponentIdWithPagination(id, sw360User, pageable);
-            if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
-                List<ReleaseLink> filtered = paginatedReleaseLinks.values().iterator().next().stream()
-                        .filter(r -> name.equalsIgnoreCase(r.getName()))
-                        .collect(Collectors.toList());
+            if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
+                List<ReleaseLink> filtered = NouveauLuceneAwareDatabaseConnector
+                        .convertPaginatorToList(paginatedReleaseLinks).stream()
+                        .filter(r -> searchText.equalsIgnoreCase(r.getName()))
+                        .toList();
                 PaginationData pageData = paginatedReleaseLinks.keySet().iterator().next();
                 pageData.setTotalRowCount(filtered.size());
                 paginatedReleaseLinks = Collections.singletonMap(pageData, filtered);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -612,12 +612,29 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             @PathVariable("id") String id,
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))
             Pageable pageable,
+            @Parameter(description = "Release search text.")
+            @RequestParam(value = "name", required = false) String name,
+            @Parameter(description = "Use Nouveau/Lucene search for releases.")
+            @RequestParam(value = "luceneSearch", required = false) boolean luceneSearch,
             HttpServletRequest request
     ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
-        Map<PaginationData, List<ReleaseLink>> paginatedReleaseLinks =
-                componentService.getReleaseLinksByComponentIdWithPagination(id, sw360User, pageable);
+        Map<PaginationData, List<ReleaseLink>> paginatedReleaseLinks;
+        if (luceneSearch && CommonUtils.isNotNullEmptyOrWhitespace(name)) {
+            paginatedReleaseLinks =
+                    componentService.searchReleaseLinksByComponentWithLucene(id, name, sw360User, pageable);
+        } else {
+            paginatedReleaseLinks = componentService.getReleaseLinksByComponentIdWithPagination(id, sw360User, pageable);
+            if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
+                List<ReleaseLink> filtered = paginatedReleaseLinks.values().iterator().next().stream()
+                        .filter(r -> name.equalsIgnoreCase(r.getName()))
+                        .collect(Collectors.toList());
+                PaginationData pageData = paginatedReleaseLinks.keySet().iterator().next();
+                pageData.setTotalRowCount(filtered.size());
+                paginatedReleaseLinks = Collections.singletonMap(pageData, filtered);
+            }
+        }
 
         PaginationResult<ReleaseLink> paginationResult = restControllerHelper.paginationResultFromPaginatedList(
                 request, pageable, paginatedReleaseLinks);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -220,6 +220,22 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         return result;
     }
 
+    public Map<PaginationData, List<ReleaseLink>> searchReleaseLinksByComponentWithLucene(
+            String id, String searchText, User user, Pageable pageable) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        PaginationData pageData = pageableToPaginationDataForReleases(pageable, ReleaseSortColumn.BY_CREATEDON, false);
+        Map<PaginationData, List<Release>> paginatedReleases =
+                sw360ComponentClient.searchAccessibleReleasesFromComponent(id, searchText, user, pageData);
+
+        PaginationData resultPageData = paginatedReleases.keySet().iterator().next();
+        List<Release> releases = paginatedReleases.values().iterator().next();
+
+        List<ReleaseLink> releaseLinks = convertReleasesToReleaseLinks(releases);
+        Map<PaginationData, List<ReleaseLink>> result = new HashMap<>();
+        result.put(resultPageData, releaseLinks);
+        return result;
+    }
+
     private List<ReleaseLink> convertReleasesToReleaseLinks(List<Release> releases) {
         List<ReleaseLink> releaseLinks = new ArrayList<>();
         releases.forEach(release -> {


### PR DESCRIPTION

### Problem
The release merge page calls `GET /api/components/{id}/releases?name=<text>`.

The endpoint existed but the `name` parameter was handled **in-memory after fetching** — it fetched the full paginated CouchDB view page, then filtered by exact `name.equalsIgnoreCase(r.getName())`. Problems:
1. It only searched within the already-loaded page, not across all releases.
2. It matched on `name` field only (not `id` or `version`).
3. No Lucene/full-text search was involved at all for this endpoint.

---

## Changes made in this branch

### 1. New Lucene search path for component releases

**components.thrift** — added:
```thrift
map<PaginationData, list<Release>> searchAccessibleReleasesFromComponent(
    1: string componentId, 2: string searchText, 3: User user, 4: PaginationData pageData);
```

**ComponentHandler.java** — implemented the thrift method, delegates to `releaseSearchHandler.searchAccessibleReleasesFromComponent(...)`.

**ReleaseSearchHandler.java** — added `searchAccessibleReleasesFromComponent(...)`:
- Uses `complexBaseSearch` with `OR` on `id`/`version` AND `AND` on `componentId`
- Entirely uses `BaseNouveauSearchHandler` query builder — no raw Lucene strings

**Sw360ComponentService.java** — added `searchReleaseLinksByComponentWithLucene(...)` which calls the thrift method and converts results to `ReleaseLink`.

**ComponentController.java** — added `luceneSearch` param to `GET /api/components/{id}/releases`:
- `luceneSearch=true` + `name` → Lucene path (server-side search across all releases)
- otherwise → existing CouchDB view path (unchanged)

### 2. Fixed `id` field indexing

Removed `IndexField.string("id")` from `RELEASE_FIELDS`. It was indexing `doc.id` (empty in stored docs) and blocking the routing in `BaseNouveauSearchHandler` from reaching the correct keyword `id` field indexed by `INDEX_ID_FIELD` from `doc._id`.

### 3. Fixed infix version search

Added `INDEX_VERSION_SEGMENTS` constant to SearchUtils.java — splits version on non-alphanumeric delimiters and emits edge n-grams per segment, so `conf` matches `2.4.1_conflict`. Used in `RELEASE_CUSTOM_JS` in `ReleaseSearchHandler`.

---

How To Test:

Search release by id or version in release merge page
<img width="1822" height="346" alt="image" src="https://github.com/user-attachments/assets/aa9d9995-936c-4868-95d3-1221fb7cf1de" />
