### PR TITLE
feat(api): make max page size configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ ENV CLOUDANT_MAX_REQUESTS_PER_HOST="-1"
 #
 # Spring controllers
 ENV ENABLE_DISKSPACE="false"
+ENV SPRING_DATA_REST_MAX_PAGE_SIZE="1000"
 # Trusted JWT issuers (Spring relaxed-binding to sw360.security.jwt.issuers[N]).
 # *_ISSUER_URI is required per slot; *_JWK_SET_URI is optional and, when set,
 # skips OpenID Connect discovery and fetches JWKS directly from that URL.

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -83,6 +83,12 @@ to tweak SW360 behaviour.
 
 #### Spring controllers / resource server
 * `ENABLE_DISKSPACE`: Enable disk space health check (default: `false`).
+* `SPRING_DATA_REST_MAX_PAGE_SIZE`: Maximum allowed value for REST pagination
+    parameter `page_entries` (default: `1000`). If a request sets
+    `page_entries` higher than this value, Spring Data REST caps it to this
+    limit. The theoretical upper bound is Java `Integer.MAX_VALUE`
+    (`2147483647`), but very high values can lead to high memory usage and slow
+    responses.
 * `SW360_SECURITY_JWT_ISSUERS_<N>_ISSUER_URI`: Public issuer URL for slot
     `<N>` (0-based). Validated against the `iss` claim of incoming Bearer
     tokens, so the value must exactly match the token issuer (scheme, host,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -61,6 +61,8 @@ import java.util.*;
 public class Sw360ResourceServer extends SpringBootServletInitializer {
 
     public static final String REST_BASE_PATH = "/api";
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int DEFAULT_MAX_PAGE_SIZE = 1000;
     public static final String EXAMPLE_HEALTH_RESPONSE = """
             {
               "status": "UP",
@@ -81,8 +83,11 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
             }
             """;
 
-    @Value("${spring.data.rest.default-page-size:10}")
+    @Value("${spring.data.rest.default-page-size:" + DEFAULT_PAGE_SIZE + "}")
     private int defaultPageSize;
+
+    @Value("${spring.data.rest.max-page-size:" + DEFAULT_MAX_PAGE_SIZE + "}")
+    private int maxPageSize;
 
     @Value("${sw360.security.http-basic.enabled:true}")
     private boolean basicAuthEnabled;
@@ -105,7 +110,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     public static final Set<String> DEFAULT_DOMAINS;
     public static final String REPORT_FILENAME_MAPPING;
     private static final String SERVER_PATH_URL;
-    public static final Map<Object, Object> versionInfo;
+    public static final Map<String, String> versionInfo;
     public static final String SVM_NOTIFICATION_URL;
 
     static {
@@ -122,7 +127,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
 
         versionInfo = new HashMap<>();
         Properties properties = CommonUtils.loadProperties(Sw360ResourceServer.class, VERSION_INFO_PROPERTIES_FILE, false);
-        versionInfo.putAll(properties);
+        properties.forEach((key, value) -> versionInfo.put(String.valueOf(key), String.valueOf(value)));
         versionInfo.put(VERSION_INFO_KEY, getRestVersion());
 
         SpringDocUtils.getConfig()
@@ -198,6 +203,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
                 .components(securityComponents)
                 .info(new Info().title("SW360 API").license(new License().name("EPL-2.0")
                                 .url("https://github.com/eclipse-sw360/sw360/blob/main/LICENSE"))
+                        .description(getApiDescription())
                         .version(restVersionString))
                 .path("/health", new PathItem().get(
                         new Operation().tags(Collections.singletonList("Health"))
@@ -211,6 +217,17 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
                                                 ))
                                 ))
                 ));
+    }
+
+    private @NonNull String getApiDescription() {
+        int effectiveDefaultPageSize = defaultPageSize > 0 ? defaultPageSize : DEFAULT_PAGE_SIZE;
+        int effectiveMaxPageSize = maxPageSize > 0 ? maxPageSize : DEFAULT_MAX_PAGE_SIZE;
+        return "SW360 REST API for software component governance, "
+                + "project compliance, and vulnerability workflows.\n\n"
+                + "**Pagination note**: list endpoints accept `page` (0-based) and "
+                + "`page_entries` parameters. The default page size on this server is "
+                + effectiveDefaultPageSize + ", and the maximum allowed value is "
+                + effectiveMaxPageSize + ". Values above the maximum are capped.";
     }
 
     /**
@@ -251,11 +268,11 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
      * @return Version string for OpenAPI docs.
      */
     public static String getRestVersion() {
-        Object buildVersion = versionInfo.get(PROJECT_VERSION_KEY);
-        Object commitCount = versionInfo.get(COMMIT_COUNT_KEY);
+        String buildVersion = versionInfo.get(PROJECT_VERSION_KEY);
+        String commitCount = versionInfo.get(COMMIT_COUNT_KEY);
         String restVersionString = "1.0.0";
         if (buildVersion != null && commitCount != null) {
-            String[] versionParts = buildVersion.toString().split("\\.");
+            String[] versionParts = buildVersion.split("\\.");
             if (versionParts.length == 3) {
                 restVersionString = versionParts[0] + "." + versionParts[1] + "." + commitCount;
             }

--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -48,6 +48,10 @@ management:
 spring:
   application:
     name: resource
+  # Uncomment to override Spring Data REST pagination cap for `page_entries`.
+  # data:
+  #   rest:
+  #     max-page-size: 1000
   mvc:
     async:
       request-timeout: 120s

--- a/scripts/docker-config/etc_sw360/rest/application.yml.template
+++ b/scripts/docker-config/etc_sw360/rest/application.yml.template
@@ -46,6 +46,9 @@ management:
 spring:
   application:
     name: resource
+  data:
+    rest:
+      max-page-size: ${SPRING_DATA_REST_MAX_PAGE_SIZE:1000}
   servlet:
     multipart:
       max-file-size: 500MB


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Make the max page size configurable with
`spring.data.rest.max-page-size` and pass on the value to Docker setup with `SPRING_DATA_REST_MAX_PAGE_SIZE` environment variable.