### PR TITLE
fix(search): use the fixed score sorting string

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -870,12 +870,11 @@ public abstract class BaseNouveauSearchHandler<T> {
      *
      * @param pageData Pagination data from the request.
      * @return Sort column names with direction ({@code -} prefix = descending).
-     * @implNote The score-sorting field must <em>not</em> be direction-prefixed; pass it as-is.
      */
     protected final @NonNull @Unmodifiable List<String> getSortColumns(@NonNull PaginationData pageData) {
         List<String> columns = mapSortColumn(pageData.getSortColumnNumber());
         return columns.stream().map(c -> {
-            if (!SCORE_SORTING_FIELD.equals(c) && !pageData.isAscending()) {
+            if (!pageData.isAscending()) {
                 if (c.startsWith("-")) {
                     return c.substring(1);
                 }

--- a/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
+++ b/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class LuceneAwareCouchDbConnector {
     public static String DEFAULT_NOUVEAU_PREFIX = "_nouveau";
     public static String DEFAULT_DESIGN_PREFIX = ""; // '_design/' not needed with Cloudant SDK
-    public static String SCORE_SORTING_FIELD = "relevance"; ///< Use to sort by score
+    public static String SCORE_SORTING_FIELD = "-<score>"; ///< Use to sort by score
 
     private final NouveauAwareDatabase database;
 


### PR DESCRIPTION
Nouveau fixed their score sorting string from `releavance` to `<score>` which can now be inverted.

See https://github.com/apache/couchdb/pull/6078

Closed as part of old PR https://github.com/eclipse-sw360/sw360/pull/4409