### PR TITLE
fix(backend): sanitize Attachment.filename to prevent path traversal in filesystem store

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
@@ -984,8 +984,14 @@ public class DatabaseHandlerUtil {
                         ATTACHMENT_ID + attachmentId);
                 Path outputFile = Paths.get(fileName);
                 Path outputFilePath = outputDir.resolve(outputFile);
+                if (!outputFilePath.normalize().startsWith(outputDir.normalize())) {
+                    log.error("Path traversal detected in attachment filename — aborting write. "
+                            + "Resolved path: " + outputFilePath);
+                    throw new IllegalArgumentException(
+                            "Attachment filename contains path traversal sequence: " + fileName);
+                }
                 log.info("Preparing to store attachment in file system" + outputFilePath);
-                if (!Files.exists(outputFile)) {
+                if (!Files.exists(outputFilePath)) {
                     Set<PosixFilePermission> perms = PosixFilePermissions
                             .fromString(ATTACHMENT_STORE_FILE_SYSTEM_PERMISSION);
                     FileAttribute<Set<PosixFilePermission>> fileAttribute = PosixFilePermissions.asFileAttribute(perms);
@@ -1032,7 +1038,7 @@ public class DatabaseHandlerUtil {
                         return;
                     executeRunnableToSaveAttachmentToFileSystem(
                             attachmentConnector.readAttachmentStream(attachmentContent), userEmail, documentId,
-                            attachmentContentId, att.getFilename());
+                            attachmentContentId, CommonUtils.sanitizeFilename(att.getFilename()));
                 });
     }
 

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtilFileSystemTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtilFileSystemTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for CWE-22 path traversal fix in filesystem attachment store.
+ */
+public class DatabaseHandlerUtilFileSystemTest {
+
+    @Test
+    public void dotDotSlashUnixTraversal_isSanitized() {
+        String malicious = "../../../../etc/passwd";
+        String sanitized = CommonUtils.sanitizeFilename(malicious);
+        assertNoPathSeparators(sanitized);
+        assertStaysInStoreDir(sanitized);
+    }
+
+    @Test
+    public void dotDotBackslashWindowsTraversal_isSanitized() {
+        String malicious = "..\\..\\..\\..\\target";
+        String sanitized = CommonUtils.sanitizeFilename(malicious);
+        assertNoPathSeparators(sanitized);
+        assertStaysInStoreDir(sanitized);
+    }
+
+    @Test
+    public void absolutePathFilename_isSanitized() {
+        String malicious = "/etc/cron.d/evil";
+        String sanitized = CommonUtils.sanitizeFilename(malicious);
+        assertNoPathSeparators(sanitized);
+        assertStaysInStoreDir(sanitized);
+    }
+
+    @Test
+    public void normalFilename_isUnchanged() {
+        String normal = "report_v2.pdf";
+        String sanitized = CommonUtils.sanitizeFilename(normal);
+        assertEquals("A benign filename must pass through unchanged", normal, sanitized);
+        assertStaysInStoreDir(sanitized);
+    }
+
+    @Test
+    public void emptyFilename_fallsBackToDefault() {
+        String sanitized = CommonUtils.sanitizeFilename("");
+        assertEquals(CommonUtils.DEFAULT_ATTACHMENT_FILENAME, sanitized);
+        assertStaysInStoreDir(sanitized);
+    }
+
+    @Test
+    public void nullFilename_fallsBackToDefault() {
+        String sanitized = CommonUtils.sanitizeFilename(null);
+        assertEquals(CommonUtils.DEFAULT_ATTACHMENT_FILENAME, sanitized);
+        assertStaysInStoreDir(sanitized);
+    }
+
+    @Test
+    public void unicodeNormalizationTraversal_isSanitized() {
+        String malicious = "\uFF0E\uFF0E\uFF0F\uFF0E\uFF0E\uFF0Fetc\uFF0Fpasswd";
+        String sanitized = CommonUtils.sanitizeFilename(malicious);
+        assertStaysInStoreDir(sanitized);
+    }
+
+    @Test
+    public void defenceInDepth_traversalPathDetected() {
+        Path outputDir = Paths.get("/store/user@example.com/doc_123/att_456");
+        Path outputFile = Paths.get("../../../../etc/passwd");
+        Path outputFilePath = outputDir.resolve(outputFile);
+
+        assertFalse("Traversal path must NOT start with the store directory",
+                outputFilePath.normalize().startsWith(outputDir.normalize()));
+    }
+
+    @Test
+    public void defenceInDepth_benignPathAllowed() {
+        Path outputDir = Paths.get("/store/user@example.com/doc_123/att_456");
+        Path outputFile = Paths.get("report_v2.pdf");
+        Path outputFilePath = outputDir.resolve(outputFile);
+
+        assertTrue("Benign path must start with the store directory",
+                outputFilePath.normalize().startsWith(outputDir.normalize()));
+    }
+
+    @Test
+    public void defenceInDepth_dotDotBackslashDetected() {
+        Path outputDir = Paths.get("/store/user@example.com/doc_123/att_456");
+        Path outputFile = Paths.get("..\\..\\..\\..\\target");
+        Path outputFilePath = outputDir.resolve(outputFile);
+
+        boolean resolvesInsideStore = outputFilePath.normalize().startsWith(outputDir.normalize());
+        boolean isWindows = "\\".equals(java.nio.file.FileSystems.getDefault().getSeparator());
+
+        if (isWindows) {
+            assertFalse("On Windows, backslash traversal path must NOT start with the store directory",
+                    resolvesInsideStore);
+        } else {
+            assertTrue("On POSIX, backslashes are literal characters and path stays inside store directory",
+                    resolvesInsideStore);
+        }
+    }
+
+    @Test
+    public void defenceInDepth_absolutePathDetected() {
+        Path outputDir = Paths.get("/store/user@example.com/doc_123/att_456");
+        Path outputFile = Paths.get("/etc/cron.d/evil");
+        Path outputFilePath = outputDir.resolve(outputFile);
+
+        assertFalse("Absolute path must NOT start with the store directory",
+                outputFilePath.normalize().startsWith(outputDir.normalize()));
+    }
+
+    @Test
+    public void existenceCheckUsesResolvedPath() {
+        // Verify that the resolved path (outputFilePath) and the relative path
+        // (outputFile) are different — ensuring the fix checks the correct one.
+        Path outputDir = Paths.get("/store/user@example.com/doc_123/att_456");
+        Path outputFile = Paths.get("report.pdf");
+        Path outputFilePath = outputDir.resolve(outputFile);
+
+        assertFalse("outputFilePath must differ from outputFile (resolved vs relative)",
+                outputFile.equals(outputFilePath));
+        assertTrue("outputFilePath must be under outputDir",
+                outputFilePath.normalize().startsWith(outputDir.normalize()));
+    }
+
+    // ------------------------------------------------------------------ //
+
+    private static void assertNoPathSeparators(String sanitized) {
+        assertFalse("Sanitized filename must not contain '/'",
+                sanitized.contains("/"));
+        assertFalse("Sanitized filename must not contain '\\'",
+                sanitized.contains("\\"));
+    }
+
+    private static void assertStaysInStoreDir(String sanitizedFilename) {
+        Path storeDir = Paths.get("/store/user@example.com/doc_123/att_456");
+        Path resolved = storeDir.resolve(Paths.get(sanitizedFilename));
+        assertTrue(
+                "Resolved path '" + resolved + "' must stay within store dir '" + storeDir + "'",
+                resolved.normalize().startsWith(storeDir.normalize()));
+    }
+}

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/FilesystemAttachmentStorePathTraversalTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/FilesystemAttachmentStorePathTraversalTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.common.SW360ConfigKeys;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * CWE-22 regression tests for path traversal in filesystem attachment store.
+ * Tests verify the defence-in-depth guard blocks traversal attempts.
+ */
+public class FilesystemAttachmentStorePathTraversalTest {
+
+    private static final String CONTENT_ID = "content-0001";
+    private static final String USER_EMAIL = "attacker@example.com";
+    private static final String DOCUMENT_ID = "doc-0001";
+    private static final byte[] ATTACKER_BYTES = "SW360-PWNED-MARKER\n".getBytes();
+
+    /**
+     * Reflectively invokes the private method to test the defence-in-depth guard.
+     */
+    private Runnable prepareFileHandlerRunnable(byte[] content, String userEmail, String documentId,
+            String attachmentId, String fileName) throws Exception {
+        Method m = DatabaseHandlerUtil.class.getDeclaredMethod("prepareFileHandlerRunnable",
+                InputStream.class, String.class, String.class, String.class, String.class);
+        m.setAccessible(true);
+        return (Runnable) m.invoke(null, new ByteArrayInputStream(content), userEmail, documentId, attachmentId,
+                fileName);
+    }
+
+    @Test
+    public void maliciousFilenameIsBlockedByDefenceInDepthGuard() throws Exception {
+        Path tmp = Paths.get(System.getProperty("java.io.tmpdir"));
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        Path storeDir = Files.createTempDirectory("sw360-store-" + unique);
+        String markerName = "sw360-PWNED-" + unique;
+        String maliciousFilename = "../../../../" + markerName;
+
+        try (MockedStatic<SW360Utils> sw360Utils = mockStatic(SW360Utils.class)) {
+            sw360Utils.when(() -> SW360Utils.readConfig(
+                    eq(SW360ConfigKeys.ATTACHMENT_STORE_FILE_SYSTEM_LOCATION), anyString()))
+                    .thenReturn(storeDir.toString());
+
+            Runnable write = prepareFileHandlerRunnable(ATTACKER_BYTES, USER_EMAIL, DOCUMENT_ID, CONTENT_ID,
+                    maliciousFilename);
+            write.run();
+        }
+
+        Path marker = tmp.resolve(markerName);
+        assertFalse(Files.exists(marker),
+                "Path traversal must be blocked — marker must NOT appear outside store dir at " + marker);
+        deleteRecursively(storeDir);
+    }
+
+    @Test
+    public void benignFilenameStaysInsideStoreDirectory() throws Exception {
+        assumeTrue(isPosixFileSystem(), "Skipping on non-POSIX filesystem (Windows)");
+
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        Path storeDir = Files.createTempDirectory("sw360-store-" + unique);
+        String benignName = "benign.txt";
+
+        try (MockedStatic<SW360Utils> sw360Utils = mockStatic(SW360Utils.class)) {
+            sw360Utils.when(() -> SW360Utils.readConfig(
+                    eq(SW360ConfigKeys.ATTACHMENT_STORE_FILE_SYSTEM_LOCATION), anyString()))
+                    .thenReturn(storeDir.toString());
+
+            Runnable write = prepareFileHandlerRunnable(ATTACKER_BYTES, USER_EMAIL, DOCUMENT_ID, CONTENT_ID,
+                    benignName);
+            write.run();
+        }
+
+        Path expectedInside = storeDir.resolve(USER_EMAIL)
+                .resolve("documentId_" + DOCUMENT_ID)
+                .resolve("attachmentId_" + CONTENT_ID)
+                .resolve(benignName);
+
+        assertTrue(Files.exists(expectedInside),
+                "Benign attachment must be written inside the store dir at " + expectedInside);
+        assertArrayEquals(ATTACKER_BYTES, Files.readAllBytes(expectedInside));
+        deleteRecursively(storeDir);
+    }
+
+    @Test
+    public void benignFilenameLogicValidation() {
+        String benignName = "report.pdf";
+        Path storeDir = Paths.get("/tmp/sw360-store");
+        Path resolved = storeDir.resolve(Paths.get(benignName));
+
+        assertTrue(resolved.normalize().startsWith(storeDir.normalize()),
+                "Benign filename must resolve within store directory");
+    }
+
+    @Test
+    public void windowsBackslashTraversalIsBlocked() throws Exception {
+        Path tmp = Paths.get(System.getProperty("java.io.tmpdir"));
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        Path storeDir = Files.createTempDirectory("sw360-store-" + unique);
+        String markerName = "sw360-WIN-" + unique;
+        String maliciousFilename = "..\\..\\..\\..\\" + markerName;
+
+        try (MockedStatic<SW360Utils> sw360Utils = mockStatic(SW360Utils.class)) {
+            sw360Utils.when(() -> SW360Utils.readConfig(
+                    eq(SW360ConfigKeys.ATTACHMENT_STORE_FILE_SYSTEM_LOCATION), anyString()))
+                    .thenReturn(storeDir.toString());
+
+            Runnable write = prepareFileHandlerRunnable(ATTACKER_BYTES, USER_EMAIL, DOCUMENT_ID, CONTENT_ID,
+                    maliciousFilename);
+            write.run();
+        }
+
+        Path marker = tmp.resolve(markerName);
+        assertFalse(Files.exists(marker),
+                "Backslash traversal must be blocked — marker must NOT appear outside store dir at " + marker);
+        deleteRecursively(storeDir);
+    }
+
+    @Test
+    public void absolutePathFilenameIsBlocked() throws Exception {
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        Path storeDir = Files.createTempDirectory("sw360-store-" + unique);
+        Path tmpTarget = Paths.get(System.getProperty("java.io.tmpdir"), "sw360-ABS-" + unique);
+
+        try (MockedStatic<SW360Utils> sw360Utils = mockStatic(SW360Utils.class)) {
+            sw360Utils.when(() -> SW360Utils.readConfig(
+                    eq(SW360ConfigKeys.ATTACHMENT_STORE_FILE_SYSTEM_LOCATION), anyString()))
+                    .thenReturn(storeDir.toString());
+
+            Runnable write = prepareFileHandlerRunnable(ATTACKER_BYTES, USER_EMAIL, DOCUMENT_ID, CONTENT_ID,
+                    tmpTarget.toString());
+            write.run();
+        }
+
+        assertFalse(Files.exists(tmpTarget),
+                "Absolute path filename must be blocked — file must NOT appear at " + tmpTarget);
+        deleteRecursively(storeDir);
+    }
+
+    private static boolean isPosixFileSystem() {
+        return java.nio.file.FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    }
+
+    private static void deleteRecursively(Path dir) {
+        try {
+            if (Files.exists(dir)) {
+                Files.walk(dir)
+                        .sorted(java.util.Comparator.reverseOrder())
+                        .forEach(p -> {
+                            try {
+                                Files.deleteIfExists(p);
+                            } catch (Exception ignored) {
+                            }
+                        });
+            }
+        } catch (Exception ignored) {
+        }
+    }
+}


### PR DESCRIPTION
Saintize filename.