### PR TITLE
fix(Project): Update multiple obligations

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -4227,13 +4227,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         ObligationList obligationList = projectService.getObligationData(sw360Project.getLinkedObligationId(), sw360User);
         Map<String, ObligationStatusInfo> obligationStatusMap = CommonUtils.nullToEmptyMap(obligationList.getLinkedObligationStatus());
 
+        // Check if all request body keys are present in the stored obligation map.
+        // If any key is missing, reload obligations from the admin section.
         boolean allObligationsPresent = requestBodyObligationStatusInfo.keySet()
-                .stream()
-                .filter(entry -> {
-                    ObligationStatusInfo statusInfo = requestBodyObligationStatusInfo.get(entry);
-                    return statusInfo.getObligationLevel() == null;
-                })
-                .collect(Collectors.toSet())
                 .stream()
                 .allMatch(obligationStatusMap::containsKey);
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

 `PATCH /api/projects/{id}/updateObligation` not updating obligations when `obligationLevel=all` is used for the first time.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4469*)
> * Did you add or update any new dependencies that are required for your change?

Closes https://github.com/eclipse-sw360/sw360/issues/4469

### Suggest Reviewer
> @GMishx .

### How To Test?
1. Create or use an existing project with no linked obligations.
2. Call the endpoint with `obligationLevel=all` and a request body containing obligations with explicit `obligationLevel` values (e.g. `ORGANISATION_OBLIGATION`):
3. Verify the response is `201 Created` with message `all Obligation Updated Successfully`.
4. Repeat the call to verify subsequent updates also succeed.
5. Confirm that `obligationLevel=organization` (specific level) still works as before.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
