### PR TITLE
fix(projects): unify email and direct excel export

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -3265,16 +3265,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return releaseNames;
     }
 
-    public String getComponentReportInEmail(User user,boolean extendedByReleases) throws TException {
-        try {
-            List<Component> componentlist = getRecentComponentsSummary(-1, user);
-            ComponentExporter exporter = getComponentExporterObject(componentlist,user, extendedByReleases);
-            return exporter.makeExcelExportForProject(componentlist, user);
-        }catch (IOException e) {
-            throw new SW360Exception(e.getMessage());
-        }
-    }
-
     private ComponentExporter getComponentExporterObject(List<Component> componentList ,User user,
                                                          boolean extendedByRelease) throws SW360Exception {
         return new ComponentExporter(ThriftClients.makeComponentClient(), componentList, user,extendedByRelease);
@@ -3295,9 +3285,8 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         try {
             List<Component> componentlist = getRecentComponentsSummary(-1, user);
             ComponentExporter exporter = getComponentExporterObject(componentlist, user, extendedByReleases);
-            InputStream stream = exporter.makeExcelExport(componentlist);
-            return ByteBuffer.wrap(IOUtils.toByteArray(stream));
-        }catch (IOException e) {
+            return exporter.toByteBuffer(componentlist);
+        } catch (IOException e) {
             throw new SW360Exception(e.getMessage());
         }
     }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.*;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentStreamConnector;
+import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.entitlement.ProjectModerator;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
@@ -49,6 +50,9 @@ import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ProjectVulnerabilityRating;
+import org.eclipse.sw360.exporter.CSVExport;
+import org.eclipse.sw360.exporter.JsonExport;
+import org.eclipse.sw360.exporter.XmlExport;
 import org.eclipse.sw360.mail.MailConstants;
 import org.eclipse.sw360.mail.MailUtil;
 import org.apache.logging.log4j.Logger;
@@ -86,6 +90,8 @@ import static org.eclipse.sw360.datahandler.common.WrappedException.wrapSW360Exc
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import org.eclipse.sw360.exporter.ProjectExporter;
+import org.jspecify.annotations.Nullable;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -2465,41 +2471,56 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 ThriftClients.makeProjectClient(), user, documents, extendedByReleases);
     }
 
-    public String getReportInEmail(User user,
-			boolean extendedByReleases, String projectId) throws TException {
-        List<Project> projectList = null;
-        try {
-            if (!isNullOrEmpty(projectId)) {
-                projectList = getProjectDetailsBasedOnId(user, projectId);
-            }else {
-                projectList = getAccessibleProjectsSummary(user);
+    public ByteBuffer getProjectReportBuffer(
+            ProjectSearchHandler searchHandler, User user, String projectId, SW360ReportBean reportBean
+    ) throws TException {
+        List<Project> projects;
+        if (CommonUtils.isNotNullEmptyOrWhitespace(projectId)) {
+            if (!isValidProject(projectId, user)) {
+                throw fail(404, "No project record found for the project Id : " + projectId);
             }
-            ProjectExporter exporter = getProjectExporterObject(projectList, user, extendedByReleases);
-            return exporter.makeExcelExportForProject(projectList, user);
-          }catch (IOException | TException e) {
-             throw new SW360Exception(e.getMessage());
-       }
-     }
+            // For a single specific project, delegate to backend for xlsx
+            // but use ProjectExporter for other formats
+            if (ReportFormat.EXCEL.equals(reportBean.getFormat())) {
+                return getReportDataStream(user, reportBean.isWithLinkedReleases(), projectId);
+            }
+            projects = List.of(getProjectById(projectId, user));
+        } else {
+            // No specific projectId: export projects matching the given filters.
+            projects = getFilteredProjects(user, reportBean, searchHandler);
+        }
+        try {
+            return createFormattedReport(projects, user, reportBean, reportBean.getFormat());
+        } catch (IOException e) {
+            TException exp = new SW360Exception("Failed to export projects in format " + reportBean.getFormat() + ": " + e.getMessage())
+                    .setErrorCode(500);
+            try {
+                throw exp.initCause(e);
+            } catch (Throwable ex) {
+                throw exp;
+            }
+        }
+    }
 
-     private List<Project> getProjectDetailsBasedOnId(User user, String projectId) throws TException {
-         final Collection<ProjectLink> projectLinks = SW360Utils.getLinkedProjectsAsFlatList(projectId, true, log, user);
-         if (projectLinks.isEmpty()) {
-             throw new TException("For the projectId : " + projectId
-                     + ", No data available. Please check the projectId and try again.");
-         }
-         List<String> linkedProjectIds = projectLinks.stream().map(ProjectLink::getId).collect(Collectors.toList());
-         return getProjectsById(linkedProjectIds, user);
-     }
+    private List<Project> getProjectDetailsBasedOnId(User user, String projectId) throws TException {
+        final Collection<ProjectLink> projectLinks = SW360Utils.getLinkedProjectsAsFlatList(projectId, true, log, user);
+        if (projectLinks.isEmpty()) {
+            throw new TException("For the projectId : " + projectId
+                    + ", No data available. Please check the projectId and try again.");
+        }
+        List<String> linkedProjectIds = projectLinks.stream().map(ProjectLink::getId).collect(Collectors.toList());
+        return getProjectsById(linkedProjectIds, user);
+    }
 
-     public ByteBuffer downloadExcel(User user, boolean extendedByReleases, String token) throws SW360Exception {
+    public ByteBuffer downloadExcel(User user, boolean extendedByReleases, String token) throws SW360Exception {
         ProjectExporter exporter = new ProjectExporter(ThriftClients.makeComponentClient(),
-				ThriftClients.makeProjectClient(), user, extendedByReleases);
-		try {
-			InputStream stream = exporter.downloadExcelSheet(token);
-			return ByteBuffer.wrap(IOUtils.toByteArray(stream));
-		} catch (IOException e) {
-			throw new SW360Exception(e.getMessage());
-		}
+                ThriftClients.makeProjectClient(), user, extendedByReleases);
+        try {
+            InputStream stream = exporter.downloadExcelSheet(token);
+            return ByteBuffer.wrap(IOUtils.toByteArray(stream));
+        } catch (IOException e) {
+            throw new SW360Exception(e.getMessage());
+        }
 	}
 
     public List<ReleaseLink> getReleaseLinksOfProjectNetWorkByTrace(List<String> trace, String projectId, User user) throws TException{
@@ -2924,5 +2945,115 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                         .collect(Collectors.toList())
         );
         return detailReleaseNode;
+    }
+
+    private boolean isValidProject(String projectId, User user) {
+        boolean validProject = true;
+        try {
+            Project project = getProjectById(projectId, user);
+            if (project == null) {
+                return false;
+            }
+        } catch (Exception e) {
+            validProject = false;
+        }
+        return validProject;
+    }
+
+    /** Retrieves all projects matching the filters in {@code reportBean} for export. */
+    private List<Project> getFilteredProjects(
+            User user, @Nullable SW360ReportBean reportBean,
+            ProjectSearchHandler searchHandler
+    ) {
+        Map<String, Set<String>> filterMap = new HashMap<>();
+        if (reportBean != null) {
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getName())) {
+                filterMap.put(Project._Fields.NAME.getFieldName(), Collections.singleton(reportBean.getName()));
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getTag())) {
+                filterMap.put(Project._Fields.TAG.getFieldName(), CommonUtils.splitToSet(reportBean.getTag()));
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getType())) {
+                filterMap.put(Project._Fields.PROJECT_TYPE.getFieldName(), CommonUtils.splitToSet(reportBean.getType()));
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getGroup())) {
+                filterMap.put(Project._Fields.BUSINESS_UNIT.getFieldName(), CommonUtils.splitToSet(reportBean.getGroup()));
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getVersion())) {
+                filterMap.put(Project._Fields.VERSION.getFieldName(), CommonUtils.splitToSet(reportBean.getVersion()));
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getProjectResponsible())) {
+                filterMap.put(Project._Fields.PROJECT_RESPONSIBLE.getFieldName(), CommonUtils.splitToSet(reportBean.getProjectResponsible()));
+            }
+            if (reportBean.getProjectState() != null && CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getProjectState().name())) {
+                filterMap.put(Project._Fields.STATE.getFieldName(), CommonUtils.splitToSet(reportBean.getProjectState().name()));
+            }
+            if (reportBean.getProjectClearingState() != null && CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getProjectClearingState().name())) {
+                filterMap.put(Project._Fields.CLEARING_STATE.getFieldName(), CommonUtils.splitToSet(reportBean.getProjectClearingState().name()));
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getAdditionalData())) {
+                filterMap.put(Project._Fields.ADDITIONAL_DATA.getFieldName(), CommonUtils.splitToSet(reportBean.getAdditionalData()));
+            }
+            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getAttachmentAuthor())) {
+                filterMap.put(SW360Constants.PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY, Collections.singleton(reportBean.getAttachmentAuthor()));
+            }
+        }
+        return getFilteredProjectsForExport(filterMap, user,
+                reportBean != null && reportBean.isLuceneSearch(), searchHandler);
+    }
+
+    /**
+     * Returns all projects matching the given filters for export.
+     *
+     * @param filterMap    field-name → accepted values
+     * @param sw360User    the authenticated user
+     * @param luceneSearch {@code true} for Lucene wildcard search, {@code false} for exact match
+     * @return flat list of all matching projects
+     */
+    private List<Project> getFilteredProjectsForExport(
+            @NotNull Map<String, Set<String>> filterMap, User sw360User,
+            boolean luceneSearch, ProjectSearchHandler searchHandler
+    ) {
+        if (filterMap.isEmpty()) {
+            return getAccessibleProjectsSummary(sw360User);
+        }
+
+        PaginationData pageData = NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+        if (luceneSearch) {
+            Map<PaginationData, List<Project>> result = searchHandler.search(filterMap, sw360User, pageData);
+            return NouveauLuceneAwareDatabaseConnector.convertPaginatorToList(result);
+        }
+
+        return NouveauLuceneAwareDatabaseConnector.convertPaginatorToList(
+                searchAccessibleProjectByExactValues(filterMap, sw360User, pageData));
+    }
+
+    private @Nullable ByteBuffer createFormattedReport(
+            List<Project> projects, User user,
+            @NotNull SW360ReportBean reportBean, ReportFormat fmt
+    ) throws IOException, SW360Exception {
+        ProjectExporter exporter = getProjectExporterObject(projects, user, reportBean.isWithLinkedReleases());
+        if (ReportFormat.EXCEL.equals(fmt)) {
+            return exporter.toByteBuffer(projects);
+        }
+        List<Map<String, String>> records = exporter.makeRecords(projects);
+        List<String> headers = reportBean.isWithLinkedReleases() ? ProjectExporter.HEADERS_EXTENDED_BY_RELEASES : ProjectExporter.HEADERS;
+        return switch (fmt) {
+            case ReportFormat.CSV -> {
+                List<List<String>> rows = new ArrayList<>();
+                for (Map<String, String> record : records) {
+                    List<String> row = new ArrayList<>();
+                    for (String header : headers) {
+                        row.add(record.getOrDefault(header, ""));
+                    }
+                    rows.add(row);
+                }
+                Iterable<Iterable<String>> iterableRows = rows.stream().map(row -> (Iterable<String>) row).collect(Collectors.toList());
+                yield CSVExport.toByteBuffer(headers, iterableRows);
+            }
+            case ReportFormat.JSON -> JsonExport.toByteBuffer(records);
+            case ReportFormat.XML -> XmlExport.toByteBuffer(records);
+            default -> null;
+        };
     }
 }

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -2455,16 +2455,15 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         try {
             if (!isNullOrEmpty(projectId)) {
                 projectList = getProjectDetailsBasedOnId(user, projectId);
-            }else {
+            } else {
                 projectList =  getAccessibleProjectsSummary(user);
             }
             ProjectExporter exporter = getProjectExporterObject(projectList, user, extendedByReleases);
-            InputStream stream = exporter.makeExcelExport(projectList);
-            return ByteBuffer.wrap(IOUtils.toByteArray(stream));
-          }catch (IOException e) {
+            return exporter.toByteBuffer(projectList);
+        } catch (IOException e) {
             throw new SW360Exception(e.getMessage());
-       }
-     }
+        }
+    }
 
     private ProjectExporter getProjectExporterObject(List<Project> documents, User user, boolean extendedByReleases) throws SW360Exception {
     	return new ProjectExporter(ThriftClients.makeComponentClient(),

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -778,11 +778,6 @@ public class ComponentHandler implements ComponentService.Iface {
 		return handler.getComponentReportDataStream(user,extendedByReleases);
 	}
 
-	@Override
-	public String getComponentReportInEmail(User user, boolean extendedByReleases) throws TException {
-		return handler.getComponentReportInEmail(user,extendedByReleases);
-	}
-
     @Override
     public boolean isReleaseActionAllowed(Release release, User user, RequestedAction action) {
         return handler.isReleaseActionAllowed(release, user, action);

--- a/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/licenses-core/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -216,9 +216,8 @@ public class LicenseDatabaseHandler {
         try {
             List<License> licenses = getLicenseSummaryForExport();
             LicenseExporter exporter = getLicenseExporterObject();
-            InputStream stream = exporter.makeExcelExport(licenses);
-            return ByteBuffer.wrap(IOUtils.toByteArray(stream));
-        }catch (IOException e) {
+            return exporter.toByteBuffer(licenses);
+        } catch (IOException e) {
             throw new SW360Exception(e.getMessage());
         }
     }

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -41,6 +41,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectData;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ObligationList;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.projects.SW360ReportBean;
 import org.eclipse.sw360.datahandler.thrift.projects.UsedReleaseRelations;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
@@ -85,14 +86,6 @@ public class ProjectHandler implements ProjectService.Iface {
     /////////////////////
     // SUMMARY GETTERS //
     /////////////////////
-    @Override
-    public List<Project> refineSearch(Map<String, Set<String>> subQueryRestrictions, User user)
-            throws TException {
-        PaginationData pageData = NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
-        Map<PaginationData, List<Project>> result = searchHandler.search(subQueryRestrictions, user, pageData);
-        return NouveauLuceneAwareDatabaseConnector.convertPaginatorToList(result);
-    }
-
     @Override
     public Map<PaginationData, List<Project>> refineSearchPageable(
             Map<String, Set<String>> subQueryRestrictions, User user,
@@ -647,10 +640,20 @@ public class ProjectHandler implements ProjectService.Iface {
         return handler.getReportDataStream(user, extendedByReleases, projectId);
     }
 
+    /**
+     * Get buffer of report content based on report {@code format} and
+     * {@code reportBean} which is sent to the user.
+     * @param user       User for access check
+     * @param projectId  Project ID if a specific project is needed
+     * @param reportBean Report bean with filter and format information.
+     * @return Report content.
+     * @throws TException If anything goes wrong.
+     */
     @Override
-    public String getReportInEmail(User user, boolean extendedByReleases, String projectId)
-            throws TException {
-        return handler.getReportInEmail(user, extendedByReleases, projectId);
+    public ByteBuffer getProjectReportBuffer(User user, String projectId, SW360ReportBean reportBean) throws TException {
+        assertUser(user);
+        assertNotNull(reportBean);
+        return handler.getProjectReportBuffer(searchHandler, user, projectId, reportBean);
     }
 
     @Override

--- a/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
+++ b/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
@@ -254,8 +254,7 @@ public class VendorDatabaseHandler {
 
     public ByteBuffer getVendorReportDataStream(List<Vendor> vendorList) throws TException{
         try {
-            InputStream stream = new VendorExporter().makeExcelExport(vendorList);
-            return ByteBuffer.wrap(IOUtils.toByteArray(stream));
+            return new VendorExporter().toByteBuffer(vendorList);
         } catch (Exception e) {
             throw new TException(e.getMessage());
         }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -58,6 +58,8 @@ public class SW360Constants {
     public static final String DUPLICATE_PACKAGE_BY_PURL = "duplicatePackagesByPurl";
     public static final String XML_FILE_EXTENSION = "xml";
     public static final String JSON_FILE_EXTENSION = "json";
+    public static final String CSV_FILE_EXTENSION = "csv";
+    public static final String EXCEL_FILE_EXTENSION = "xlsx";
     public static final String PROJECT_IDS = "projectIds";
     public static final String RELEASE_IDS = "releaseIds";
     public static final String PACKAGE_IDS = "packageIds";

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -984,7 +984,9 @@ public class SW360Utils {
             if (user == null) {
                 projectsUsings = projectClient.refineSearchWithoutUser(filterMap);
             } else {
-                projectsUsings = projectClient.refineSearch(filterMap, user);
+                PaginationData pageData = NouveauLuceneAwareDatabaseConnector.pageDataForAllRecords();
+                Map<PaginationData, List<Project>> result = projectClient.refineSearchPageable(filterMap, user, pageData);
+                projectsUsings = NouveauLuceneAwareDatabaseConnector.convertPaginatorToList(result);
             }
         } catch (TException e) {
             log.error("Could not fetch projects");

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -1080,10 +1080,6 @@ service ComponentService {
     * get report data stream
     */
     binary getComponentReportDataStream(1: User user, 2: bool extendedByReleases) throws (1: SW360Exception exp);
-    /*
-    * get component report in mail
-    */
-    string getComponentReportInEmail(1: User user, 2: bool extendedByReleases) throws (1: SW360Exception exp);
 
     /**
     * Check accessible of release

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -47,6 +47,7 @@ typedef licenses.ObligationLevel ObligationLevel
 typedef vendors.Vendor Vendor
 typedef components.ReleaseNode ReleaseNode
 typedef sw360.ProjectPackageRelationship ProjectPackageRelationship
+typedef sw360.ReportFormat ReportFormat
 
 const string CLEARING_TEAM_UNKNOWN = "Unknown"
 
@@ -351,6 +352,32 @@ struct ProjectDTO{
     204: optional list<ReleaseNode> dependencyNetwork
 }
 
+struct SW360ReportBean {
+    1: bool withLinkedReleases;
+    2: bool excludeReleaseVersion;
+    3: string generatorClassName;
+    4: string variant;
+    5: string template;
+    6: string externalIds;
+    7: bool withSubProject;
+    8: string bomType;
+    9: list<ReleaseRelationship> selectedRelRelationship;
+    10: ReportFormat format = ReportFormat.EXCEL;
+
+    // Project search/filter parameters for filtered export
+    51: string name;
+    52: string type;
+    53: string group;
+    54: string tag;
+    55: string version;
+    56: string projectResponsible;
+    57: optional ProjectState projectState;
+    58: optional ProjectClearingState projectClearingState;
+    59: string additionalData;
+    60: string attachmentAuthor;
+    61: bool luceneSearch;
+}
+
 service ProjectService {
 
     // Summary getters
@@ -375,12 +402,6 @@ service ProjectService {
     set<Project> getAccessibleProjects(1: User user);
 
     // Search functions
-    /**
-     * returns a list of projects which match `text` and the
-     * `subQueryRestrictions` and are visible to the `user`
-     */
-    list<Project> refineSearch(1: map<string,set<string>> subQueryRestrictions, 2: User user);
-
     /**
      * search projects in database that match searchText in
      * name, description, tag or projectResponsible fields.
@@ -672,7 +693,7 @@ service ProjectService {
     /**
      * Get the SBOM import statistics information from attachment as String (JSON formatted)
      */
-    string getSbomImportInfoFromAttachmentAsString(string attachmentContentId) throws (1: SW360Exception exp);
+    string getSbomImportInfoFromAttachmentAsString(1: string attachmentContentId) throws (1: SW360Exception exp);
 
     /**
      * create clearing request for project
@@ -707,14 +728,16 @@ service ProjectService {
     * make excel export
     */
     binary getReportDataStream(1: User user,2: bool extendedByReleases,3: string projectId) throws (1: SW360Exception exp);
-     /*
-    * excel export - return the filepath
-    */
-    string getReportInEmail(1: User user, 2: bool extendedByReleases, string projectId) throws (1: SW360Exception exp);
     /*
     * download excel
     */
     binary downloadExcel(1:User user,2:bool extendedByReleases,3:string token) throws (1: SW360Exception exc);
+
+    /*
+     * Get report binary which can be sent over an email or directly to user
+     * for project.
+     */
+    binary getProjectReportBuffer(1: User user, 2: string projectId, 3: SW360ReportBean reportBean);
 
     /**
     * get list ReleaseLink in release network of project by project id and trace

--- a/libraries/datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/datahandler/src/main/thrift/sw360.thrift
@@ -184,6 +184,13 @@ enum CycloneDxComponentType {
     OPERATING_SYSTEM = 7,
 }
 
+enum ReportFormat {
+    EXCEL = 0,
+    CSV = 1,
+    JSON = 2,
+    XML = 3,
+}
+
 struct ConfigContainer {
     1: optional string id,
     2: optional string revision,

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/CSVExport.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/CSVExport.java
@@ -13,23 +13,40 @@ import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.apache.commons.csv.CSVPrinter;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.ByteBuffer;
 
 /**
  * @author johannes.najjar@tngtech.com
  */
 public class CSVExport {
+    /**
+     * @deprecated Use {@link #toByteBuffer} instead.
+     */
+    @Deprecated
     @NotNull
     public static ByteArrayInputStream createCSV(Iterable<String> csvHeaderIterable, Iterable<Iterable<String>> inputIterable) throws IOException {
-        final ByteArrayOutputStream outB = getCSVOutputStream(csvHeaderIterable, inputIterable);
+        return new ByteArrayInputStream(getCSVOutputStream(csvHeaderIterable, inputIterable).toByteArray());
+    }
 
-        return new ByteArrayInputStream(outB.toByteArray());
+    /**
+     * Returns a {@link ByteBuffer} backed directly by the internal write buffer — no
+     * {@code Arrays.copyOf} is performed. Prefer this over {@link #createCSV} when the
+     * result will be wrapped in a {@link ByteBuffer} anyway.
+     */
+    @NotNull
+    public static ByteBuffer toByteBuffer(Iterable<String> csvHeaderIterable, Iterable<Iterable<String>> inputIterable) throws IOException {
+        return getCSVOutputStream(csvHeaderIterable, inputIterable).asByteBuffer();
     }
 
     @NotNull
-    private static ByteArrayOutputStream getCSVOutputStream(Iterable<String> csvHeaderIterable, Iterable<Iterable<String>> inputIterable) throws IOException {
-        final ByteArrayOutputStream outB = new ByteArrayOutputStream();
-        try(Writer out = new BufferedWriter(new OutputStreamWriter(outB));) {
+    private static ExposedByteArrayOutputStream getCSVOutputStream(Iterable<String> csvHeaderIterable, Iterable<Iterable<String>> inputIterable) throws IOException {
+        final ExposedByteArrayOutputStream outB = new ExposedByteArrayOutputStream();
+        try (Writer out = new BufferedWriter(new OutputStreamWriter(outB))) {
             CSVPrinter csvPrinter = new CSVPrinter(out, CommonUtils.sw360CsvFormat);
             csvPrinter.printRecord(csvHeaderIterable);
             csvPrinter.printRecords(inputIterable);
@@ -39,8 +56,6 @@ public class CSVExport {
             outB.close();
             throw e;
         }
-
-            return outB;
-
+        return outB;
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/CSVExport.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/CSVExport.java
@@ -14,7 +14,6 @@ import org.apache.commons.csv.CSVPrinter;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -25,18 +24,8 @@ import java.nio.ByteBuffer;
  */
 public class CSVExport {
     /**
-     * @deprecated Use {@link #toByteBuffer} instead.
-     */
-    @Deprecated
-    @NotNull
-    public static ByteArrayInputStream createCSV(Iterable<String> csvHeaderIterable, Iterable<Iterable<String>> inputIterable) throws IOException {
-        return new ByteArrayInputStream(getCSVOutputStream(csvHeaderIterable, inputIterable).toByteArray());
-    }
-
-    /**
      * Returns a {@link ByteBuffer} backed directly by the internal write buffer — no
-     * {@code Arrays.copyOf} is performed. Prefer this over {@link #createCSV} when the
-     * result will be wrapped in a {@link ByteBuffer} anyway.
+     * {@code Arrays.copyOf} is performed.
      */
     @NotNull
     public static ByteBuffer toByteBuffer(Iterable<String> csvHeaderIterable, Iterable<Iterable<String>> inputIterable) throws IOException {

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -32,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -48,8 +49,8 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
     private static final Logger log = LogManager.getLogger(ExcelExporter.class);
 
     protected final U helper;
-    private static final String SLASH = "/";
-    private static final String TMP_EXPORTEDFILES = "/tmp/";
+    public static final String SLASH = "/";
+    public static final String TMP_EXPORTEDFILES = "/tmp/";
 
     public ExcelExporter(U helper) {
         this.helper = helper;
@@ -77,10 +78,12 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
         return records;
     }
 
-    public InputStream makeExcelExport(List<T> documents) throws IOException, SW360Exception {
-        final SXSSFWorkbook workbook = new SXSSFWorkbook();
-        final ByteArrayInputStream stream;
-        try {
+    /**
+     * Builds the workbook for the given documents and writes it to the provided output stream.
+     * Prefer {@link #toByteBuffer} when the result will be wrapped in a {@link java.nio.ByteBuffer}.
+     */
+    private void writeExcelExport(List<T> documents, OutputStream out) throws IOException, SW360Exception {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook()) {
             SXSSFSheet sheet = workbook.createSheet("Data");
 
             /** Adding styles to cells */
@@ -97,14 +100,29 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
 
             // removed autosizing of spreadsheet columns for performance reasons
 
-            /** Copy the streams */
-            final ByteArrayOutputStream out = new ByteArrayOutputStream();
             workbook.write(out);
-            stream = new ByteArrayInputStream(out.toByteArray());
-        } finally {
-            workbook.close();
         }
-        return stream;
+    }
+
+    /**
+     * @deprecated Use {@link #toByteBuffer} instead.
+     */
+    @Deprecated
+    public InputStream makeExcelExport(List<T> documents) throws IOException, SW360Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeExcelExport(documents, out);
+        return new ByteArrayInputStream(out.toByteArray());
+    }
+
+    /**
+     * Returns a {@link ByteBuffer} backed directly by the internal write buffer — no
+     * {@code Arrays.copyOf} is performed. Prefer this over {@link #makeExcelExport} when
+     * the result will be wrapped in a {@link ByteBuffer} anyway.
+     */
+    public ByteBuffer toByteBuffer(List<T> documents) throws IOException, SW360Exception {
+        ExposedByteArrayOutputStream out = new ExposedByteArrayOutputStream();
+        writeExcelExport(documents, out);
+        return out.asByteBuffer();
     }
 
     public String makeExcelExportForProject(List<T> documents, User user) throws IOException, SW360Exception {
@@ -145,7 +163,6 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
             try (OutputStream outputStream = new FileOutputStream(file.getPath())) {
                 workbook.setZip64Mode(Zip64Mode.Always);
                 workbook.write(outputStream);
-                outputStream.close();
             }
         } finally {
             workbook.close();

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -10,25 +10,19 @@
 package org.eclipse.sw360.exporter;
 
 
-import org.apache.commons.compress.archivers.zip.Zip64Mode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
-import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.exporter.helper.ExporterHelper;
 import org.eclipse.sw360.exporter.utils.SubTable;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -37,7 +31,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * Created on 06/02/15.
@@ -49,6 +42,11 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
     private static final Logger log = LogManager.getLogger(ExcelExporter.class);
 
     protected final U helper;
+    /**
+     * <p>File layout: {@code /tmp/<userEmail>/file/<timestamp>_<uuid>}
+     * The <em>relative</em> path {@code <userEmail>/file/<filename>} is used as the
+     * download token,</p>
+     */
     public static final String SLASH = "/";
     public static final String TMP_EXPORTEDFILES = "/tmp/";
 
@@ -105,69 +103,13 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
     }
 
     /**
-     * @deprecated Use {@link #toByteBuffer} instead.
-     */
-    @Deprecated
-    public InputStream makeExcelExport(List<T> documents) throws IOException, SW360Exception {
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        writeExcelExport(documents, out);
-        return new ByteArrayInputStream(out.toByteArray());
-    }
-
-    /**
      * Returns a {@link ByteBuffer} backed directly by the internal write buffer — no
-     * {@code Arrays.copyOf} is performed. Prefer this over {@link #makeExcelExport} when
-     * the result will be wrapped in a {@link ByteBuffer} anyway.
+     * {@code Arrays.copyOf} is performed.
      */
     public ByteBuffer toByteBuffer(List<T> documents) throws IOException, SW360Exception {
         ExposedByteArrayOutputStream out = new ExposedByteArrayOutputStream();
         writeExcelExport(documents, out);
         return out.asByteBuffer();
-    }
-
-    public String makeExcelExportForProject(List<T> documents, User user) throws IOException, SW360Exception {
-        final SXSSFWorkbook workbook = new SXSSFWorkbook();
-        String token = UUID.randomUUID().toString();
-        String filePath = TMP_EXPORTEDFILES + user.getEmail() + SLASH + "file" + SLASH;
-        String relativePath;
-        try {
-            File dir = new File(filePath);
-            if (!dir.mkdirs() && !dir.exists()) {
-                log.error("Failed to create export directory: {}", dir.getAbsolutePath());
-                throw new IOException("Failed to create export directory: " + dir.getAbsolutePath());
-            }
-            File file = new File(dir.getPath() + SLASH + SW360Utils.getCreatedOn() + "_" + token);
-            if (!file.createNewFile()) {
-                log.error("Failed to create export file: {}", file.getAbsolutePath());
-                throw new IOException("Failed to create export file: " + file.getAbsolutePath());
-            }
-            relativePath = user.getEmail() + SLASH + "file" + SLASH + file.getName();
-            SXSSFSheet sheet = workbook.createSheet("Data");
-
-            /** Adding styles to cells */
-            CellStyle cellStyle = createCellStyle(workbook);
-            CellStyle headerStyle = createHeaderStyle(workbook);
-
-            /** Create header row */
-            Row headerRow = sheet.createRow(0);
-            List<String> headerNames = helper.getHeaders();
-            fillRow(headerRow, headerNames, headerStyle);
-
-            /** Create data rows */
-            fillValues(sheet, documents, cellStyle);
-
-            // removed autosizing of spreadsheet columns for performance reasons
-
-            /** Copy the streams */
-
-            try (OutputStream outputStream = new FileOutputStream(file.getPath())) {
-                workbook.setZip64Mode(Zip64Mode.Always);
-                workbook.write(outputStream);
-            }
-        } finally {
-            workbook.close();
-        }
-        return relativePath;
     }
 
     public InputStream downloadExcelSheet(String token) throws FileNotFoundException {

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExposedByteArrayOutputStream.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExposedByteArrayOutputStream.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.exporter;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * A {@link ByteArrayOutputStream} subclass that exposes the internal {@code buf} array directly,
+ * allowing callers to obtain a zero-copy {@link ByteBuffer} view instead of calling
+ * {@link #toByteArray()}, which always performs an {@code Arrays.copyOf}.
+ */
+class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
+
+    ExposedByteArrayOutputStream() {
+        super();
+    }
+
+    ExposedByteArrayOutputStream(int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    /**
+     * Returns a {@link ByteBuffer} backed directly by the internal buffer — no copy is made.
+     * The buffer's position is 0 and limit equals the number of bytes written so far.
+     */
+    ByteBuffer asByteBuffer() {
+        return ByteBuffer.wrap(buf, 0, count);
+    }
+}

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/JsonExport.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/JsonExport.java
@@ -13,9 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 public class JsonExport {
 
@@ -25,11 +24,14 @@ public class JsonExport {
     private JsonExport() {
     }
 
+    /**
+     * Returns a {@link ByteBuffer} backed directly by the internal write buffer — no
+     * {@code Arrays.copyOf} is performed.
+     */
     @NotNull
-    public static ByteArrayInputStream toJson(Object data) throws IOException {
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            MAPPER.writeValue(out, data);
-            return new ByteArrayInputStream(out.toByteArray());
-        }
+    public static ByteBuffer toByteBuffer(Object data) throws IOException {
+        ExposedByteArrayOutputStream out = new ExposedByteArrayOutputStream();
+        MAPPER.writeValue(out, data);
+        return out.asByteBuffer();
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseInfoExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/LicenseInfoExporter.java
@@ -12,66 +12,29 @@ package org.eclipse.sw360.exporter;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.sw360.datahandler.common.SW360Utils;
-import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.UUID;
+
+import static org.eclipse.sw360.exporter.ExcelExporter.TMP_EXPORTEDFILES;
 
 /**
  * Handles saving and downloading license info reports (docx / xhtml / text)
  * to/from the local file system,
  *
- * <p>File layout: {@code /tmp/<userEmail>/file/<timestamp>_<uuid>}
- * The <em>relative</em> path {@code <userEmail>/file/<filename>} is used as the
- * download token,</p>
  */
 public class LicenseInfoExporter {
 
     private static final Logger log = LogManager.getLogger(LicenseInfoExporter.class);
 
-    private static final String TMP_EXPORTEDFILES = "/tmp/";
-    private static final String SLASH = "/";
-
-    /**
-     * Saves the generated license-info report buffer to a temp file and
-     * returns the relative path (token) for later download.
-     *
-     * @param buffer the report content
-     * @param user   the requesting user (email used as directory name)
-     * @return relative path used as download token, e.g.
-     *         {@code user@example.com/file/2024-01-01_<uuid>}
-     * @throws IOException on any file-system error
-     */
-    public String saveReportToFile(ByteBuffer buffer, User user) throws IOException {
-        String token = UUID.randomUUID().toString();
-        String filePath = TMP_EXPORTEDFILES + user.getEmail() + SLASH + "file" + SLASH;
-        File dir = new File(filePath);
-        if (!dir.mkdirs() && !dir.exists()) {
-            log.error("Failed to create export directory: {}", dir.getAbsolutePath());
-            throw new IOException("Failed to create export directory: " + dir.getAbsolutePath());
-        }
-        File file = new File(dir.getPath() + SLASH + SW360Utils.getCreatedOn() + "_" + token);
-        if (!file.createNewFile()) {
-            log.error("Failed to create export file: {}", file.getAbsolutePath());
-            throw new IOException("Failed to create export file: " + file.getAbsolutePath());
-        }
-        try (FileOutputStream fos = new FileOutputStream(file)) {
-            fos.write(buffer.array());
-        }
-        return user.getEmail() + SLASH + "file" + SLASH + file.getName();
-    }
-
     /**
      * Reads the license-info report identified by {@code token} and returns its content.
      *
-     * @param token the relative path returned by {@link #saveReportToFile}
+     * @param token the relative path from email.
      * @return the file content as a {@link ByteBuffer}
      * @throws FileNotFoundException if the file does not exist or the token is invalid
      * @throws IOException           on any other file-system error
@@ -93,4 +56,3 @@ public class LicenseInfoExporter {
         }
     }
 }
-

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/XmlExport.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/XmlExport.java
@@ -14,9 +14,8 @@ import org.jetbrains.annotations.NotNull;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -25,9 +24,14 @@ public class XmlExport {
     private XmlExport() {
     }
 
+    /**
+     * Returns a {@link ByteBuffer} backed directly by the internal write buffer — no
+     * {@code Arrays.copyOf} is performed.
+     */
     @NotNull
-    public static ByteArrayInputStream toXml(List<Map<String, String>> records) throws IOException {
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+    public static ByteBuffer toByteBuffer(@NotNull List<Map<String, String>> records) throws IOException {
+        ExposedByteArrayOutputStream out = new ExposedByteArrayOutputStream();
+        try {
             XMLOutputFactory factory = XMLOutputFactory.newInstance();
             XMLStreamWriter writer = factory.createXMLStreamWriter(out, "UTF-8");
 
@@ -50,7 +54,7 @@ public class XmlExport {
             writer.flush();
             writer.close();
 
-            return new ByteArrayInputStream(out.toByteArray());
+            return out.asByteBuffer();
         } catch (XMLStreamException e) {
             throw new IOException("Failed to generate XML", e);
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -1803,11 +1803,14 @@ public class RestControllerHelper<T> {
      * @return Filter Map based on parameters passed.
      */
     public static Map<String, Set<String>> getFilterMapForProject(
-            String tag, String projectType, String group, String version, String projectResponsible,
+            String name, String tag, String projectType, String group, String version, String projectResponsible,
             ProjectState projectState, ProjectClearingState projectClearingState, String additionalData,
             String attachmentAuthor
     ) {
         Map<String, Set<String>> filterMap = new HashMap<>();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
+            filterMap.put(Project._Fields.NAME.getFieldName(), Collections.singleton(name));
+        }
         if (CommonUtils.isNotNullEmptyOrWhitespace(tag)) {
             filterMap.put(Project._Fields.TAG.getFieldName(), CommonUtils.splitToSet(tag));
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestExceptionHandler.java
@@ -52,6 +52,15 @@ public class RestExceptionHandler {
 
     @ExceptionHandler({Exception.class, TException.class, ResourceClassNotFoundException.class})
     public ResponseEntity<ErrorMessage> handleException(Exception e) {
+        if (e instanceof SW360Exception sw360e) {
+            HttpStatus status = codeToStatus(sw360e.getErrorCode());
+            return new ResponseEntity<>(
+                    new ErrorMessage(
+                            sw360e.getCause() != null ? (Exception) sw360e.getCause() : sw360e,
+                            status
+                    ), status
+            );
+        }
         return new ResponseEntity<>(new ErrorMessage(e, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -159,6 +168,17 @@ public class RestExceptionHandler {
     private void logClientAbort(Exception e) {
         LOGGER.warn("Client disconnected while writing response: {}", e.getMessage());
         LOGGER.debug("Client abort details", e);
+    }
+
+    private HttpStatus codeToStatus(int code) {
+        if (code < 100) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        HttpStatus status = HttpStatus.resolve(code);
+        if (status == null) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return status;
     }
 
     @Data

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/importexport/Sw360ImportExportService.java
@@ -23,9 +23,9 @@ import static org.eclipse.sw360.importer.ComponentImportUtils.writeAttachmentsTo
 import static org.eclipse.sw360.importer.ComponentImportUtils.writeReleaseLinksToDatabase;
 import static org.eclipse.sw360.importer.ComponentImportUtils.writeToDatabase;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -62,7 +62,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -90,10 +89,10 @@ public class Sw360ImportExportService {
         final Iterable<Iterable<String>> inputIterable = ImmutableList.of(ComponentCSVRecord.getSampleInputIterable());
         final Iterable<String> csvHeaderIterable = ComponentCSVRecord.getCSVHeaderIterable();
 
-        ByteArrayInputStream byteArrayInputStream = CSVExport.createCSV(csvHeaderIterable, inputIterable);
+        ByteBuffer csvBuf = CSVExport.toByteBuffer(csvHeaderIterable, inputIterable);
         String filename = String.format("ComponentsReleasesVendorsSample_%s.csv", SW360Utils.getCreatedOn());
         response.setHeader(CONTENT_DISPOSITION, String.format("Components; filename=\"%s\"", filename));
-        FileCopyUtils.copy(byteArrayInputStream, response.getOutputStream());
+        response.getOutputStream().write(csvBuf.array(), csvBuf.arrayOffset(), csvBuf.limit());
     }
 
     public void getDownloadAttachmentTemplate(User sw360User, HttpServletResponse response) throws IOException {
@@ -104,10 +103,10 @@ public class Sw360ImportExportService {
         final Iterable<Iterable<String>> inputIterable = ImmutableList
                 .of(ComponentAttachmentCSVRecord.getSampleInputIterable());
 
-        ByteArrayInputStream byteArrayInputStream = CSVExport.createCSV(csvHeaderIterable, inputIterable);
+        ByteBuffer csvBuf = CSVExport.toByteBuffer(csvHeaderIterable, inputIterable);
         String filename = String.format("AttachmentInfo_Sample_%s.csv", SW360Utils.getCreatedOn());
         response.setHeader(CONTENT_DISPOSITION, String.format("Attachment; filename=\"%s\"", filename));
-        FileCopyUtils.copy(byteArrayInputStream, response.getOutputStream());
+        response.getOutputStream().write(csvBuf.array(), csvBuf.arrayOffset(), csvBuf.limit());
     }
 
     public void getDownloadAttachmentInfo(User sw360User, HttpServletResponse response) throws IOException, TTransportException {
@@ -122,11 +121,10 @@ public class Sw360ImportExportService {
                 printReleasesAttachments(component, csvRows);
             }
         }
-        ByteArrayInputStream byteArrayInputStream = CSVExport
-                .createCSV(ComponentAttachmentCSVRecord.getCSVHeaderIterable(), csvRows);
+        ByteBuffer csvBuf = CSVExport.toByteBuffer(ComponentAttachmentCSVRecord.getCSVHeaderIterable(), csvRows);
         String filename = String.format("AttachmentInfo_%s.csv", SW360Utils.getCreatedOn());
         response.setHeader(CONTENT_DISPOSITION, String.format("Attachment; filename=\"%s\"", filename));
-        FileCopyUtils.copy(byteArrayInputStream, response.getOutputStream());
+        response.getOutputStream().write(csvBuf.array(), csvBuf.arrayOffset(), csvBuf.limit());
     }
 
     private void printReleasesAttachments(Component component, List<Iterable<String>> csvRows) {
@@ -184,10 +182,10 @@ public class Sw360ImportExportService {
         final Iterable<String> csvHeaderIterable = ReleaseLinkCSVRecord.getCSVHeaderIterable();
         final Iterable<Iterable<String>> inputIterable = ImmutableList
                 .of(ReleaseLinkCSVRecord.getSampleInputIterable());
-        ByteArrayInputStream byteArrayInputStream = CSVExport.createCSV(csvHeaderIterable, inputIterable);
+        ByteBuffer csvBuf = CSVExport.toByteBuffer(csvHeaderIterable, inputIterable);
         String filename = String.format("ReleaseLinkInfo_Sample_%s.csv", SW360Utils.getCreatedOn());
         response.setHeader(CONTENT_DISPOSITION, String.format("Release; filename=\"%s\"", filename));
-        FileCopyUtils.copy(byteArrayInputStream, response.getOutputStream());
+        response.getOutputStream().write(csvBuf.array(), csvBuf.arrayOffset(), csvBuf.limit());
     }
 
     public void getDownloadReleaseLink(User sw360User, HttpServletResponse response) throws TException, IOException {
@@ -205,11 +203,10 @@ public class Sw360ImportExportService {
             }
         }
 
-        ByteArrayInputStream byteArrayInputStream = CSVExport.createCSV(ReleaseLinkCSVRecord.getCSVHeaderIterable(),
-                csvRows);
+        ByteBuffer csvBuf = CSVExport.toByteBuffer(ReleaseLinkCSVRecord.getCSVHeaderIterable(), csvRows);
         String filename = String.format("ReleaseLinkInfo_%s.csv", SW360Utils.getCreatedOn());
         response.setHeader(CONTENT_DISPOSITION, String.format("Release; filename=\"%s\"", filename));
-        FileCopyUtils.copy(byteArrayInputStream, response.getOutputStream());
+        response.getOutputStream().write(csvBuf.array(), csvBuf.arrayOffset(), csvBuf.limit());
     }
 
     private void dealWithReleaseLinksContainedInComponent(Map<String, Component> componentsById,
@@ -262,10 +259,10 @@ public class Sw360ImportExportService {
         final List<Component> componentDetailedSummaryForExport = getComponentDetailedSummaryForExport();
         List<Iterable<String>> csvRows = getFlattenedView(componentDetailedSummaryForExport);
 
-        ByteArrayInputStream byteArrayInputStream = CSVExport.createCSV(csvHeaderIterable, csvRows);
+        ByteBuffer csvBuf = CSVExport.toByteBuffer(csvHeaderIterable, csvRows);
         String filename = String.format("ComponentsReleasesVendors_%s.csv", SW360Utils.getCreatedOn());
         response.setHeader(CONTENT_DISPOSITION, String.format("Components; filename=\"%s\"", filename));
-        FileCopyUtils.copy(byteArrayInputStream, response.getOutputStream());
+        response.getOutputStream().write(csvBuf.array(), csvBuf.arrayOffset(), csvBuf.limit());
 
     }
 
@@ -358,11 +355,11 @@ public class Sw360ImportExportService {
             csvRows.add(row);
         }
 
-        ByteArrayInputStream byteArrayInputStream = CSVExport.createCSV(headers, csvRows);
+        ByteBuffer csvBuf = CSVExport.toByteBuffer(headers, csvRows);
 
         String filename = String.format("AllUsersData_%s.csv", SW360Utils.getCreatedOn());
         response.setHeader(CONTENT_DISPOSITION, String.format("Users; filename=\"%s\"", filename));
-        FileCopyUtils.copy(byteArrayInputStream, response.getOutputStream());
+        response.getOutputStream().write(csvBuf.array(), csvBuf.arrayOffset(), csvBuf.limit());
     }
 
     UserService.@NonNull Iface getUserClient() {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -299,11 +299,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Map<PaginationData, List<Project>> paginatedProjects = null;
 
         Map<String, Set<String>> filterMap = RestControllerHelper.getFilterMapForProject(
-                tag, projectType, group, version, projectResponsible, projectState, projectClearingState, additionalData, attachmentAuthor);
-        if (CommonUtils.isNotNullEmptyOrWhitespace(name)) {
-            Set<String> values = Collections.singleton(name);
-            filterMap.put(Project._Fields.NAME.getFieldName(), values);
-        }
+                name, tag, projectType, group, version, projectResponsible,
+                projectState, projectClearingState, additionalData, attachmentAuthor
+        );
 
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) && !filterMap.isEmpty()) {
             throw new BadRequestClientException("Use either only \"searchText\" or other filters, not both.");

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -73,8 +73,6 @@ import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -1310,31 +1308,6 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 // Can be sorted on name and createdOn, but using different default value for score sorting
                 ProjectSortColumn.BY_NAME, true);
         return sw360ProjectClient.refineSearchPageable(filterMap, sw360User, pageData);
-    }
-
-    /**
-     * Returns all projects matching the given filters for export.
-     *
-     * @param filterMap    field-name → accepted values
-     * @param sw360User    the authenticated user
-     * @param luceneSearch {@code true} for Lucene wildcard search, {@code false} for exact match
-     * @return flat list of all matching projects
-     */
-    public List<Project> getFilteredProjectsForExport(
-            Map<String, Set<String>> filterMap, User sw360User, boolean luceneSearch
-    ) throws TException {
-        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-
-        if (filterMap.isEmpty()) {
-            return sw360ProjectClient.getAccessibleProjectsSummary(sw360User);
-        }
-
-        if (luceneSearch) {
-            return sw360ProjectClient.refineSearch(filterMap, sw360User);
-        }
-
-        return fetchAllPages((page) -> searchAccessibleProjectByExactValues(filterMap, sw360User,
-                PageRequest.of(page, DatabaseSettings.LUCENE_SEARCH_LIMIT)));
     }
 
     /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.sw360.datahandler.thrift.ReportFormat;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 
@@ -40,11 +41,11 @@ import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
+import org.eclipse.sw360.datahandler.thrift.projects.SW360ReportBean;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.rest.resourceserver.core
-        .BadRequestClientException;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.jetbrains.annotations.Contract;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -52,7 +53,6 @@ import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.google.gson.JsonObject;
@@ -75,7 +75,6 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     private static final String ZIP_CONTENT_TYPE = "application/zip";
     private static final String EXPORT_CREATE_PROJ_CLEARING_REPORT = "exportCreateProjectClearingReport";
     private static final List<String> GENERATOR_MODULES = List.of(LICENSE_INFO, EXPORT_CREATE_PROJ_CLEARING_REPORT);
-    private static final List<String> SUPPORTED_FORMATS = List.of("xlsx", "csv", "json", "xml");
     public static final String ATTACHMENT_FILENAME_S = "attachment; filename=\"%s\"";
     @NonNull
     private final RestControllerHelper restControllerHelper;
@@ -161,7 +160,6 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "additionalData", required = false) String additionalData,
             @Parameter(description = "Use Lucene search for filtering. Applies to module=projects export.")
             @RequestParam(value = "luceneSearch", required = false, defaultValue = "false") boolean luceneSearch,
-            HttpServletRequest request,
             HttpServletResponse response
     ) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
@@ -169,19 +167,15 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         if (GENERATOR_MODULES.contains(module) && (isNullOrEmpty(generatorClassName) || isNullOrEmpty(variant))) {
             throw new BadRequestClientException("Error : GeneratorClassName and Variant is required for module " + module);
         }
-        format = format.toLowerCase(Locale.ROOT);
-        if (!SUPPORTED_FORMATS.contains(format)) {
-            throw new BadRequestClientException("Unsupported format: " + format + ". Supported formats: " + SUPPORTED_FORMATS);
-        }
+        ReportFormat fmt = convertToReportFormat(format.toLowerCase(Locale.ROOT));
         SW360ReportBean reportBean = createReportBeanObject(withLinkedReleases, excludeReleaseVersion, generatorClassName, variant,
-                template, externalIds, withSubProject, bomType, selectedRelRelationship, format,
+                template, externalIds, withSubProject, bomType, selectedRelRelationship, fmt,
                 name, type, group, tag, version, projectResponsible, projectState, projectClearingState,
                 additionalData, luceneSearch);
-        String baseUrl = getBaseUrl(request);
         if (SW360Constants.PROJECTS.equalsIgnoreCase(module)) {
-            getProjectReports(response, sw360User, module, projectId, baseUrl, reportBean);
+            getProjectReports(response, sw360User, module, projectId, reportBean);
         } else if (SW360Constants.COMPONENTS.equalsIgnoreCase(module)) {
-            getComponentsReports(response, sw360User, module, baseUrl, reportBean);
+            getComponentsReports(response, sw360User, module, reportBean);
         } else if (SW360Constants.LICENSES.equalsIgnoreCase(module)) {
             getLicensesReports(response, sw360User, module, reportBean);
         } else if (LICENSE_INFO.equals(module)) {
@@ -222,13 +216,15 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
      * @param luceneSearch            use Lucene search for filtering
      * @return a SW360ReportBean object with the specified parameters
      */
-    private SW360ReportBean createReportBeanObject(boolean withLinkedReleases, boolean excludeReleaseVersion, String generatorClassName,
-                                                   String variant, String template, String externalIds, boolean withSubProject, String bomType,
-                                                   List<ReleaseRelationship> selectedRelRelationship, String format,
-                                                   String name, String type, String group, String tag, String version,
-                                                   String projectResponsible, ProjectState projectState,
-                                                   ProjectClearingState projectClearingState, String additionalData,
-                                                   boolean luceneSearch) {
+    private SW360ReportBean createReportBeanObject(
+            boolean withLinkedReleases, boolean excludeReleaseVersion, String generatorClassName,
+            String variant, String template, String externalIds, boolean withSubProject, String bomType,
+            List<ReleaseRelationship> selectedRelRelationship, ReportFormat format,
+            String name, String type, String group, String tag, String version,
+            String projectResponsible, ProjectState projectState,
+            ProjectClearingState projectClearingState, String additionalData,
+            boolean luceneSearch
+    ) {
         SW360ReportBean reportBean = new SW360ReportBean();
         reportBean.setWithLinkedReleases(withLinkedReleases);
         reportBean.setExcludeReleaseVersion(excludeReleaseVersion);
@@ -255,22 +251,18 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
 
     private void getProjectReports(
             HttpServletResponse response, User sw360User, String module, String projectId,
-            String baseUrl, SW360ReportBean reportBean
+            SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
             if (SW360Utils.readConfig(MAIL_REQUEST_FOR_REPORT, false)) {
-                sw360ReportService.getUploadedProjectPath(sw360User, reportBean.isWithLinkedReleases(), baseUrl, projectId);
+                sw360ReportService.getUploadedProjectPath(sw360User, reportBean, projectId);
                 JsonObject responseJson = new JsonObject();
                 responseJson.addProperty("response", "The downloaded report link will be send to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
                 downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
             }
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException | SW360Exception e) {
             throw e;
         } catch (Exception e) {
             log.error(e);
@@ -279,22 +271,18 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     }
 
     private void getComponentsReports(
-            HttpServletResponse response, User sw360User, String module, String baseUrl, SW360ReportBean reportBean
+            HttpServletResponse response, User sw360User, String module, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
             if (SW360Utils.readConfig(MAIL_REQUEST_FOR_REPORT, false)) {
-                sw360ReportService.getUploadedComponentPath(sw360User, reportBean.isWithLinkedReleases(), baseUrl);
+                sw360ReportService.getUploadedComponentPath(sw360User, reportBean.isWithLinkedReleases());
                 JsonObject responseJson = new JsonObject();
                 responseJson.addProperty("response", "Component report download link will get send to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
                 downloadExcelReport(response, sw360User, module, null, defaultByteBufferVal, reportBean);
             }
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             log.error(e);
@@ -307,11 +295,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             downloadExcelReport(response, sw360User, module, null, defaultByteBufferVal, reportBean);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             log.error(e);
@@ -332,11 +316,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             } else {
                 downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
             }
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             log.error(e);
@@ -349,11 +329,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
@@ -365,11 +341,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             log.error(e);
@@ -387,10 +359,9 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
 
             if (SW360Constants.PROJECTS.equalsIgnoreCase(module)) {
-                String format = reportBean.getFormat();
-                buff = sw360ReportService.getProjectBuffer(user, reportBean.isWithLinkedReleases(), projectId, format, reportBean);
-                fileName = sw360ReportService.getDocumentName(user, projectId, module, format);
-                setContentTypeForFormat(response, format);
+                buff = sw360ReportService.getProjectReportBuffer(user, projectId, reportBean);
+                fileName = sw360ReportService.getDocumentName(user, projectId, module, reportBean.getFormat());
+                setContentTypeForFormat(response, reportBean.getFormat());
             } else if (SW360Constants.COMPONENTS.equalsIgnoreCase(module)) {
                 buff = sw360ReportService.getComponentBuffer(user, reportBean.isWithLinkedReleases());
             } else if (SW360Constants.LICENSES.equalsIgnoreCase(module)) {
@@ -413,11 +384,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             }
             setContentDisposition(response, fileName);
             copyDataStreamToResponse(response, buff);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             log.error(e);
@@ -432,11 +399,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             ByteBuffer buffer = sw360ReportService.downloadSourceCodeBundle(projectId, sw360User, reportBean.isWithSubProject());
             downloadExcelReport(response, sw360User, module, projectId,
                     buffer, reportBean);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
@@ -459,11 +422,11 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                 "attachment; filename=\"" + asciiName + "\"; filename*=UTF-8''" + encodedName);
     }
 
-    private void setContentTypeForFormat(HttpServletResponse response, String format) {
+    private void setContentTypeForFormat(HttpServletResponse response, ReportFormat format) {
         setContentTypeForDownload(response, format, null);
     }
 
-    private void setContentTypeForDownload(HttpServletResponse response, String format, String generatorClassName) {
+    private void setContentTypeForDownload(HttpServletResponse response, ReportFormat format, String generatorClassName) {
         if (generatorClassName != null) {
             switch (generatorClassName) {
                 case "DocxGenerator":
@@ -479,15 +442,14 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                     break;
             }
         }
-        String fmt = (format == null) ? "xlsx" : format.trim().toLowerCase();
-        switch (fmt) {
-            case "csv":
+        switch (format) {
+            case CSV:
                 response.setContentType(SW360Constants.CONTENT_TYPE_CSV);
                 break;
-            case "json":
+            case JSON:
                 response.setContentType(SW360Constants.CONTENT_TYPE_JSON);
                 break;
-            case "xml":
+            case XML:
                 response.setContentType(SW360Constants.CONTENT_TYPE_XML);
                 break;
             default:
@@ -560,19 +522,11 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             }
             setContentDisposition(response, fileName);
             copyDataStreamToResponse(response, buffer);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (BadRequestClientException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
             throw new SW360Exception(e.getMessage());
         }
-    }
-
-    private String getBaseUrl(HttpServletRequest request) {
-        return restControllerHelper.getBaseUrl(request) + "/";
     }
 
     private void exportSBOM(
@@ -599,5 +553,15 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             log.error(e);
             throw new SW360Exception("Unable to generate SBOM report.");
         }
+    }
+
+    @Contract(pure = true)
+    private ReportFormat convertToReportFormat(@NonNull String format) {
+        return switch (format) {
+            case "csv" -> ReportFormat.CSV;
+            case "json" -> ReportFormat.JSON;
+            case "xml" -> ReportFormat.XML;
+            default -> ReportFormat.EXCEL;
+        };
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -275,7 +275,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     ) throws SW360Exception {
         try {
             if (SW360Utils.readConfig(MAIL_REQUEST_FOR_REPORT, false)) {
-                sw360ReportService.getUploadedComponentPath(sw360User, reportBean.isWithLinkedReleases());
+                sw360ReportService.getUploadedComponentPath(sw360User, reportBean);
                 JsonObject responseJson = new JsonObject();
                 responseJson.addProperty("response", "Component report download link will get send to the end user.");
                 response.getWriter().write(responseJson.toString());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -260,7 +260,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                 responseJson.addProperty("response", "The downloaded report link will be send to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
-                downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+                downloadExcelReport(response, sw360User, module, projectId, reportBean);
             }
         } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException | SW360Exception e) {
             throw e;
@@ -280,7 +280,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                 responseJson.addProperty("response", "Component report download link will get send to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
-                downloadExcelReport(response, sw360User, module, null, defaultByteBufferVal, reportBean);
+                downloadExcelReport(response, sw360User, module, null, reportBean);
             }
         } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
@@ -294,7 +294,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
-            downloadExcelReport(response, sw360User, module, null, defaultByteBufferVal, reportBean);
+            downloadExcelReport(response, sw360User, module, null, reportBean);
         } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
@@ -314,7 +314,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                 responseJson.addProperty("response", "The license info report link will be sent to the end user.");
                 response.getWriter().write(responseJson.toString());
             } else {
-                downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+                downloadExcelReport(response, sw360User, module, projectId, reportBean);
             }
         } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
@@ -328,7 +328,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, String projectId, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
-            downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+            downloadExcelReport(response, sw360User, module, projectId, reportBean);
         } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
@@ -340,7 +340,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             HttpServletResponse response, User sw360User, String module, String projectId, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
-            downloadExcelReport(response, sw360User, module, projectId, defaultByteBufferVal, reportBean);
+            downloadExcelReport(response, sw360User, module, projectId, reportBean);
         } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {
@@ -350,8 +350,8 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
     }
 
     private void downloadExcelReport(
-            HttpServletResponse response, User user, String module, String projectId,
-            ByteBuffer buffer, SW360ReportBean reportBean
+            HttpServletResponse response, User user, String module,
+            String projectId, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
             ByteBuffer buff = null;
@@ -368,7 +368,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                 buff = sw360ReportService.getLicenseBuffer();
                 fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
             } else if (LICENSES_RESOURCE_BUNDLE.equals(module)) {
-                buff = buffer;
+                buff = sw360ReportService.downloadSourceCodeBundle(projectId, user, reportBean.isWithSubProject());
                 response.setContentType(ZIP_CONTENT_TYPE);
                 fileName = sw360ReportService.getSourceCodeBundleName(projectId, user);
             } else if (LICENSE_INFO.equals(module) || EXPORT_CREATE_PROJ_CLEARING_REPORT.equals(module)) {
@@ -396,9 +396,8 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             String projectId, HttpServletResponse response, User sw360User, String module, SW360ReportBean reportBean
     ) throws SW360Exception {
         try {
-            ByteBuffer buffer = sw360ReportService.downloadSourceCodeBundle(projectId, sw360User, reportBean.isWithSubProject());
             downloadExcelReport(response, sw360User, module, projectId,
-                    buffer, reportBean);
+                    reportBean);
         } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
             throw e;
         } catch (Exception e) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -242,12 +242,13 @@ public class SW360ReportService {
         projectclient.sendExportSpreadsheetSuccessMail(emailURL, email);
     }
 
-    public void getUploadedComponentPath(User sw360User, boolean withLinkedReleases) {
+    public void getUploadedComponentPath(User sw360User, SW360ReportBean reportBean) {
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {
-                String componentPath = componentclient.getComponentReportInEmail(sw360User, withLinkedReleases);
+                ByteBuffer buff = getComponentBuffer(sw360User, reportBean.isWithLinkedReleases());
+                String componentPath = writeToTempFile(buff, sw360User);
                 String downloadUrl = frontendUrl + "/reports/download?module=components"
-                        + "&extendedByReleases=" + withLinkedReleases + "&token="
+                        + "&extendedByReleases=" + reportBean.isWithLinkedReleases() + "&token="
                         + URLEncoder.encode(componentPath, StandardCharsets.UTF_8);
                 URL emailURL = new URI(downloadUrl).toURL();
                 log.debug("Report download link for user {}: {}", sw360User.getEmail(), emailURL);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -166,7 +166,8 @@ public class SW360ReportService {
         }
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {
-                String licenseInfoPath = generateLicenseInfoReport(user, projectId, reportBean);
+                ByteBuffer buff = getLicenseInfoBuffer(user, projectId, reportBean);
+                String licenseInfoPath = writeToTempFile(buff, user);
                 String downloadUrl = frontendUrl + "/reports/download?module=licenseInfo"
                         + "&withSubProject=" + withSubProject
                         + "&projectId=" + projectId
@@ -190,12 +191,6 @@ public class SW360ReportService {
         });
         Thread asyncThread = new Thread(asyncRunnable);
         asyncThread.start();
-    }
-
-    private String generateLicenseInfoReport(User user, String projectId, SW360ReportBean reportBean)
-            throws TException, IOException {
-        ByteBuffer buffer = getLicenseInfoBuffer(user, projectId, reportBean);
-        return licenseInfoExporter.saveReportToFile(buffer, user);
     }
 
     public ByteBuffer getLicenseInfoReportStreamFromUrl(String token) throws TException {
@@ -340,16 +335,16 @@ public class SW360ReportService {
                 usedAttachmentContentIds, selectedReleaseAndAttachmentIds, excludedLicensesPerAttachments, listOfSelectedRelationshipsInString);
 
         String outputGeneratorClassNameWithVariant = reportBean.getGeneratorClassName() + "::" + reportBean.getVariant();
-        String fileName = "";
+        String templateFileName = "";
         if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getTemplate())
                 && CommonUtils.isNotNullEmptyOrWhitespace(REPORT_FILENAME_MAPPING)) {
             Map<String, String> orgToTemplate = Arrays.stream(REPORT_FILENAME_MAPPING.split(","))
                     .collect(Collectors.toMap(k -> k.split(":")[0], v -> v.split(":")[1]));
-            fileName = orgToTemplate.get(reportBean.getTemplate());
+            templateFileName = orgToTemplate.get(reportBean.getTemplate());
         }
         final LicenseInfoFile licenseInfoFile = licenseInfoService.getLicenseInfoFile(sw360Project, sw360User,
                 outputGeneratorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicensesPerAttachments,
-                reportBean.getExternalIds(), fileName, reportBean.isExcludeReleaseVersion());
+                reportBean.getExternalIds(), templateFileName, reportBean.isExcludeReleaseVersion());
         return licenseInfoFile.bufferForGeneratedOutput();
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -5,11 +5,20 @@ SPDX-License-Identifier: EPL-2.0
 package org.eclipse.sw360.rest.resourceserver.report;
 
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.CSV_FILE_EXTENSION;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.EXCEL_FILE_EXTENSION;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.JSON_FILE_EXTENSION;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.XML_FILE_EXTENSION;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
+import static org.eclipse.sw360.exporter.ExcelExporter.SLASH;
+import static org.eclipse.sw360.exporter.ExcelExporter.TMP_EXPORTEDFILES;
 import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.REPORT_FILENAME_MAPPING;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -51,22 +60,17 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatInfo;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.projects.SW360ReportBean;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentStreamConnector;
-import org.eclipse.sw360.exporter.CSVExport;
-import org.eclipse.sw360.exporter.JsonExport;
 import org.eclipse.sw360.exporter.LicenseInfoExporter;
-import org.eclipse.sw360.exporter.ProjectExporter;
 import org.eclipse.sw360.exporter.ReleaseExporter;
-import org.eclipse.sw360.exporter.XmlExport;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
-import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
-import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
+import org.jetbrains.annotations.Contract;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -83,9 +87,6 @@ public class SW360ReportService {
     private final Sw360ProjectService projectService;
 
     @NonNull
-    private final Sw360LicenseService licenseService;
-
-    @NonNull
     private final Sw360ComponentService componentService;
 
     @NonNull
@@ -98,100 +99,14 @@ public class SW360ReportService {
     private String frontendUrl;
 
     private static final Logger log = LogManager.getLogger(SW360ReportService.class);
-    private static final Set<String> SUPPORTED_FORMATS = Set.of("xlsx", "csv", "json", "xml");
     private final LicenseInfoExporter licenseInfoExporter = new LicenseInfoExporter();
     ProjectService.Iface projectclient = ThriftClients.makeProjectClient();
     ComponentService.Iface componentclient = ThriftClients.makeComponentClient();
     LicenseService.Iface licenseClient = ThriftClients.makeLicenseClient();
     AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
 
-    public ByteBuffer getProjectBuffer(User user, boolean extendedByReleases, String projectId, String format) throws TException {
-        return getProjectBuffer(user, extendedByReleases, projectId, format, null);
-    }
-
-    public ByteBuffer getProjectBuffer(User user, boolean extendedByReleases, String projectId, String format,
-                                       SW360ReportBean reportBean) throws TException {
-        String fmt = (format == null) ? "xlsx" : format.trim().toLowerCase();
-        validateFormat(fmt);
-        try {
-            List<Project> projects;
-            if (projectId != null) {
-                if (!validateProject(projectId, user)) {
-                    throw new ResourceNotFoundException("No project record found for the project Id : " + projectId);
-                }
-                // For a single specific project, delegate to backend for xlsx
-                // but use ProjectExporter for other formats
-                if ("xlsx".equals(fmt)) {
-                    return projectclient.getReportDataStream(user, extendedByReleases, projectId);
-                }
-                Project project = projectclient.getProjectById(projectId, user);
-                if (project == null) {
-                    throw new ResourceNotFoundException("No project record found for the project Id : " + projectId);
-                }
-                projects = List.of(project);
-            } else {
-                // No specific projectId: export projects matching the given filters.
-                projects = getFilteredProjects(user, reportBean);
-                if ("xlsx".equals(fmt)) {
-                    // Build xlsx from the filtered project list via ProjectExporter
-                    ProjectExporter exporter = new ProjectExporter(componentclient, projectclient, user, projects, extendedByReleases);
-                    return ByteBuffer.wrap(IOUtils.toByteArray(exporter.makeExcelExport(projects)));
-                }
-            }
-            ProjectExporter exporter = new ProjectExporter(componentclient, projectclient, user, projects, extendedByReleases);
-            List<Map<String, String>> records = exporter.makeRecords(projects);
-            List<String> headers = extendedByReleases ? ProjectExporter.HEADERS_EXTENDED_BY_RELEASES : ProjectExporter.HEADERS;
-            return convertToFormat(records, headers, fmt);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
-            throw e;
-        } catch (TException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new TException("Failed to export projects in format " + fmt + ": " + e.getMessage(), e);
-        }
-    }
-
-    /** Retrieves all projects matching the filters in {@code reportBean} for export. */
-    private List<Project> getFilteredProjects(User user, SW360ReportBean reportBean) throws TException {
-        Map<String, Set<String>> filterMap;
-        if (reportBean == null) {
-            filterMap = new HashMap<>();
-        } else {
-            filterMap = RestControllerHelper.getFilterMapForProject(
-                    reportBean.getTag(), reportBean.getType(), reportBean.getGroup(), reportBean.getVersion(),
-                    reportBean.getProjectResponsible(), reportBean.getProjectState(), reportBean.getProjectClearingState(),
-                    reportBean.getAdditionalData(), null
-            );
-            if (CommonUtils.isNotNullEmptyOrWhitespace(reportBean.getName())) {
-                filterMap.put(Project._Fields.NAME.getFieldName(), CommonUtils.splitToSet(reportBean.getName()));
-            }
-        }
-        return projectService.getFilteredProjectsForExport(filterMap, user,
-                reportBean != null && reportBean.isLuceneSearch());
-    }
-
-    private ByteBuffer convertToFormat(List<Map<String, String>> records, List<String> headers, String format) throws IOException {
-        switch (format) {
-            case "csv":
-                List<List<String>> rows = new ArrayList<>();
-                for (Map<String, String> record : records) {
-                    List<String> row = new ArrayList<>();
-                    for (String header : headers) {
-                        row.add(record.getOrDefault(header, ""));
-                    }
-                    rows.add(row);
-                }
-                Iterable<Iterable<String>> iterableRows = rows.stream().map(row -> (Iterable<String>) row).collect(Collectors.toList());
-                return ByteBuffer.wrap(IOUtils.toByteArray(CSVExport.createCSV(headers, iterableRows)));
-            case "json":
-                return ByteBuffer.wrap(IOUtils.toByteArray(JsonExport.toJson(records)));
-            case "xml":
-                return ByteBuffer.wrap(IOUtils.toByteArray(XmlExport.toXml(records)));
-            default:
-                throw new BadRequestClientException("Unsupported format: " + format);
-        }
+    public ByteBuffer getProjectReportBuffer(User user, String projectId, SW360ReportBean reportBean) throws TException {
+        return projectclient.getProjectReportBuffer(user, projectId, reportBean);
     }
 
     private boolean validateProject(String projectId, User user) throws TException {
@@ -208,16 +123,14 @@ public class SW360ReportService {
     }
 
     public String getDocumentName(User user, String projectId, String module) throws TException {
-        return getDocumentName(user, projectId, module, "xlsx");
+        return getDocumentName(user, projectId, module, ReportFormat.EXCEL);
     }
 
-    public String getDocumentName(User user, String projectId, String module, String format) throws TException {
-        String fmt = (format == null) ? "xlsx" : format.trim().toLowerCase();
-        validateFormat(fmt);
-        String extension = getFileExtension(fmt);
+    public String getDocumentName(User user, String projectId, String module, ReportFormat format) throws TException {
+        String extension = getFileExtension(format);
         String documentName = String.format("projects-%s.%s", SW360Utils.getCreatedOn(), extension);
         if (SW360Constants.PROJECTS.equalsIgnoreCase(module)) {
-            if (projectId != null && !projectId.equalsIgnoreCase("null")) {
+            if (CommonUtils.isNotNullEmptyOrWhitespace(projectId) && !projectId.equalsIgnoreCase("null")) {
                 Project project = projectclient.getProjectById(projectId, user);
                 documentName = String.format("project-%s-%s-%s.%s", project.getName(), project.getVersion(),
                         SW360Utils.getCreatedOn(), extension);
@@ -227,7 +140,7 @@ public class SW360ReportService {
         } else if (SW360Constants.LICENSES.equalsIgnoreCase(module)) {
             documentName = String.format("licenses-%s.%s", SW360Utils.getCreatedOn(), extension);
         } else if (SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO.equals(module)) {
-            if (projectId != null && !projectId.equalsIgnoreCase("null")) {
+            if (CommonUtils.isNotNullEmptyOrWhitespace(projectId) && !projectId.equalsIgnoreCase("null")) {
                 Project project = projectclient.getProjectById(projectId, user);
                 documentName = String.format("releases-%s-%s-%s.%s", project.getName(), project.getVersion(),
                         SW360Utils.getCreatedOn(), extension);
@@ -236,24 +149,14 @@ public class SW360ReportService {
         return documentName;
     }
 
-    private void validateFormat(String format) {
-        if (!SUPPORTED_FORMATS.contains(format)) {
-            throw new IllegalArgumentException("Unsupported export format: " + format + ". Supported formats: " + SUPPORTED_FORMATS);
-        }
-    }
-
-    private String getFileExtension(String format) {
-        switch (format) {
-            case "csv":
-                return "csv";
-            case "json":
-                return "json";
-            case "xml":
-                return "xml";
-            case "xlsx":
-            default:
-                return "xlsx";
-        }
+    @Contract(pure = true)
+    private @NonNull String getFileExtension(@NonNull ReportFormat format) {
+        return switch (format) {
+            case CSV -> CSV_FILE_EXTENSION;
+            case JSON -> JSON_FILE_EXTENSION;
+            case XML -> XML_FILE_EXTENSION;
+            default -> EXCEL_FILE_EXTENSION;
+        };
     }
 
     public void getUploadedLicenseInfoPath(User user, boolean withSubProject, String base, String projectId,
@@ -279,9 +182,7 @@ public class SW360ReportService {
                 if (!CommonUtils.isNullEmptyOrWhitespace(licenseInfoPath)) {
                     sendExportSpreadsheetSuccessMail(emailURL.toString(), user.getEmail());
                 }
-            } catch (ResourceNotFoundException exp) {
-                throw exp;
-            } catch (AccessDeniedException exp) {
+            } catch (ResourceNotFoundException | AccessDeniedException exp) {
                 throw exp;
             } catch (Exception exp) {
                 throw new TException(exp.getMessage());
@@ -305,25 +206,25 @@ public class SW360ReportService {
         }
     }
 
-    public void getUploadedProjectPath(User user, boolean withLinkedReleases, String base, String projectId)
-            throws TException {
-        if (projectId!=null && !validateProject(projectId, user)) {
+    public void getUploadedProjectPath(
+            User user, SW360ReportBean reportBean, String projectId
+    ) throws TException {
+        if (CommonUtils.isNotNullEmptyOrWhitespace(projectId) && !validateProject(projectId, user)) {
             throw new SW360Exception("No project record found for the project Id : " + projectId);
         }
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {
-                String projectPath = projectclient.getReportInEmail(user, withLinkedReleases, projectId);
+                ByteBuffer buff = getProjectReportBuffer(user, projectId, reportBean);
+                String projectPath = writeToTempFile(buff, user);
                 String downloadUrl = frontendUrl + "/reports/download?module=projects"
-                        + "&extendedByReleases=" + withLinkedReleases + "&projectId=" + projectId + "&token="
+                        + "&extendedByReleases=" + reportBean.isWithLinkedReleases() + "&projectId=" + projectId + "&token="
                         + URLEncoder.encode(projectPath, StandardCharsets.UTF_8);
                 URL emailURL = new URI(downloadUrl).toURL();
                 log.debug("Report download link for user {}: {}", user.getEmail(), emailURL);
                 if (!CommonUtils.isNullEmptyOrWhitespace(projectPath)) {
                     sendExportSpreadsheetSuccessMail(emailURL.toString(), user.getEmail());
                 }
-            } catch (ResourceNotFoundException exp) {
-                throw exp;
-            } catch (AccessDeniedException exp) {
+            } catch (SW360Exception exp) {
                 throw exp;
             } catch (Exception exp) {
                 throw new TException(exp.getMessage());
@@ -341,7 +242,7 @@ public class SW360ReportService {
         projectclient.sendExportSpreadsheetSuccessMail(emailURL, email);
     }
 
-    public void getUploadedComponentPath(User sw360User, boolean withLinkedReleases, String base) {
+    public void getUploadedComponentPath(User sw360User, boolean withLinkedReleases) {
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {
                 String componentPath = componentclient.getComponentReportInEmail(sw360User, withLinkedReleases);
@@ -353,9 +254,7 @@ public class SW360ReportService {
                 if (!CommonUtils.isNullEmptyOrWhitespace(componentPath)) {
                     sendComponentExportSpreadsheetSuccessMail(emailURL.toString(), sw360User.getEmail());
                 }
-            } catch (ResourceNotFoundException exp) {
-                throw exp;
-            } catch (AccessDeniedException exp) {
+            } catch (ResourceNotFoundException | AccessDeniedException exp) {
                 throw exp;
             } catch (Exception exp) {
                 throw new TException(exp.getMessage());
@@ -632,14 +531,12 @@ public class SW360ReportService {
             releases = releaseStringMap.stream().map(ReleaseClearingStatusData::getRelease)
                     .sorted(Comparator.comparing(SW360Utils::printFullname)).collect(Collectors.toList());
             exporter = new ReleaseExporter(componentclient, releases, user, releaseStringMap);
-        } catch (ResourceNotFoundException e) {
-            throw e;
-        } catch (AccessDeniedException e) {
+        } catch (ResourceNotFoundException | AccessDeniedException e) {
             throw e;
         } catch (Exception e) {
             throw new TException(e.getMessage());
         }
-        return ByteBuffer.wrap(IOUtils.toByteArray(exporter.makeExcelExport(releases)));
+        return exporter.toByteBuffer(releases);
     }
 
     public String getProjectSBOMBuffer(User user, String projectId, String bomType, boolean withSubProject) throws TException {
@@ -673,13 +570,39 @@ public class SW360ReportService {
         String documentName = "";
         if(projectId != null && !projectId.equalsIgnoreCase("null")) {
             Project project = projectclient.getProjectById(projectId, user);
-            documentName = String.format("project_%s(%s)_%s.xml", project.getName(), project.getVersion(),
+            documentName = String.format("project_%s(%s)_%s%s.xml", project.getName(), project.getVersion(),
                     SW360Utils.getCreatedOnTime(), "_SBOM");
-            if(SW360Constants.JSON_FILE_EXTENSION.equalsIgnoreCase(bomType)){
-                documentName = String.format("project_%s(%s)_%s.json", project.getName(), project.getVersion(),
+            if(JSON_FILE_EXTENSION.equalsIgnoreCase(bomType)){
+                documentName = String.format("project_%s(%s)_%s%s.json", project.getName(), project.getVersion(),
                         SW360Utils.getCreatedOnTime(), "_SBOM");
             }
         }
         return documentName;
+    }
+
+    @NonNull
+    private static String writeToTempFile(@NonNull ByteBuffer buffer, @NonNull User user) throws IOException {
+        String token = UUID.randomUUID().toString();
+        String filePath = TMP_EXPORTEDFILES + user.getEmail() + SLASH + "file" + SLASH;
+        String relativePath;
+        File dir = new File(filePath);
+        if (!dir.mkdirs() && !dir.exists()) {
+            log.error("Failed to create export directory: {}", dir.getAbsolutePath());
+            throw new IOException("Failed to create export directory: " + dir.getAbsolutePath());
+        }
+        File file = new File(dir.getPath() + SLASH + SW360Utils.getCreatedOn() + "_" + token);
+        if (!file.createNewFile()) {
+            log.error("Failed to create export file: {}", file.getAbsolutePath());
+            throw new IOException("Failed to create export file: " + file.getAbsolutePath());
+        }
+        relativePath = user.getEmail() + SLASH + "file" + SLASH + file.getName();
+
+        buffer.rewind();
+        try (FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.WRITE)) {
+            while (buffer.hasRemaining()) {
+                channel.write(buffer);
+            }
+        }
+        return relativePath;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -1485,7 +1485,7 @@ public class ProjectTest extends TestIntegrationBase {
 
     @Test
     public void should_get_project_report() throws IOException, TException {
-        given(this.sw360ReportServiceMock.getProjectBuffer(any(), anyBoolean(), any(), any(), any())).willReturn(ByteBuffer.wrap(new byte[]{1, 2, 3, 4}));
+        given(this.sw360ReportServiceMock.getProjectReportBuffer(any(), any(), any())).willReturn(ByteBuffer.wrap(new byte[]{1, 2, 3, 4}));
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<byte[]> response =

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
 import org.eclipse.sw360.datahandler.thrift.projects.*;
+import org.eclipse.sw360.datahandler.thrift.projects.SW360ReportBean;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -540,7 +540,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.importSPDX(any(),any())).willReturn(requestSummaryForSPDX);
         given(this.projectServiceMock.importCycloneDX(any(),any(),any(),anyBoolean())).willReturn(requestSummaryForCycloneDX);
         given(this.sw360ReportServiceMock.getDocumentName(any(), any(), any(), any())).willReturn(projectName);
-        given(this.sw360ReportServiceMock.getProjectBuffer(any(),anyBoolean(),any(),any(),any())).willReturn(ByteBuffer.allocate(10000));
+        given(this.sw360ReportServiceMock.getProjectReportBuffer(any(), any(),any())).willReturn(ByteBuffer.allocate(10000));
         given(this.sw360ReportServiceMock.getProjectReleaseSpreadSheetWithEcc(any(),any())).willReturn(ByteBuffer.allocate(10000));
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), any())).willReturn(project);
         given(this.projectServiceMock.searchAccessibleProjectByExactValues(any(), any(), any())).willReturn(


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Over the period, the report exporters have been modified. But they had 2 separate paths for direct downloads and email based downloads. The code slowly drifted apart and resulted in different behavior on each path.

This PR
1. Unified all the paths
2. Simplify the logic for backend to just generate file content.
3. Let Resource Server decide what to do, email (save temp file) or send to client (direct download).
4. Optimize the conversion of buffers -> wrap -> translation -> load 3x data in memory.