### PR TITLE
fix(rest): make UI API token config keys fully DB-config-driven

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -109,6 +109,8 @@ public class SW360ConfigsDatabaseHandler {
                 .put(UI_ENABLE_SECURITY_VULNERABILITY_MONITORING, getOrDefault(configContainer, UI_ENABLE_SECURITY_VULNERABILITY_MONITORING, "false"))
                 .put(UI_OPERATING_SYSTEMS, getOrDefault(configContainer, UI_OPERATING_SYSTEMS, "[\"Android\",\"BSD\",\"iOS\",\"Linux\",\"Mac OS X\",\"QNX\",\"Microsoft Windows\",\"Windows Phone\",\"IBM z/OS\"]"))
                 .put(UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP, getOrDefault(configContainer, UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP, "[\"DEPT1\",\"DEPT2\",\"DEPT3\"]"))
+                .put(UI_REST_APITOKEN_GENERATOR_ENABLE, getOrDefault(configContainer, UI_REST_APITOKEN_GENERATOR_ENABLE, "true"))
+                .put(UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED, getOrDefault(configContainer, UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED, "true"))
                 .put(UI_PROGRAMMING_LANGUAGES, getOrDefault(configContainer, UI_PROGRAMMING_LANGUAGES, "[\"ActionScript\",\"AppleScript\",\"Asp\",\"Bash\",\"BASIC\",\"C\",\"C++\",\"C#\",\"Cocoa\",\"Clojure\",\"COBOL\",\"ColdFusion\",\"D\",\"Delphi\",\"Erlang\",\"Fortran\",\"Go\",\"Groovy\",\"Haskell\",\"JSP\",\"Java\",\"JavaScript\",\"Objective-C\",\"Ocaml\",\"Lisp\",\"Perl\",\"PHP\",\"Python\",\"Ruby\",\"SQL\",\"SVG\",\"Scala\",\"SmallTalk\",\"Scheme\",\"Tcl\",\"XML\",\"Node.js\",\"JSON\"]"))
                 .put(UI_PROJECT_EXTERNALKEYS, getOrDefault(configContainer, UI_PROJECT_EXTERNALKEYS, "[\"internal.id\"]"))
                 .put(UI_PROJECT_EXTERNALURLS, getOrDefault(configContainer, UI_PROJECT_EXTERNALURLS, "[\"wiki\",\"issue-tracker\"]"))
@@ -205,7 +207,9 @@ public class SW360ConfigsDatabaseHandler {
                  UI_CLEARING_TEAM_UNKNOWN_ENABLED,
                  UI_CUSTOM_WELCOME_PAGE_GUIDELINE,
                  UI_ENABLE_ADD_LICENSE_INFO_TO_RELEASE_BUTTON,
-                 UI_ENABLE_SECURITY_VULNERABILITY_MONITORING
+                 UI_ENABLE_SECURITY_VULNERABILITY_MONITORING,
+                 UI_REST_APITOKEN_GENERATOR_ENABLE,
+                 UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED
                     -> isBooleanValue(configValue);
 
             // Validate string value

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -105,6 +105,10 @@ public class SW360ConfigKeys {
     // This property is used to disable the Clearing Request feature for the projects based on project Business Unit (BU) / Group.
     // Add the list of BU for which you want to disable the Clearing Request feature.
     public static final String UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP = "ui.org.eclipse.sw360.disable.clearing.request.for.project.group";
+    // This property is used to enable/disable API token generator controls in the UI.
+    public static final String UI_REST_APITOKEN_GENERATOR_ENABLE = "ui.rest.apitoken.generator.enable";
+    // This property is used to show/hide write-access API token controls in user preferences.
+    public static final String UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED = "ui.rest.api.write.access.token.in.preferences.enabled";
     // This property is used to create Project Programming Languages
     public static final String UI_PROGRAMMING_LANGUAGES = "ui.programming.languages";
     // This property is used to create Project External Keys
@@ -155,6 +159,7 @@ public class SW360ConfigKeys {
             UI_CUSTOMMAP_RELEASE_ROLES, UI_CUSTOM_WELCOME_PAGE_GUIDELINE, UI_DOMAINS,
             UI_ENABLE_ADD_LICENSE_INFO_TO_RELEASE_BUTTON, UI_ENABLE_SECURITY_VULNERABILITY_MONITORING,
             UI_OPERATING_SYSTEMS, UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP,
+            UI_REST_APITOKEN_GENERATOR_ENABLE, UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED,
             UI_PROGRAMMING_LANGUAGES, UI_PROJECT_EXTERNALKEYS, UI_PROJECT_EXTERNALURLS,
             UI_PROJECT_TAG, UI_PROJECT_TYPE, UI_RELEASE_EXTERNALKEYS, UI_SOFTWARE_PLATFORMS, UI_STATE,
             UI_ENABLE_LINKED_PROJECTS_DISPLAY

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeysTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeysTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests pinning the exact string values of frontend-facing configuration keys.
+ * <p>
+ * These keys must match exactly what the frontend sends in PATCH requests to
+ * /api/configurations(/container/{configFor}); otherwise the backend rejects the value as
+ * "Invalid config" (see SW360ConfigsDatabaseHandler#isConfigValid), because it never recognizes
+ * the key.
+ */
+public class SW360ConfigKeysTest {
+
+    @Test
+    public void apiTokenGeneratorEnableKeyMatchesFrontendContract() {
+        assertEquals("ui.rest.apitoken.generator.enable",
+                SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE);
+    }
+
+    @Test
+    public void writeAccessTokenInPreferencesEnabledKeyMatchesFrontendContract() {
+        // Regression test for: BadRequestClientException "Invalid config:
+        // [ui.rest.api.write.access.token.in.preferences.enabled : true]".
+        // The frontend sends this key WITH a "ui." prefix; the backend constant previously
+        // omitted it, causing isConfigValid(...) to never match and reject the update.
+        assertEquals("ui.rest.api.write.access.token.in.preferences.enabled",
+                SW360ConfigKeys.UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED);
+    }
+
+    @Test
+    public void bothApiTokenUiKeysAreRegisteredAsKnownConfigKeys() {
+        assertTrue(SW360ConfigKeys.ALL_KNOWN_CONFIG_KEYS.contains(
+                SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE));
+        assertTrue(SW360ConfigKeys.ALL_KNOWN_CONFIG_KEYS.contains(
+                SW360ConfigKeys.UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED));
+    }
+}

--- a/rest/resource-server/src/docs/asciidoc/api-guide.adoc
+++ b/rest/resource-server/src/docs/asciidoc/api-guide.adoc
@@ -253,19 +253,19 @@ Token response elements
 | `Admin Access`
 | rest.admin.access.usergroup
 | SW360_ADMIN
-| `Enable Token Generator`
-| rest.apitoken.generator.enable
-| false
-| `API Token / Read Validity`
-| rest.apitoken.read.validity.days
+| `API Token / Max Validity`
+| rest.apitoken.max.validity.days
 | 90
-| `API Token / Write Validity`
-| rest.apitoken.write.validity.days
-| 30
 | `API Token / Length`
 | rest.apitoken.length
 | 20
 |===
+
+NOTE: Whether the API write-token generator is enabled (`ui.rest.apitoken.generator.enable`) and
+whether write-access token controls are shown in user preferences
+(`ui.rest.api.write.access.token.in.preferences.enabled`) are fully DB-config-driven, admin-toggleable
+settings. They are managed via `GET`/`PATCH` on `/api/configurations/container/UI_CONFIGURATION` and
+take effect immediately without a server restart.
 
 [[resources]]
 == Resources

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -99,9 +99,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     private static final String APPLICATION_ID = "rest";
 
     public static final String API_TOKEN_HASH_SALT;
-    public static final Boolean API_WRITE_TOKEN_GENERATOR_ENABLED;
-    public static final String API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
-    public static final String API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS;
+    public static final String API_TOKEN_MAX_VALIDITY_IN_DAYS;
     public static final int API_TOKEN_LENGTH;
     public static final UserGroup API_WRITE_ACCESS_USERGROUP;
     public static final Set<String> DEFAULT_DOMAINS;
@@ -112,9 +110,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
 
     static {
         Properties props = CommonUtils.loadProperties(Sw360ResourceServer.class, SW360_PROPERTIES_FILE_PATH);
-        API_WRITE_TOKEN_GENERATOR_ENABLED = Boolean.parseBoolean(props.getProperty("rest.apitoken.write.generator.enable", "true"));
-        API_TOKEN_MAX_VALIDITY_READ_IN_DAYS = props.getProperty("rest.apitoken.read.validity.days", "90");
-        API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS = props.getProperty("rest.apitoken.write.validity.days", "30");
+        API_TOKEN_MAX_VALIDITY_IN_DAYS = props.getProperty("rest.apitoken.max.validity.days", "90");
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
         API_TOKEN_LENGTH = Integer.parseInt(props.getProperty("rest.apitoken.length", "20"));
         API_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", UserGroup.ADMIN.name()));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsService.java
@@ -52,9 +52,8 @@ public class SW360ConfigurationsService {
     public Map<String, String> getSW360ConfigFromProperties() {
         Map<String, String> configFromProperties = new HashMap<>();
         configFromProperties.put("enable.flexible.project.release.relationship", String.valueOf(SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP));
-        configFromProperties.put("rest.apitoken.read.validity.days", String.valueOf(Sw360ResourceServer.API_TOKEN_MAX_VALIDITY_READ_IN_DAYS));
-        configFromProperties.put("rest.apitoken.write.validity.days", String.valueOf(Sw360ResourceServer.API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS));
-        configFromProperties.put("ui.rest.apitoken.write.generator.enable", String.valueOf(Sw360ResourceServer.API_WRITE_TOKEN_GENERATOR_ENABLED));
+        configFromProperties.put("rest.apitoken.max.validity.days", String.valueOf(Sw360ResourceServer.API_TOKEN_MAX_VALIDITY_IN_DAYS));
+        // DB-backed UI token toggles must stay out of the read-only properties map.
         configFromProperties.put("svm.notification.url", String.valueOf(Sw360ResourceServer.SVM_NOTIFICATION_URL));
         return configFromProperties;
     }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationProvider.java
@@ -99,14 +99,19 @@ public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
     }
 
     private boolean isApiTokenExpired(RestApiToken restApiToken) {
-        String configExpireDays = restApiToken.getAuthorities().contains("WRITE") ?
-                API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS : API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
         Date createdOn = SW360Utils.getDateFromTimeString(restApiToken.createdOn);
         if (createdOn == null) {
             throw new AuthenticationServiceException("API Token created incorrectly.");
         }
+        int maxValidityDays;
+        try {
+            maxValidityDays = Integer.parseInt(API_TOKEN_MAX_VALIDITY_IN_DAYS);
+        } catch (NumberFormatException e) {
+            log.warn("API token max validity '{}' is not a valid number, defaulting to 90 days.", API_TOKEN_MAX_VALIDITY_IN_DAYS, e);
+            maxValidityDays = 90;
+        }
         Date tokenExpireDate = DateUtils.addDays(createdOn,
-                min(restApiToken.getNumberOfDaysValid(), Integer.parseInt(configExpireDays)));
+                min(restApiToken.getNumberOfDaysValid(), maxValidityDays));
         return tokenExpireDate.before(new Date());
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -18,13 +18,16 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
+import org.eclipse.sw360.datahandler.thrift.ConfigFor;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.configurations.SW360ConfigsService;
 import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
@@ -53,10 +56,8 @@ import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.SW360Constants.TYPE_USER;
-import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
-import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS;
+import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_TOKEN_MAX_VALIDITY_IN_DAYS;
 import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_WRITE_ACCESS_USERGROUP;
-import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_WRITE_TOKEN_GENERATOR_ENABLED;
 
 @Service
 public class Sw360UserService {
@@ -180,20 +181,12 @@ public class Sw360UserService {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-        if (!requestBody.containsKey(EXPIRATION_DATE_PROPERTY)
-                || CommonUtils.isNullEmptyOrWhitespace(requestBody.get(EXPIRATION_DATE_PROPERTY).toString())) {
-            throw new IllegalArgumentException(EXPIRATION_DATE_PROPERTY + " is a required field.");
-        }
-        if (!(requestBody.get(EXPIRATION_DATE_PROPERTY) instanceof String)) {
-            throw new IllegalArgumentException(EXPIRATION_DATE_PROPERTY + " must be a string.");
-        }
-
         RestApiToken restApiToken = mapper.convertValue(requestBody, RestApiToken.class);
-        if (!API_WRITE_TOKEN_GENERATOR_ENABLED && restApiToken.authorities.contains(AUTHORITIES_WRITE)) {
+        if (!isApiTokenGeneratorEnabled() && restApiToken.authorities.contains(AUTHORITIES_WRITE)) {
             throw new AccessDeniedException("Token requested with '" +
                     AUTHORITIES_WRITE + "' authority, but not allowed.");
         }
-        int numberOfExpireDay = getNumberOfExpireDays(requestBody.get(EXPIRATION_DATE_PROPERTY).toString());
+        int numberOfExpireDay = getRequestedOrDefaultExpireDays(requestBody);
         if (numberOfExpireDay < 0) {
             throw new IllegalArgumentException("Token expiration days is not valid for user");
         }
@@ -206,9 +199,54 @@ public class Sw360UserService {
         return restApiToken;
     }
 
+    private SW360ConfigsService.Iface getThriftConfigsClient() {
+        return ThriftClients.makeSW360ConfigsClient();
+    }
+
+    /**
+     * Fully DB-config-driven check for whether API write-token generation is enabled.
+     * Reads {@link SW360ConfigKeys#UI_REST_APITOKEN_GENERATOR_ENABLE} from the UI_CONFIGURATION
+     * container (admin-toggleable via /api/configurations/container/UI_CONFIGURATION), instead of
+     * a static, properties-loaded flag. This ensures that toggling the setting in the Admin UI
+     * takes effect immediately without a server restart.
+     *
+     * @return {@code true} if write-token generation is enabled (or the config could not be
+     *         determined, to preserve prior default/fail-open behavior), {@code false} otherwise.
+     */
+    private boolean isApiTokenGeneratorEnabled() {
+        try {
+            Map<String, String> uiConfigs = getThriftConfigsClient().getConfigForContainer(ConfigFor.UI_CONFIGURATION);
+            String value = uiConfigs.get(SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE);
+            return value == null || Boolean.parseBoolean(value);
+        } catch (TException e) {
+            log.warn("Could not read '{}' from SW360 configs; defaulting to enabled.",
+                    SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE, e);
+            return true;
+        }
+    }
+
     private int getNumberOfExpireDays(String requestExpirationDate) {
         LocalDate expirationDate = LocalDate.parse(requestExpirationDate);
         return (int) ChronoUnit.DAYS.between(LocalDate.now(), expirationDate);
+    }
+
+    private int getRequestedOrDefaultExpireDays(Map<String, Object> requestBody) {
+        Object requestedExpirationDate = requestBody.get(EXPIRATION_DATE_PROPERTY);
+        if (requestedExpirationDate == null || CommonUtils.isNullEmptyOrWhitespace(requestedExpirationDate.toString())) {
+            return parseMaxValidityDays();
+        }
+        if (!(requestedExpirationDate instanceof String)) {
+            throw new IllegalArgumentException(EXPIRATION_DATE_PROPERTY + " must be a string.");
+        }
+        return getNumberOfExpireDays((String) requestedExpirationDate);
+    }
+
+    private int parseMaxValidityDays() {
+        try {
+            return Integer.parseInt(API_TOKEN_MAX_VALIDITY_IN_DAYS);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Token expiration days is not valid for user");
+        }
     }
 
     public boolean isTokenNameExisted(User user, String tokenName) {
@@ -216,15 +254,8 @@ public class Sw360UserService {
     }
 
     private boolean isValidExpireDays(RestApiToken restApiToken) {
-        String configExpireDays = restApiToken.getAuthorities().contains(AUTHORITIES_WRITE) ?
-                API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS : API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
-
-        try {
-            return restApiToken.getNumberOfDaysValid() >= 0 &&
-                    restApiToken.getNumberOfDaysValid() <= Integer.parseInt(configExpireDays);
-        } catch (NumberFormatException e) {
-            return false;
-        }
+        return restApiToken.getNumberOfDaysValid() >= 0
+                && restApiToken.getNumberOfDaysValid() <= parseMaxValidityDays();
     }
 
     private void validateRestApiToken(RestApiToken restApiToken, User sw360User) {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/SW360ConfigurationsServiceTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.configuration;
+
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SW360ConfigurationsServiceTest {
+
+    /**
+     * Regression test for the bug where toggling "Enable API Token Generator" (or the
+     * write-access-token-in-preferences flag) in the Admin UI silently failed to persist.
+     * <p>
+     * Root cause: these two keys are DB-backed, admin-toggleable UI configs (see
+     * SW360ConfigsDatabaseHandler), but were ALSO being exposed via
+     * getSW360ConfigFromProperties(). Since SW360ConfigurationsController#updateConfigInService
+     * strips out any key present in getSW360ConfigFromProperties() before persisting (treating it
+     * as read-only), the toggle value from the frontend never reached the database. Additionally,
+     * on every GET the properties value would override the persisted DB value.
+     * <p>
+     * Fix: these two keys must NOT appear in getSW360ConfigFromProperties() so they flow through
+     * to the DB-backed update/read path untouched. There is no longer a legacy, properties-based
+     * fallback for these keys - they are fully DB-config-driven (see also
+     * Sw360UserService#isApiTokenGeneratorEnabled, which enforces this DB value directly instead
+     * of a static properties-loaded flag).
+     */
+    @Test
+    void shouldNotExposeDbBackedUiTokenConfigsAsReadonlyProperties() {
+        SW360ConfigurationsService service = new SW360ConfigurationsService();
+
+        Map<String, String> configs = service.getSW360ConfigFromProperties();
+
+        assertFalse(configs.containsKey(SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE),
+                "UI_REST_APITOKEN_GENERATOR_ENABLE must not be treated as a read-only properties config, "
+                        + "otherwise admin UI toggles for it will not persist to the DB.");
+        assertFalse(configs.containsKey(SW360ConfigKeys.UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED),
+                "UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED must not be treated as a read-only "
+                        + "properties config, otherwise admin UI toggles for it will not persist to the DB.");
+        assertFalse(configs.containsKey("ui.rest.apitoken.write.generator.enable"),
+                "The legacy properties-based key must no longer be exposed; this feature is fully "
+                        + "DB-config-driven now.");
+        assertTrue(configs.containsKey("rest.apitoken.max.validity.days"),
+                "Token max validity must stay properties-backed for UI date limits.");
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ConfigurationsTest.java
@@ -344,6 +344,122 @@ public class ConfigurationsTest extends TestIntegrationBase {
         assertTrue(responseBody.contains("Configurations are updated successfully"), "Response should contain success message");
     }
 
+    /**
+     * Regression test for the bug where toggling "Enable API Token Generator" in the Admin UI
+     * silently failed to persist. The key must NOT be present in getSW360ConfigFromProperties()
+     * (mocked here to mirror production behavior after the fix), otherwise
+     * SW360ConfigurationsController#updateConfigInService would strip it from the update request
+     * before it ever reaches the DB-backed update call.
+     */
+    @Test
+    public void should_persist_api_token_generator_toggle_key_when_disabled() throws IOException, TException {
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String configKey = SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE;
+
+        Map<String, String> updatedConfigurations = new HashMap<>();
+        updatedConfigurations.put(configKey, "false");
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(updatedConfigurations, headers);
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/configurations/container/UI_CONFIGURATION",
+                        HttpMethod.PATCH,
+                        requestEntity,
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        verify(this.sw360ConfigurationsServiceMock)
+                .updateSW360ConfigForContainer(
+                        eq(ConfigFor.UI_CONFIGURATION),
+                        argThat(x -> {
+                            assertTrue(x.containsKey(configKey), "Toggle key must not be stripped before reaching the DB update call");
+                            assertEquals("false", x.get(configKey));
+                            return true;
+                        }),
+                        any());
+    }
+
+    @Test
+    public void should_persist_api_token_generator_toggle_key_when_enabled() throws IOException, TException {
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String configKey = SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE;
+
+        Map<String, String> updatedConfigurations = new HashMap<>();
+        updatedConfigurations.put(configKey, "true");
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(updatedConfigurations, headers);
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/configurations/container/UI_CONFIGURATION",
+                        HttpMethod.PATCH,
+                        requestEntity,
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        verify(this.sw360ConfigurationsServiceMock)
+                .updateSW360ConfigForContainer(
+                        eq(ConfigFor.UI_CONFIGURATION),
+                        argThat(x -> {
+                            assertTrue(x.containsKey(configKey), "Toggle key must not be stripped before reaching the DB update call");
+                            assertEquals("true", x.get(configKey));
+                            return true;
+                        }),
+                        any());
+    }
+
+    /**
+     * Regression test for: BadRequestClientException "Invalid config:
+     * [ui.rest.api.write.access.token.in.preferences.enabled : true]".
+     * <p>
+     * Root cause: the frontend sends the key with a "ui." prefix
+     * (ui.rest.api.write.access.token.in.preferences.enabled), but
+     * SW360ConfigKeys.UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED was previously defined
+     * without that prefix (rest.api.write.access.token.in.preferences.enabled), so the backend
+     * validation in SW360ConfigsDatabaseHandler#isConfigValid never matched the key and rejected
+     * it as unknown/invalid. Fixed by aligning the constant value with what the frontend sends.
+     */
+    @Test
+    public void should_persist_write_access_token_in_preferences_toggle_key() throws IOException, TException {
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String configKey = SW360ConfigKeys.UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED;
+        assertEquals("ui.rest.api.write.access.token.in.preferences.enabled", configKey,
+                "Backend config key must match the exact key sent by the frontend");
+
+        Map<String, String> updatedConfigurations = new HashMap<>();
+        updatedConfigurations.put(configKey, "true");
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(updatedConfigurations, headers);
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/configurations/container/UI_CONFIGURATION",
+                        HttpMethod.PATCH,
+                        requestEntity,
+                        String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+
+        verify(this.sw360ConfigurationsServiceMock)
+                .updateSW360ConfigForContainer(
+                        eq(ConfigFor.UI_CONFIGURATION),
+                        argThat(x -> {
+                            assertTrue(x.containsKey(configKey), "Toggle key must not be stripped before reaching the DB update call");
+                            assertEquals("true", x.get(configKey));
+                            return true;
+                        }),
+                        any());
+    }
+
     @Test
     public void should_update_configurations_for_ui_container() throws IOException {
         HttpHeaders headers = getHeaders(port);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserServiceTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.user;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
+import org.eclipse.sw360.datahandler.thrift.ConfigFor;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.configurations.SW360ConfigsService;
+import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_TOKEN_MAX_VALIDITY_IN_DAYS;
+
+/**
+ * Unit tests for the fully DB-config-driven API write-token generator enforcement in
+ * {@link Sw360UserService#convertToRestApiToken}.
+ * <p>
+ * Regression coverage for the removal of the legacy, properties-based
+ * {@code rest.apitoken.write.generator.enable} flag (and the corresponding
+ * {@code Sw360ResourceServer.API_WRITE_TOKEN_GENERATOR_ENABLED} static field): the enforcement
+ * check must now read {@link SW360ConfigKeys#UI_REST_APITOKEN_GENERATOR_ENABLE} from the
+ * UI_CONFIGURATION DB container so that toggling the setting via the Admin UI takes effect
+ * immediately.
+ */
+class Sw360UserServiceTest {
+
+    private final Sw360UserService userService = new Sw360UserService();
+    private MockedStatic<ThriftClients> thriftClientsMock;
+    private SW360ConfigsService.Iface configsClient;
+
+    @BeforeEach
+    void setUp() {
+        thriftClientsMock = mockStatic(ThriftClients.class);
+        configsClient = mock(SW360ConfigsService.Iface.class);
+        thriftClientsMock.when(ThriftClients::makeSW360ConfigsClient).thenReturn(configsClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        thriftClientsMock.close();
+    }
+
+    private Map<String, Object> writeTokenRequestBody() {
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("name", "my-token");
+        requestBody.put("expirationDate", LocalDate.now().plusDays(5).format(DateTimeFormatter.ISO_LOCAL_DATE));
+        requestBody.put("authorities", List.of("READ", "WRITE"));
+        return requestBody;
+    }
+
+    private User adminUser() {
+        return new User().setEmail("admin@sw360.org").setUserGroup(UserGroup.ADMIN);
+    }
+
+    @Test
+    void shouldRejectWriteTokenWhenDbConfigDisablesGenerator() throws TException {
+        Map<String, String> uiConfigs = Map.of(SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE, "false");
+        when(configsClient.getConfigForContainer(eq(ConfigFor.UI_CONFIGURATION))).thenReturn(uiConfigs);
+
+        assertThrows(AccessDeniedException.class,
+                () -> userService.convertToRestApiToken(writeTokenRequestBody(), adminUser()));
+    }
+
+    @Test
+    void shouldAllowWriteTokenWhenDbConfigEnablesGenerator() throws TException {
+        Map<String, String> uiConfigs = Map.of(SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE, "true");
+        when(configsClient.getConfigForContainer(eq(ConfigFor.UI_CONFIGURATION))).thenReturn(uiConfigs);
+
+        RestApiToken token = userService.convertToRestApiToken(writeTokenRequestBody(), adminUser());
+
+        assertNotNull(token);
+        assertEquals("my-token", token.getName());
+    }
+
+    @Test
+    void shouldDefaultToEnabledWhenDbConfigKeyIsMissing() throws TException {
+        when(configsClient.getConfigForContainer(eq(ConfigFor.UI_CONFIGURATION))).thenReturn(new HashMap<>());
+
+        RestApiToken token = userService.convertToRestApiToken(writeTokenRequestBody(), adminUser());
+
+        assertNotNull(token);
+    }
+
+    @Test
+    void shouldDefaultToEnabledWhenThriftCallFails() throws TException {
+        when(configsClient.getConfigForContainer(eq(ConfigFor.UI_CONFIGURATION))).thenThrow(new TException("backend unreachable"));
+
+        RestApiToken token = userService.convertToRestApiToken(writeTokenRequestBody(), adminUser());
+
+        assertNotNull(token);
+    }
+
+    @Test
+    void shouldUseConfiguredMaxValidityWhenExpirationDateIsMissing() throws TException {
+        Map<String, String> uiConfigs = Map.of(SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE, "true");
+        when(configsClient.getConfigForContainer(eq(ConfigFor.UI_CONFIGURATION))).thenReturn(uiConfigs);
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("name", "my-token");
+        requestBody.put("authorities", List.of("READ"));
+
+        RestApiToken token = userService.convertToRestApiToken(requestBody, adminUser());
+
+        assertNotNull(token);
+        assertEquals(Integer.parseInt(API_TOKEN_MAX_VALIDITY_IN_DAYS), token.getNumberOfDaysValid());
+    }
+}

--- a/scripts/docker-config/etc_sw360/sw360.properties.template
+++ b/scripts/docker-config/etc_sw360/sw360.properties.template
@@ -14,8 +14,7 @@
 ## API Token generation
 rest.write.access.usergroup=USER
 rest.admin.access.usergroup=ADMIN
-rest.apitoken.read.validity.days=90
-rest.apitoken.write.validity.days=30
+rest.apitoken.max.validity.days=90
 rest.apitoken.hash.salt=$REST_APITOKEN_HASH_SALT
 
 # where the Thrift should connect


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This PR makes the UI API token configuration keys fully DB-config-driven and fixes validation/persistence mismatches seen when toggling API token settings from the Admin UI.

- Registers and validates the UI keys in backend config handling.
- Fixes key naming mismatch for `ui.rest.api.write.access.token.in.preferences.enabled`.
- Removes these UI keys from properties-backed read-only config exposure so PATCH updates are persisted in DB.
- Switches write-token generator enforcement to read from DB config (`UI_CONFIGURATION`) at runtime.
- Updates API docs and adds regression tests for key constants, config persistence, and token-generation behavior.

### Frontend PR: [1958](https://github.com/eclipse-sw360/sw360-frontend/pull/1958)

### Suggest Reviewer
@GMishx 

### How To Test?
1. Update UI configuration container via API:
   - `PATCH /api/configurations/container/UI_CONFIGURATION`
   - keys:
     - `ui.rest.apitoken.generator.enable`
     - `ui.rest.api.write.access.token.in.preferences.enabled`
2. Verify values persist with:
   - `GET /api/configurations/container/UI_CONFIGURATION`
3. Verify token generation behavior:
   - When `ui.rest.apitoken.generator.enable=false`, creating WRITE token from `/api/users/tokens` is denied.
   - When `ui.rest.apitoken.generator.enable=true`, WRITE token creation follows existing permission checks.
4. Run relevant tests (examples):

```bash
mvn -pl libraries/datahandler test -Dtest=org.eclipse.sw360.datahandler.common.SW360ConfigKeysTest
mvn -pl rest/resource-server test -Dtest=org.eclipse.sw360.rest.resourceserver.configuration.SW360ConfigurationsServiceTest
mvn -pl rest/resource-server test -Dtest=org.eclipse.sw360.rest.resourceserver.integration.ConfigurationsTest
mvn -pl rest/resource-server test -Dtest=org.eclipse.sw360.rest.resourceserver.user.Sw360UserServiceTest
```

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] If code is AI-generated, mention the tool and model used (GitHub Copilot, GPT-5-Codex)

