### PR TITLE
fix(rest): route empty lucene calls for components

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -195,16 +195,16 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             filterMap.put(Component._Fields.NAME.getFieldName(), values);
         }
 
-        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) && !filterMap.isEmpty()) {
+        if (CommonUtils.isNotNullEmptyOrWhitespace(searchText) && !CommonUtils.isNullOrEmptyMap(filterMap)) {
             throw new BadRequestClientException("Use either only \"searchText\" or other filters, not both.");
         }
 
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             paginatedComponents = componentService.searchFilteredComponents(searchText, sw360User, pageable);
-        } else if (luceneSearch) {
+        } else if (luceneSearch && !CommonUtils.isNullOrEmptyMap(filterMap)) {
             paginatedComponents = componentService.refineSearch(filterMap, sw360User, pageable);
         } else {
-            if (filterMap.isEmpty()) {
+            if (CommonUtils.isNullOrEmptyMap(filterMap)) {
                 paginatedComponents = componentService.getRecentComponentsSummaryWithPagination(sw360User, pageable);
             } else {
                 paginatedComponents = componentService.searchComponentByExactValues(filterMap, sw360User, pageable);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -88,7 +88,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 @RestController
 @SecurityRequirement(name = "tokenAuth")
 @SecurityRequirement(name = "basic")
-@Tag(name = "ModerationRequests", description = "Operations related to moderation requests on SW360 server.\n" +
+@Tag(name = "Moderation Requests", description = "Operations related to moderation requests on SW360 server.\n" +
         "Endpoints with pagination can use column names: [`score`, " +
         "`documentName`, `documentType`, `componentType`, `moderationState`, `requestingUser`, " +
         "`requestDate` or `requestingUserDepartment`].")


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
This PR fixes the route for calls `/components?luceneSearch=true`. Here the filterMap is empty does not need nouveau but can be handled by default route as well.

Also fix the wrong tag of Merge Requests.

### Suggest Reviewer
@rudra-superrr 

### How To Test?
1. Make call to `/components?luceneSearch=true` and `/components?luceneSearch=false` and compare the results should be the same.
2. Make call to `/components?luceneSearch=true` with some parameters and the search should work as expected.
3. Load the Swagger docs for the API, there should be only one Moderation Requests controller.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR