### PR TITLE
feat(search): enhance search test cases

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,12 +45,19 @@ jobs:
 
     services:
       couchdb:
-        image: couchdb:3
+        image: couchdb:3.5
         ports:
           - 5984:5984
         env:
           COUCHDB_USER: ${{ env.COUCHDB_USER }}
           COUCHDB_PASSWORD: ${{ env.COUCHDB_PASSWORD }}
+
+      couchdb-nouveau:
+        image: couchdb:3.5-nouveau
+        ports:
+          - 5987:5987
+        env:
+          JAVA_TOOL_OPTIONS: "-Ddw.rootDir=/opt/nouveau/data/nouveau"
 
     steps:
       - name: Harden Runner
@@ -65,6 +72,22 @@ jobs:
         run: |
           chmod +x .github/testForLicenseHeaders.sh
           bash .github/testForLicenseHeaders.sh
+
+      - name: Configure CouchDB Nouveau
+        run: |
+          echo "⏳ Waiting for CouchDB..."
+          timeout 60 bash -c 'until curl -fsS http://localhost:5984/_up >/dev/null 2>&1; do sleep 2; done'
+          echo "✅ CouchDB is ready"
+
+          echo "⏳ Waiting for Nouveau sidecar..."
+          timeout 60 bash -c 'until curl -sS -o /dev/null --connect-timeout 3 http://localhost:5987 2>/dev/null; do sleep 2; done'
+          echo "✅ Nouveau sidecar is ready"
+
+          echo "Enabling Nouveau in CouchDB..."
+          curl -sS -X PUT "http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@localhost:5984/_node/_local/_config/nouveau/enable" -d '"true"'
+          curl -sS -X PUT "http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@localhost:5984/_node/_local/_config/nouveau/url" -d '"http://couchdb-nouveau:5987"'
+          echo ""
+          echo "✅ Nouveau configured in CouchDB"
 
       - name: Update properties with DB credentials
         run: |

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandler.java
@@ -13,6 +13,7 @@ import com.ibm.cloud.cloudant.v1.Cloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
@@ -94,10 +95,14 @@ public class VulnerabilitySearchHandler extends BaseNouveauSearchHandler<Vulnera
     private final NouveauLuceneAwareDatabaseConnector connector;
 
     public VulnerabilitySearchHandler(Cloudant client) throws IOException {
+        this(client, DatabaseSettings.COUCH_DB_VM);
+    }
+
+    public VulnerabilitySearchHandler(Cloudant client, String dbName) throws IOException {
         // Creates the database connector and adds the lucene search view
         super(Vulnerability.class, "vulnerabilities", VULNERABILITY_INDEX_DEFINITION);
-        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, "sw360vm");
-        connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, "sw360vm", db.getInstance().getGson());
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(client, dbName);
+        connector = new NouveauLuceneAwareDatabaseConnector(db, DDOC_NAME, dbName, db.getInstance().getGson());
         setup(connector, db);
     }
 

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandlerTest.java
@@ -9,11 +9,27 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.Visibility;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentSortColumn;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.TestUtils.assumeCanConnectTo;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,6 +45,25 @@ class ComponentSearchHandlerTest {
             case ComponentSortColumn.BY_CREATEDON -> List.of("createdOn");
             case null, default -> List.of(SCORE_SORTING_FIELD);
         };
+    }
+
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final User user1 = new User().setEmail("user1").setDepartment("AB CD EF");
+
+    private static ComponentSearchHandler searchHandler;
+
+    @BeforeAll
+    static void setUpDatabase() throws Exception {
+        assumeCanConnectTo(DatabaseSettingsTest.getCouchDbUrl());
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        for (Component c : createSeedComponents()) { db.add(c); }
+        searchHandler = new ComponentSearchHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @AfterAll
+    static void tearDownDatabase() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
     }
 
     @Test
@@ -115,5 +150,250 @@ class ComponentSearchHandlerTest {
         int shortMax = org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler.EDGE_NGRAM_SHORT_MAX_LENGTH;
         assertEquals(50, max);
         assertEquals(10, shortMax);
+    }
+
+    // --- Search / filter tests -----------------------------------------------
+
+    @Test
+    void exactNameSearch_shouldReturnMatchingComponent() {
+        var result = searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("FT_Apache Commons")), user1, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(c -> "FT_Apache Commons".equals(c.getName())));
+    }
+
+    @Test
+    void nonExistentTerm_shouldReturnEmpty() {
+        assertTrue(items(searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("zzz_nonexistent_999")), user1, allPages())).isEmpty());
+    }
+
+    @Test
+    void prefixSearch_shouldMatchViaEdgeNgram() {
+        assertTrue(items(searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("FT_Apa")), user1, allPages()))
+                .stream().anyMatch(c -> c.getName().contains("Apache")));
+    }
+
+    @Test
+    void secondWordPrefixSearch_shouldMatchViaEdgeNgram() {
+        // "Commo" is an edge-ngram prefix of "Commons" — must match "FT_Apache Commons"
+        assertTrue(items(searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("Commo")), null, allPages()))
+                .stream().anyMatch(c -> c.getName().contains("Commons")));
+    }
+
+    @Test
+    void shortPrefixSearch_shouldMatchMultipleComponentsWithSamePrefix() {
+        // "FT_B" matches "FT_Bootstrap UI", "FT_Bare Component", "FT_Build Plugin"
+        var result = items(searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("FT_B")), null, allPages()));
+        assertTrue(result.size() >= 2);
+        result.forEach(c -> assertTrue(c.getName().startsWith("FT_B"),
+                "Unexpected match: " + c.getName()));
+    }
+
+    @Test
+    void caseInsensitiveSearch_shouldMatch() {
+        assertTrue(items(searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("ft_apache")), user1, allPages()))
+                .stream().anyMatch(c -> c.getName().contains("Apache")));
+    }
+
+    @Test
+    void keywordField_shouldRequireExactMatch() {
+        assertFalse(items(searchHandler.searchAccessibleComponents(
+                Map.of("componentType", Set.of("OSS")), null, allPages())).isEmpty());
+        assertTrue(items(searchHandler.searchAccessibleComponents(
+                Map.of("componentType", Set.of("OS")), null, allPages())).isEmpty());
+    }
+
+    @Test
+    void emailField_shouldMatchCreator() {
+        var result = searchHandler.searchAccessibleComponents(
+                Map.of("createdBy", Set.of("user1@test.sw360.org")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(c -> assertEquals("user1@test.sw360.org", c.getCreatedBy()));
+    }
+
+    @Test
+    void multiFieldAndFilter_shouldReturnIntersection() {
+        var result = searchHandler.searchAccessibleComponents(
+                Map.of("componentType", Set.of("OSS"), "createdBy", Set.of("user2@test.sw360.org")),
+                null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(c -> {
+            assertEquals("OSS", c.getComponentType().name());
+            assertEquals("user2@test.sw360.org", c.getCreatedBy());
+        });
+    }
+
+    @Test
+    void categoriesArraySearch_shouldMatchSingleElement() {
+        var result = searchHandler.searchAccessibleComponents(
+                Map.of("categories", Set.of("Library")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(c -> assertTrue(c.getCategories() != null && c.getCategories().contains("Library")));
+    }
+
+    @Test
+    void languagesArraySearch_shouldFilterByLanguage() {
+        var result = searchHandler.searchAccessibleComponents(
+                Map.of("languages", Set.of("Java")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(c -> assertTrue(c.getLanguages() != null && c.getLanguages().contains("Java")));
+    }
+
+    @Test
+    void componentTypeFilter_shouldReturnExactMatch() {
+        var result = searchHandler.searchAccessibleComponents(
+                Map.of("componentType", Set.of("INNER_SOURCE")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(c -> assertEquals("INNER_SOURCE", c.getComponentType().name()));
+    }
+
+    // --- Sorting tests -------------------------------------------------------
+
+    @Test
+    void sortByNameAscending_shouldReturnAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredComponents("FT_", user1,
+                pageSorted(ComponentSortColumn.BY_NAME.getValue(), true));
+        List<String> names = items(result).stream().map(Component::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), names);
+    }
+
+    @Test
+    void sortByNameDescending_shouldReturnReverseAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredComponents("FT_", user1,
+                pageSorted(ComponentSortColumn.BY_NAME.getValue(), false));
+        List<String> names = items(result).stream().map(Component::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER.reversed()).toList(), names);
+    }
+
+    @Test
+    void sortByTypeAscending_shouldReturnGroupedByTypeAlphabetically() {
+        var result = searchHandler.searchFilteredComponents("FT_", null,
+                pageSorted(ComponentSortColumn.BY_TYPE.getValue(), true));
+        List<String> types = items(result).stream().map(c -> c.getComponentType().name()).toList();
+        assertEquals(types.stream().sorted().toList(), types,
+                "Component types should appear in ascending alphabetical order");
+    }
+
+    @Test
+    void sortByCreatedOnAscending_shouldReturnChronologicalOrder() {
+        var result = searchHandler.searchFilteredComponents("FT_", null,
+                pageSorted(ComponentSortColumn.BY_CREATEDON.getValue(), true));
+        List<String> dates = items(result).stream().map(Component::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted().toList(), dates,
+                "createdOn should be in ascending chronological order");
+    }
+
+    @Test
+    void sortByCreatedOnDescending_shouldReturnReverseChronologicalOrder() {
+        var result = searchHandler.searchFilteredComponents("FT_", null,
+                pageSorted(ComponentSortColumn.BY_CREATEDON.getValue(), false));
+        List<String> dates = items(result).stream().map(Component::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted(Comparator.reverseOrder()).toList(), dates,
+                "createdOn should be in descending chronological order");
+    }
+
+    // --- Pagination tests ----------------------------------------------------
+
+    @Test
+    void firstPage_shouldReturnRequestedPageSize() {
+        assertTrue(items(searchHandler.searchFilteredComponents("FT_", user1, page(0, 5))).size() <= 5);
+    }
+
+    @Test
+    void paginationAcrossPages_shouldProduceNoDuplicates() {
+        Set<String> allIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            List<Component> pg = items(searchHandler.searchFilteredComponents("FT_", user1, page(i, 3)));
+            if (pg.isEmpty()) break;
+            for (Component c : pg) { assertTrue(allIds.add(c.getId()), "Duplicate: " + c.getId()); }
+        }
+    }
+
+    // --- Edge case tests -----------------------------------------------------
+
+    @Test
+    void specialCharacters_shouldNotCauseException() {
+        assertDoesNotThrow(() -> searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("FT_Alpha & Beta")), null, allPages()));
+    }
+
+    @Test
+    void nullDescription_shouldStillBeIndexed() {
+        assertTrue(items(searchHandler.searchAccessibleComponents(
+                Map.of("name", Set.of("FT_No Description")), null, allPages()))
+                .stream().anyMatch(c -> c.getName().contains("No Description")));
+    }
+
+    // =========================================================================
+    //  Test data & helpers
+    // =========================================================================
+
+    private static <T> List<T> items(Map<PaginationData, List<T>> r) {
+        return r.values().iterator().next();
+    }
+
+    private PaginationData allPages() {
+        return NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+    }
+
+    private PaginationData page(int p, int size) {
+        return new PaginationData().setRowsPerPage(size).setDisplayStart(p * size)
+                .setAscending(true).setSortColumnNumber(0);
+    }
+
+    private PaginationData pageSorted(int col, boolean asc) {
+        return new PaginationData().setRowsPerPage(200).setDisplayStart(0)
+                .setAscending(asc).setSortColumnNumber(col);
+    }
+
+    /**
+     * Creates seed components programmatically using Thrift objects to avoid
+     * data model drift that can occur with external JSON fixtures.
+     */
+    private static List<Component> createSeedComponents() {
+        return List.of(
+                cmp("ft-cmp-001", "FT_Apache Commons", "Library for utilities", ComponentType.OSS, "user1@test.sw360.org", "2024-01-10", List.of("Library", "Utility"), List.of("Java"), Visibility.EVERYONE, List.of("Apache"), List.of("Apache-2.0")),
+                cmp("ft-cmp-002", "FT_Spring Framework", "Enterprise Java framework", ComponentType.OSS, "user1@test.sw360.org", "2024-02-15", List.of("Framework", "Enterprise"), List.of("Java", "Kotlin"), Visibility.EVERYONE, List.of("VMware"), List.of("Apache-2.0")),
+                cmp("ft-cmp-003", "FT_React UI", "Frontend UI library", ComponentType.OSS, "user2@test.sw360.org", "2024-03-20", List.of("Library", "Frontend"), List.of("JavaScript"), Visibility.EVERYONE, List.of("Meta"), List.of("MIT")),
+                cmp("ft-cmp-004", "FT_Internal Tool", "Internal dev tool", ComponentType.INNER_SOURCE, "user1@test.sw360.org", "2024-04-25", List.of("Tool"), List.of("Python"), Visibility.BUISNESSUNIT_AND_MODERATORS, List.of(), List.of()),
+                cmp("ft-cmp-005", "FT_Commercial SDK", "Licensed commercial SDK", ComponentType.COTS, "user1@test.sw360.org", "2024-05-30", List.of("SDK"), List.of("C++"), Visibility.EVERYONE, List.of("Vendor Corp"), List.of("Proprietary")),
+                cmp("ft-cmp-006", "FT_Bootstrap UI", "CSS framework", ComponentType.OSS, "user2@test.sw360.org", "2024-06-05", List.of("Framework", "CSS"), List.of("JavaScript"), Visibility.EVERYONE, List.of("Bootstrap Team"), List.of("MIT")),
+                cmp("ft-cmp-007", "FT_Logging Library", "Centralized logging", ComponentType.OSS, "user1@test.sw360.org", "2024-07-10", List.of("Library", "Logging"), List.of("Java"), Visibility.EVERYONE, List.of("Apache"), List.of("Apache-2.0")),
+                cmp("ft-cmp-008", "FT_Database Driver", "DB connectivity", ComponentType.OSS, "user1@test.sw360.org", "2024-08-15", List.of("Driver"), List.of("Java"), Visibility.EVERYONE, List.of("Oracle"), List.of("GPL-2.0")),
+                cmp("ft-cmp-009", "FT_Security Module", "Security utilities", ComponentType.OSS, "user2@test.sw360.org", "2024-09-20", List.of("Library", "Security"), List.of("Java", "Go"), Visibility.EVERYONE, List.of("OWASP"), List.of("Apache-2.0", "MIT")),
+                cmp("ft-cmp-010", "FT_CLI Tool", "Command line tool", ComponentType.FREESOFTWARE, "user1@test.sw360.org", "2024-10-25", List.of("Tool", "CLI"), List.of("Rust"), Visibility.EVERYONE, List.of(), List.of("GPL-3.0")),
+                cmp("ft-cmp-011", "FT_Bare Component", "No categories", ComponentType.OSS, "user1@test.sw360.org", "2024-11-01", List.of(), List.of(), Visibility.EVERYONE, List.of(), List.of()),
+                cmp("ft-cmp-012", "FT_Private Component", "Private", ComponentType.OSS, "user1@test.sw360.org", "2024-11-15", List.of("Library"), List.of("Java"), Visibility.PRIVATE, List.of(), List.of("MIT")),
+                cmp("ft-cmp-013", "FT_Config Library", "Config mgmt", ComponentType.OSS, "user1@test.sw360.org", "2024-12-01", List.of("Library"), List.of("Java"), Visibility.EVERYONE, List.of("LightBend"), List.of("Apache-2.0")),
+                cmp("ft-cmp-014", "FT_Metrics SDK", "Metrics collection", ComponentType.OSS, "user1@test.sw360.org", "2025-01-05", List.of("SDK"), List.of("Go"), Visibility.EVERYONE, List.of("DataDog"), List.of("Apache-2.0")),
+                cmp("ft-cmp-015", "FT_Test Framework", "Testing infrastructure", ComponentType.OSS, "user1@test.sw360.org", "2025-02-10", List.of("Framework"), List.of("Java"), Visibility.EVERYONE, List.of("JUnit Team"), List.of("EPL-2.0")),
+                cmp("ft-cmp-016", "FT_Alpha & Beta", "Special chars", ComponentType.OSS, "user1@test.sw360.org", "2025-03-01", List.of("Library"), List.of("Java"), Visibility.EVERYONE, List.of(), List.of("MIT")),
+                cmp("ft-cmp-017", "FT_No Description", null, ComponentType.OSS, "user1@test.sw360.org", "2025-03-15", List.of("Library"), List.of("Java"), Visibility.EVERYONE, List.of(), List.of()),
+                cmp("ft-cmp-018", "FT_Analytics Engine", "Analytics processing engine", ComponentType.INNER_SOURCE, "user2@test.sw360.org", "2025-04-01", List.of("Engine", "Analytics"), List.of("Python", "Java"), Visibility.EVERYONE, List.of("Analytics Corp"), List.of("BSD-3-Clause")),
+                cmp("ft-cmp-019", "FT_Zulu Runtime", "Zulu JDK distribution", ComponentType.COTS, "user1@test.sw360.org", "2025-04-15", List.of("Runtime"), List.of("Java"), Visibility.EVERYONE, List.of("Azul"), List.of("GPL-2.0-with-classpath-exception")),
+                cmp("ft-cmp-020", "FT_Build Plugin", "Build automation plugin", ComponentType.FREESOFTWARE, "user1@test.sw360.org", "2025-05-01", List.of("Tool", "Build"), List.of("Groovy", "Java"), Visibility.EVERYONE, List.of("Gradle Inc"), List.of("Apache-2.0"))
+        );
+    }
+
+    private static Component cmp(String id, String name, String description, ComponentType type,
+                                  String createdBy, String createdOn, List<String> categories,
+                                  List<String> languages, Visibility visibility,
+                                  List<String> vendorNames, List<String> mainLicenseIds) {
+        Component c = new Component(name).setId(id).setType("component")
+                .setComponentType(type)
+                .setCreatedBy(createdBy).setCreatedOn(createdOn)
+                .setCategories(new HashSet<>(categories))
+                .setLanguages(new HashSet<>(languages))
+                .setVisbility(visibility)
+                .setBusinessUnit("AB CD EF");
+        if (description != null) c.setDescription(description);
+        if (!vendorNames.isEmpty()) c.setVendorNames(new HashSet<>(vendorNames));
+        if (!mainLicenseIds.isEmpty()) c.setMainLicenseIds(new HashSet<>(mainLicenseIds));
+        return c;
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ObligationSearchHandlerTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationSortColumn;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.eclipse.sw360.datahandler.TestUtils.assumeCanConnectTo;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ObligationSearchHandlerTest {
+
+
+
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        return switch (ObligationSortColumn.findByValue(sortColumnNumber)) {
+            case ObligationSortColumn.BY_TITLE -> List.of("title_sort", SCORE_SORTING_FIELD, "text_sort");
+            case ObligationSortColumn.BY_TEXT -> List.of("text_sort", SCORE_SORTING_FIELD, "title_sort");
+            case ObligationSortColumn.BY_LEVEL -> List.of("obligationLevel_sort");
+            case null, default -> List.of(SCORE_SORTING_FIELD, "title_sort", "text_sort");
+        };
+    }
+
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+
+    private static ObligationSearchHandler searchHandler;
+
+    @BeforeAll
+    static void setUpDatabase() throws Exception {
+        assumeCanConnectTo(DatabaseSettingsTest.getCouchDbUrl());
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        for (Obligation o : createSeedObligations()) { db.add(o); }
+        searchHandler = new ObligationSearchHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @AfterAll
+    static void tearDownDatabase() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @Test
+    void byTitle_shouldReturnTitleSortWithScoreAndTextTiebreakers() {
+        assertEquals(List.of("title_sort", SCORE_SORTING_FIELD, "text_sort"),
+                mapSortColumnDirect(ObligationSortColumn.BY_TITLE.getValue()));
+    }
+
+    @Test
+    void byText_shouldReturnTextSortWithScoreAndTitleTiebreakers() {
+        assertEquals(List.of("text_sort", SCORE_SORTING_FIELD, "title_sort"),
+                mapSortColumnDirect(ObligationSortColumn.BY_TEXT.getValue()));
+    }
+
+    @Test
+    void byLevel_shouldReturnOnlyObligationLevelSort() {
+        assertEquals(List.of("obligationLevel_sort"),
+                mapSortColumnDirect(ObligationSortColumn.BY_LEVEL.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToScoreWithTiebreakers() {
+        assertEquals(List.of(SCORE_SORTING_FIELD, "title_sort", "text_sort"),
+                mapSortColumnDirect(999));
+    }
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (ObligationSortColumn column : ObligationSortColumn.values()) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertNotNull(columns);
+            assertFalse(columns.isEmpty(), column + " returned empty list");
+        }
+    }
+
+    @Test
+    void namedColumns_shouldContainScoreField() {
+        for (ObligationSortColumn column : List.of(
+                ObligationSortColumn.BY_TITLE,
+                ObligationSortColumn.BY_TEXT)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertTrue(columns.contains(SCORE_SORTING_FIELD), column + " missing score");
+        }
+    }
+
+
+
+    // --- Search / filter tests -----------------------------------------------
+
+    @Test
+    void titleSearch_shouldReturnMatchingObligation() {
+        var result = searchHandler.searchWithPagination("FT_Attribution", null, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(o -> o.getTitle().contains("Attribution")));
+    }
+
+    @Test
+    void textSearch_shouldReturnMatchingObligation() {
+        var result = searchHandler.searchWithPagination("copyright", null, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(o -> o.getText().toLowerCase().contains("copyright")));
+    }
+
+    @Test
+    void nonExistentTerm_shouldReturnEmpty() {
+        assertTrue(items(searchHandler.searchWithPagination("zzz_nonexistent_999", null, allPages())).isEmpty());
+    }
+
+    @Test
+    void prefixSearch_shouldMatchViaEdgeNgram() {
+        // "FT_Attrib" is an edge-ngram prefix of "FT_Attribution Notice"
+        assertTrue(items(searchHandler.searchWithPagination("FT_Attrib", null, allPages()))
+                .stream().anyMatch(o -> o.getTitle().contains("Attribution")));
+    }
+
+    @Test
+    void levelFilter_shouldReturnOnlyMatchingLevel() {
+        var result = searchHandler.searchWithPagination(null, ObligationLevel.LICENSE_OBLIGATION, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(o -> assertEquals(ObligationLevel.LICENSE_OBLIGATION, o.getObligationLevel()));
+    }
+
+    @Test
+    void combinedTextAndLevelFilter_shouldReturnIntersection() {
+        var result = searchHandler.searchWithPagination("FT_", ObligationLevel.PROJECT_OBLIGATION, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(o -> assertEquals(ObligationLevel.PROJECT_OBLIGATION, o.getObligationLevel()));
+    }
+
+    @Test
+    void allLevelsPresent_shouldReturnNonEmptyForEachLevel() {
+        for (ObligationLevel level : ObligationLevel.values()) {
+            var result = searchHandler.searchWithPagination(null, level, allPages());
+            assertFalse(items(result).isEmpty(), "No obligations found for level: " + level);
+        }
+    }
+
+    // --- Sorting tests -------------------------------------------------------
+
+    @Test
+    void sortByTitleAscending_shouldReturnAlphabeticalOrder() {
+        var result = searchHandler.searchWithPagination("FT_", null,
+                pageSorted(ObligationSortColumn.BY_TITLE.getValue(), true));
+        List<String> titles = items(result).stream().map(Obligation::getTitle).toList();
+        assertEquals(titles.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), titles);
+    }
+
+    @Test
+    void sortByTitleDescending_shouldReturnReverseAlphabeticalOrder() {
+        var result = searchHandler.searchWithPagination("FT_", null,
+                pageSorted(ObligationSortColumn.BY_TITLE.getValue(), false));
+        List<String> titles = items(result).stream().map(Obligation::getTitle).toList();
+        assertEquals(titles.stream().sorted(String.CASE_INSENSITIVE_ORDER.reversed()).toList(), titles);
+    }
+
+    @Test
+    void sortByLevelAscending_shouldReturnGroupedByLevel() {
+        var result = searchHandler.searchWithPagination("FT_", null,
+                pageSorted(ObligationSortColumn.BY_LEVEL.getValue(), true));
+        List<String> levels = items(result).stream().map(o -> o.getObligationLevel().name()).toList();
+        assertFalse(levels.isEmpty());
+        assertEquals(levels.stream().sorted().toList(), levels,
+                "Obligation levels should appear in ascending alphabetical order");
+    }
+
+    // --- Pagination tests ----------------------------------------------------
+
+    @Test
+    void firstPage_shouldReturnRequestedPageSize() {
+        assertTrue(items(searchHandler.searchWithPagination("FT_", null, page(0, 3))).size() <= 3);
+    }
+
+    @Test
+    void paginationAcrossPages_shouldProduceNoDuplicates() {
+        Set<String> allIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            List<Obligation> pg = items(searchHandler.searchWithPagination("FT_", null, page(i, 3)));
+            if (pg.isEmpty()) break;
+            for (Obligation o : pg) { assertTrue(allIds.add(o.getId()), "Duplicate: " + o.getId()); }
+        }
+    }
+
+    // --- Edge case tests -----------------------------------------------------
+
+    @Test
+    void emptySearchText_shouldReturnAllWhenLevelProvided() {
+        var result = searchHandler.searchWithPagination("", ObligationLevel.ORGANISATION_OBLIGATION, allPages());
+        assertFalse(items(result).isEmpty());
+    }
+
+    @Test
+    void nullSearchTextAndLevel_shouldReturnEmptyWhenNoFiltersProvided() {
+        var result = searchHandler.searchWithPagination(null, null, allPages());
+        assertTrue(items(result).isEmpty(),
+                "Empty restrictions should yield no results from complexBaseSearch");
+    }
+
+    // =========================================================================
+    //  Test data & helpers
+    // =========================================================================
+
+    private static <T> List<T> items(Map<PaginationData, List<T>> r) {
+        return r.values().iterator().next();
+    }
+
+    private PaginationData allPages() {
+        return NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+    }
+
+    private PaginationData page(int p, int size) {
+        return new PaginationData().setRowsPerPage(size).setDisplayStart(p * size)
+                .setAscending(true).setSortColumnNumber(0);
+    }
+
+    private PaginationData pageSorted(int col, boolean asc) {
+        return new PaginationData().setRowsPerPage(200).setDisplayStart(0)
+                .setAscending(asc).setSortColumnNumber(col);
+    }
+
+    /**
+     * Creates seed obligations programmatically using Thrift objects to avoid
+     * data model drift that can occur with external JSON fixtures.
+     */
+    private static List<Obligation> createSeedObligations() {
+        return List.of(
+                obl("ft-obl-001", "FT_Attribution Notice", "Include copyright notice in documentation", ObligationLevel.LICENSE_OBLIGATION),
+                obl("ft-obl-002", "FT_Binary Distribution", "Provide source code alongside binary distribution", ObligationLevel.COMPONENT_OBLIGATION),
+                obl("ft-obl-003", "FT_Change Log Required", "Document all modifications in a change log", ObligationLevel.PROJECT_OBLIGATION),
+                obl("ft-obl-004", "FT_Disclose Source", "Make source code publicly available", ObligationLevel.ORGANISATION_OBLIGATION),
+                obl("ft-obl-005", "FT_Export Control Check", "Verify export control classification before distribution", ObligationLevel.ORGANISATION_OBLIGATION),
+                obl("ft-obl-006", "FT_Include License Text", "Include full license text with the software", ObligationLevel.LICENSE_OBLIGATION),
+                obl("ft-obl-007", "FT_No Trademark Use", "Do not use project trademarks without permission", ObligationLevel.COMPONENT_OBLIGATION),
+                obl("ft-obl-008", "FT_Patent Grant", "Grant patent rights to downstream recipients", ObligationLevel.LICENSE_OBLIGATION),
+                obl("ft-obl-009", "FT_Reciprocal Sharing", "Share modifications under the same license terms", ObligationLevel.PROJECT_OBLIGATION),
+                obl("ft-obl-010", "FT_Security Review", "Conduct security review before each release", ObligationLevel.PROJECT_OBLIGATION),
+                obl("ft-obl-011", "FT_Vulnerability Scan", "Scan dependencies for known vulnerabilities", ObligationLevel.COMPONENT_OBLIGATION),
+                obl("ft-obl-012", "FT_Written Offer", "Provide written offer for source code valid for three years", ObligationLevel.ORGANISATION_OBLIGATION)
+        );
+    }
+
+    private static Obligation obl(String id, String title, String text, ObligationLevel level) {
+        return new Obligation().setId(id).setType("obligation")
+                .setTitle(title).setText(text)
+                .setObligationLevel(level);
+    }
+}

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/PackageSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/PackageSearchHandlerTest.java
@@ -9,20 +9,36 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.packages.Package;
+import org.eclipse.sw360.datahandler.thrift.packages.PackageManager;
 import org.eclipse.sw360.datahandler.thrift.packages.PackageSortColumn;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.TestUtils.assumeCanConnectTo;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PackageSearchHandlerTest {
 
+
     private static List<String> mapSortColumnDirect(int sortColumnNumber) {
         String revDir = "-";
         return switch (PackageSortColumn.findByValue(sortColumnNumber)) {
-            case PackageSortColumn.BY_NAME -> List.of("name_sort", revDir + "createdOn");
+            case PackageSortColumn.BY_NAME -> List.of("name_sort", "version_sort", revDir + "createdOn");
             case PackageSortColumn.BY_VERSION -> List.of("version_sort", "name_sort", revDir + "createdOn");
             case PackageSortColumn.BY_PACKAGE_MANAGER -> List.of("packageManager_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "createdOn");
             case PackageSortColumn.BY_CREATEDON -> List.of("createdOn");
@@ -30,10 +46,28 @@ class PackageSearchHandlerTest {
         };
     }
 
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final User user1 = new User().setEmail("user1").setDepartment("AB CD EF");
+
+    private static PackageSearchHandler searchHandler;
+
+    @BeforeAll
+    static void setUpDatabase() throws Exception {
+        assumeCanConnectTo(DatabaseSettingsTest.getCouchDbUrl());
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        for (Package p : createSeedPackages()) { db.add(p); }
+        searchHandler = new PackageSearchHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @AfterAll
+    static void tearDownDatabase() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
     @Test
-    void byName_shouldReturnNameSortWithCreatedOnTiebreaker() {
+    void byName_shouldReturnNameSortWithVersionAndCreatedOnTiebreakers() {
         List<String> columns = mapSortColumnDirect(PackageSortColumn.BY_NAME.getValue());
-        assertEquals(List.of("name_sort", "-createdOn"), columns);
+        assertEquals(List.of("name_sort", "version_sort", "-createdOn"), columns);
         assertFalse(columns.contains(SCORE_SORTING_FIELD));
     }
 
@@ -91,5 +125,191 @@ class PackageSearchHandlerTest {
         int createdOnIdx = columns.indexOf("-createdOn");
         assertTrue(scoreIdx < nameIdx, "score should come before name_sort");
         assertTrue(nameIdx < createdOnIdx, "name_sort should come before -createdOn");
+    }
+
+    // --- Search / filter tests -----------------------------------------------
+
+    @Test
+    void exactNameSearch_shouldReturnMatchingPackage() {
+        var result = searchHandler.searchAccessiblePackages(
+                Map.of("name", Set.of("FT_commons-lang3")), user1, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(p -> "FT_commons-lang3".equals(p.getName())));
+    }
+
+    @Test
+    void nonExistentTerm_shouldReturnEmpty() {
+        assertTrue(items(searchHandler.searchAccessiblePackages(
+                Map.of("name", Set.of("zzz_nonexistent_999")), user1, allPages())).isEmpty());
+    }
+
+    @Test
+    void prefixSearch_shouldMatchViaEdgeNgram() {
+        assertTrue(items(searchHandler.searchAccessiblePackages(
+                Map.of("name", Set.of("FT_comm")), null, allPages()))
+                .stream().anyMatch(p -> p.getName().contains("commons")));
+    }
+
+    @Test
+    void caseInsensitiveSearch_shouldMatch() {
+        assertTrue(items(searchHandler.searchAccessiblePackages(
+                Map.of("name", Set.of("ft_commons")), null, allPages()))
+                .stream().anyMatch(p -> p.getName().contains("commons")));
+    }
+
+    @Test
+    void keywordField_shouldRequireExactMatchForPackageManager() {
+        assertFalse(items(searchHandler.searchAccessiblePackages(
+                Map.of("packageManager", Set.of("MAVEN")), null, allPages())).isEmpty());
+        assertTrue(items(searchHandler.searchAccessiblePackages(
+                Map.of("packageManager", Set.of("MAV")), null, allPages())).isEmpty());
+    }
+
+    @Test
+    void packageManagerFilter_shouldReturnOnlyMatchingManager() {
+        var result = searchHandler.searchAccessiblePackages(
+                Map.of("packageManager", Set.of("NPM")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertEquals(PackageManager.NPM, p.getPackageManager()));
+    }
+
+    @Test
+    void purlSearch_shouldMatchByPrefix() {
+        var result = searchHandler.searchAccessiblePackages(
+                Map.of("purl", Set.of("pkg:maven")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertTrue(p.getPurl().startsWith("pkg:maven")));
+    }
+
+    @Test
+    void filteredSearch_shouldMatchAcrossMultipleFields() {
+        var result = searchHandler.searchFilteredPackages("FT_commons", allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(p -> p.getName().contains("commons")));
+    }
+
+    // --- Sorting tests -------------------------------------------------------
+
+    @Test
+    void sortByNameAscending_shouldReturnAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredPackages("FT_",
+                pageSorted(PackageSortColumn.BY_NAME.getValue(), true));
+        List<String> names = items(result).stream().map(Package::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), names);
+    }
+
+    @Test
+    void sortByNameDescending_shouldReturnReverseAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredPackages("FT_",
+                pageSorted(PackageSortColumn.BY_NAME.getValue(), false));
+        List<String> names = items(result).stream().map(Package::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER.reversed()).toList(), names);
+    }
+
+    @Test
+    void sortByCreatedOnAscending_shouldReturnChronologicalOrder() {
+        var result = searchHandler.searchFilteredPackages("FT_",
+                pageSorted(PackageSortColumn.BY_CREATEDON.getValue(), true));
+        List<String> dates = items(result).stream().map(Package::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted().toList(), dates,
+                "createdOn should be in ascending chronological order");
+    }
+
+    @Test
+    void sortByCreatedOnDescending_shouldReturnReverseChronologicalOrder() {
+        var result = searchHandler.searchFilteredPackages("FT_",
+                pageSorted(PackageSortColumn.BY_CREATEDON.getValue(), false));
+        List<String> dates = items(result).stream().map(Package::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted(Comparator.reverseOrder()).toList(), dates,
+                "createdOn should be in descending chronological order");
+    }
+
+    // --- Pagination tests ----------------------------------------------------
+
+    @Test
+    void firstPage_shouldReturnRequestedPageSize() {
+        assertTrue(items(searchHandler.searchFilteredPackages("FT_", page(0, 5))).size() <= 5);
+    }
+
+    @Test
+    void paginationAcrossPages_shouldProduceNoDuplicates() {
+        Set<String> allIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            List<Package> pg = items(searchHandler.searchFilteredPackages("FT_", page(i, 3)));
+            if (pg.isEmpty()) break;
+            for (Package p : pg) { assertTrue(allIds.add(p.getId()), "Duplicate: " + p.getId()); }
+        }
+    }
+
+    // --- Edge case tests -----------------------------------------------------
+
+    @Test
+    void specialCharacters_shouldNotCauseException() {
+        assertDoesNotThrow(() -> searchHandler.searchAccessiblePackages(
+                Map.of("name", Set.of("FT_Special & Chars")), null, allPages()));
+    }
+
+    @Test
+    void nullDescription_shouldStillBeIndexed() {
+        assertTrue(items(searchHandler.searchAccessiblePackages(
+                Map.of("name", Set.of("FT_Special & Chars")), null, allPages()))
+                .stream().anyMatch(p -> p.getName().contains("Special")));
+    }
+
+    // =========================================================================
+    //  Test data & helpers
+    // =========================================================================
+
+    private static <T> List<T> items(Map<PaginationData, List<T>> r) {
+        return r.values().iterator().next();
+    }
+
+    private PaginationData allPages() {
+        return NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+    }
+
+    private PaginationData page(int p, int size) {
+        return new PaginationData().setRowsPerPage(size).setDisplayStart(p * size)
+                .setAscending(true).setSortColumnNumber(0);
+    }
+
+    private PaginationData pageSorted(int col, boolean asc) {
+        return new PaginationData().setRowsPerPage(200).setDisplayStart(0)
+                .setAscending(asc).setSortColumnNumber(col);
+    }
+
+    /**
+     * Creates seed packages programmatically using Thrift objects to avoid
+     * data model drift that can occur with external JSON fixtures.
+     */
+    private static List<Package> createSeedPackages() {
+        return List.of(
+                pkg("ft-pkg-001", "FT_commons-lang3", "3.14.0", "pkg:maven/org.apache.commons/commons-lang3@3.14.0", PackageManager.MAVEN, "user1@test.sw360.org", "2024-01-10", "Apache Commons Lang utilities"),
+                pkg("ft-pkg-002", "FT_spring-boot-starter", "3.3.0", "pkg:maven/org.springframework.boot/spring-boot-starter@3.3.0", PackageManager.MAVEN, "user1@test.sw360.org", "2024-02-15", "Spring Boot starter dependency"),
+                pkg("ft-pkg-003", "FT_react", "18.2.0", "pkg:npm/react@18.2.0", PackageManager.NPM, "user2@test.sw360.org", "2024-03-20", "React UI library"),
+                pkg("ft-pkg-004", "FT_flask", "3.0.0", "pkg:pypi/flask@3.0.0", PackageManager.PYPI, "user1@test.sw360.org", "2024-04-25", "Flask web framework"),
+                pkg("ft-pkg-005", "FT_tokio", "1.37.0", "pkg:cargo/tokio@1.37.0", PackageManager.CARGO, "user1@test.sw360.org", "2024-05-30", "Async runtime for Rust"),
+                pkg("ft-pkg-006", "FT_gin", "1.9.1", "pkg:golang/github.com/gin-gonic/gin@1.9.1", PackageManager.GOLANG, "user2@test.sw360.org", "2024-06-15", "Gin HTTP web framework for Go"),
+                pkg("ft-pkg-007", "FT_jackson-core", "2.17.0", "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.17.0", PackageManager.MAVEN, "user1@test.sw360.org", "2024-07-10", "Jackson JSON processing core"),
+                pkg("ft-pkg-008", "FT_lodash", "4.17.21", "pkg:npm/lodash@4.17.21", PackageManager.NPM, "user1@test.sw360.org", "2024-08-01", "Lodash utility library"),
+                pkg("ft-pkg-009", "FT_requests", "2.31.0", "pkg:pypi/requests@2.31.0", PackageManager.PYPI, "user2@test.sw360.org", "2024-09-01", "HTTP library for Python"),
+                pkg("ft-pkg-010", "FT_newtonsoft-json", "13.0.3", "pkg:nuget/Newtonsoft.Json@13.0.3", PackageManager.NUGET, "user1@test.sw360.org", "2024-10-15", "JSON framework for .NET"),
+                pkg("ft-pkg-011", "FT_guava", "33.1.0-jre", "pkg:maven/com.google.guava/guava@33.1.0-jre", PackageManager.MAVEN, "user1@test.sw360.org", "2024-11-01", "Google Guava core libraries"),
+                pkg("ft-pkg-012", "FT_axios", "1.6.0", "pkg:npm/axios@1.6.0", PackageManager.NPM, "user1@test.sw360.org", "2024-12-01", "Axios HTTP client"),
+                pkg("ft-pkg-013", "FT_serde", "1.0.200", "pkg:cargo/serde@1.0.200", PackageManager.CARGO, "user1@test.sw360.org", "2025-01-10", "Serialization framework for Rust"),
+                pkg("ft-pkg-014", "FT_Special & Chars", "1.0.0", "pkg:generic/special-chars@1.0.0", PackageManager.GENERIC, "user1@test.sw360.org", "2025-02-01", null),
+                pkg("ft-pkg-015", "FT_zlib", "1.3.1", "pkg:generic/zlib@1.3.1", PackageManager.GENERIC, "user1@test.sw360.org", "2025-03-01", "Compression library")
+        );
+    }
+
+    private static Package pkg(String id, String name, String version, String purl,
+                                PackageManager packageManager, String createdBy,
+                                String createdOn, String description) {
+        Package p = new Package().setId(id).setType("package").setName(name).setVersion(version)
+                .setPurl(purl)
+                .setPackageManager(packageManager)
+                .setCreatedBy(createdBy).setCreatedOn(createdOn);
+        if (description != null) p.setDescription(description);
+        return p;
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandlerTest.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.Visibility;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.eclipse.sw360.datahandler.TestUtils.assumeCanConnectTo;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class ProjectSearchHandlerTest {
+
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (ProjectSortColumn.findByValue(sortColumnNumber)) {
+            case ProjectSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_DESCRIPTION -> List.of("description_sort", SCORE_SORTING_FIELD, revDir + "createdOn");
+            case ProjectSortColumn.BY_RESPONSIBLE -> List.of("projectResponsible_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_STATE -> List.of("state_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_CREATEDON -> List.of("createdOn");
+            case ProjectSortColumn.BY_TYPE -> List.of("projectType_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            case null, default -> List.of(SCORE_SORTING_FIELD);
+        };
+    }
+
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final User user1 = new User().setEmail("user1").setDepartment("AB CD EF");
+    private static final User user2 = new User().setEmail("user2").setDepartment("XY ZZ AA");
+
+    private static ProjectSearchHandler searchHandler;
+
+    @BeforeAll
+    static void setUpDatabase() throws Exception {
+        assumeCanConnectTo(DatabaseSettingsTest.getCouchDbUrl());
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        for (Project p : createSeedProjects()) { db.add(p); }
+        searchHandler = new ProjectSearchHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @AfterAll
+    static void tearDownDatabase() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @Test
+    void byName_shouldReturnNameSortWithVersionAndCreatedOnTiebreakers() {
+        assertEquals(List.of("name_sort", "-version_sort", "-createdOn"),
+                mapSortColumnDirect(ProjectSortColumn.BY_NAME.getValue()));
+    }
+
+    @Test
+    void byDescription_shouldReturnDescriptionSortWithScoreAndCreatedOn() {
+        assertEquals(List.of("description_sort", SCORE_SORTING_FIELD, "-createdOn"),
+                mapSortColumnDirect(ProjectSortColumn.BY_DESCRIPTION.getValue()));
+    }
+
+    @Test
+    void byResponsible_shouldReturnResponsibleSortWithFullTiebreakers() {
+        assertEquals(List.of("projectResponsible_sort", SCORE_SORTING_FIELD, "name_sort", "-version_sort", "-createdOn"),
+                mapSortColumnDirect(ProjectSortColumn.BY_RESPONSIBLE.getValue()));
+    }
+
+    @Test
+    void byState_shouldReturnStateSortWithFullTiebreakers() {
+        assertEquals(List.of("state_sort", SCORE_SORTING_FIELD, "name_sort", "-version_sort", "-createdOn"),
+                mapSortColumnDirect(ProjectSortColumn.BY_STATE.getValue()));
+    }
+
+    @Test
+    void byCreatedOn_shouldReturnOnlyCreatedOn() {
+        assertEquals(List.of("createdOn"), mapSortColumnDirect(ProjectSortColumn.BY_CREATEDON.getValue()));
+    }
+
+    @Test
+    void byType_shouldReturnProjectTypeSortWithFullTiebreakers() {
+        assertEquals(List.of("projectType_sort", SCORE_SORTING_FIELD, "name_sort", "-version_sort", "-createdOn"),
+                mapSortColumnDirect(ProjectSortColumn.BY_TYPE.getValue()));
+    }
+
+    @Test
+    void byScore_shouldReturnOnlyScoreField() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(ProjectSortColumn.BY_SCORE.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToScore() {
+        assertEquals(List.of(SCORE_SORTING_FIELD), mapSortColumnDirect(999));
+    }
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (ProjectSortColumn column : ProjectSortColumn.values()) {
+            assertFalse(mapSortColumnDirect(column.getValue()).isEmpty(), column + " returned empty list");
+        }
+    }
+
+    @Test
+    void nonPrimaryColumns_shouldHaveCorrectTiebreakerOrder() {
+        for (ProjectSortColumn column : List.of(
+                ProjectSortColumn.BY_RESPONSIBLE, ProjectSortColumn.BY_STATE, ProjectSortColumn.BY_TYPE)) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            int scoreIdx = columns.indexOf(SCORE_SORTING_FIELD);
+            int nameIdx = columns.indexOf("name_sort");
+            assertTrue(scoreIdx > 0 && nameIdx > scoreIdx, column + ": tiebreaker order invalid");
+        }
+    }
+
+    // --- Search / filter tests -----------------------------------------------
+
+    @Test
+    void exactNameSearch_shouldReturnMatchingProject() {
+        var result = searchHandler.search(Map.of("name", Set.of("FT_Alpha Project")), user1, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(p -> "FT_Alpha Project".equals(p.getName())));
+    }
+
+    @Test
+    void nonExistentTerm_shouldReturnEmpty() {
+        assertTrue(items(searchHandler.search(
+                Map.of("name", Set.of("zzz_nonexistent_999")), user1, allPages())).isEmpty());
+    }
+
+    @Test
+    void prefixSearch_shouldMatchViaEdgeNgram() {
+        assertTrue(items(searchHandler.search(Map.of("name", Set.of("FT_Al")), user1, allPages()))
+                .stream().anyMatch(p -> p.getName().contains("Alpha")));
+    }
+
+    @Test
+    void secondWordPrefixSearch_shouldMatchViaEdgeNgram() {
+        // "Platf" is an edge-ngram prefix of "Platform" — must match "FT_Beta Platform"
+        assertTrue(items(searchHandler.search(Map.of("name", Set.of("Platf")), null, allPages()))
+                .stream().anyMatch(p -> p.getName().contains("Platform")));
+    }
+
+    @Test
+    void shortPrefixSearch_shouldMatchMultipleProjectsWithSamePrefix() {
+        // "FT_B" is an edge-ngram prefix shared by "FT_Beta Platform" and "FT_BU Only Project"
+        var result = items(searchHandler.search(Map.of("name", Set.of("FT_B")), null, allPages()));
+        assertTrue(result.size() >= 2);
+        result.forEach(p -> assertTrue(p.getName().startsWith("FT_B"),
+                "Unexpected match: " + p.getName()));
+    }
+
+    @Test
+    void caseInsensitiveSearch_shouldMatch() {
+        assertTrue(items(searchHandler.search(Map.of("name", Set.of("ft_alpha")), user1, allPages()))
+                .stream().anyMatch(p -> p.getName().contains("Alpha")));
+    }
+
+    @Test
+    void keywordField_shouldRequireExactMatch() {
+        assertFalse(items(searchHandler.search(Map.of("state", Set.of("ACTIVE")), null, allPages())).isEmpty());
+        assertTrue(items(searchHandler.search(Map.of("state", Set.of("ACT")), null, allPages())).isEmpty());
+    }
+
+    @Test
+    void singleFieldFilter_shouldReturnOnlyMatchingState() {
+        var result = searchHandler.search(Map.of("state", Set.of("PHASE_OUT")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertEquals("PHASE_OUT", p.getState().name()));
+    }
+
+    @Test
+    void multiFieldAndFilter_shouldReturnIntersection() {
+        var result = searchHandler.search(Map.of("state", Set.of("ACTIVE"), "tag", Set.of("internal")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> {
+            assertEquals("ACTIVE", p.getState().name());
+            assertEquals("internal", p.getTag());
+        });
+    }
+
+    @Test
+    void multiValueOrWithinField_shouldReturnUnion() {
+        var result = searchHandler.search(Map.of("state", Set.of("ACTIVE", "PHASE_OUT")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertTrue(Set.of("ACTIVE", "PHASE_OUT").contains(p.getState().name())));
+    }
+
+    @Test
+    void emptyAwareSentinel_shouldFindDocsWithNoTag() {
+        var result = searchHandler.search(Map.of("tag", Set.of(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN)), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertTrue(p.getTag() == null || p.getTag().isEmpty()));
+    }
+
+    @Test
+    void normalTagSearch_shouldExcludeEmptyTagDocs() {
+        var result = searchHandler.search(Map.of("tag", Set.of("security")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertEquals("security", p.getTag()));
+    }
+
+    @Test
+    void searchByBusinessUnit_shouldReturnOnlyMatchingBU() {
+        var result = searchHandler.search(Map.of("businessUnit", Set.of("AB CD EF")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertEquals("AB CD EF", p.getBusinessUnit()));
+    }
+
+    @Test
+    void searchByProjectType_shouldReturnExactTypeMatch() {
+        var result = searchHandler.search(Map.of("projectType", Set.of("SERVICE")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertEquals("SERVICE", p.getProjectType().name()));
+    }
+
+    @Test
+    void searchByProjectResponsible_shouldReturnMatchingProjects() {
+        var result = searchHandler.search(Map.of("projectResponsible", Set.of("alice@example.com")), null, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(p -> assertEquals("alice@example.com", p.getProjectResponsible()));
+    }
+
+    // --- Sorting tests -------------------------------------------------------
+
+    @Test
+    void sortByNameAscending_shouldReturnAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_NAME.getValue(), true));
+        List<String> names = items(result).stream().map(Project::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), names);
+    }
+
+    @Test
+    void sortByNameDescending_shouldReturnReverseAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_NAME.getValue(), false));
+        List<String> names = items(result).stream().map(Project::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER.reversed()).toList(), names);
+    }
+
+    @Test
+    void sortByName_sameNameProjectsShouldTieBreakByVersionDescending() {
+        // BY_NAME sort spec is [name_sort, -version_sort, -createdOn]:
+        // equal names break by version descending → 3.0, 2.0, 1.0.
+        var result = searchHandler.searchFilteredProjects("FT_Alpha", null,
+                pageSorted(ProjectSortColumn.BY_NAME.getValue(), true));
+        List<String> alphaVersions = items(result).stream()
+                .filter(p -> "FT_Alpha Project".equals(p.getName()))
+                .map(Project::getVersion)
+                .toList();
+        assertEquals(List.of("3.0", "2.0", "1.0"), alphaVersions,
+                "Same-name projects must be ordered by version descending");
+    }
+
+    @Test
+    void sortByCreatedOnAscending_shouldReturnChronologicalOrder() {
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_CREATEDON.getValue(), true));
+        List<String> dates = items(result).stream().map(Project::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted().toList(), dates,
+                "createdOn should be in ascending chronological order");
+    }
+
+    @Test
+    void sortByCreatedOnDescending_shouldReturnReverseChronologicalOrder() {
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_CREATEDON.getValue(), false));
+        List<String> dates = items(result).stream().map(Project::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted(Comparator.reverseOrder()).toList(), dates,
+                "createdOn should be in descending chronological order");
+    }
+
+    @Test
+    void sortByStateAscending_shouldReturnGroupedByStateAlphabetically() {
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_STATE.getValue(), true));
+        List<String> states = items(result).stream().map(p -> p.getState().name()).toList();
+        assertEquals(states.stream().sorted().toList(), states,
+                "States should appear in ascending alphabetical order (ACTIVE < PHASE_OUT < UNKNOWN)");
+    }
+
+    @Test
+    void sortByTypeAscending_shouldReturnGroupedByTypeAlphabetically() {
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_TYPE.getValue(), true));
+        List<String> types = items(result).stream().map(p -> p.getProjectType().name()).toList();
+        assertEquals(types.stream().sorted().toList(), types,
+                "Project types should appear in ascending alphabetical order");
+    }
+
+    @Test
+    void sortByResponsibleAscending_shouldReturnAlphabeticalResponsibleOrder() {
+        // Seed data responsibles (ascending): alice@example.com < bob@example.com
+        //   < carol@example.com < user1 < user2
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_RESPONSIBLE.getValue(), true));
+        List<String> responsibles = items(result).stream()
+                .map(Project::getProjectResponsible)
+                .filter(Objects::nonNull)
+                .toList();
+        assertFalse(responsibles.isEmpty());
+        assertEquals(responsibles.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), responsibles,
+                "Project responsibles should appear in ascending alphabetical order");
+    }
+
+    @Test
+    void sortByDescriptionAscending_shouldOrderNonNullDescriptionsAlphabetically() {
+        // Lucene places missing description_sort values at one end; the non-null
+        // descriptions must form a monotonically ascending sequence in the results.
+        var result = searchHandler.searchFilteredProjects("FT_", null,
+                pageSorted(ProjectSortColumn.BY_DESCRIPTION.getValue(), true));
+        List<String> descriptions = items(result).stream()
+                .map(Project::getDescription)
+                .filter(Objects::nonNull)
+                .toList();
+        assertFalse(descriptions.isEmpty());
+        assertEquals(descriptions.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), descriptions,
+                "Non-null descriptions must appear in ascending alphabetical order");
+    }
+
+    @Test
+    void sortByScore_shouldReturnNonEmptyResultsWithoutException() {
+        assertDoesNotThrow(() -> {
+            var result = searchHandler.searchFilteredProjects("FT_", null,
+                    pageSorted(ProjectSortColumn.BY_SCORE.getValue(), true));
+            assertFalse(items(result).isEmpty());
+        });
+    }
+
+    // --- Pagination tests ----------------------------------------------------
+
+    @Test
+    void firstPage_shouldReturnRequestedPageSize() {
+        assertTrue(items(searchHandler.searchFilteredProjects("FT_", null, page(0, 5))).size() <= 5);
+    }
+
+    @Test
+    void secondPage_shouldNotOverlapWithFirstPage() {
+        Set<String> p0 = items(searchHandler.searchFilteredProjects("FT_", null, page(0, 5)))
+                .stream().map(Project::getId).collect(Collectors.toSet());
+        Set<String> p1 = items(searchHandler.searchFilteredProjects("FT_", null, page(1, 5)))
+                .stream().map(Project::getId).collect(Collectors.toSet());
+        if (!p1.isEmpty()) { p1.retainAll(p0); assertTrue(p1.isEmpty()); }
+    }
+
+    @Test
+    void pageBeyondTotal_shouldReturnEmpty() {
+        assertTrue(items(searchHandler.searchFilteredProjects("FT_", null, page(100, 5))).isEmpty());
+    }
+
+    @Test
+    void paginationAcrossPages_shouldProduceNoDuplicates() {
+        Set<String> allIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            List<Project> pg = items(searchHandler.searchFilteredProjects("FT_", null, page(i, 3)));
+            if (pg.isEmpty()) break;
+            for (Project p : pg) { assertTrue(allIds.add(p.getId()), "Duplicate: " + p.getId()); }
+        }
+    }
+
+    // --- Access control tests ------------------------------------------------
+
+    @Test
+    void restrictedUser_shouldSeeFewerThanAdmin() {
+        int adminCount = items(searchHandler.searchFilteredProjects("FT_", user1, allPages())).size();
+        int otherCount = items(searchHandler.searchFilteredProjects("FT_", user2, allPages())).size();
+        assertTrue(otherCount <= adminCount);
+    }
+
+    // --- Edge case tests -----------------------------------------------------
+
+    @Test
+    void specialCharacters_shouldNotCauseException() {
+        assertDoesNotThrow(() -> searchHandler.search(Map.of("name", Set.of("FT_Special & Chars")), null, allPages()));
+    }
+
+    @Test
+    void documentWithNullOptionalFields_shouldStillBeIndexed() {
+        assertTrue(items(searchHandler.search(Map.of("name", Set.of("FT_Delta Service")), null, allPages()))
+                .stream().anyMatch(p -> p.getName().contains("Delta")));
+    }
+
+    // =========================================================================
+    //  Test data & helpers
+    // =========================================================================
+
+    private static <T> List<T> items(Map<PaginationData, List<T>> r) {
+        return r.values().iterator().next();
+    }
+
+    private PaginationData allPages() {
+        return NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+    }
+
+    private PaginationData page(int p, int size) {
+        return new PaginationData().setRowsPerPage(size).setDisplayStart(p * size)
+                .setAscending(true).setSortColumnNumber(0);
+    }
+
+    private PaginationData pageSorted(int col, boolean asc) {
+        return new PaginationData().setRowsPerPage(200).setDisplayStart(0)
+                .setAscending(asc).setSortColumnNumber(col);
+    }
+
+    /**
+     * Creates seed projects programmatically using Thrift objects to avoid
+     * data model drift that can occur with external JSON fixtures.
+     */
+    private static List<Project> createSeedProjects() {
+        return List.of(
+                prj("ft-prj-001", "FT_Alpha Project", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2024-01-15", "user1", Visibility.EVERYONE, "Alpha project description", "user1"),
+                prj("ft-prj-002", "FT_Beta Platform", "2.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "external", "AB CD EF", "2024-03-20", "user1", Visibility.EVERYONE, "Beta platform for testing", "user2"),
+                prj("ft-prj-003", "FT_Gamma Suite", "1.0", ProjectState.PHASE_OUT, ProjectType.INNER_SOURCE, "internal", "AB CD EF", "2023-10-05", "user1", Visibility.EVERYONE, "Gamma suite phase out", "user1"),
+                prj("ft-prj-004", "FT_Delta Service", "3.0", ProjectState.ACTIVE, ProjectType.SERVICE, null, "AB CD EF", "2023-06-01", "user1", Visibility.EVERYONE, null, "user2"),
+                prj("ft-prj-005", "FT_Epsilon Core", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "security", "XY ZZ AA", "2024-08-01", "user2", Visibility.EVERYONE, "Epsilon core security", "user2"),
+                prj("ft-prj-006", "FT_Zeta Framework", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2024-07-10", "user1", Visibility.EVERYONE, "Zeta open source framework", "user1"),
+                prj("ft-prj-007", "FT_Private Project", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2024-06-15", "user1", Visibility.PRIVATE, "Private project", "user1"),
+                prj("ft-prj-008", "FT_BU Only Project", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2024-05-20", "user1", Visibility.BUISNESSUNIT_AND_MODERATORS, "BU restricted project", "user1"),
+                prj("ft-prj-009", "FT_Eta Component", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2024-09-01", "user1", Visibility.EVERYONE, "Eta component system", "user1"),
+                prj("ft-prj-010", "FT_Theta Module", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "external", "AB CD EF", "2024-09-15", "user1", Visibility.EVERYONE, "Theta module integration", "user1"),
+                prj("ft-prj-011", "FT_Iota Library", "1.0", ProjectState.ACTIVE, ProjectType.INNER_SOURCE, "internal", "AB CD EF", "2024-10-01", "user1", Visibility.EVERYONE, "Iota library collection", "user1"),
+                prj("ft-prj-012", "FT_Kappa System", "2.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "security", "AB CD EF", "2024-10-15", "user1", Visibility.EVERYONE, "Kappa system analysis", "user1"),
+                prj("ft-prj-013", "FT_Lambda App", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, null, "AB CD EF", "2024-11-01", "user1", Visibility.EVERYONE, "Lambda application suite", "user1"),
+                prj("ft-prj-014", "FT_Mu Service", "1.0", ProjectState.ACTIVE, ProjectType.SERVICE, "internal", "AB CD EF", "2024-11-15", "user1", Visibility.EVERYONE, "Mu service delivery", "user1"),
+                prj("ft-prj-015", "FT_Nu Platform", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2024-12-01", "user1", Visibility.EVERYONE, "Nu platform release", "user1"),
+                prj("ft-prj-016", "FT_Alpha Project", "2.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2025-01-10", "user1", Visibility.EVERYONE, null, "user1"),
+                prj("ft-prj-017", "FT_Alpha Project", "3.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2025-02-20", "user1", Visibility.EVERYONE, null, "user1"),
+                prj("ft-prj-018", "FT_Special & Chars", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2025-03-01", "user1", Visibility.EVERYONE, null, "user1"),
+                prj("ft-prj-019", "FT_Xi Platform", "1.0", ProjectState.ACTIVE, ProjectType.PRODUCT, "internal", "AB CD EF", "2025-04-01", "user1", Visibility.EVERYONE, "Architecture platform review", "alice@example.com"),
+                prj("ft-prj-020", "FT_Omicron Suite", "1.0", ProjectState.ACTIVE, ProjectType.INNER_SOURCE, "internal", "AB CD EF", "2025-04-15", "user1", Visibility.EVERYONE, "Continuous integration suite", "carol@example.com"),
+                prj("ft-prj-021", "FT_Pi Dashboard", "1.0", ProjectState.UNKNOWN, ProjectType.PRODUCT, "internal", "AB CD EF", "2025-05-01", "user1", Visibility.EVERYONE, "Monitoring dashboard tool", "bob@example.com"),
+                prj("ft-prj-022", "FT_Rho Report", "1.0", ProjectState.ACTIVE, ProjectType.SERVICE, "internal", "AB CD EF", "2025-05-15", "user1", Visibility.EVERYONE, "Zero-trust security reporting", "user1")
+        );
+    }
+
+    private static Project prj(String id, String name, String version, ProjectState state,
+                                ProjectType type, String tag, String bu, String createdOn,
+                                String createdBy, Visibility vis, String desc,
+                                String projectResponsible) {
+        Project p = new Project().setId(id).setType("project").setName(name).setVersion(version)
+                .setState(state).setProjectType(type).setBusinessUnit(bu).setCreatedOn(createdOn)
+                .setCreatedBy(createdBy).setVisbility(vis);
+        if (tag != null) p.setTag(tag);
+        if (desc != null) p.setDescription(desc);
+        if (projectResponsible != null) p.setProjectResponsible(projectResponsible);
+        return p;
+    }
+}

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandlerTest.java
@@ -9,20 +9,32 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.MainlineState;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseSortColumn;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.TestUtils.assumeCanConnectTo;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ReleaseSearchHandlerTest {
 
-    /**
-     * Mirror of {@link ReleaseSearchHandler#mapSortColumn(int)} so we can test
-     * sorting logic without needing a CouchDB connection.
-     */
     private static List<String> mapSortColumnDirect(int sortColumnNumber) {
         String revDir = "-";
         return switch (ReleaseSortColumn.findByValue(sortColumnNumber)) {
@@ -33,6 +45,26 @@ class ReleaseSearchHandlerTest {
             case ReleaseSortColumn.BY_CREATEDON -> List.of("createdOn");
             case null, default -> List.of(SCORE_SORTING_FIELD);
         };
+    }
+
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final User user1 = new User().setEmail("user1").setDepartment("AB CD EF");
+
+    private static ReleaseSearchHandler searchHandler;
+
+    @BeforeAll
+    static void setUpDatabase() throws Exception {
+        assumeCanConnectTo(DatabaseSettingsTest.getCouchDbUrl());
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(
+                DatabaseSettingsTest.getConfiguredClient(), dbName);
+        for (Release r : createSeedReleases()) { db.add(r); }
+        searchHandler = new ReleaseSearchHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @AfterAll
+    static void tearDownDatabase() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
     }
 
     @Test
@@ -109,5 +141,217 @@ class ReleaseSearchHandlerTest {
             assertTrue(nameIdx > scoreIdx, column + ": name_sort should follow score");
             assertTrue(createdOnIdx > nameIdx, column + ": createdOn should be last");
         }
+    }
+
+
+    // --- Search / filter tests -----------------------------------------------
+
+    @Test
+    void exactNameSearch_shouldReturnMatchingRelease() {
+        var result = searchHandler.searchAccessibleReleases(
+                Map.of("name", Set.of("FT_Apache Commons")), user1, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(r -> "FT_Apache Commons".equals(r.getName())));
+    }
+
+    @Test
+    void nonExistentTerm_shouldReturnEmpty() {
+        assertTrue(items(searchHandler.searchAccessibleReleases(
+                Map.of("name", Set.of("zzz_nonexistent_999")), user1, allPages())).isEmpty());
+    }
+
+    @Test
+    void prefixSearch_shouldMatchViaEdgeNgram() {
+        assertTrue(items(searchHandler.searchAccessibleReleases(
+                Map.of("name", Set.of("FT_Apa")), user1, allPages()))
+                .stream().anyMatch(r -> r.getName().contains("Apache")));
+    }
+
+    @Test
+    void secondWordPrefixSearch_shouldMatchViaEdgeNgram() {
+        // "Frame" is an edge-ngram prefix of "Framework"
+        assertTrue(items(searchHandler.searchAccessibleReleases(
+                Map.of("name", Set.of("Frame")), null, allPages()))
+                .stream().anyMatch(r -> r.getName().contains("Framework")));
+    }
+
+    @Test
+    void caseInsensitiveSearch_shouldMatch() {
+        assertTrue(items(searchHandler.searchAccessibleReleases(
+                Map.of("name", Set.of("ft_apache")), user1, allPages()))
+                .stream().anyMatch(r -> r.getName().contains("Apache")));
+    }
+
+    @Test
+    void keywordField_shouldRequireExactMatch() {
+        assertFalse(items(searchHandler.searchAccessibleReleases(
+                Map.of("clearingState", Set.of("APPROVED")), user1, allPages())).isEmpty());
+        assertTrue(items(searchHandler.searchAccessibleReleases(
+                Map.of("clearingState", Set.of("APP")), user1, allPages())).isEmpty());
+    }
+
+    @Test
+    void clearingStateFilter_shouldReturnOnlyMatchingState() {
+        var result = searchHandler.searchAccessibleReleases(
+                Map.of("clearingState", Set.of("APPROVED")), user1, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(r -> assertEquals(ClearingState.APPROVED, r.getClearingState()));
+    }
+
+    @Test
+    void mainlineStateFilter_shouldReturnOnlyMatchingState() {
+        var result = searchHandler.searchAccessibleReleases(
+                Map.of("mainlineState", Set.of("MAINLINE")), user1, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(r -> assertEquals(MainlineState.MAINLINE, r.getMainlineState()));
+    }
+
+    @Test
+    void versionSearch_shouldReturnExactVersionMatch() {
+        var result = searchHandler.searchAccessibleReleases(
+                Map.of("version", Set.of("1.2.3")), user1, allPages());
+        assertFalse(items(result).isEmpty());
+        items(result).forEach(r -> assertEquals("1.2.3", r.getVersion()));
+    }
+
+    // --- Sorting tests -------------------------------------------------------
+
+    @Test
+    void sortByNameAscending_shouldReturnAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredReleases("FT_", user1,
+                pageSorted(ReleaseSortColumn.BY_NAME.getValue(), true));
+        List<String> names = items(result).stream().map(Release::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), names);
+    }
+
+    @Test
+    void sortByNameDescending_shouldReturnReverseAlphabeticalOrder() {
+        var result = searchHandler.searchFilteredReleases("FT_", user1,
+                pageSorted(ReleaseSortColumn.BY_NAME.getValue(), false));
+        List<String> names = items(result).stream().map(Release::getName).toList();
+        assertEquals(names.stream().sorted(String.CASE_INSENSITIVE_ORDER.reversed()).toList(), names);
+    }
+
+    @Test
+    void sortByName_sameNameReleasesShouldTieBreakByVersionDescending() {
+        var result = searchHandler.searchFilteredReleases("FT_Apache", user1,
+                pageSorted(ReleaseSortColumn.BY_NAME.getValue(), true));
+        List<String> apacheVersions = items(result).stream()
+                .filter(r -> "FT_Apache Commons".equals(r.getName()))
+                .map(Release::getVersion)
+                .toList();
+        assertEquals(List.of("2.0.0", "1.0.0"), apacheVersions,
+                "Same-name releases must be ordered by version descending");
+    }
+
+    @Test
+    void sortByClearingStateAscending_shouldReturnGroupedByState() {
+        var result = searchHandler.searchFilteredReleases("FT_", user1,
+                pageSorted(ReleaseSortColumn.BY_CLEARING_STATE.getValue(), true));
+        List<String> states = items(result).stream().map(r -> r.getClearingState().name()).toList();
+        assertEquals(states.stream().sorted().toList(), states,
+                "Clearing states should appear in ascending alphabetical order");
+    }
+
+    @Test
+    void sortByCreatedOnAscending_shouldReturnChronologicalOrder() {
+        var result = searchHandler.searchFilteredReleases("FT_", user1,
+                pageSorted(ReleaseSortColumn.BY_CREATEDON.getValue(), true));
+        List<String> dates = items(result).stream().map(Release::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted().toList(), dates,
+                "createdOn should be in ascending chronological order");
+    }
+
+    @Test
+    void sortByCreatedOnDescending_shouldReturnReverseChronologicalOrder() {
+        var result = searchHandler.searchFilteredReleases("FT_", user1,
+                pageSorted(ReleaseSortColumn.BY_CREATEDON.getValue(), false));
+        List<String> dates = items(result).stream().map(Release::getCreatedOn).toList();
+        assertEquals(dates.stream().sorted(Comparator.reverseOrder()).toList(), dates,
+                "createdOn should be in descending chronological order");
+    }
+
+    // --- Pagination tests ----------------------------------------------------
+
+    @Test
+    void firstPage_shouldReturnRequestedPageSize() {
+        assertTrue(items(searchHandler.searchFilteredReleases("FT_", user1, page(0, 5))).size() <= 5);
+    }
+
+    @Test
+    void paginationAcrossPages_shouldProduceNoDuplicates() {
+        Set<String> allIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            List<Release> pg = items(searchHandler.searchFilteredReleases("FT_", user1, page(i, 3)));
+            if (pg.isEmpty()) break;
+            for (Release r : pg) { assertTrue(allIds.add(r.getId()), "Duplicate: " + r.getId()); }
+        }
+    }
+
+    // --- Edge case tests -----------------------------------------------------
+
+    @Test
+    void specialCharacters_shouldNotCauseException() {
+        assertDoesNotThrow(() -> searchHandler.searchAccessibleReleases(
+                Map.of("name", Set.of("FT_Alpha & Beta")), user1, allPages()));
+    }
+
+    // =========================================================================
+    //  Test data & helpers
+    // =========================================================================
+
+    private static <T> List<T> items(Map<PaginationData, List<T>> r) {
+        return r.values().iterator().next();
+    }
+
+    private PaginationData allPages() {
+        return NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+    }
+
+    private PaginationData page(int p, int size) {
+        return new PaginationData().setRowsPerPage(size).setDisplayStart(p * size)
+                .setAscending(true).setSortColumnNumber(0);
+    }
+
+    private PaginationData pageSorted(int col, boolean asc) {
+        return new PaginationData().setRowsPerPage(200).setDisplayStart(0)
+                .setAscending(asc).setSortColumnNumber(col);
+    }
+
+    /**
+     * Creates seed releases programmatically using Thrift objects to avoid
+     * data model drift that can occur with external JSON fixtures.
+     */
+    private static List<Release> createSeedReleases() {
+        return List.of(
+                rel("ft-rel-001", "FT_Apache Commons", "1.0.0", "ft-c-001", ClearingState.NEW_CLEARING, MainlineState.OPEN, "user1@test.sw360.org", "2024-01-15"),
+                rel("ft-rel-002", "FT_Apache Commons", "2.0.0", "ft-c-001", ClearingState.REPORT_AVAILABLE, MainlineState.MAINLINE, "user1@test.sw360.org", "2024-06-15"),
+                rel("ft-rel-003", "FT_Spring Framework", "5.3.0", "ft-c-002", ClearingState.APPROVED, MainlineState.MAINLINE, "user1@test.sw360.org", "2024-03-01"),
+                rel("ft-rel-004", "FT_Spring Framework", "6.0.0", "ft-c-002", ClearingState.NEW_CLEARING, MainlineState.OPEN, "user2@test.sw360.org", "2024-09-01"),
+                rel("ft-rel-005", "FT_React UI", "18.0.0", "ft-c-003", ClearingState.APPROVED, MainlineState.MAINLINE, "user2@test.sw360.org", "2024-04-01"),
+                rel("ft-rel-006", "FT_Bootstrap UI", "5.3.0", "ft-c-006", ClearingState.NEW_CLEARING, MainlineState.OPEN, "user1@test.sw360.org", "2024-07-01"),
+                rel("ft-rel-007", "FT_Logging Library", "2.20.0", "ft-c-007", ClearingState.UNDER_CLEARING, MainlineState.SPECIFIC, "user1@test.sw360.org", "2024-08-01"),
+                rel("ft-rel-008", "FT_Security Module", "1.0.0", "ft-c-009", ClearingState.APPROVED, MainlineState.MAINLINE, "user2@test.sw360.org", "2024-10-01"),
+                rel("ft-rel-009", "FT_Internal Tool", "1.0.0", "ft-c-004", ClearingState.NEW_CLEARING, MainlineState.OPEN, "user1@test.sw360.org", "2024-05-01"),
+                rel("ft-rel-010", "FT_libA", "1.2.3", "ft-c-007", ClearingState.APPROVED, MainlineState.MAINLINE, "user1@test.sw360.org", "2024-11-01"),
+                rel("ft-rel-011", "FT_libB", "1.2.3", "ft-c-007", ClearingState.APPROVED, MainlineState.MAINLINE, "user1@test.sw360.org", "2024-11-02"),
+                rel("ft-rel-012", "FT_libM", "1.2.3", "ft-c-007", ClearingState.APPROVED, MainlineState.MAINLINE, "user1@test.sw360.org", "2024-11-03"),
+                rel("ft-rel-013", "FT_libZ", "1.2.3", "ft-c-007", ClearingState.APPROVED, MainlineState.MAINLINE, "user1@test.sw360.org", "2024-11-04"),
+                rel("ft-rel-014", "FT_libK", "2.0.0", "ft-c-007", ClearingState.NEW_CLEARING, MainlineState.OPEN, "user1@test.sw360.org", "2024-11-05"),
+                rel("ft-rel-015", "FT_CLI Tool", "0.9.0", "ft-c-010", ClearingState.NEW_CLEARING, MainlineState.OPEN, "user1@test.sw360.org", "2025-01-01"),
+                rel("ft-rel-016", "FT_Alpha & Beta", "1.0.0", "ft-c-016", ClearingState.NEW_CLEARING, MainlineState.OPEN, "user1@test.sw360.org", "2025-02-01"),
+                rel("ft-rel-017", "FT_Analytics Engine", "3.1.0", "ft-c-018", ClearingState.UNDER_CLEARING, MainlineState.SPECIFIC, "user2@test.sw360.org", "2025-03-01"),
+                rel("ft-rel-018", "FT_Zulu Runtime", "21.0.0", "ft-c-019", ClearingState.APPROVED, MainlineState.MAINLINE, "user1@test.sw360.org", "2025-04-01")
+        );
+    }
+
+    private static Release rel(String id, String name, String version, String componentId,
+                                ClearingState clearingState, MainlineState mainlineState,
+                                String createdBy, String createdOn) {
+        return new Release().setId(id).setType("release").setName(name).setVersion(version)
+                .setComponentId(componentId)
+                .setClearingState(clearingState)
+                .setMainlineState(mainlineState)
+                .setCreatedBy(createdBy).setCreatedOn(createdOn);
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/VulnerabilitySearchHandlerTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilitySortColumn;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.eclipse.sw360.datahandler.TestUtils.assumeCanConnectTo;
+import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VulnerabilitySearchHandlerTest {
+
+
+    private static List<String> mapSortColumnDirect(int sortColumnNumber) {
+        String revDir = "-";
+        return switch (VulnerabilitySortColumn.findByValue(sortColumnNumber)) {
+            case VulnerabilitySortColumn.BY_EXTERNALID -> List.of("externalId_sort", revDir + "lastUpdateDate");
+            case VulnerabilitySortColumn.BY_TITLE -> List.of("title_sort", revDir + "lastUpdateDate");
+            case VulnerabilitySortColumn.BY_WEIGHTING -> List.of("cvss", SCORE_SORTING_FIELD);
+            case VulnerabilitySortColumn.BY_PUBLISHDATE -> List.of("publishDate");
+            case null, default -> List.of(revDir + "lastUpdateDate");
+        };
+    }
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+
+    private static VulnerabilitySearchHandler searchHandler;
+
+    @BeforeAll
+    static void setUpDatabase() throws Exception {
+        assumeCanConnectTo(DatabaseSettingsTest.getCouchDbUrl());
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        for (Vulnerability v : createSeedVulnerabilities()) { db.add(v); }
+        searchHandler = new VulnerabilitySearchHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @AfterAll
+    static void tearDownDatabase() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+
+    @Test
+    void byExternalId_shouldReturnExternalIdSortWithLastUpdateDateTiebreaker() {
+        assertEquals(List.of("externalId_sort", "-lastUpdateDate"),
+                mapSortColumnDirect(VulnerabilitySortColumn.BY_EXTERNALID.getValue()));
+    }
+
+    @Test
+    void byTitle_shouldReturnTitleSortWithLastUpdateDateTiebreaker() {
+        assertEquals(List.of("title_sort", "-lastUpdateDate"),
+                mapSortColumnDirect(VulnerabilitySortColumn.BY_TITLE.getValue()));
+    }
+
+    @Test
+    void byWeighting_shouldReturnCvssWithScoreTiebreaker() {
+        List<String> columns = mapSortColumnDirect(VulnerabilitySortColumn.BY_WEIGHTING.getValue());
+        assertEquals(List.of("cvss", SCORE_SORTING_FIELD), columns);
+    }
+
+    @Test
+    void byPublishDate_shouldReturnOnlyPublishDate() {
+        assertEquals(List.of("publishDate"),
+                mapSortColumnDirect(VulnerabilitySortColumn.BY_PUBLISHDATE.getValue()));
+    }
+
+    @Test
+    void unknownColumn_shouldDefaultToLastUpdateDateDescending() {
+        assertEquals(List.of("-lastUpdateDate"), mapSortColumnDirect(999));
+    }
+
+    @Test
+    void allColumns_shouldProduceNonEmptyLists() {
+        for (VulnerabilitySortColumn column : VulnerabilitySortColumn.values()) {
+            List<String> columns = mapSortColumnDirect(column.getValue());
+            assertNotNull(columns);
+            assertFalse(columns.isEmpty(), column + " returned empty list");
+        }
+    }
+
+
+
+    // --- Search / filter tests -----------------------------------------------
+
+    @Test
+    void titleSearch_shouldReturnMatchingVulnerability() {
+        var result = searchHandler.search("FT_Buffer", null, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(v -> v.getTitle().contains("Buffer Overflow")));
+    }
+
+    @Test
+    void externalIdSearch_shouldReturnMatchingVulnerability() {
+        var result = searchHandler.search("CVE-2024-0001", null, allPages());
+        assertFalse(items(result).isEmpty());
+        assertTrue(items(result).stream().anyMatch(v -> "CVE-2024-0001".equals(v.getExternalId())));
+    }
+
+    @Test
+    void nonExistentTerm_shouldReturnEmpty() {
+        assertTrue(items(searchHandler.search("zzz_nonexistent_999", null, allPages())).isEmpty());
+    }
+
+    @Test
+    void prefixSearch_shouldMatchViaEdgeNgram() {
+        // "FT_Buff" is an edge-ngram prefix of "FT_Buffer Overflow in libpng"
+        assertTrue(items(searchHandler.search("FT_Buff", null, allPages()))
+                .stream().anyMatch(v -> v.getTitle().contains("Buffer")));
+    }
+
+    @Test
+    void caseInsensitiveSearch_shouldMatch() {
+        assertTrue(items(searchHandler.search("ft_buffer", null, allPages()))
+                .stream().anyMatch(v -> v.getTitle().contains("Buffer")));
+    }
+
+    // --- Sorting tests -------------------------------------------------------
+
+    @Test
+    void sortByExternalIdAscending_shouldReturnAlphabeticalOrder() {
+        var result = searchHandler.search("FT_", null,
+                pageSorted(VulnerabilitySortColumn.BY_EXTERNALID.getValue(), true));
+        List<String> ids = items(result).stream().map(Vulnerability::getExternalId).toList();
+        assertEquals(ids.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), ids);
+    }
+
+    @Test
+    void sortByExternalIdDescending_shouldReturnReverseAlphabeticalOrder() {
+        var result = searchHandler.search("FT_", null,
+                pageSorted(VulnerabilitySortColumn.BY_EXTERNALID.getValue(), false));
+        List<String> ids = items(result).stream().map(Vulnerability::getExternalId).toList();
+        assertEquals(ids.stream().sorted(String.CASE_INSENSITIVE_ORDER.reversed()).toList(), ids);
+    }
+
+    @Test
+    void sortByTitleAscending_shouldReturnAlphabeticalOrder() {
+        var result = searchHandler.search("FT_", null,
+                pageSorted(VulnerabilitySortColumn.BY_TITLE.getValue(), true));
+        List<String> titles = items(result).stream().map(Vulnerability::getTitle).toList();
+        assertEquals(titles.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList(), titles);
+    }
+
+    @Test
+    void sortByPublishDateAscending_shouldReturnChronologicalOrder() {
+        var result = searchHandler.search("FT_", null,
+                pageSorted(VulnerabilitySortColumn.BY_PUBLISHDATE.getValue(), true));
+        List<String> dates = items(result).stream().map(Vulnerability::getPublishDate).toList();
+        assertEquals(dates.stream().sorted().toList(), dates,
+                "publishDate should be in ascending chronological order");
+    }
+
+    @Test
+    void sortByPublishDateDescending_shouldReturnReverseChronologicalOrder() {
+        var result = searchHandler.search("FT_", null,
+                pageSorted(VulnerabilitySortColumn.BY_PUBLISHDATE.getValue(), false));
+        List<String> dates = items(result).stream().map(Vulnerability::getPublishDate).toList();
+        assertEquals(dates.stream().sorted(Comparator.reverseOrder()).toList(), dates,
+                "publishDate should be in descending chronological order");
+    }
+
+    @Test
+    void sortByWeighting_shouldReturnNonEmptyResults() {
+        assertDoesNotThrow(() -> {
+            var result = searchHandler.search("FT_", null,
+                    pageSorted(VulnerabilitySortColumn.BY_WEIGHTING.getValue(), true));
+            assertFalse(items(result).isEmpty());
+        });
+    }
+
+    // --- Pagination tests ----------------------------------------------------
+
+    @Test
+    void firstPage_shouldReturnRequestedPageSize() {
+        assertTrue(items(searchHandler.search("FT_", null, page(0, 3))).size() <= 3);
+    }
+
+    @Test
+    void paginationAcrossPages_shouldProduceNoDuplicates() {
+        Set<String> allIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            List<Vulnerability> pg = items(searchHandler.search("FT_", null, page(i, 3)));
+            if (pg.isEmpty()) break;
+            for (Vulnerability v : pg) { assertTrue(allIds.add(v.getId()), "Duplicate: " + v.getId()); }
+        }
+    }
+
+    // --- Edge case tests -----------------------------------------------------
+
+    @Test
+    void specialCharacters_shouldNotCauseException() {
+        assertDoesNotThrow(() -> searchHandler.search("CVE & XSS", null, allPages()));
+    }
+
+    // =========================================================================
+    //  Test data & helpers
+    // =========================================================================
+
+    private static <T> List<T> items(Map<PaginationData, List<T>> r) {
+        return r.values().iterator().next();
+    }
+
+    private PaginationData allPages() {
+        return NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+    }
+
+    private PaginationData page(int p, int size) {
+        return new PaginationData().setRowsPerPage(size).setDisplayStart(p * size)
+                .setAscending(true).setSortColumnNumber(0);
+    }
+
+    private PaginationData pageSorted(int col, boolean asc) {
+        return new PaginationData().setRowsPerPage(200).setDisplayStart(0)
+                .setAscending(asc).setSortColumnNumber(col);
+    }
+
+    /**
+     * Creates seed vulnerabilities programmatically using Thrift objects to avoid
+     * data model drift that can occur with external JSON fixtures.
+     */
+    private static List<Vulnerability> createSeedVulnerabilities() {
+        return List.of(
+                vul("ft-vul-001", "CVE-2024-0001", "FT_Buffer Overflow in libpng", "A buffer overflow vulnerability in libpng allows remote attackers to execute arbitrary code", "2024-01-10", "2024-02-15", 9.8),
+                vul("ft-vul-002", "CVE-2024-0002", "FT_SQL Injection in web framework", "SQL injection vulnerability allows attackers to access database", "2024-02-20", "2024-03-10", 8.5),
+                vul("ft-vul-003", "CVE-2024-0003", "FT_Cross-Site Scripting in CMS", "XSS vulnerability in content management system", "2024-03-15", "2024-04-01", 6.1),
+                vul("ft-vul-004", "CVE-2024-0004", "FT_Denial of Service in parser", "DoS vulnerability in XML parser via crafted input", "2024-04-05", "2024-05-20", 7.5),
+                vul("ft-vul-005", "CVE-2024-0005", "FT_Authentication Bypass", "Authentication bypass in REST API allowing unauthorized access", "2024-05-01", "2024-06-15", 9.1),
+                vul("ft-vul-006", "CVE-2024-0006", "FT_Information Disclosure", "Information disclosure via error messages in debug mode", "2024-06-10", "2024-07-01", 4.3),
+                vul("ft-vul-007", "CVE-2024-0007", "FT_Path Traversal in file handler", "Path traversal allows reading arbitrary files on the server", "2024-07-15", "2024-08-10", 7.2),
+                vul("ft-vul-008", "CVE-2024-0008", "FT_Remote Code Execution via deserialization", "RCE through unsafe Java deserialization", "2024-08-01", "2024-09-01", 10.0),
+                vul("ft-vul-009", "CVE-2024-0009", "FT_Privilege Escalation in kernel module", "Local privilege escalation through kernel module vulnerability", "2024-09-05", "2024-10-15", 8.8),
+                vul("ft-vul-010", "CVE-2024-0010", "FT_Certificate Validation Bypass", "TLS certificate validation bypass allows man-in-the-middle attacks", "2024-10-01", "2024-11-20", 5.9),
+                vul("ft-vul-011", "CVE-2025-0001", "FT_Zero Day in compression library", "Zero-day vulnerability in widely used compression library", "2025-01-15", "2025-02-28", 9.5),
+                vul("ft-vul-012", "CVE-2025-0002", "FT_XML External Entity Injection", "XXE injection allowing server-side request forgery", "2025-02-20", "2025-03-15", 7.0)
+        );
+    }
+
+    private static Vulnerability vul(String id, String externalId, String title,
+                                      String description, String publishDate,
+                                      String lastUpdateDate, Double cvss) {
+        Vulnerability v = new Vulnerability().setId(id).setType("vulnerability")
+                .setExternalId(externalId).setTitle(title)
+                .setPublishDate(publishDate).setLastUpdateDate(lastUpdateDate);
+        if (description != null) v.setDescription(description);
+        if (cvss != null) v.setCvss(cvss);
+        return v;
+    }
+}

--- a/scripts/startCouchdbForTests.sh
+++ b/scripts/startCouchdbForTests.sh
@@ -11,6 +11,8 @@
 set -e -o pipefail
 
 NAME=couchdb-for-sw360-testing
+NOUVEAU_NAME=couchdb-nouveau-for-sw360-testing
+NETWORK_NAME=sw360-test-net
 
 # Get SW360 directory
 current_dir=$(realpath "$(dirname "$0")")
@@ -21,12 +23,43 @@ if [[ "$(docker ps -q -f name=$NAME)" ]]; then
     docker stop "$NAME"
 fi
 
+if [[ "$(docker ps -q -f name=$NOUVEAU_NAME)" ]]; then
+    echo "Nouveau test container is running, shutting it down ..."
+    docker stop "$NOUVEAU_NAME"
+fi
+
+# Create network if it doesn't exist
+docker network create "$NETWORK_NAME" 2>/dev/null || true
+
+# Start Nouveau sidecar
+docker run \
+    -d \
+    --rm \
+    -p 5987:5987 \
+    -e JAVA_TOOL_OPTIONS="-Ddw.rootDir=/opt/nouveau/data/nouveau" \
+    --network "$NETWORK_NAME" \
+    --name "$NOUVEAU_NAME" \
+    couchdb:3.5-nouveau
+
+echo "Nouveau sidecar is started and listening on 5987."
+
+# Start CouchDB
 docker run \
     -d \
     -v "$sw360_dir"/config/couchdb/sw360_setup.ini:/opt/couchdb/etc/local.d/sw360_setup.ini \
     --rm \
     -p 5984:5984 \
+    --network "$NETWORK_NAME" \
     --name "$NAME" \
-    couchdb:3
+    couchdb:3.5
 
-echo "Test container is started and listening on 5984."
+echo "Waiting for CouchDB to be ready..."
+timeout 30 bash -c 'until curl -fsS http://localhost:5984/_up >/dev/null 2>&1; do sleep 1; done'
+
+# Configure Nouveau in CouchDB
+echo "Configuring Nouveau in CouchDB..."
+curl -sS -X PUT "http://localhost:5984/_node/_local/_config/nouveau/enable" -d '"true"'
+curl -sS -X PUT "http://localhost:5984/_node/_local/_config/nouveau/url" -d "\"http://${NOUVEAU_NAME}:5987\""
+echo ""
+
+echo "Test containers are started. CouchDB on 5984, Nouveau on 5987."


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This PR enhances the search handler integration test suite across all major backend search handlers. Inline seed data has been added to external JSON resources, test coverage has been broadened to include sorting, n-gram/prefix search, pagination, and edge cases.

Issue: 

### Suggest Reviewer
@GMishx 


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] Test codes were generated with help from GitHub Copilot and reviewed/adjusted manually.
