### PR TITLE
fix(backend): configure Jackson 2 converter for FossologyRestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,28 @@ Then run the current build script:
 ```bash
 ./third-party/thrift/install-thrift.sh
 ```
+### Development Prerequisites
+
+Before building SW360 locally, make sure the following tools are installed:
+
+- Java 21
+- Maven 3.8.7 or newer
+- Git
+- Docker
+- Python
+- pre-commit
+- Apache Thrift 0.20.0
+
+Additional tools may be required depending on the module being developed.
+
+### Clone the Repository
+
+Clone the repository and enter the project directory:
+
+```bash
+git clone https://github.com/eclipse-sw360/sw360.git
+cd sw360
+```
 
 ### Local Building
 

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyConfig.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/config/FossologyConfig.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.MalformedURLException;
@@ -96,7 +97,7 @@ public class FossologyConfig {
      * Enhanced RestTemplate configuration for v2 API
      */
     @Bean
-    public RestTemplate restTemplate() {
+    public RestTemplate restTemplate(ObjectMapper objectMapper) {
         RestTemplate restTemplate = new RestTemplate();
 
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
@@ -104,6 +105,9 @@ public class FossologyConfig {
         requestFactory.setReadTimeout(300000);   // 5 minutes for large file
 
         restTemplate.setRequestFactory(requestFactory);
+
+        MappingJackson2HttpMessageConverter jackson2Converter = new MappingJackson2HttpMessageConverter(objectMapper);
+        restTemplate.getMessageConverters().add(0, jackson2Converter);
 
         log.info("RestTemplate configured for FOSSology v2 API with enhanced timeouts");
         return restTemplate;

--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/rest/FossologyRestClient.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -99,6 +100,13 @@ public class FossologyRestClient {
 
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         restTemplate.setRequestFactory(requestFactory);
+        if (objectMapper != null) {
+            boolean hasJackson2Converter = restTemplate.getMessageConverters().stream()
+                    .anyMatch(c -> c instanceof MappingJackson2HttpMessageConverter);
+            if (!hasJackson2Converter) {
+                restTemplate.getMessageConverters().add(0, new MappingJackson2HttpMessageConverter(objectMapper));
+            }
+        }
         this.restTemplate = restTemplate;
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary of Changes
Fixes FOSSology REST integration failure in release 20.1.0 caused by the Spring Boot 4 / Jackson 3 upgrade.

* **Issue**: This PR addresses issue #4494 (`Fossology integration broken in 20.1.0: Spring Boot 4 / Jackson 3 upgrade breaks FossologyRestClient`). In Spring Boot 4, `RestTemplate` defaults to Jackson 3 (`tools.jackson`), causing deserialization into Jackson 2 `com.fasterxml.jackson.databind.JsonNode` to throw `InvalidDefinitionException`.
* **Solution**: Registered `MappingJackson2HttpMessageConverter` with the Jackson 2 `ObjectMapper` bean on `RestTemplate` in `FossologyConfig` and added a fallback check in `FossologyRestClient` constructor.
* **Dependencies**: No new dependencies were added or updated.

Issue: #4494

### Suggest Reviewer
@CKnoppas @ritankarsaha 

### How To Test?
1. Deploy `sw360-backend` (20.1.0) connected to a working FOSSology instance.
2. Trigger FOSSology process via `GET /resource/api/releases/{id}/triggerFossologyProcess?markFossologyProcessOutdated=true` or check FOSSology connection.
3. Verify backend log output: observe that calls to `getUploadId` and `uploadFileAndScan` succeed without throwing `org.springframework.http.converter.HttpMessageConversionException: Type definition error: [simple type, class com.fasterxml.jackson.databind.JsonNode]`.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR (`Fixes #4494`)
- [x] Code compiled clean and checked locally
- [x] All commits signed-off with ECA email (`git commit -s`)