### PR TITLE
fix(Project): Add readmeOssObligationCount in obligation api

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -3279,11 +3279,13 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     .count();
         }
 
+        int readmeOssObligationCount = getObligationsFromReadmeOSSCount(obligationStatusMap);
+
         Sw360ProjectService.ProjectEccCounts eccCounts = projectService.getProjectEccCounts(id, sw360User);
 
         return new ResponseEntity<>(new ProjectDetailTabCounts(vulnerabilityCount, vulnerabilityRatedCount,
                 obligationCount, obligationNonOpenCount,
-                eccCounts.classifiedCount(), eccCounts.openCount()), HttpStatus.OK);
+                eccCounts.classifiedCount(), eccCounts.openCount(), readmeOssObligationCount), HttpStatus.OK);
     }
 
     /**
@@ -3298,6 +3300,22 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             return ObligationLevel.LICENSE_OBLIGATION.equals(statusInfo.getObligationLevel());
         }
         return statusInfo.isSetLicenseIds() && !statusInfo.getLicenseIds().isEmpty();
+    }
+
+    /**
+     * Counts README_OSS-sourced obligations (i.e. those with a null {@code obligationLevel}).
+     *
+     * @param obligationStatusMap the obligation status map computed for the project
+     * @return count of README_OSS obligations; {@code 0} if the map is empty
+     */
+    private int getObligationsFromReadmeOSSCount(Map<String, ObligationStatusInfo> obligationStatusMap) {
+        if (CommonUtils.isNotEmpty(obligationStatusMap.keySet())) {
+            return Math.toIntExact(
+                    obligationStatusMap.values().stream()
+                            .filter(obligation -> obligation.getObligationLevel() == null)
+                            .count());
+        }
+        return 0;
     }
 
     @Operation(

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectDetailTabCounts.java
@@ -39,13 +39,17 @@ public class ProjectDetailTabCounts {
     @Schema(description = "Count of releases with ECC status OPEN")
     private final int eccOpenCount;
 
+    @Schema(description = "Count of obligations derived from README_OSS attachments linked to the project's releases")
+    private final int readmeOssObligationCount;
+
     public ProjectDetailTabCounts(int vulnerabilityCount, int vulnerabilityRatedCount, int obligationCount,
-            int obligationNonOpenCount, int eccClassifiedCount, int eccOpenCount) {
+            int obligationNonOpenCount, int eccClassifiedCount, int eccOpenCount, int readmeOssObligationCount) {
         this.vulnerabilityCount = vulnerabilityCount;
         this.vulnerabilityRatedCount = vulnerabilityRatedCount;
         this.obligationCount = obligationCount;
         this.obligationNonOpenCount = obligationNonOpenCount;
         this.eccClassifiedCount = eccClassifiedCount;
         this.eccOpenCount = eccOpenCount;
+        this.readmeOssObligationCount = readmeOssObligationCount;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -2459,7 +2459,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("obligationCount").description("Count of obligations linked to the project"),
                                 fieldWithPath("obligationNonOpenCount").description("Count of obligations whose status is not OPEN"),
                                 fieldWithPath("eccClassifiedCount").description("Count of releases with a classified ECC status"),
-                                fieldWithPath("eccOpenCount").description("Count of releases with ECC status OPEN")
+                                fieldWithPath("eccOpenCount").description("Count of releases with ECC status OPEN"),
+                                fieldWithPath("readmeOssObligationCount").description("Count of obligations derived from README_OSS attachments linked to the project's releases")
                         )));
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Adds a `readmeOssObligationCount` field to the `GET /api/projects/{id}/tabCounts` response so the frontend can render a badge for obligations. 
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4496*)
> * Did you add or update any new dependencies that are required for your change?

Closes: https://github.com/eclipse-sw360/sw360/issues/4496

### Suggest Reviewer
> @GMishx .

Frontend PR : https://github.com/eclipse-sw360/sw360-frontend/pull/1950

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
