### PR TITLE
fix(query): remove extra braces added by query builder

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -853,7 +853,7 @@ public abstract class BaseNouveauSearchHandler<T> {
         StringBuilder query = new StringBuilder();
         if (queries.size() > 1) {
             query.append("(");
-            query.append(String.join(") OR (", queries));
+            query.append(String.join(" OR ", queries));
             query.append(")");
         } else {
             query.append(queries.getFirst());


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Description:
The query formed by the current query builder function has extra braces:
```
((requestingUser:"admin@sw360.org") OR (moderators:"admin@sw360.org")) AND (((moderationState:"PENDING")**)** OR **(**(moderationState:"INPROGRESS")) AND (timestamp:20260812))
```
The query should have been formed like this:
```((requestingUser:"admin@sw360.org") OR (moderators:"admin@sw360.org")) AND (((moderationState:"APPROVED") OR (moderationState:"REJECTED")) AND (timestamp:20260812))```

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
