### PR TITLE
feat(export): add CSV, JSON, and XML export for component reports

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -58,6 +58,9 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerability
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityCheckStatus;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityService;
 import org.eclipse.sw360.exporter.ComponentExporter;
+import org.eclipse.sw360.exporter.CSVExport;
+import org.eclipse.sw360.exporter.JsonExport;
+import org.eclipse.sw360.exporter.XmlExport;
 import org.eclipse.sw360.mail.MailConstants;
 import org.eclipse.sw360.mail.MailUtil;
 import org.apache.logging.log4j.Logger;
@@ -67,6 +70,7 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.spdx.SpdxBOMImporter;
 import org.eclipse.sw360.spdx.SpdxBOMImporterSink;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -3281,14 +3285,45 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
     }
 
-    public ByteBuffer getComponentReportDataStream(User user, boolean extendedByReleases) throws TException{
+    public ByteBuffer getComponentReportDataStream(User user, boolean extendedByReleases) throws TException {
+        return getComponentReportBuffer(user, extendedByReleases, ReportFormat.EXCEL);
+    }
+
+    public ByteBuffer getComponentReportBuffer(User user, boolean extendedByReleases, ReportFormat format) throws TException {
         try {
             List<Component> componentlist = getRecentComponentsSummary(-1, user);
-            ComponentExporter exporter = getComponentExporterObject(componentlist, user, extendedByReleases);
-            return exporter.toByteBuffer(componentlist);
+            return createFormattedReport(componentlist, user, extendedByReleases, format);
         } catch (IOException e) {
             throw new SW360Exception(e.getMessage());
         }
+    }
+
+    private @Nullable ByteBuffer createFormattedReport(
+            List<Component> components, User user, boolean extendedByReleases, ReportFormat fmt
+    ) throws IOException, SW360Exception {
+        ComponentExporter exporter = getComponentExporterObject(components, user, extendedByReleases);
+        if (ReportFormat.EXCEL.equals(fmt)) {
+            return exporter.toByteBuffer(components);
+        }
+        List<Map<String, String>> records = exporter.makeRecords(components);
+        List<String> headers = extendedByReleases ? ComponentExporter.HEADERS_EXTENDED_BY_RELEASES : ComponentExporter.HEADERS;
+        return switch (fmt) {
+            case ReportFormat.CSV -> {
+                List<List<String>> rows = new ArrayList<>();
+                for (Map<String, String> record : records) {
+                    List<String> row = new ArrayList<>();
+                    for (String header : headers) {
+                        row.add(record.getOrDefault(header, ""));
+                    }
+                    rows.add(row);
+                }
+                Iterable<Iterable<String>> iterableRows = rows.stream().map(row -> (Iterable<String>) row).collect(Collectors.toList());
+                yield CSVExport.toByteBuffer(headers, iterableRows);
+            }
+            case ReportFormat.JSON -> JsonExport.toByteBuffer(records);
+            case ReportFormat.XML -> XmlExport.toByteBuffer(records);
+            default -> null;
+        };
     }
 
     public List<Release> getReleaseByIds(List<String> ids) {

--- a/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -787,6 +787,11 @@ public class ComponentHandler implements ComponentService.Iface {
 	}
 
     @Override
+    public ByteBuffer getComponentReportBuffer(User user, boolean extendedByReleases, ReportFormat format) throws TException {
+        return handler.getComponentReportBuffer(user, extendedByReleases, format);
+    }
+
+    @Override
     public boolean isReleaseActionAllowed(Release release, User user, RequestedAction action) {
         return handler.isReleaseActionAllowed(release, user, action);
     }

--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -27,6 +27,7 @@ typedef sw360.ReleaseRelationship ReleaseRelationship
 typedef sw360.MainlineState MainlineState
 typedef sw360.ProjectReleaseRelationship ProjectReleaseRelationship
 typedef sw360.SW360Exception SW360Exception
+typedef sw360.ReportFormat ReportFormat
 typedef sw360.PaginationData PaginationData
 typedef sw360.ClearingReportStatus ClearingReportStatus
 typedef sw360.ImportBomRequestPreparation ImportBomRequestPreparation
@@ -1085,6 +1086,11 @@ service ComponentService {
     * get report data stream
     */
     binary getComponentReportDataStream(1: User user, 2: bool extendedByReleases) throws (1: SW360Exception exp);
+
+    /*
+     * Get component report binary in the requested format (xlsx, csv, json, xml).
+     */
+    binary getComponentReportBuffer(1: User user, 2: bool extendedByReleases, 3: ReportFormat format) throws (1: SW360Exception exp);
 
     /**
     * Check accessible of release

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -137,7 +137,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "bomType", required = false) String bomType,
             @Parameter(description = "Selected release relationships. Can be supplied with modules [" + LICENSE_INFO + "]", example = "CONTAINED,UNKNOWN")
             @RequestParam(value = "selectedRelRelationship", required = false) List<ReleaseRelationship> selectedRelRelationship,
-            @Parameter(description = "Export format for projects module. Supported values: xlsx, csv, json, xml. Default is xlsx.",
+            @Parameter(description = "Export format for projects and components modules. Supported values: xlsx, csv, json, xml. Default is xlsx.",
                     schema = @Schema(allowableValues = {"xlsx", "csv", "json", "xml"}))
             @RequestParam(value = "format", required = false, defaultValue = "xlsx") String format,
             @Parameter(description = "Filter projects by name. Applies to module=projects export.")
@@ -363,7 +363,9 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                 fileName = sw360ReportService.getDocumentName(user, projectId, module, reportBean.getFormat());
                 setContentTypeForFormat(response, reportBean.getFormat());
             } else if (SW360Constants.COMPONENTS.equalsIgnoreCase(module)) {
-                buff = sw360ReportService.getComponentBuffer(user, reportBean.isWithLinkedReleases());
+                buff = sw360ReportService.getComponentBuffer(user, reportBean.isWithLinkedReleases(), reportBean.getFormat());
+                fileName = sw360ReportService.getDocumentName(user, null, module, reportBean.getFormat());
+                setContentTypeForFormat(response, reportBean.getFormat());
             } else if (SW360Constants.LICENSES.equalsIgnoreCase(module)) {
                 buff = sw360ReportService.getLicenseBuffer();
                 fileName = String.format("licenses-%s.xlsx", SW360Utils.getCreatedOn());
@@ -483,7 +485,10 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @RequestParam(value = "generatorClassName", required = false) String generatorClassName,
             @Parameter(description = "Variant of the license info report. Required for module [" + LICENSE_INFO + "]",
                     schema = @Schema(implementation = OutputFormatVariant.class))
-            @RequestParam(value = "variant", required = false) String variant
+            @RequestParam(value = "variant", required = false) String variant,
+            @Parameter(description = "Export format for components module. Supported values: xlsx, csv, json, xml. Default is xlsx.",
+                    schema = @Schema(allowableValues = {"xlsx", "csv", "json", "xml"}))
+            @RequestParam(value = "format", required = false, defaultValue = "xlsx") String format
     ) throws SW360Exception {
         final User user = restControllerHelper.getSw360UserFromAuthentication();
         try {
@@ -496,6 +501,9 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
                     break;
                 case SW360Constants.COMPONENTS:
                     buffer = sw360ReportService.getComponentReportStreamFromURl(user, extendedByReleases, token);
+                    ReportFormat componentFormat = convertToReportFormat(format.toLowerCase(Locale.ROOT));
+                    fileName = sw360ReportService.getDocumentName(user, null, module, componentFormat);
+                    setContentTypeForFormat(response, componentFormat);
                     break;
                 case SW360Constants.LICENSES:
                     buffer = sw360ReportService.getLicenseReportStreamFromURl(token);
@@ -516,7 +524,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             if (null == buffer) {
                 throw new TException("No data available for the user " + user.getEmail());
             }
-            if (!LICENSE_INFO.equals(module)) {
+            if (!LICENSE_INFO.equals(module) && !SW360Constants.COMPONENTS.equals(module)) {
                 response.setContentType(CONTENT_TYPE_OPENXML_SPREADSHEET);
             }
             setContentDisposition(response, fileName);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -240,10 +240,12 @@ public class SW360ReportService {
     public void getUploadedComponentPath(User sw360User, SW360ReportBean reportBean) {
         Runnable asyncRunnable = () -> wrapTException(() -> {
             try {
-                ByteBuffer buff = getComponentBuffer(sw360User, reportBean.isWithLinkedReleases());
+                ByteBuffer buff = getComponentBuffer(sw360User, reportBean.isWithLinkedReleases(), reportBean.getFormat());
                 String componentPath = writeToTempFile(buff, sw360User);
                 String downloadUrl = frontendUrl + "/reports/download?module=components"
-                        + "&extendedByReleases=" + reportBean.isWithLinkedReleases() + "&token="
+                        + "&extendedByReleases=" + reportBean.isWithLinkedReleases()
+                        + "&format=" + toFormatParam(reportBean.getFormat())
+                        + "&token="
                         + URLEncoder.encode(componentPath, StandardCharsets.UTF_8);
                 URL emailURL = new URI(downloadUrl).toURL();
                 log.debug("Report download link for user {}: {}", sw360User.getEmail(), emailURL);
@@ -260,8 +262,8 @@ public class SW360ReportService {
         asyncThread.start();
     }
 
-    public ByteBuffer getComponentBuffer(User sw360User, boolean withLinkedReleases) throws TException {
-        return componentclient.getComponentReportDataStream(sw360User, withLinkedReleases);
+    public ByteBuffer getComponentBuffer(User sw360User, boolean withLinkedReleases, ReportFormat format) throws TException {
+        return componentclient.getComponentReportBuffer(sw360User, withLinkedReleases, format);
     }
 
     public ByteBuffer getLicenseBuffer() throws TException {
@@ -574,6 +576,16 @@ public class SW360ReportService {
             }
         }
         return documentName;
+    }
+
+    @Contract(pure = true)
+    private @NonNull String toFormatParam(@NonNull ReportFormat format) {
+        return switch (format) {
+            case CSV -> CSV_FILE_EXTENSION;
+            case JSON -> JSON_FILE_EXTENSION;
+            case XML -> XML_FILE_EXTENSION;
+            default -> EXCEL_FILE_EXTENSION;
+        };
     }
 
     @NonNull

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -117,7 +117,7 @@ public class ComponentTest extends TestIntegrationBase {
                 .splitComponents(any(), any(), any());
 
         Mockito.doReturn(ByteBuffer.allocate(10000)).when(sw360ReportServiceMock)
-                .getComponentBuffer(any(), anyBoolean());
+                .getComponentBuffer(any(), anyBoolean(), any());
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -279,7 +279,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         new PaginationData().setRowsPerPage(componentList.size()).setDisplayStart(0).setTotalRowCount(componentList.size()),
                         componentList)
                 );
-        given(this.sw360ReportServiceMock.getComponentBuffer(any(),anyBoolean())).willReturn(ByteBuffer.allocate(10000));
+        given(this.sw360ReportServiceMock.getComponentBuffer(any(), anyBoolean(), any())).willReturn(ByteBuffer.allocate(10000));
         given(this.componentServiceMock.getRecentComponents(any())).willReturn(componentList);
         given(this.componentServiceMock.refineSearch(any(), any(), any()))
                 .willReturn(Collections.singletonMap(


### PR DESCRIPTION
Enable machine-readable spreadsheet export for components via the reports API, mirroring the existing project export support. Fixes #309.

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
