### PR TITLE
chore(api): perf for components and releases

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -821,10 +821,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public Map<PaginationData, List<Component>> searchComponentByExactValues(Map<String,Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
         Map<PaginationData, List<Component>> resultMap = componentRepository.searchComponentByExactValues(subQueryRestrictions, user, pageData);
-        List<Component> resultComponentList = resultMap.get(pageData);
-        for (Component component : resultComponentList) {
-            makePermission(component, user).fillPermissionsInOther(component);
-        }
+        List<Component> resultComponentList = resultMap.values().iterator().next()
+                .parallelStream()
+                .peek(component -> makePermission(component, user).fillPermissionsInOther(component))
+                .toList();
         return Collections.singletonMap(pageData, resultComponentList);
     }
 
@@ -2405,13 +2405,9 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     private List<Release> getAccessibleReleaseList(List<Release> releaseList, User user) {
-        List<Release> resultList = new ArrayList<Release>();
-        for (Release release : releaseList) {
-            if (isReleaseActionAllowed(release, user, RequestedAction.READ)) {
-                resultList.add(release);
-            }
-        }
-        return resultList;
+        return releaseList.parallelStream()
+                .filter(release -> isReleaseActionAllowed(release, user, RequestedAction.READ))
+                .toList();
     }
 
     public Set<Component> searchComponentsByExternalIds(Map<String, Set<String>> externalIds) {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -10,8 +10,10 @@
 package org.eclipse.sw360.datahandler.db;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
+import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
@@ -120,13 +123,18 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
             @Nullable User user,
             PaginationData pageData
     ) {
-        Map<PaginationData, List<Component>> resultComponentList = baseSearch(connector, subQueryRestrictions, pageData);
+        Map<PaginationData, List<Component>> resultComponentList;
+        if (CommonUtils.isNullOrEmptyMap(subQueryRestrictions)) {
+            resultComponentList = connector.searchView(Component.class, getIndexName(), "*:*", pageData, getSortColumns(pageData));
+        } else {
+            resultComponentList = baseSearch(connector, subQueryRestrictions, pageData);
+        }
 
         PaginationData respPageData = resultComponentList.keySet().iterator().next();
         List<Component> componentList = resultComponentList.values().iterator().next();
 
         if (user != null) {
-            componentList = componentList.stream().filter(component ->
+            componentList = componentList.parallelStream().filter(component ->
                             makePermission(component, user).isActionAllowed(RequestedAction.READ))
                     .toList();
         }
@@ -148,7 +156,7 @@ public class ComponentSearchHandler extends BaseNouveauSearchHandler<Component> 
         PaginationData respPageData = resultComponentList.keySet().iterator().next();
         List<Component> componentList = resultComponentList.values().iterator().next();
 
-        componentList = componentList.stream().filter(component ->
+        componentList = componentList.parallelStream().filter(component ->
                         makePermission(component, user).isActionAllowed(RequestedAction.READ))
                 .toList();
 

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -121,13 +121,20 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
      * Paginated search with permission filtering.
      */
     public Map<PaginationData, List<Release>> searchAccessibleReleases(
-            final Map<String, Set<String>> subQueryRestrictions, User user, PaginationData pageData) {
-        Map<PaginationData, List<Release>> resultReleaseList = baseSearch(connector, subQueryRestrictions, pageData);
+            final Map<String, Set<String>> subQueryRestrictions, User user,
+            PaginationData pageData
+    ) {
+        Map<PaginationData, List<Release>> resultReleaseList;
+        if (CommonUtils.isNullOrEmptyMap(subQueryRestrictions)) {
+            resultReleaseList = connector.searchView(Release.class, getIndexName(), "*:*", pageData, getSortColumns(pageData));
+        } else {
+            resultReleaseList = baseSearch(connector, subQueryRestrictions, pageData);
+        }
 
         PaginationData respPageData = resultReleaseList.keySet().iterator().next();
         List<Release> releaseList = resultReleaseList.values().iterator().next();
 
-        releaseList = releaseList.stream().filter(release ->
+        releaseList = releaseList.parallelStream().filter(release ->
                 makePermission(release, user).isActionAllowed(RequestedAction.READ))
                 .toList();
 
@@ -149,7 +156,7 @@ public class ReleaseSearchHandler extends BaseNouveauSearchHandler<Release> {
         PaginationData respPageData = resultReleaseList.keySet().iterator().next();
         List<Release> releaseList = resultReleaseList.values().iterator().next();
 
-        releaseList = releaseList.stream().filter(release ->
+        releaseList = releaseList.parallelStream().filter(release ->
                 makePermission(release, user).isActionAllowed(RequestedAction.READ))
                 .toList();
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -201,7 +201,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
 
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             paginatedComponents = componentService.searchFilteredComponents(searchText, sw360User, pageable);
-        } else if (luceneSearch && !CommonUtils.isNullOrEmptyMap(filterMap)) {
+        } else if (luceneSearch) {
             paginatedComponents = componentService.refineSearch(filterMap, sw360User, pageable);
         } else {
             if (CommonUtils.isNullOrEmptyMap(filterMap)) {
@@ -211,9 +211,9 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             }
         }
 
-        PaginationResult<Component> paginationResult;
-        paginationResult = restControllerHelper.paginationResultFromPaginatedList(
-                request, pageable, paginatedComponents);
+        PaginationResult<Component> paginationResult =
+                restControllerHelper.paginationResultFromPaginatedList(
+                        request, pageable, paginatedComponents);
 
         CollectionModel<EntityModel<Component>> resources = getFilteredComponentResources(fields, allDetails, sw360User, paginationResult);
         return new ResponseEntity<>(resources, HttpStatus.OK);
@@ -241,7 +241,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
             componentResources.add(embeddedComponentResource);
         };
 
-        paginationResult.getResources().forEach(consumer);
+        paginationResult.getResources().parallelStream().forEach(consumer);
 
         CollectionModel<EntityModel<Component>> resources;
         if (componentResources.isEmpty()) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.release;
 
+import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_PACKAGE_PORTLET_ENABLED;
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.SPDX_DOCUMENT_ENABLED;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -216,7 +217,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
 
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             paginatedReleases = releaseService.searchFilteredReleases(searchText, sw360User, pageable);
-        } else if (luceneSearch && CommonUtils.isNotNullEmptyOrWhitespace(name)) {
+        } else if (luceneSearch) {
             paginatedReleases = releaseService.refineSearch(name, sw360User, pageable);
         } else {
             if (sha1 != null && !sha1.isEmpty()) {
@@ -236,16 +237,17 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         List<Release> sw360Releases = new ArrayList<>(paginatedReleases.values().iterator().next());
 
         if (allDetails) {
-            for (Release release : sw360Releases) {
-                if (!CommonUtils.isNullEmptyOrWhitespace(release.getVendorId())) {
-                    try {
-                        Vendor relVendor = vendorService.getVendorById(release.getVendorId());
-                        release.setVendor(relVendor);
-                    } catch (RuntimeException ignore) {
-                        log.error("Unable to find vendor with ID {}", release.getVendorId());
-                    }
-                }
-            }
+            sw360Releases.parallelStream()
+                    .forEach(release -> {
+                        if (!CommonUtils.isNullEmptyOrWhitespace(release.getVendorId())) {
+                            try {
+                                Vendor relVendor = vendorService.getVendorById(release.getVendorId());
+                                release.setVendor(relVendor);
+                            } catch (RuntimeException ignore) {
+                                log.error("Unable to find vendor with ID {}", release.getVendorId());
+                            }
+                        }
+                    });
         }
 
         if (CommonUtils.isNotNullEmptyOrWhitespace(sha1) || CommonUtils.isNotNullEmptyOrWhitespace(name)) {
@@ -260,18 +262,19 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         paginationResult = restControllerHelper.paginationResultFromPaginatedList(
                 request, pageable, Map.of(paginatedReleases.keySet().iterator().next(), sw360Releases));
 
-        List<EntityModel<Release>> releaseResources = new ArrayList<>();
-        for (Release sw360Release : paginationResult.getResources()) {
-            EntityModel<Release> releaseResource = null;
-            if (!allDetails) {
-                Release embeddedRelease = restControllerHelper.convertToEmbeddedRelease(sw360Release, fields);
-                releaseResource = EntityModel.of(embeddedRelease);
-            } else {
-                releaseResource = createHalReleaseResourceWithAllDetails(sw360Release);
-            }
-
-            releaseResources.add(releaseResource);
-        }
+        List<EntityModel<Release>> releaseResources = paginationResult.getResources()
+                .parallelStream()
+                .map(sw360Release -> {
+                    EntityModel<Release> releaseResource;
+                    if (allDetails) {
+                        releaseResource = createHalReleaseResourceWithAllDetails(sw360Release);
+                    } else {
+                        Release embeddedRelease = restControllerHelper.convertToEmbeddedRelease(sw360Release, fields);
+                        releaseResource = EntityModel.of(embeddedRelease);
+                    }
+                    return releaseResource;
+                })
+                .toList();
 
         CollectionModel<EntityModel<Release>> resources = null;
         if (CommonUtils.isNotEmpty(releaseResources)) {
@@ -2008,23 +2011,22 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         }
         return halRelease;
     }
-    private HalResource<Release> createHalReleaseResourceWithAllDetails(Release release) {
+
+    private @NonNull HalResource<Release> createHalReleaseResourceWithAllDetails(Release release) {
         HalResource<Release> halRelease = new HalResource<>(release);
         Link componentLink = linkTo(ReleaseController.class)
                 .slash("api" + ComponentController.COMPONENTS_URL + "/" + release.getComponentId())
                 .withRel("component");
         halRelease.add(componentLink);
         release.setComponentId(null);
-        Set<String> packageIds = release.getPackageIds();
-
-        if (packageIds != null) {
+        if (SW360Utils.readConfig(IS_PACKAGE_PORTLET_ENABLED, true) && release.getPackageIds() != null) {
             for (String id : release.getPackageIds()) {
                 Link packageLink = linkTo(ReleaseController.class)
                         .slash("api" + PackageController.PACKAGES_URL + "/" + id).withRel("packages");
                 halRelease.add(packageLink);
             }
+            release.setPackageIds(null);
         }
-        release.setPackageIds(null);
         for (Entry<Release._Fields, String> field : mapOfFieldsTobeEmbedded.entrySet()) {
             restControllerHelper.addEmbeddedFields(field.getValue(), release.getFieldValue(field.getKey()), halRelease);
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -1345,9 +1345,8 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
      */
     public Map<PaginationData, List<Release>> refineSearch(String searchText, User sw360User, Pageable pageable) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        Map<String, Set<String>> filterMap = Map.of(
-                Release._Fields.NAME.getFieldName(), Collections.singleton(searchText)
-        );
+        Map<String, Set<String>> filterMap = CommonUtils.isNotNullEmptyOrWhitespace(searchText) ?
+            Map.of(Release._Fields.NAME.getFieldName(), Collections.singleton(searchText)) : Collections.emptyMap();
         PaginationData pageData = pageableToPaginationData(pageable, ReleaseSortColumn.BY_CREATEDON, false);
         return sw360ComponentClient.refineSearchAccessibleReleases(filterMap, sw360User, pageData);
     }


### PR DESCRIPTION
Performance improvements for /components and /releases
1. Use Nouveau by default if no filtering is provided and `luceneSearch` is true.
2. Use `parallelStream` to perform operations where possible.