### PR TITLE
fix(project): handled update of fields set by backend

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -441,6 +441,15 @@ public class JacksonCustomizations {
             @Override
             @JsonProperty(access = Access.READ_ONLY)
             abstract public String getClearingRequestId();
+
+            // Audit fields - read-only (auto-set by backend)
+            @Override
+            @JsonProperty(access = Access.READ_ONLY)
+            abstract public String getModifiedOn();
+
+            @Override
+            @JsonProperty(access = Access.READ_ONLY)
+            abstract public String getModifiedBy();
         }
 
         static abstract class EmbeddedProjectMixin extends ProjectMixin {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -179,6 +179,11 @@ public class RestControllerHelper<T> {
             Project._Fields.CREATED_ON,
             Project._Fields.CREATED_BY
     );
+    private static final Set<Project._Fields> BACKEND_MANAGED_PROJECT_FIELDS = EnumSet.of(
+            Project._Fields.ID,
+            Project._Fields.MODIFIED_ON,
+            Project._Fields.MODIFIED_BY
+    );
     private static final Set<Component._Fields> IMMUTABLE_COMPONENT_FIELDS = EnumSet.of(
             Component._Fields.ID,
             Component._Fields.TYPE,
@@ -735,6 +740,41 @@ public class RestControllerHelper<T> {
                 .slash("api" + ProjectController.PROJECTS_URL + "/" + project.getId()).withSelfRel();
         halProject.add(projectLink);
         halResource.addEmbeddedResource(isSingleProject ? "sw360:project" : "sw360:projects", halProject);
+    }
+
+    /**
+     * Rejects the request when the payload attempts to set fields that are managed
+     * exclusively by the backend (e.g. {@code id}, {@code createdBy}, {@code modifiedOn}).
+     * These fields are auto-populated on create/update or driven by internal workflows
+     * (moderation, clearing request, obligation linking) and must not be supplied by
+     * the client via UI or REST API request body.
+     *
+     * @param reqBodyMap                    the raw request body map received from the client
+     * @param mapOfProjectFieldsToRequestBody mapping of Thrift fields to alternate JSON
+     *                                        keys used in the SW360 REST API
+     * @throws BadRequestClientException if any backend-managed field is present in the body
+     */
+    public void validateNoBackendManagedProjectFields(Map<String, Object> reqBodyMap,
+            ImmutableMap<Project._Fields, String> mapOfProjectFieldsToRequestBody) {
+        if (reqBodyMap == null || reqBodyMap.isEmpty()) {
+            return;
+        }
+        List<String> rejectedFields = new ArrayList<>();
+        for (Project._Fields field : BACKEND_MANAGED_PROJECT_FIELDS) {
+            String reqBodyKey = field.getFieldName();
+            if (mapOfProjectFieldsToRequestBody != null
+                    && mapOfProjectFieldsToRequestBody.containsKey(field)) {
+                reqBodyKey = mapOfProjectFieldsToRequestBody.get(field);
+            }
+            if (reqBodyMap.containsKey(reqBodyKey)) {
+                rejectedFields.add(reqBodyKey);
+            }
+        }
+        if (!rejectedFields.isEmpty()) {
+            throw new BadRequestClientException(
+                    "The following fields are set automatically by the backend and "
+                            + "cannot be provided in the request body: " + rejectedFields);
+        }
     }
 
     public Project updateProject(Project projectToUpdate, Project requestBodyProject, Map<String, Object> reqBodyMap,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -841,6 +841,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             throw new BadRequestClientException(
                     "Field name or version should be present in request body to create duplicate of a project");
         }
+        restControllerHelper.validateNoBackendManagedProjectFields(reqBodyMap, mapOfProjectFieldsToRequestBody);
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Project sw360Project = projectService.getProjectForUserById(id, user);
         Project updateProject = convertToProject(reqBodyMap);
@@ -4784,6 +4785,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             throw new BadRequestClientException(
                     "Field name or version should be present in request body to create duplicate of a project");
         }
+        restControllerHelper.validateNoBackendManagedProjectFields(reqBodyMap, mapOfProjectFieldsToRequestBody);
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Project duplicatedProject = projectService.getProjectForUserById(id, sw360User);
         Project projectFromRequest = convertToProject(reqBodyMap);


### PR DESCRIPTION
Description :

Clicking on Duplicate button for a Project opens "Create Project" view. But the field "modifiedBy" is also filled with old info which is wrong. This field should be empty and let backend fix it.

Frontend PR merged here : https://github.com/eclipse-sw360/sw360-frontend/pull/1933

### Suggest Reviewer
@GMishx 
