### PR TITLE
fix(backend): harden attachment filesystem path handling

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
@@ -984,8 +984,14 @@ public class DatabaseHandlerUtil {
                         ATTACHMENT_ID + attachmentId);
                 Path outputFile = Paths.get(fileName);
                 Path outputFilePath = outputDir.resolve(outputFile);
+                if (!outputFilePath.normalize().startsWith(outputDir.normalize())) {
+                    log.error("Path traversal detected in attachment filename - aborting write. "
+                            + "Resolved path: " + outputFilePath);
+                    throw new IllegalArgumentException(
+                            "Attachment filename contains path traversal sequence: " + fileName);
+                }
                 log.info("Preparing to store attachment in file system" + outputFilePath);
-                if (!Files.exists(outputFile)) {
+                if (!Files.exists(outputFilePath)) {
                     Set<PosixFilePermission> perms = PosixFilePermissions
                             .fromString(ATTACHMENT_STORE_FILE_SYSTEM_PERMISSION);
                     FileAttribute<Set<PosixFilePermission>> fileAttribute = PosixFilePermissions.asFileAttribute(perms);


### PR DESCRIPTION
## Summary

This PR updates attachment file path handling in `backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java` 

## Changes

- add a resolved-path containment check before writing attachment content
- use the resolved path in the file existence check
- keep write behavior unchanged for valid paths
- align the related log message text

## Files changed

- `backend/common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java`

## Suggested Reviewer
@GMishx 