### PR TITLE
fix(Release): invalid source code url

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -561,8 +561,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 || verifyLinkedPackages(Collections.emptySet(), CommonUtils.nullToEmptySet(release.getPackageIds()), "") ) {
             return new AddDocumentRequestSummary()
                     .setRequestStatus(AddDocumentRequestStatus.INVALID_INPUT);
-        } else if(!validSourceCodeDownloadUrl(release)){
-            return new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.INVALID_SOURCE_CODE_URL);
         }
 
         // Block nested release linking if disabled by configuration
@@ -1217,9 +1215,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         } else if (!isDependenciesExistsInRelease(release)
                 || verifyLinkedPackages(CommonUtils.nullToEmptySet(actual.getPackageIds()), CommonUtils.nullToEmptySet(release.getPackageIds()), release.getId())) {
             return RequestStatus.INVALID_INPUT;
-        }else if(!validSourceCodeDownloadUrl(release)){
-            return RequestStatus.INVALID_SOURCE_CODE_URL;
-        }else {
+        } else {
             DocumentPermissions<Release> permissions = makePermission(actual, user);
             boolean hasChangesInEccFields = hasChangesInEccFields(release, actual);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -290,8 +290,6 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
             throw new DataIntegrityViolationException("sw360 release with name '" + SW360Utils.printName(release) + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
             throw new BadRequestClientException("Dependent document Id/ids not valid.");
-        } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_SOURCE_CODE_URL) {
-            throw new BadRequestClientException("Invalid source code URL.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
             throw new BadRequestClientException(
                     "Release name and version field cannot be empty or contain only whitespace character");
@@ -327,12 +325,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         }
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new BadRequestClientException("Dependent document Id/ids not valid.");
-        }
-        else if (requestStatus == RequestStatus.INVALID_SOURCE_CODE_URL ){
-            throw new BadRequestClientException("Invalid source code URL.");
-        }
-
-        else if (requestStatus == RequestStatus.NAMINGERROR) {
+        } else if (requestStatus == RequestStatus.NAMINGERROR) {
             throw new BadRequestClientException(
                     "Release name and version field cannot be empty or contain only whitespace character");
         } else if (requestStatus == RequestStatus.DUPLICATE_ATTACHMENT) {


### PR DESCRIPTION
**Description**
Currently, while creating a Release, the backend validates the Source Code Download URL. If the URL is invalid or unreachable, the Release creation fails.
This validation should be removed from the backend so that an invalid Source Code Download URL does not prevent Release creation.
Frontend-side validation can be introduced separately in a follow-up change.

**Expected Behavior**
Release creation should not fail because the Source Code Download URL is invalid or unreachable.
Remove the backend validation/check for the Source Code Download URL during Release creation.
The Source Code Download URL should still be stored as provided.
Frontend validation will be handled separately at a later stage.