### PR TITLE
fix(Project): Restrict license obligation updates to CLEARING_ADMIN and SW360_ADMIN roles

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -93,6 +93,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectDTO;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ProjectVulnerabilityRating;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityCheckStatus;
@@ -3910,12 +3911,12 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     @PreAuthorize("hasAuthority('WRITE')")
     @Operation(
             summary = "Update License Obligations ",
-            description = "Pass a map of obligations in request body.",
+            description = "Pass a map of obligations in request body. Only users with CLEARING_ADMIN or SW360_ADMIN role can perform this operation.",
             tags = {"Projects"}
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "License obligation updated successfully"),
-        @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to modify this project",
+        @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to modify this project, or does not have CLEARING_ADMIN/SW360_ADMIN role",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class))),
         @ApiResponse(responseCode = "409", description = "Conflict - cannot update license obligation due to data integrity violation",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class)))
@@ -3928,6 +3929,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     ) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
+        if (!PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, sw360User)
+                && !PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, sw360User)) {
+            throw new AccessDeniedException("Only users with CLEARING_ADMIN or SW360_ADMIN role are allowed to update license obligations.");
+        }
         Map<String, ObligationStatusInfo> obligationStatusMap = new HashMap<>();
         try {
             obligationStatusMap = processLicenseObligations(id, sw360User, requestBodyObligationStatusInfo);
@@ -4083,12 +4088,14 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
                 NOTE: obligationLevel cannot have `license` as parameter value, license obligations are updated
                 in the case obligationLevel=all, otherwise they are ignored.
+
+                Only users with CLEARING_ADMIN or SW360_ADMIN role can perform this operation.
                 """,
             tags = {"Projects"}
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Obligation updated successfully"),
-        @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to modify this project",
+        @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to modify this project, or does not have CLEARING_ADMIN/SW360_ADMIN role",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class))),
         @ApiResponse(responseCode = "409", description = "Conflict - cannot update obligation due to data integrity violation",
                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class)))
@@ -4132,10 +4139,14 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 example = "all")
             @RequestParam(value = "obligationLevel", required = true) String oblLevel
     ) {
+        final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        restControllerHelper.throwIfSecurityUser(sw360User);
+        if (!PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, sw360User)
+                && !PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, sw360User)) {
+            throw new AccessDeniedException("Only users with CLEARING_ADMIN or SW360_ADMIN role are allowed to update obligations.");
+        }
         Map<String, ObligationStatusInfo> obligationStatusMap = new HashMap<>();
         try {
-            final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-            restControllerHelper.throwIfSecurityUser(sw360User);
             if ("all".equals(oblLevel)) {
                 Map<String, ObligationStatusInfo> filteredMap = requestBodyObligationStatusInfo.entrySet()
                         .stream()


### PR DESCRIPTION

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

>Restrict obligation update endpoints to CLEARING_ADMIN / SW360_ADMIN roles.

* Added a role check to `PATCH /api/projects/{id}/updateLicenseObligation` and `PATCH /api/projects/{id}/updateObligation` in `ProjectController` so that only users with the `CLEARING_ADMIN` or `SW360_ADMIN` role can update  license/project/organization/component obligations on a project.Previously, any user with `WRITE` authority could update obligations,regardless of their user group.
* Updated the OpenAPI `@Operation` descriptions and `403` `@ApiResponse` documentation for both endpoints to reflect the  new role requirement.
* No new dependencies were added or updated for this change.
* 
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4499*)
> * Did you add or update any new dependencies that are required for your change?

Issue: https://github.com/eclipse-sw360/sw360/issues/4499

### Suggest Reviewer
> @GMishx .

### How To Test?
* Call `PATCH /api/projects/{id}/updateLicenseObligation` or `PATCH /api/projects/{id}/updateObligation` as a user who is **not**  `CLEARING_ADMIN` or `SW360_ADMIN` and verify the response is `403 Forbidden`.
* Call the same endpoints as a user with `CLEARING_ADMIN` or `SW360_ADMIN` (or `ADMIN`, which is above both in the role hierarchy) and verify the obligations are updated successfully as before (`201 Created`).

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
