### PR TITLE
refactor(rest): replace field-level @Autowired with constructor injection

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -18,7 +18,6 @@ import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
 import org.eclipse.sw360.rest.authserver.client.service.Sw360UserMirrorService;
 import org.eclipse.sw360.rest.common.security.Sw360GrantedAuthority;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,6 +51,7 @@ import java.util.stream.Stream;
 @RestController
 @RequestMapping(path = "/" + OAuthClientController.ENDPOINT_URL)
 @PreAuthorize("hasAuthority('ADMIN')")
+@RequiredArgsConstructor
 public class OAuthClientController {
 
     public static final String ENDPOINT_URL = "client-management";
@@ -68,17 +68,14 @@ public class OAuthClientController {
      */
     public static final String UNUSED_REDIRECT_URI = "https://localhost/unused-redirect";
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${security.oauth2.resource.id}")
     private String resourceId;
 
-    @Autowired
-    private OAuthClientRepository repo;
+    private final OAuthClientRepository repo;
 
-    @Autowired
-    private Sw360UserMirrorService userMirrorService;
+    private final Sw360UserMirrorService userMirrorService;
 
     /**
      * Normalize a caller-supplied {@code scope} set to the canonical

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
@@ -18,7 +18,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
 import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
@@ -28,9 +27,12 @@ import org.springframework.security.oauth2.server.authorization.settings.ClientS
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+
 import static org.eclipse.sw360.rest.authserver.client.rest.OAuthClientController.UNUSED_REDIRECT_URI;
 
 @Service
+@RequiredArgsConstructor
 public class Sw360ClientDetailsService implements RegisteredClientRepository {
 
     private final Logger log = LogManager.getLogger(this.getClass());
@@ -49,8 +51,7 @@ public class Sw360ClientDetailsService implements RegisteredClientRepository {
     @Value("${security.refreshtoken.validity:360}")
     private Integer defaultRefreshTokenValiditySeconds;
 
-    @Autowired
-    private OAuthClientRepository clientRepo;
+    private final OAuthClientRepository clientRepo;
 
     @Override
     public RegisteredClient findByClientId(@Nonnull String clientId) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/changelog/ChangeLogController.java
@@ -40,7 +40,6 @@ import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -74,8 +73,9 @@ public class ChangeLogController implements RepresentationModelProcessor<Reposit
     private static final Logger log = LogManager.getLogger(ChangeLogController.class);
 
     public static final String CHANGE_LOG_URL = "/changelog";
-    @Autowired
-    private Sw360ChangeLogService sw360ChangeLogService;
+
+    @NonNull
+    private final Sw360ChangeLogService sw360ChangeLogService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/clearingrequest/ClearingRequestController.java
@@ -48,7 +48,6 @@ import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.moderationrequest.Sw360ModerationRequestService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -79,8 +78,8 @@ public class ClearingRequestController implements RepresentationModelProcessor<R
 
     private static final Logger log = LogManager.getLogger(ClearingRequestController.class);
 
-    @Autowired
-    private Sw360ClearingRequestService sw360ClearingRequestService;
+    @NonNull
+    private final Sw360ClearingRequestService sw360ClearingRequestService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/ModerationRequestController.java
@@ -52,7 +52,6 @@ import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -98,8 +97,8 @@ public class ModerationRequestController implements RepresentationModelProcessor
     private static final String REQUESTING_USER = "requestingUser";
     public static final String MODERATION_REQUEST_URL = "/moderationrequest";
 
-    @Autowired
-    private Sw360ModerationRequestService sw360ModerationRequestService;
+    @NonNull
+    private final Sw360ModerationRequestService sw360ModerationRequestService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/search/SearchController.java
@@ -37,7 +37,6 @@ import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.BasePathAwareController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
@@ -64,8 +63,8 @@ public class SearchController implements RepresentationModelProcessor<Repository
 
     public static final String SEARCH_URL = "/search";
 
-    @Autowired
-    private Sw360SearchService sw360SearchService;
+    @NonNull
+    private final Sw360SearchService sw360SearchService;
 
     @NonNull
     private final RestControllerHelper restControllerHelper;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/jwt/Sw360JWTAccessTokenConverter.java
@@ -13,7 +13,6 @@ import org.eclipse.sw360.rest.common.security.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.common.security.jwt.AbstractSw360JwtAuthenticationConverter;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.jspecify.annotations.Nullable;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.GrantedAuthority;
@@ -39,13 +38,13 @@ public class Sw360JWTAccessTokenConverter extends AbstractSw360JwtAuthentication
     @Value("${jwt.auth.converter.principle-attribute:email}")
     private String principleAttribute;
 
-    @Autowired
-    private Sw360UserService userService;
+    private final Sw360UserService userService;
 
-    public Sw360JWTAccessTokenConverter() {
+    public Sw360JWTAccessTokenConverter(Sw360UserService userService) {
         super(new JwtGrantedAuthoritiesConverter(),
                 Sw360GrantedAuthoritiesCalculator.CONFIG_WRITE_ACCESS_USERGROUP,
                 Sw360GrantedAuthoritiesCalculator.CONFIG_ADMIN_ACCESS_USERGROUP);
+        this.userService = userService;
     }
 
     @Override

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/client/service/Sw360OidcUserInfoService.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/client/service/Sw360OidcUserInfoService.java
@@ -4,9 +4,9 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.common.client.service;
 
+import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.common.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.stereotype.Service;
 
@@ -18,13 +18,13 @@ import java.util.Map;
  * @author smruti.sahoo@siemens.com
  */
 @Service
+@RequiredArgsConstructor
 public class Sw360OidcUserInfoService {
 
 	public static final String USER_GROUP = "userGroup";
 	public static final String DEPARTMENT = "department";
 	public static final String PRIMARY_ROLES = "primaryRoles";
-	@Autowired
-	private Sw360UserDetailsProvider sw360UserDetailsProvider;
+	private final Sw360UserDetailsProvider sw360UserDetailsProvider;
 
 	public OidcUserInfo loadUser(String username) {
 

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/client/service/Sw360UserDetailsService.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/client/service/Sw360UserDetailsService.java
@@ -7,26 +7,25 @@ package org.eclipse.sw360.rest.common.client.service;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
+import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.common.security.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.common.security.Sw360UserDetailsProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class Sw360UserDetailsService implements UserDetailsService {
 
     private final Logger log = LogManager.getLogger(this.getClass());
 
-    @Autowired
-    private Sw360UserDetailsProvider userProvider;
+    private final Sw360UserDetailsProvider userProvider;
 
-    @Autowired
-    private Sw360GrantedAuthoritiesCalculator authoritiesCalculator;
+    private final Sw360GrantedAuthoritiesCalculator authoritiesCalculator;
 
     /**
      * @param username the username identifying the user whose data is required.

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/security/Sw360TokenCustomizerConfig.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/security/Sw360TokenCustomizerConfig.java
@@ -4,8 +4,8 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.common.security;
 
+import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.rest.common.client.service.Sw360OidcUserInfoService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
@@ -24,6 +24,7 @@ import java.util.Set;
  * @author smruti.sahoo@siemens.com
  */
 @Configuration
+@RequiredArgsConstructor
 public class Sw360TokenCustomizerConfig {
 
 	public static final String USER_NAME = "user_name";
@@ -32,8 +33,7 @@ public class Sw360TokenCustomizerConfig {
 	public static final String SUB = "sub";
 	public static final String SCOPE = "scope";
 	public static final String SW360_REST_API = "sw360-REST-API";
-	@Autowired
-	private Sw360OidcUserInfoService sw360OidcUserInfoService;
+	private final Sw360OidcUserInfoService sw360OidcUserInfoService;
 
 	@Bean
 	public OAuth2TokenCustomizer<JwtEncodingContext> tokenCustomizer() {

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/security/authproviders/Sw360UserAuthenticationProvider.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/security/authproviders/Sw360UserAuthenticationProvider.java
@@ -4,8 +4,8 @@ SPDX-License-Identifier: EPL-2.0
 */
 package org.eclipse.sw360.rest.common.security.authproviders;
 
+import lombok.RequiredArgsConstructor;
 import org.eclipse.sw360.rest.common.client.service.Sw360UserDetailsService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,13 +21,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class Sw360UserAuthenticationProvider implements AuthenticationProvider {
 
-    @Autowired
-    private Sw360UserDetailsService userDetailsService;
+    private final Sw360UserDetailsService userDetailsService;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * @param authentication the authentication request object.


### PR DESCRIPTION
### What does this PR do?

This PR tackles part of #3696 by replacing field-level `@Autowired` annotations with **constructor injection** using Lombok's `@RequiredArgsConstructor` and `private final` fields across the `rest-common`, `resource-server`, and `authorization-server` modules.

This is a straightforward, low-risk refactoring — no business logic has been changed.

---

### Why?

Field injection (`@Autowired` on private fields) is considered an anti-pattern in modern Spring development because:

- Fields can't be marked `final`, so dependencies are mutable and not thread-safe.
- Classes become difficult to unit test without spinning up the full Spring context.
- Missing dependencies fail silently at runtime instead of at startup.

Constructor injection fixes all of these issues and is the [officially recommended approach](https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-collaborators.html#beans-constructor-injection) by the Spring team.

SW360 already enforces this pattern via `DependencyInjectionRulesTest.java` — this PR brings the remaining classes into compliance.

---

### Files changed

**`rest-common`**
- `Sw360UserDetailsService.java`
- `Sw360OidcUserInfoService.java`
- `Sw360UserAuthenticationProvider.java`
- `Sw360TokenCustomizerConfig.java`

**`resource-server`**
- `SearchController.java`
- `ModerationRequestController.java`
- `ClearingRequestController.java`
- `ChangeLogController.java`
- `Sw360JWTAccessTokenConverter.java`

**`authorization-server`**
- `Sw360ClientDetailsService.java`
- `OAuthClientController.java`

---

### What was NOT changed

- **Test classes** — `@Autowired` in test classes (e.g., `TestRestDocsSpecBase`, `IntegrationTestBase`) is standard Spring Boot test practice and was intentionally left as-is.
- **`@Autowired` on constructors** (e.g., `FossologyHandler`, `FossologyServlet`) — these are already constructor injection, just with an explicit annotation. No change needed.
- **Business logic** — zero functional changes; this is a pure structural refactoring.

---

### How to verify

- All modified classes follow the same `@RequiredArgsConstructor` + `private final` pattern already used throughout the codebase (e.g., `VulnerabilityController`, `UserController`, `VendorController`).
- The existing `DependencyInjectionRulesTest` architectural test should continue to pass (and will now cover these classes too).

Closes #3696

