### PR TITLE
feat(archival): Add records/search endpoint for archived-entity suggestions

### DIFF
--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalController.java
@@ -13,6 +13,7 @@ import org.eclipse.sw360.common.utils.UserUtils;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.services.archival.ArchivalEntityType;
 import org.eclipse.sw360.datahandler.services.archival.ArchivalRecord;
 import org.eclipse.sw360.datahandler.services.archival.ArchivePreview;
 import org.eclipse.sw360.datahandler.services.archival.ArchiveRequest;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
@@ -96,6 +98,14 @@ public class ArchivalController {
     @GetMapping("/records")
     public List<ArchivalRecord> listRecords() {
         return handler.getAll();
+    }
+
+    /** Suggests previously archived entities matching a name (for the create forms). */
+    @GetMapping("/records/search")
+    public List<ArchivalRecord> searchRecords(
+            @RequestParam("name") String name,
+            @RequestParam(value = "type", required = false) ArchivalEntityType type) {
+        return handler.searchArchived(name, type);
     }
 
     @GetMapping("/records/{id}")

--- a/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalHandler.java
+++ b/backend/archival/src/main/java/org/eclipse/sw360/archival/ArchivalHandler.java
@@ -436,6 +436,18 @@ public class ArchivalHandler {
         return db.getAll();
     }
 
+    public List<ArchivalRecord> searchArchived(String nameQuery, ArchivalEntityType type) {
+        String q = nameQuery == null ? "" : nameQuery.trim().toLowerCase();
+        if (q.isEmpty()) {
+            return List.of();
+        }
+        return db.getAll().stream()
+                .filter(r -> r.getStatus() == ArchivalStatus.ARCHIVED)
+                .filter(r -> type == null || r.getEntityType() == type)
+                .filter(r -> r.getEntityName() != null && r.getEntityName().toLowerCase().contains(q))
+                .toList();
+    }
+
     public boolean delete(String id) {
         return db.delete(id);
     }


### PR DESCRIPTION
### Description

Adds a read-only search endpoint for archived entities, allowing users to find previously archived records by name and type. This supports the create-form hint that helps admins restore an existing entity instead of creating a duplicate.

### Changes

* Added `ArchivalHandler.searchArchived(name, type)` for case-insensitive name search with optional type filtering.
* Added `GET /records/search?name=<q>&type=<PROJECT|COMPONENT|RELEASE|PACKAGE>`.
* Blank queries return no results, and `type` is optional.
* Search uses the existing archival registry and has no side effects.
* The endpoint is not admin-gated so create forms can use it for restoration hints.

### Testing

* `mvn -o -pl backend/archival compile` — clean.
* Verified locally with CouchDB, including name search, type filtering, blank queries, and searches without a type.
