### PR TITLE
fix(backend): add self-merge guard to mergeVendors, mergeComponents, mergeReleases

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -957,6 +957,11 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public RequestStatus mergeComponents(String mergeTargetId, String mergeSourceId, Component mergeSelection,
                                          User sessionUser) throws TException {
+        if (mergeTargetId.equals(mergeSourceId)) {
+            log.error("Cannot merge component [" + mergeSourceId + "] into itself.");
+            return RequestStatus.FAILURE;
+        }
+
         Component mergeTarget = getComponent(mergeTargetId, sessionUser);
         Component mergeSource = getComponent(mergeSourceId, sessionUser);
         Component mergeTargetOriginal = mergeTarget.deepCopy();
@@ -1723,6 +1728,11 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public RequestStatus mergeReleases(String mergeTargetId, String mergeSourceId, Release mergeSelection,
                                        User sessionUser) throws TException {
+
+        if (mergeTargetId.equals(mergeSourceId)) {
+            log.error("Cannot merge release [" + mergeSourceId + "] into itself.");
+            return RequestStatus.FAILURE;
+        }
 
         Release mergeTarget = getRelease(mergeTargetId, sessionUser);
         Release mergeSource = getRelease(mergeSourceId, sessionUser);

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -1241,4 +1241,26 @@ public class ComponentDatabaseHandlerTest {
         changed.getEccInformation().setEccStatus(ECCStatus.APPROVED).setAssessorDepartment("XYZ").setAssessorContactPerson("");
         assertFalse(handler.hasChangesInEccFields(changed, original));
     }
+
+    @Test
+    public void testMergeComponents_selfMerge_returnsFailure() throws Exception {
+        RequestStatus status = handler.mergeComponents("C1", "C1", new Component(), user1);
+
+        assertEquals(RequestStatus.FAILURE, status);
+
+        Component stillExists = handler.getComponent("C1", user1);
+        assertNotNull(stillExists);
+        assertEquals("component1", stillExists.getName());
+    }
+
+    @Test
+    public void testMergeReleases_selfMerge_returnsFailure() throws Exception {
+        RequestStatus status = handler.mergeReleases("R1A", "R1A", new Release(), user1);
+
+        assertEquals(RequestStatus.FAILURE, status);
+
+        Release stillExists = handler.getRelease("R1A", user1);
+        assertNotNull(stillExists);
+        assertEquals("component1", stillExists.getName());
+    }
 }

--- a/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
+++ b/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
@@ -156,6 +156,11 @@ public class VendorDatabaseHandler {
     }
 
     public RequestStatus mergeVendors(String mergeTargetId, String mergeSourceId, Vendor mergeSelection, User user) throws TException {
+        if (mergeTargetId.equals(mergeSourceId)) {
+            log.error("Cannot merge vendor [" + mergeSourceId + "] into itself.");
+            return RequestStatus.FAILURE;
+        }
+
         Vendor mergeTarget = getByID(mergeTargetId);
         Vendor mergeSource = getByID(mergeSourceId);
 

--- a/backend/vendors/src/test/java/org/eclipse/sw360/vendors/VendorDatabaseHandlerTest.java
+++ b/backend/vendors/src/test/java/org/eclipse/sw360/vendors/VendorDatabaseHandlerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Kavya Popat, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.vendors;
+
+import org.eclipse.sw360.datahandler.TestUtils;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class VendorDatabaseHandlerTest {
+
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+
+    private VendorDatabaseHandler handler;
+    private Vendor existingVendor;
+    private final User user = new User().setEmail("merge-test@sw360.org").setUserGroup(UserGroup.ADMIN);
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+
+        DatabaseConnectorCloudant databaseConnector = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        existingVendor = new Vendor().setShortname("Apache").setFullname("The Apache Software Foundation").setUrl("http://www.apache.org");
+        databaseConnector.add(existingVendor);
+
+        handler = new VendorDatabaseHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
+    }
+
+    @Test
+    public void testMergeVendors_selfMerge_returnsFailure() throws Exception {
+        String vendorId = existingVendor.getId();
+
+        RequestStatus status = handler.mergeVendors(vendorId, vendorId, new Vendor(), user);
+
+        assertEquals(RequestStatus.FAILURE, status);
+
+        // the guard fired before any fetch/permission/delete logic ran
+        // the vendor must still exist, completely untouched
+        Vendor stillExists = handler.getByID(vendorId);
+        assertNotNull(stillExists);
+        assertEquals("The Apache Software Foundation", stillExists.getFullname());
+    }
+}


### PR DESCRIPTION
> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

`mergeVendors` (`VendorDatabaseHandler.java`), `mergeComponents`, and `mergeReleases` (both in `ComponentDatabaseHandler.java`) did not guard against `mergeTargetId` and `mergeSourceId` being the same ID. Since each method's final step unconditionally deletes the source document, passing the same ID for both silently deletes the vendor/component/release the caller intended to keep, while still returning `RequestStatus.SUCCESS`.

This PR adds an early guard as the first statement in each of the three methods, rejecting the request with `RequestStatus.FAILURE` before any database fetch, permission check, or side effect occurs.

No new dependencies were added or updated.

Issue: Fixes #4519

### Suggest Reviewer
> @GMishx 

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

Run the added unit/integration tests:
- `VendorDatabaseHandlerTest#testMergeVendors_selfMerge_returnsFailure`
- `ComponentDatabaseHandlerTest#testMergeComponents_selfMerge_returnsFailure`
- `ComponentDatabaseHandlerTest#testMergeReleases_selfMerge_returnsFailure`

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
