### PR TITLE
fix(rest): return 404 when patching a non-existent vendor

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorService.java
@@ -30,6 +30,7 @@ import org.eclipse.sw360.datahandler.thrift.vendors.VendorSortColumn;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
@@ -113,16 +114,17 @@ public class Sw360VendorService {
         try {
             VendorService.Iface sw360VendorClient = getThriftVendorClient();
             Vendor existingVendor = sw360VendorClient.getByID(id);
-            if (existingVendor != null) {
-                if (vendor.getShortname() != null) {
-                    existingVendor.setShortname(vendor.getShortname());
-                }
-                if (vendor.getFullname() != null) {
-                    existingVendor.setFullname(vendor.getFullname());
-                }
-                if (vendor.getUrl() != null) {
-                    existingVendor.setUrl(vendor.getUrl());
-                }
+            if (existingVendor == null) {
+                throw new ResourceNotFoundException("Vendor not found with ID: " + id);
+            }
+            if (vendor.getShortname() != null) {
+                existingVendor.setShortname(vendor.getShortname());
+            }
+            if (vendor.getFullname() != null) {
+                existingVendor.setFullname(vendor.getFullname());
+            }
+            if (vendor.getUrl() != null) {
+                existingVendor.setUrl(vendor.getUrl());
             }
             RequestStatus requestStatus = sw360VendorClient.updateVendor(existingVendor, sw360User);
             return requestStatus;
@@ -165,7 +167,7 @@ public class Sw360VendorService {
         }
     }
 
-    private VendorService.Iface getThriftVendorClient() throws TTransportException {
+    VendorService.Iface getThriftVendorClient() throws TTransportException {
         return ThriftClients.makeVendorClient();
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -280,6 +280,15 @@ public class VendorController implements RepresentationModelProcessor<Repository
                                             value = "{\"message\": \"A Vendor with same fullname 'ABC_XYZ' already exists!\"}"
                                     ))
                     }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "Vendor not found.",
+                    content = {
+                            @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = "{\"message\": \"Vendor not found with ID: 1234\"}"
+                                    ))
+                    }
             )
     })
     @PreAuthorize("hasAuthority('ADMIN')")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/vendor/Sw360VendorServiceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Kavya Popat, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.vendor;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class Sw360VendorServiceTest {
+
+    @Mock
+    private VendorService.Iface vendorClient;
+
+    private Sw360VendorService vendorService;
+
+    @BeforeEach
+    public void setUp() throws TException {
+        vendorService = spy(new Sw360VendorService());
+        doReturn(vendorClient).when(vendorService).getThriftVendorClient();
+    }
+
+    @Test
+    public void vendorUpdate_throwsResourceNotFoundException_whenVendorDoesNotExist() throws TException {
+        when(vendorClient.getByID("nonexistent-id")).thenReturn(null);
+
+        Vendor patch = new Vendor();
+        patch.setFullname("New Name");
+
+        assertThatThrownBy(() -> vendorService.vendorUpdate(patch, new User(), "nonexistent-id"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("nonexistent-id");
+    }
+
+    @Test
+    public void vendorUpdate_onlyPatchesNonNullFields_whenVendorExists() throws TException {
+        Vendor existing = new Vendor();
+        existing.setId("existing-id");
+        existing.setFullname("Old Fullname");
+        existing.setShortname("OldShort");
+        existing.setUrl("http://old.example.com");
+
+        when(vendorClient.getByID("existing-id")).thenReturn(existing);
+        when(vendorClient.updateVendor(any(), any())).thenReturn(RequestStatus.SUCCESS);
+
+        Vendor patch = new Vendor();
+        patch.setFullname("New Fullname");
+        // shortname and url intentionally left null - should NOT be overwritten
+
+        RequestStatus result = vendorService.vendorUpdate(patch, new User(), "existing-id");
+
+        assertThat(result).isEqualTo(RequestStatus.SUCCESS);
+        assertThat(existing.getFullname()).isEqualTo("New Fullname");
+        assertThat(existing.getShortname()).isEqualTo("OldShort");
+        assertThat(existing.getUrl()).isEqualTo("http://old.example.com");
+    }
+
+    @Test
+    public void vendorUpdate_wrapsThriftException_asRuntimeException() throws TException {
+        when(vendorClient.getByID("id")).thenThrow(new TException("thrift connection failed"));
+
+        assertThatThrownBy(() -> vendorService.vendorUpdate(new Vendor(), new User(), "id"))
+                .isInstanceOf(RuntimeException.class);
+    }
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

`PATCH /vendors/{id}` doesn't return a 404 when the vendor id doesn't exist. In `Sw360VendorService.vendorUpdate()`, `existingVendor` is fetched by id and only patched if it's not null, but it still gets passed to `updateVendor()` even when it is null. Added a check that throws `ResourceNotFoundException` in that case, and updated the Swagger docs to mention 404 as a possible response.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Fixes #4501
No new dependencies.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

Added `Sw360VendorServiceTest.java` - tests that it throws 404 when vendor doesn't exist, that it still only updates non-null fields when it does exist, and that thrift exceptions still get wrapped like before.

To test manually: PATCH /vendors/{id} with a bad id, should get 404 now instead of an error.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
