### PR TITLE
perf(projects): optimizations for ecc and clearing

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -16,6 +16,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.*;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -76,6 +79,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.*;
@@ -90,6 +94,7 @@ import static org.eclipse.sw360.datahandler.common.WrappedException.wrapSW360Exc
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import org.eclipse.sw360.exporter.ProjectExporter;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.nio.ByteBuffer;
@@ -110,6 +115,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     private static final int DELETION_SANITY_CHECK_THRESHOLD = 5;
     private static final String DUMMY_NEW_PROJECT_ID = "newproject";
     public static final int SVMML_JSON_LOG_CUTOFF_LENGTH = 3000;
+    private static final int PARALLEL_RELEASE_CLEARING_STATUS_THRESHOLD = 32;
     private static final boolean WITH_ALL_RELEASES = true;
     private static final boolean WITH_ROOT_RELEASES_ONLY = false;
 
@@ -155,6 +161,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             Project._Fields.SPECIAL_RISKS3RD_PARTY, Project._Fields.DELIVERY_CHANNELS,
             Project._Fields.REMARKS_ADDITIONAL_REQUIREMENTS, Project._Fields.OBLIGATIONS_TEXT,
             Project._Fields.LICENSE_INFO_HEADER_TEXT);
+    private final LoadingCache<String, Project> projectLookupCache;
     private Map<String, Project> cachedAllProjectsIdMap;
     private Instant cachedAllProjectsIdMapLoadingInstant;
 
@@ -196,6 +203,16 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         vendorRepository = new VendorRepository(db);
         releaseRepository = new ReleaseRepository(db, vendorRepository);
         packageRepository = new PackageRepository(db);
+        projectLookupCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(ALL_PROJECTS_ID_MAP_CACHE_LIFETIME)
+                .build(new CacheLoader<>() {
+                    @Override
+                    public @NonNull Project load(@NonNull String projectId) throws SW360Exception {
+                        Project project = repository.get(projectId);
+                        assertNotNull(project);
+                        return project;
+                    }
+                });
 
         // Create the moderator
         this.moderator = moderator;
@@ -1343,68 +1360,108 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         Project project = getProjectById(projectId, user);
         SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject = releaseIdToProjects(project, user);
         List<Release> releasesById = componentDatabaseHandler.getDetailedReleasesForExport(releaseIdsToProject.keySet());
-        Map<String, Component> componentsById = ThriftUtils.getIdMap(
-                componentDatabaseHandler.getComponentsShort(
-                        releasesById.stream().map(Release::getComponentId).collect(Collectors.toSet())));
-
-        List<ReleaseClearingStatusData> releaseClearingStatuses = new ArrayList<>();
-        for (Release release : releasesById) {
-            List<String> projectNames = new ArrayList<>();
-            List<String> mainlineStates = new ArrayList<>();
-
-            for (ProjectWithReleaseRelationTuple projectWithReleaseRelation : releaseIdsToProject.get(release.getId())) {
-                projectNames.add(printName(projectWithReleaseRelation.getProject()));
-                mainlineStates.add(ThriftEnumUtils.enumToString(projectWithReleaseRelation.getRelation().getMainlineState()));
-                if (projectNames.size() > 3) {
-                    projectNames.add("...");
-                    mainlineStates.add("...");
-                    break;
-                }
-
-            }
-            releaseClearingStatuses.add(new ReleaseClearingStatusData(release)
-                    .setProjectNames(joinStrings(projectNames))
-                    .setMainlineStates(joinStrings(mainlineStates))
-                    .setComponentType(componentsById.get(release.getComponentId()).getComponentType()));
-        }
-        return releaseClearingStatuses;
+        return buildReleaseClearingStatuses(releasesById, releaseIdsToProject, null);
     }
 
     public List<ReleaseClearingStatusData> getReleaseClearingStatusesWithAccessibility(String projectId, User user) throws SW360Exception {
         Project project = getProjectById(projectId, user);
         SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject = releaseIdToProjects(project, user);
         List<Release> releasesById = componentDatabaseHandler.getDetailedReleasesWithAccessibilityForExport(releaseIdsToProject.keySet(), user);
-        Map<String, Component> componentsById = ThriftUtils.getIdMap(
-                componentDatabaseHandler.getComponentsShort(
-                        releasesById.stream().map(Release::getComponentId).collect(Collectors.toSet())));
-
-        List<ReleaseClearingStatusData> releaseClearingStatuses = new ArrayList<>();
-        for (Release release : releasesById) {
-            List<String> projectNames = new ArrayList<>();
-            List<String> mainlineStates = new ArrayList<>();
-
-            for (ProjectWithReleaseRelationTuple projectWithReleaseRelation : releaseIdsToProject.get(release.getId())) {
-                projectNames.add(printName(projectWithReleaseRelation.getProject()));
-                mainlineStates.add(ThriftEnumUtils.enumToString(projectWithReleaseRelation.getRelation().getMainlineState()));
-                if (projectNames.size() > 3) {
-                    projectNames.add("...");
-                    mainlineStates.add("...");
-                    break;
-                }
-
+        return buildReleaseClearingStatuses(releasesById, releaseIdsToProject, release -> {
+            Map<RequestedAction, Boolean> permissions = release.getPermissions();
+            if (permissions != null && permissions.containsKey(RequestedAction.READ)) {
+                return permissions.get(RequestedAction.READ);
             }
-            ReleaseClearingStatusData releaseClearingStatusData = new ReleaseClearingStatusData(release)
-                    .setProjectNames(joinStrings(projectNames))
-                    .setMainlineStates(joinStrings(mainlineStates))
-                    .setComponentType(componentsById.get(release.getComponentId()).getComponentType());
+            return componentDatabaseHandler.isReleaseActionAllowed(release, user, RequestedAction.READ);
+        });
+    }
 
-            boolean isAccessible = componentDatabaseHandler.isReleaseActionAllowed(release, user, RequestedAction.READ);
-            releaseClearingStatusData.setAccessible(isAccessible);
-            releaseClearingStatuses.add(releaseClearingStatusData);
+    /**
+     * Conver list of Releases and Map of release to Project relation as a list
+     * of Release Clearing Status information to show to the user. The function
+     * also checks for release access if provided as
+     * {@code accessibilityResolver}.
+     * @param releasesById          List of releases
+     * @param releaseIdsToProject   Map of release to project relation
+     * @param accessibilityResolver Release access checker, nullable.
+     * @return List of Release Clearing Status for the Project releases.
+     */
+    private List<ReleaseClearingStatusData> buildReleaseClearingStatuses(
+            List<Release> releasesById,
+            SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject,
+            @Nullable Function<Release, Boolean> accessibilityResolver
+    ) {
+        ImmutableMap<String, Component> componentsById = ImmutableMap.copyOf(ThriftUtils.getIdMap(
+                componentDatabaseHandler.getComponentsShort(
+                        releasesById.stream().map(Release::getComponentId).collect(Collectors.toSet()))
+        ));
+        ImmutableSetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProjectSnapshot =
+                ImmutableSetMultimap.copyOf(releaseIdsToProject);
+
+        return getReleaseClearingStatusStream(releasesById)
+                .map(release -> createReleaseClearingStatusData(
+                        release, releaseIdsToProjectSnapshot,
+                        componentsById, accessibilityResolver))
+                .toList();
+    }
+
+    /**
+     * Use parallel stream if number of releases above the threshold. Instead
+     * use sequential stream to optimize memory usage.
+     * @param releasesById List of releases to be provided as stream.
+     * @return Stream of list of relases.
+     */
+    private Stream<Release> getReleaseClearingStatusStream(@NonNull List<Release> releasesById) {
+        return releasesById.size() >= PARALLEL_RELEASE_CLEARING_STATUS_THRESHOLD
+                ? releasesById.parallelStream()
+                : releasesById.stream();
+    }
+
+    /**
+     * For a given Release and map of Release and Project Relation map, get a
+     * ReleaseClearingStatus.
+     * @param release Current Release to process.
+     * @param releaseIdsToProject Map of Release and Project relation
+     * @param componentsById Map of Components, indexed by ID.
+     * @param accessibilityResolver Check access of Release if provided.
+     * @return ReleaseClearingStatus data for given release.
+     */
+    private ReleaseClearingStatusData createReleaseClearingStatusData(
+            @NonNull Release release,
+            @NonNull SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject,
+            Map<String, Component> componentsById,
+            @Nullable Function<Release, Boolean> accessibilityResolver
+    ) {
+        List<String> projectNames = new ArrayList<>();
+        List<String> mainlineStates = new ArrayList<>();
+
+        for (ProjectWithReleaseRelationTuple projectWithReleaseRelation : releaseIdsToProject.get(release.getId())) {
+            projectNames.add(printName(projectWithReleaseRelation.getProject()));
+            mainlineStates.add(ThriftEnumUtils.enumToString(projectWithReleaseRelation.getRelation().getMainlineState()));
+            if (projectNames.size() > 3) {
+                projectNames.add("...");
+                mainlineStates.add("...");
+                break;
+            }
         }
-        return releaseClearingStatuses;
-     }
 
+        ReleaseClearingStatusData releaseClearingStatusData = new ReleaseClearingStatusData(release)
+                .setProjectNames(joinStrings(projectNames))
+                .setMainlineStates(joinStrings(mainlineStates))
+                .setComponentType(componentsById.get(release.getComponentId()).getComponentType());
+        if (accessibilityResolver != null) {
+            releaseClearingStatusData.setAccessible(accessibilityResolver.apply(release));
+        }
+        return releaseClearingStatusData;
+    }
+
+    /**
+     * Creates a map of ReleaseID as key and release relation as value.
+     * @param project Project to get the map for
+     * @param user    User who is trying to access
+     * @return Map of ReleaseID to ReleaseRelation
+     * @throws SW360Exception If record does not exist
+     */
     SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdToProjects(Project project, User user) throws SW360Exception {
         Set<String> visitedProjectIds = new HashSet<>();
         SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdToProjects = HashMultimap.create();
@@ -1417,6 +1474,14 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return DatabaseHandlerUtil.getCyclicLinkedPath(project, this, user);
     }
 
+    /**
+     * Recursive function call to generate the releaseIdToProjects map.
+     * @param project Project currently in process.
+     * @param user    User trying to access.
+     * @param visitedProjectIds Projects which have been visited already.
+     * @param releaseIdToProjects Release Relation map updated at each call.
+     * @throws SW360Exception If a record does not exists.
+     */
     private void releaseIdToProjects(Project project, User user, Set<String> visitedProjectIds, Multimap<String, ProjectWithReleaseRelationTuple> releaseIdToProjects) throws SW360Exception {
 
         if (nothingTodo(project, visitedProjectIds)) return;
@@ -1427,17 +1492,16 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         Map<String, ProjectProjectRelationship> linkedProjects = project.getLinkedProjects();
         if (linkedProjects != null) {
+            for (String projectId : linkedProjects.keySet()) {
+                if (visitedProjectIds.contains(projectId)) continue;
 
-                for (String projectId : linkedProjects.keySet()) {
-                    if (visitedProjectIds.contains(projectId)) continue;
-
-                    try {
-                        Project linkedProject = getProjectById(projectId, user);
-                        releaseIdToProjects(linkedProject, user, visitedProjectIds, releaseIdToProjects);
-                    } catch (SW360Exception e) {
-                        log.warn("Could not get linked project with ID: {}", projectId, e);
-                    }
+                try {
+                    Project linkedProject = getCachedProjectById(projectId, user);
+                    releaseIdToProjects(linkedProject, user, visitedProjectIds, releaseIdToProjects);
+                } catch (SW360Exception e) {
+                    log.warn("Could not get linked project with ID: {}", projectId, e);
                 }
+            }
         }
     }
 
@@ -1454,6 +1518,24 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
         visitedProjectIds.add(id);
         return false;
+    }
+
+    private Project getCachedProjectById(String id, User user) throws SW360Exception {
+        Project project;
+        try {
+            project = projectLookupCache.get(id).deepCopy();
+        } catch (ExecutionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof SW360Exception sw360Exception) {
+                throw sw360Exception;
+            }
+            throw new SW360Exception(cause != null ? cause.getMessage() : exception.getMessage());
+        }
+
+        if (!makePermission(project, user).isActionAllowed(RequestedAction.READ)) {
+            throw fail(403, "User: %s is not allowed to view the requested project: %s", user.getEmail(), project.getId());
+        }
+        return project;
     }
 
     public List<Project> fillClearingStateSummaryIncludingSubprojects(List<Project> projects, User user) {
@@ -3062,5 +3144,27 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             case ReportFormat.XML -> XmlExport.toByteBuffer(records);
             default -> null;
         };
+    }
+
+    /**
+     * Get Release IDs used by a Project. If transitive is requested, the
+     * function fetches the information recursively (checking Releases of linked
+     * Projects as well). Otherwise, the Releases of the current Project only is
+     * returned.
+     * @param projectId  Project to get used Release IDs for.
+     * @param transitive Get Release IDs recursively or for current Project only.
+     * @param user       User requesting the data.
+     * @return Set of Release IDs used by the Project.
+     * @throws SW360Exception If Project is not found.
+     */
+    public Set<String> getReleasesIdsOfProject(
+            String projectId, boolean transitive, User user
+    ) throws SW360Exception {
+        Project project = getCachedProjectById(projectId, user);
+        if (!transitive) {
+            return nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
+        }
+        SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject = releaseIdToProjects(project, user);
+        return releaseIdsToProject.keySet();
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
@@ -20,6 +20,7 @@ import org.eclipse.sw360.datahandler.entitlement.ProjectModerator;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.projects.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
@@ -413,6 +414,72 @@ public class ProjectDatabaseHandlerTest {
         Assert.assertTrue(containsInAnyOrder(createTuple(p1)).matches(releaseIdToProjects.get("r5")));
         Assert.assertTrue(containsInAnyOrder(createTuple(p1)).matches(releaseIdToProjects.get("r6")));
 
+    }
+
+    @Test
+    public void testGetReleaseClearingStatuses() throws Exception {
+        Project p1 = handler.getProjectById("P1", user1);
+        p1.setLinkedProjects(ImmutableMap.of("P2", new ProjectProjectRelationship(ProjectRelationship.CONTAINED)));
+        handler.updateProject(p1, user1);
+        Project p2 = handler.getProjectById("P2", user1);
+
+        List<ReleaseClearingStatusData> statuses = handler.getReleaseClearingStatuses("P1", user1);
+        Map<String, ReleaseClearingStatusData> statusesById = new HashMap<>();
+        for (ReleaseClearingStatusData status : statuses) {
+            statusesById.put(status.getRelease().getId(), status);
+        }
+
+        Assert.assertEquals(6, statuses.size());
+        Assert.assertTrue(containsInAnyOrder("r1", "r2", "r3", "r4", "r5", "r6").matches(statusesById.keySet()));
+        Assert.assertTrue(containsInAnyOrder(printName(p1), printName(p2))
+                .matches(Arrays.asList(statusesById.get("r1").getProjectNames().split(", "))));
+        Assert.assertEquals("Mainline, Mainline", statusesById.get("r1").getMainlineStates());
+        Assert.assertEquals(printName(p1), statusesById.get("r4").getProjectNames());
+    }
+
+    @Test
+    public void testGetReleaseClearingStatusesWithAccessibility() throws Exception {
+        List<ReleaseClearingStatusData> statuses = handler.getReleaseClearingStatusesWithAccessibility("P1", user1);
+
+        Assert.assertEquals(6, statuses.size());
+        for (ReleaseClearingStatusData status : statuses) {
+            Assert.assertTrue(status.isAccessible());
+        }
+    }
+
+    @Test
+    public void testGetReleasesOfProjectDirectOnly() throws Exception {
+        Set<String> releaseIds = handler.getReleasesIdsOfProject("P1", false, user1);
+        Assert.assertTrue(containsInAnyOrder("r1", "r2", "r3", "r4", "r5", "r6").matches(releaseIds));
+    }
+
+    @Test
+    public void testGetReleasesOfProjectTransitiveIncludesLinkedProjects() throws Exception {
+        Project p5 = handler.getProjectById("P5", user1);
+        p5.setLinkedProjects(ImmutableMap.of("P2", new ProjectProjectRelationship(ProjectRelationship.CONTAINED)));
+        handler.updateProject(p5, user1);
+
+        Set<String> transitiveReleaseIds = handler.getReleasesIdsOfProject("P5", true, user1);
+        Set<String> directReleaseIds = handler.getReleasesIdsOfProject("P5", false, user1);
+
+        Assert.assertTrue(containsInAnyOrder("r1", "r2", "r3").matches(transitiveReleaseIds));
+        Assert.assertTrue(directReleaseIds.isEmpty());
+    }
+
+    @Test
+    public void testGetReleasesOfProjectReturnsEmptyWhenNoReleasesAndNoLinks() throws Exception {
+        Set<String> releaseIds = handler.getReleasesIdsOfProject("P3", true, user3);
+        Assert.assertTrue(releaseIds.isEmpty());
+    }
+
+    @Test
+    public void testGetReleasesOfProjectReturnsEmptyWhenOnlyLinkedProjectsWithoutReleases() throws Exception {
+        Project p5 = handler.getProjectById("P5", user1);
+        p5.setLinkedProjects(ImmutableMap.of("P3", new ProjectProjectRelationship(ProjectRelationship.CONTAINED)));
+        handler.updateProject(p5, user1);
+
+        Set<String> releaseIds = handler.getReleasesIdsOfProject("P5", true, user1);
+        Assert.assertTrue(releaseIds.isEmpty());
     }
 
     @Test

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -709,4 +709,11 @@ public class ProjectHandler implements ProjectService.Iface {
             throws SW360Exception {
         return handler.getLinkedReleasesInDependencyNetworkOfProject(projectId, sw360User);
     }
+
+    @Override
+    public Set<String> getReleasesIdsOfProject(String projectId, boolean transitive, User user) throws TException {
+        assertNotNull(projectId);
+        assertUser(user);
+        return handler.getReleasesIdsOfProject(projectId, transitive, user);
+    }
 }

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -151,6 +151,12 @@ public class ThriftUtils {
         }
     }
 
+    /**
+     * Convert a list of Records to {id -> Record} map.
+     * @param in Collection of Records.
+     * @return Map of Records with their ID as key and record as value.
+     * @param <T> Type of record.
+     */
     public static <T> Map<String, T> getIdMap(Collection<T> in) {
         return Maps.uniqueIndex(in, value -> {
             if (value instanceof Document doc) {

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -787,4 +787,9 @@ service ProjectService {
     * Get linked releases information in dependency network of a project
     */
     list<ReleaseNode> getLinkedReleasesInDependencyNetworkOfProject(1: string projectId, 2: User sw360User) throws (1: SW360Exception exp);
+
+    /**
+     * Get a set of IDs of Releases attached/used in a Project
+     */
+    set<string> getReleasesIdsOfProject(1: string projectId, 2: bool transitive, 3: User user);
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -98,7 +98,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -213,7 +212,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
 
         PaginationResult<Component> paginationResult =
                 restControllerHelper.paginationResultFromPaginatedList(
-                        request, pageable, paginatedComponents);
+                        request, pageable, CommonUtils.nullToEmptyMap(paginatedComponents));
 
         CollectionModel<EntityModel<Component>> resources = getFilteredComponentResources(fields, allDetails, sw360User, paginationResult);
         return new ResponseEntity<>(resources, HttpStatus.OK);
@@ -222,26 +221,23 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     private CollectionModel<EntityModel<Component>> getFilteredComponentResources(
             List<String> fields, boolean allDetails, User sw360User, PaginationResult<Component> paginationResult
     ) throws URISyntaxException {
-        List<EntityModel<Component>> componentResources = new ArrayList<>();
-        Consumer<Component> consumer = c -> {
-            EntityModel<Component> embeddedComponentResource = null;
-            if (!allDetails) {
-                Component embeddedComponent = restControllerHelper.convertToEmbeddedComponent(c, fields);
-                embeddedComponentResource = EntityModel.of(embeddedComponent);
-            } else {
-                try {
-                    embeddedComponentResource = createHalComponent(c, sw360User);
-                } catch (TException e) {
-                    throw new RuntimeException(e);
-                }
-                if (embeddedComponentResource == null) {
-                    return;
-                }
-            }
-            componentResources.add(embeddedComponentResource);
-        };
-
-        paginationResult.getResources().parallelStream().forEach(consumer);
+        List<EntityModel<Component>> componentResources = paginationResult.getResources()
+                .parallelStream()
+                .map(c -> {
+                    if (c == null) return null;
+                    if (!allDetails) {
+                        Component embeddedComponent = restControllerHelper.convertToEmbeddedComponent(c, fields);
+                        return EntityModel.of(embeddedComponent);
+                    } else {
+                        try {
+                            return createHalComponent(c, sw360User);
+                        } catch (TException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
 
         CollectionModel<EntityModel<Component>> resources;
         if (componentResources.isEmpty()) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -264,10 +264,11 @@ public class RestControllerHelper<T> {
             request.setAttribute(PAGINATION_PARAM_PAGE, pageable.getPageNumber());
             request.setAttribute(PAGINATION_PARAM_PAGE_ENTRIES, pageable.getPageSize());
         }
-        List<T> resources = paginationDataListMap.values().stream()
+        Map<PaginationData, List<T>> nonNullListMap = CommonUtils.nullToEmptyMap(paginationDataListMap);
+        List<T> resources = nonNullListMap.values().stream()
                 .findFirst()
                 .orElse(Collections.emptyList());
-        int totalCount = Math.toIntExact(paginationDataListMap.keySet().stream()
+        int totalCount = Math.toIntExact(nonNullListMap.keySet().stream()
                 .findFirst()
                 .map(PaginationData::getTotalRowCount)
                 .orElse(0L));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -455,7 +455,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         //check the below condition when releaseRelation is not null
         if (releaseRelation != null && sw360Project.getReleaseIdToUsage() != null) {
-            Map<String, ProjectReleaseRelationship> filteredReleaseIdToUsage = sw360Project.getReleaseIdToUsage().entrySet().stream()
+            Map<String, ProjectReleaseRelationship> filteredReleaseIdToUsage = sw360Project.getReleaseIdToUsage()
+                    .entrySet()
+                    .parallelStream()
                     .filter(entry -> entry.getValue().getReleaseRelation() == releaseRelation)
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
@@ -468,13 +470,15 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         List<Release> releases = projectService.getFilteredReleases(releaseIds, sw360User, clearingState, componentType, releaseService);
 
         // Extract all release IDs from the provided list
-        Set<String> validReleaseIds = releases.stream()
+        Set<String> validReleaseIds = releases.parallelStream().unordered()
                 .map(Release::getId)
                 .collect(Collectors.toSet());
 
         // Filter the releaseIdToUsage map
         if (sw360Project.getReleaseIdToUsage() != null) {
-            Map<String, ProjectReleaseRelationship> filteredReleaseIdData = sw360Project.getReleaseIdToUsage().entrySet().stream()
+            Map<String, ProjectReleaseRelationship> filteredReleaseIdData = sw360Project.getReleaseIdToUsage()
+                    .entrySet()
+                    .parallelStream()
                     .filter(entry -> validReleaseIds.contains(entry.getKey()))
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
@@ -484,7 +488,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
 
         Map<String, ProjectReleaseRelationship> releaseIdToUsageMap = sw360Project.getReleaseIdToUsage();
-        List<EntityModel<Release>> releaseList = releases.stream().map(sw360Release -> wrapTException(() -> {
+        List<EntityModel<Release>> releaseList = releases.parallelStream().map(sw360Release -> wrapTException(() -> {
             final Release embeddedRelease = restControllerHelper.convertToEmbeddedLinkedRelease(sw360Release);
             if (releaseIdToUsageMap != null) {
                 ProjectReleaseRelationship relationship = releaseIdToUsageMap.get(sw360Release.getId());
@@ -1263,12 +1267,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
-        List<Release> releases = new ArrayList<>();
         final Set<String> releaseIds = projectService.getReleaseIds(id, sw360User, transitive);
-        for (final String releaseId : releaseIds) {
-            Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
-            releases.add(sw360Release);
-        }
+        List<Release> releases = releaseService.getReleasesWithPermissions(releaseIds, sw360User);
 
         PaginationResult<Release> paginationResult = restControllerHelper.createPaginationResult(request, pageable, releases, SW360Constants.TYPE_RELEASE);
         final List<EntityModel<Release>> releaseResources = new ArrayList<>();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1017,28 +1017,17 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
     public Set<String> getReleaseIds(String projectId, User sw360User, boolean transitive) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        if (transitive) {
-            List<ReleaseClearingStatusData> releaseClearingStatusData = sw360ProjectClient
-                    .getReleaseClearingStatuses(projectId, sw360User);
-            return releaseClearingStatusData.stream().map(r -> r.release.getId()).collect(Collectors.toSet());
-        } else {
-            final Project project = getProjectForUserById(projectId, sw360User);
-            if (project.getReleaseIdToUsage() == null) {
-                return new HashSet<String>();
-            }
-            return project.getReleaseIdToUsage().keySet();
-        }
+        return sw360ProjectClient.getReleasesIdsOfProject(projectId, transitive, sw360User);
     }
 
     public ProjectEccCounts getProjectEccCounts(String projectId, User sw360User) throws TException {
-        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
-        List<ReleaseClearingStatusData> releaseClearingStatusData = sw360ProjectClient
-                .getReleaseClearingStatuses(projectId, sw360User);
+        ComponentService.Iface releaseClient = ThriftClients.makeComponentClient();
+        final Set<String> releaseIds = getReleaseIds(projectId, sw360User, true);
+        List<Release> releases = releaseClient.getReleasesWithPermissions(releaseIds, sw360User);
 
         int eccClassifiedCount = 0;
         int eccOpenCount = 0;
-        for (ReleaseClearingStatusData clearingStatusData : CommonUtils.nullToEmptyList(releaseClearingStatusData)) {
-            Release release = clearingStatusData.release;
+        for (Release release : releases) {
             if (release == null || release.getEccInformation() == null
                     || release.getEccInformation().getEccStatus() == null) {
                 continue;
@@ -1999,25 +1988,26 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         ComponentService.Iface componentClient = ThriftClients.makeComponentClient();
         List<Release> releases = componentClient.getAccessibleReleasesById(releaseIds, sw360User);
         releaseService.setComponentDependentFieldsInRelease(releases, sw360User);
-        return releases.stream()
-        .filter(Objects::nonNull)
-        .filter(release -> {
-        // Filter by componentType if provided
-        if (componentType != null && !componentType.isEmpty()) {
-                ComponentType releaseType = release.getComponentType();
-                if (releaseType == null || componentType.stream().noneMatch(input -> input == releaseType)) {
-                    return false;
-                }
-            }
-            // Filter by clearingState if provided
-            if (clearingState != null && !clearingState.isEmpty()) {
-                ClearingState releaseState = release.getClearingState();
-                if (releaseState == null || clearingState.stream().noneMatch(input -> input == releaseState)) {
-                    return false;
-                }
-            }
-            return true;
-        }).collect(Collectors.toList());
+        return releases.parallelStream().unordered()
+                .filter(Objects::nonNull)
+                .filter(release -> {
+                    // Filter by componentType if provided
+                    if (CommonUtils.isNotEmpty(componentType)) {
+                        ComponentType releaseType = release.getComponentType();
+                        if (releaseType == null || componentType.stream().noneMatch(input -> input == releaseType)) {
+                            return false;
+                        }
+                    }
+                    // Filter by clearingState if provided
+                    if (CommonUtils.isNotEmpty(clearingState)) {
+                        ClearingState releaseState = release.getClearingState();
+                        if (releaseState == null || clearingState.stream().noneMatch(input -> input == releaseState)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                })
+                .toList();
     }
 
     /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -34,6 +34,7 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
@@ -188,6 +189,15 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return sw360ComponentClient.getAccessibleReleasesById(releaseIds, sw360User);
     }
 
+    public List<Release> getReleasesWithPermissions(Set<String> releaseIds, User sw360User) throws TException {
+        if (CommonUtils.isNullOrEmptyCollection(releaseIds)) {
+            return Collections.emptyList();
+        }
+
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.getReleasesWithPermissions(releaseIds, sw360User);
+    }
+
     public List<ReleaseLink> getLinkedReleaseRelations(Release release, User user) throws TException {
         List<ReleaseLink> linkedReleaseRelations = getLinkedReleaseRelationsWithAccessibility(release, user);
         linkedReleaseRelations = linkedReleaseRelations.stream().filter(Objects::nonNull).sorted(Comparator.comparing(
@@ -226,7 +236,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         try {
             ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
             List<Component> components = sw360ComponentClient.getComponentSummary(sw360User);
-            componentIdMap = components.stream().collect(Collectors.toMap(Component::getId, c -> c));
+            componentIdMap = ThriftUtils.getIdMap(components);
         } catch (TException e) {
             throw new BadRequestClientException("No Components found");
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -707,10 +707,13 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         rel.setMainlineState(MainlineState.MAINLINE);
         rel.setVendor(new Vendor("TV", "Test Vendor", "http://testvendor.com"));
         rel.setPackageIds(linkedPackages);
+        rel.setEccInformation(eccInformation);
 
         given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), any())).willReturn(release);
         given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), any())).willReturn(release2);
         given(this.releaseServiceMock.getReleaseForUserById(eq(release7.getId()), any())).willReturn(release7);
+        given(this.releaseServiceMock.getReleasesWithPermissions(eq(Set.of(rel.getId())), any()))
+                .willReturn(new ArrayList<>(List.of(rel)));
 
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789").setUserGroup(UserGroup.ADMIN));


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

1. Optimize `getReleaseClearingStatuses` and `getReleaseClearingStatusesWithAccessibility` with parallel streams and Guvava cache.
2. New function `getReleasesOfProject` to get all Releases used by a Project transitive, or otherwise.
3. Minor optimizations with parallel streams and unorder.
4. Optimize calls for `/releases/ecc`, `/{id}/licenseClearing` and `/{id}/tabCounts` explicitly.

### Suggest Reviewer
@rudra-superrr

### How To Test?
Make sure the License Clearing tab, ECC tab, ECC count all loads correctly with the Frontend. This change should not result in data model change, just speed optimizations.