### PR TITLE
fix(release): single-character version searches

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -48,7 +48,7 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
 
     private static final List<IndexField> RELEASE_FIELDS = List.of(
             IndexField.standard("name"),
-            IndexField.standard("version"),
+            IndexField.standard("version", 1, BaseNouveauSearchHandler.EDGE_NGRAM_MAX_LENGTH),
             IndexField.simple("componentId", "keyword"),
             IndexField.simple("clearingState", "keyword"),
             IndexField.simple("mainlineState", "keyword"),

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SearchUtils.java
@@ -125,8 +125,8 @@ public class SearchUtils {
             if (doc.version && typeof(doc.version) == 'string') {
               var vParts = doc.version.toLowerCase().split(/[^a-z0-9]+/);
               for (var vi = 0; vi < vParts.length; vi++) {
-                if (vParts[vi].length >= 2) {
-                  emitEdgeNGrams('version_ngram', vParts[vi], 2, %d);
+                if (vParts[vi].length >= 1) {
+                  emitEdgeNGrams('version_ngram', vParts[vi], 1, %d);
                 }
               }
             }


### PR DESCRIPTION
Description: Changed n-gram minimum from 2 to 1 so single-character version searches (for example 2) are indexed and matched, including segmented versions like 2.4.1_conflict.
