### PR TITLE
fix(rest): Improve Used By Projects loading reduce usedBy response time.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -456,7 +456,9 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             tags = {"Releases"}
     )
     @GetMapping(value = RELEASES_URL + "/usedBy" + "/{id}")
-    public ResponseEntity<CollectionModel<EntityModel>> getUsedByResourceDetails(@PathVariable("id") String id)
+    public ResponseEntity<CollectionModel<EntityModel>> getUsedByResourceDetails(
+            @PathVariable("id") String id,
+            @RequestParam(value = "includeRestrictedCount", defaultValue = "true") boolean includeRestrictedCount)
             throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication(); // Project
         Set<org.eclipse.sw360.datahandler.thrift.projects.Project> sw360Projects = releaseService.getProjectsByRelease(id, user);
@@ -473,9 +475,11 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             resources.add(EntityModel.of(embeddedComponent));
         });
 
-        RestrictedResource restrictedResource = new RestrictedResource();
-        restrictedResource.setProjects(releaseService.countProjectsByReleaseId(id) - sw360Projects.size());
-        resources.add(EntityModel.of(restrictedResource));
+        if (includeRestrictedCount) {
+            RestrictedResource restrictedResource = new RestrictedResource();
+            restrictedResource.setProjects(releaseService.countProjectsByReleaseId(id) - sw360Projects.size());
+            resources.add(EntityModel.of(restrictedResource));
+        }
 
         CollectionModel<EntityModel> finalResources = restControllerHelper.createResources(resources);
         HttpStatus status = finalResources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;


### PR DESCRIPTION


[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

This PR updates the release used-by API to make restricted project count optional.
- Added optional query parameter: `includeRestrictedCount` (default: `true`)
- When `includeRestrictedCount=false`, API skips restricted project counting
- Default behavior is unchanged for existing clients

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?


Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.
@GMishx 

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

1. Start backend service.
2. Call endpoint with default behavior:
   - `GET /resource/api/releases/usedBy/{releaseId}`
   - Verify response includes restricted count resource.
3. Call optimized behavior:
   - `GET /resource/api/releases/usedBy/{releaseId}?includeRestrictedCount=false`
   - Verify restricted count resource is not present.
4. Compare both responses:
   - Projects/components data should still be correct.
   - Only restricted count block should differ.
5. Optional: check response time improvement for `includeRestrictedCount=false`.

Additional tests:
- Manual API verification done.
- No new automated tests added in this PR.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
