### PR TITLE
feat(rest): add conditional API response caching for getAllComponents

### DIFF
--- a/libraries/datahandler/src/main/resources/sw360.properties
+++ b/libraries/datahandler/src/main/resources/sw360.properties
@@ -79,3 +79,21 @@
 #rest.cache.releases-without-alldetails.ttl.seconds=86400
 #rest.cache.releases-without-alldetails.max.stale.seconds=300
 #rest.cache.releases-without-alldetails.per.role.caching=true
+
+## Components list cache — allDetails=true (/components?allDetails=true)
+## Cache is evaluated conditionally (first page + page size threshold + no-filters rule +
+## matching allDetails value — see ComponentCacheCondition). The "sort" parameter is folded
+## into the cache variant (not a filter), so different sort orders get their own cache file.
+#rest.cache.components-all-details.enabled=false
+#rest.cache.components-all-details.ttl.seconds=60
+#rest.cache.components-all-details.max.stale.seconds=300
+#rest.cache.components-all-details.per.role.caching=true
+
+## Components list cache — allDetails=false/absent (/components)
+#rest.cache.components-without-alldetails.enabled=false
+#rest.cache.components-without-alldetails.ttl.seconds=60
+#rest.cache.components-without-alldetails.max.stale.seconds=300
+#rest.cache.components-without-alldetails.per.role.caching=true
+
+## Shared minimum page_entries threshold for both component list cache buckets above
+#rest.cache.components-all.min.page.size=1000

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CacheCondition.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CacheCondition.java
@@ -20,4 +20,20 @@ public interface CacheCondition {
     CachedEndpoint endpoint();
 
     boolean isCacheable(HttpServletRequest request);
+
+    /**
+     * Optional additional cache-key discriminator derived from the request, appended (via
+     * {@link CacheReadFilter}) to the role-based variant resolved by
+     * {@code CacheVariantResolver}.
+     *
+     * <p>Override this when the cached response body can differ based on a request parameter
+     * that is <em>not</em> already covered by a separate {@link CachedEndpoint} constant (e.g.
+     * sort order) — without it, requests that only differ by that parameter would incorrectly
+     * share (and overwrite) the same cache file.</p>
+     *
+     * @return a filesystem-safe, non-null suffix (no path separators), or {@code ""} for none.
+     */
+    default String variantSuffix(HttpServletRequest request) {
+        return "";
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CacheReadFilter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CacheReadFilter.java
@@ -15,6 +15,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -54,7 +55,8 @@ public class CacheReadFilter extends OncePerRequestFilter {
 
     /** URL patterns that are potentially cacheable. Must sync with CacheCondition implementations. */
     private static final String[] CACHEABLE_PATH_PATTERNS = {
-            "/api/releases"
+            "/api/releases",
+            "/api/components"
     };
 
     private final ApiResponseCacheManager cacheManager;
@@ -112,10 +114,10 @@ public class CacheReadFilter extends OncePerRequestFilter {
             return;
         }
 
-        // Step 3: Resolve cache variant (e.g., by user role)
-        String variant = cacheManager.isPerRoleCachingEnabled(endpoint)
-                ? variantResolver.resolve()
-                : ApiResponseCacheManager.DEFAULT_VARIANT;
+        // Step 3: Resolve cache variant (e.g., by user role, plus any endpoint-specific
+        // discriminator such as sort order — see CacheCondition#variantSuffix)
+        CacheCondition condition = conditionMap.get(endpoint);
+        String variant = resolveVariant(endpoint, condition, request);
 
         // Step 4: Check cache for HIT
         ResponseCache<?> cache = cacheManager.getCache(endpoint, variant);
@@ -236,6 +238,20 @@ public class CacheReadFilter extends OncePerRequestFilter {
             }
         }
         return false;
+    }
+
+    /**
+     * Resolve the full cache variant: the role-based variant (or {@link ApiResponseCacheManager#DEFAULT_VARIANT}
+     * when per-role caching is disabled for the endpoint), plus an optional condition-supplied
+     * suffix for request parameters that change the response body but aren't covered by a
+     * dedicated {@link CachedEndpoint} constant (e.g. sort order).
+     */
+    private String resolveVariant(CachedEndpoint endpoint, CacheCondition condition, HttpServletRequest request) {
+        String baseVariant = cacheManager.isPerRoleCachingEnabled(endpoint)
+                ? variantResolver.resolve()
+                : ApiResponseCacheManager.DEFAULT_VARIANT;
+        String suffix = condition != null ? condition.variantSuffix(request) : "";
+        return CommonUtils.isNullEmptyOrWhitespace(suffix) ? baseVariant : baseVariant + "-" + suffix;
     }
 
     private CachedEndpoint findCacheableEndpoint(HttpServletRequest request) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CachedEndpoint.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/cache/CachedEndpoint.java
@@ -31,7 +31,19 @@ public enum CachedEndpoint {
      * Per-role caching: Different users may see different releases based on permissions.
      */
     RELEASES_ALL_DETAILS("releases-all-details", "GET /releases?allDetails=true", true),
-    RELEASES_WITHOUT_DETAILS("releases-without-alldetails", "GET /releases?allDetails=false", true);
+    RELEASES_WITHOUT_DETAILS("releases-without-alldetails", "GET /releases?allDetails=false", true),
+
+    /**
+     * GET /components?allDetails=true
+     * GET /components (allDetails=false or absent)
+     * Cache is evaluated conditionally (first page + page size threshold + no-filters rule +
+     * matching allDetails value, see {@code ComponentCacheCondition}). Per-role caching
+     * prevents cross-role response reuse; the {@code sort} parameter is folded into the cache
+     * variant (not a filter) so different sort orders don't collide — see
+     * {@code CacheCondition#variantSuffix}.
+     */
+    COMPONENTS_ALL_DETAILS("components-all-details", "GET /components?allDetails=true", true),
+    COMPONENTS_WITHOUT_DETAILS("components-without-alldetails", "GET /components", true);
 
     private final String cacheKey;
     private final String endpointDescription;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentCacheCondition.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentCacheCondition.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.rest.resourceserver.cache.CacheCondition;
+import org.eclipse.sw360.rest.resourceserver.cache.CachedEndpoint;
+import org.eclipse.sw360.rest.resourceserver.component.cache.ComponentCacheDecisionContext;
+import org.eclipse.sw360.rest.resourceserver.component.cache.ComponentCachingCriteria;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Configuration for the {@code GET /api/components} (getAllComponents) cache conditions.
+ *
+ * <p>Mirrors the {@code allDetails} split used by {@code ReleaseCacheCondition}: two separate
+ * {@link CachedEndpoint} constants/cache buckets — {@link CachedEndpoint#COMPONENTS_ALL_DETAILS}
+ * and {@link CachedEndpoint#COMPONENTS_WITHOUT_DETAILS} — so both representations can be cached
+ * independently instead of one clobbering the other.</p>
+ *
+ * <p>A request is only cache-eligible when:</p>
+ * <ol>
+ *   <li>it targets the plain component listing endpoint ({@code /api/components}) with no
+ *       filters applied — i.e. the same branch that calls
+ *       {@code getRecentComponentsSummaryWithPagination}, and</li>
+ *   <li>it requests the first page ({@code page=0} or absent) — pagination beyond the first
+ *       page is a different result subset, not just a representation choice, and</li>
+ *   <li>its {@code allDetails} value matches the bean's target endpoint, and</li>
+ *   <li>every registered {@link ComponentCachingCriteria} (e.g. {@code PageSizeCriteria})
+ *       agrees the request should be cached.</li>
+ * </ol>
+ *
+ * <p><b>Allow-list (acceptance) design, on purpose:</b> "no filters applied" is decided by
+ * checking that every query parameter on the request belongs to
+ * {@link #SAFE_LISTING_PARAMS} — the small, explicit set of parameters known not to change
+ * which components are matched. This is the deliberate opposite of a deny-list (checking each
+ * known filter parameter is absent): if {@link ComponentController#getComponents} gains a new
+ * filter/search parameter in the future and this class is not updated, the new parameter is
+ * automatically treated as unsafe and the request bypasses the cache — a forgotten deny-list
+ * entry would instead silently make the new filter cacheable and risk serving stale or
+ * incorrect results.</p>
+ *
+ * <p><b>{@code sort} handling:</b> {@code sort} is in the safe/allow-listed set (doesn't cause a
+ * bypass) because its value is folded into the cache <em>variant</em> via
+ * {@link #sortVariantSuffix(HttpServletRequest)} (see {@link CacheCondition#variantSuffix}), so
+ * distinct sort orders get their own cache file instead of overwriting one another.</p>
+ *
+ * <p>Permission-sensitive isolation is handled by the shared per-role cache variant
+ * mechanism ({@code CacheVariantResolver} + {@code *.per.role.caching}), which takes effect only
+ * for requests this condition marks eligible. Any request carrying search/filter parameters is
+ * rejected here first, before per-role varianting is even considered.</p>
+ *
+ * <p>To add a new component caching criterion: register a Spring bean implementing
+ * {@link ComponentCachingCriteria} — it is auto-included via {@code List<ComponentCachingCriteria>}
+ * injection, no changes needed here.</p>
+ */
+@Configuration
+public class ComponentCacheCondition {
+
+    private static final Logger log = LogManager.getLogger(ComponentCacheCondition.class);
+
+    private static final String PARAM_PAGE = "page";
+    private static final String PARAM_SORT = "sort";
+    private static final String PARAM_ALL_DETAILS = "allDetails";
+
+    /**
+     * Query parameters that never change which components are matched for the plain listing
+     * branch ({@code getRecentComponentsSummaryWithPagination}) — pagination/representation
+     * selectors handled explicitly elsewhere in this class (first-page check, allDetails
+     * split, sort-aware variant). Any parameter not in this set (recognized filter or not) is
+     * treated as unsafe.
+     */
+    private static final Set<String> SAFE_LISTING_PARAMS =
+            Set.of(PARAM_PAGE, "page_entries", PARAM_SORT, PARAM_ALL_DETAILS);
+
+    /**
+     * Check if request path targets the components collection endpoint exactly
+     * (not a sub-resource such as {@code /api/components/{id}}).
+     */
+    private static boolean isComponentsEndpoint(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path != null && path.endsWith("/api/components");
+    }
+
+    /**
+     * Check that every query parameter present on the request is a known pagination-safe
+     * parameter (see {@link #SAFE_LISTING_PARAMS}). Mirrors the branch in
+     * {@code ComponentController#getComponents} that calls
+     * {@code getRecentComponentsSummaryWithPagination} (the plain listing path).
+     *
+     * <p>Allow-list check: an empty/absent parameter map means "no filters" (eligible); any
+     * unrecognized parameter name — whether it's a filter SW360 already knows about or a
+     * brand-new one added later — makes the request unsafe to cache.</p>
+     */
+    private static boolean hasOnlySafeParameters(HttpServletRequest request) {
+        Map<String, String[]> parameterMap = request.getParameterMap();
+        if (CommonUtils.isNullOrEmptyMap(parameterMap)) {
+            return true;
+        }
+        return SAFE_LISTING_PARAMS.containsAll(parameterMap.keySet());
+    }
+
+    /**
+     * Only {@code page=0} (or absent, defaulting to the first page) is safe to cache: any other
+     * page number is a different result subset, and the shared response cache stores a single
+     * blob per (endpoint, variant) — see {@code CacheVariantResolver} — so serving it for a
+     * different page would return the wrong data.
+     */
+    private static boolean isFirstPageOrAbsent(HttpServletRequest request) {
+        String page = request.getParameter(PARAM_PAGE);
+        if (CommonUtils.isNullEmptyOrWhitespace(page)) {
+            return true;
+        }
+        try {
+            return Integer.parseInt(page.trim()) == 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private static boolean isAllDetailsRequested(HttpServletRequest request) {
+        return "true".equalsIgnoreCase(request.getParameter(PARAM_ALL_DETAILS));
+    }
+
+    private static boolean isPlainComponentsListing(HttpServletRequest request) {
+        return isComponentsEndpoint(request)
+                && hasOnlySafeParameters(request)
+                && isFirstPageOrAbsent(request);
+    }
+
+    /**
+     * Builds the cache-variant suffix for the {@code sort} parameter so that different sort
+     * orders are cached separately instead of sharing (and overwriting) one file. Returns
+     * {@code ""} when no sort is requested, so the common case keeps the plain role-based
+     * variant name unchanged.
+     */
+    private static String sortVariantSuffix(HttpServletRequest request) {
+        String[] sortValues = request.getParameterValues(PARAM_SORT);
+        if (sortValues == null || sortValues.length == 0) {
+            return "";
+        }
+        String sanitized = String.join("_", sortValues)
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9_]+", "-");
+        return sanitized.isEmpty() ? "" : "sort-" + sanitized;
+    }
+
+    /**
+     * Shared eligibility evaluation for both allDetails variants.
+     *
+     * @param requireAllDetails the {@code allDetails} value this bean's {@link CachedEndpoint}
+     *                          bucket represents (e.g. {@code true} for
+     *                          {@link CachedEndpoint#COMPONENTS_ALL_DETAILS}).
+     */
+    private static boolean isCacheable(
+            HttpServletRequest request, List<ComponentCachingCriteria> criteriaChain, boolean requireAllDetails) {
+        ComponentCacheDecisionContext context = new ComponentCacheDecisionContext(
+                request.getRequestURI() + "?" + CommonUtils.nullToEmptyString(request.getQueryString()));
+
+        if (!isPlainComponentsListing(request)) {
+            context.markRejected("not-plain-components-listing");
+            context.setPermissionSensitive(true);
+            log.debug("Component cache bypass for {}: {}",
+                    context.getRequestUriWithQuery(), context.getRejectedBy());
+            return false;
+        }
+
+        if (isAllDetailsRequested(request) != requireAllDetails) {
+            context.markRejected("all-details-mismatch");
+            log.debug("Component cache bypass for {}: allDetails={} does not match this bucket (requireAllDetails={})",
+                    context.getRequestUriWithQuery(), request.getParameter(PARAM_ALL_DETAILS), requireAllDetails);
+            return false;
+        }
+
+        if (criteriaChain.isEmpty()) {
+            // No registered criteria = no positive match = bypass (default to no caching).
+            context.markRejected("no-criteria-registered");
+            log.debug("Component cache bypass for {}: no criteria beans registered",
+                    context.getRequestUriWithQuery());
+            return false;
+        }
+
+        for (ComponentCachingCriteria criterion : criteriaChain) {
+            if (!criterion.shouldCache(request)) {
+                context.markRejected(criterion.name());
+                log.debug("Component cache bypass for {}: rejected by {}",
+                        context.getRequestUriWithQuery(), criterion.name());
+                return false;
+            }
+        }
+
+        context.markEligible();
+        log.debug("Component cache eligible for {}", context.getRequestUriWithQuery());
+        return true;
+    }
+
+    /**
+     * Cache condition for {@code GET /components?allDetails=true}.
+     */
+    @Bean
+    public CacheCondition componentsAllDetailsCacheCondition(List<ComponentCachingCriteria> criteriaChain) {
+        return new CacheCondition() {
+            @Override
+            public CachedEndpoint endpoint() {
+                return CachedEndpoint.COMPONENTS_ALL_DETAILS;
+            }
+
+            @Override
+            public boolean isCacheable(HttpServletRequest request) {
+                return ComponentCacheCondition.isCacheable(request, criteriaChain, true);
+            }
+
+            @Override
+            public String variantSuffix(HttpServletRequest request) {
+                return sortVariantSuffix(request);
+            }
+        };
+    }
+
+    /**
+     * Cache condition for {@code GET /components} (allDetails=false or absent).
+     */
+    @Bean
+    public CacheCondition componentsWithoutDetailsCacheCondition(List<ComponentCachingCriteria> criteriaChain) {
+        return new CacheCondition() {
+            @Override
+            public CachedEndpoint endpoint() {
+                return CachedEndpoint.COMPONENTS_WITHOUT_DETAILS;
+            }
+
+            @Override
+            public boolean isCacheable(HttpServletRequest request) {
+                return ComponentCacheCondition.isCacheable(request, criteriaChain, false);
+            }
+
+            @Override
+            public String variantSuffix(HttpServletRequest request) {
+                return sortVariantSuffix(request);
+            }
+        };
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -53,6 +53,8 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerability
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerabilityRelationDTO;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityState;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.cache.CachedEndpoint;
+import org.eclipse.sw360.rest.resourceserver.cache.CachedResponse;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
@@ -146,6 +148,7 @@ public class ComponentController implements RepresentationModelProcessor<Reposit
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Paginated list of components.")
     })
+    @CachedResponse(endpoints = {CachedEndpoint.COMPONENTS_ALL_DETAILS, CachedEndpoint.COMPONENTS_WITHOUT_DETAILS})
     @GetMapping(value = COMPONENTS_URL)
     public ResponseEntity<CollectionModel<EntityModel<Component>>> getComponents(
             @Parameter(description = "Pagination requests", schema = @Schema(implementation = OpenAPIPaginationHelper.class))

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/cache/ComponentCacheDecisionContext.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/cache/ComponentCacheDecisionContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.component.cache;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ComponentCacheDecisionContext {
+
+    private final String requestUriWithQuery;
+    private boolean eligible;
+    private final List<String> rejectedBy;
+    @Setter
+    private boolean permissionSensitive;
+
+    public ComponentCacheDecisionContext(String requestUriWithQuery) {
+        this.requestUriWithQuery = requestUriWithQuery;
+        this.rejectedBy = new ArrayList<>();
+    }
+
+    public void markRejected(String criterionName) {
+        this.eligible = false;
+        this.rejectedBy.add(criterionName);
+    }
+
+    public void markEligible() {
+        this.eligible = true;
+    }
+
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/cache/ComponentCachingCriteria.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/cache/ComponentCachingCriteria.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.component.cache;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Contract for component endpoint cache-eligibility checks.
+ */
+public interface ComponentCachingCriteria {
+
+    String name();
+
+    boolean shouldCache(HttpServletRequest request);
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/cache/PageSizeCriteria.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/cache/PageSizeCriteria.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.component.cache;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Properties;
+
+/**
+ * Built-in {@link ComponentCachingCriteria} that only allows caching of
+ * {@code GET /api/components} requests whose requested page size ({@code page_entries})
+ * is greater than or equal to the configured threshold.
+ *
+ * <p>Threshold is sourced from {@code sw360.properties} key
+ * {@code rest.cache.components-all.min.page.size} (default {@code 1000}).</p>
+ */
+@Component
+public class PageSizeCriteria implements ComponentCachingCriteria {
+
+    private static final Logger log = LogManager.getLogger(PageSizeCriteria.class);
+
+    private static final String SW360_PROPERTIES_FILE_PATH = "/sw360.properties";
+    private static final String CONFIG_KEY_MIN_PAGE_SIZE = "rest.cache.components-all.min.page.size";
+    private static final int DEFAULT_MIN_PAGE_SIZE = 1000;
+    private static final String PAGE_ENTRIES_PARAM = "page_entries";
+
+    private final int minPageSize;
+
+    public PageSizeCriteria() {
+        this(loadConfiguredMinPageSize());
+    }
+
+    /**
+     * Package-private constructor allowing explicit threshold injection —
+     * primarily for tests (avoids depending on the system-wide
+     * {@code sw360.properties} that
+     * {@link CommonUtils#loadProperties(Class, String, boolean)} overlays from
+     * {@code SYSTEM_CONFIGURATION_PATH}). Production wiring uses the no-arg
+     * constructor, which Spring Boot 4 auto-wires as the single public
+     * constructor.
+     */
+    PageSizeCriteria(int minPageSize) {
+        this.minPageSize = minPageSize;
+    }
+
+    private static int loadConfiguredMinPageSize() {
+        Properties properties = CommonUtils.loadProperties(PageSizeCriteria.class, SW360_PROPERTIES_FILE_PATH, true);
+        return parseMinPageSize(properties.getProperty(CONFIG_KEY_MIN_PAGE_SIZE));
+    }
+
+    private static int parseMinPageSize(String configuredValue) {
+        if (CommonUtils.isNullEmptyOrWhitespace(configuredValue)) {
+            return DEFAULT_MIN_PAGE_SIZE;
+        }
+        try {
+            return Integer.parseInt(configuredValue.trim());
+        } catch (NumberFormatException e) {
+            log.warn("Invalid value for {}: '{}' — falling back to default {}",
+                    CONFIG_KEY_MIN_PAGE_SIZE, configuredValue, DEFAULT_MIN_PAGE_SIZE);
+            return DEFAULT_MIN_PAGE_SIZE;
+        }
+    }
+
+    @Override
+    public String name() {
+        return "PageSizeCriteria";
+    }
+
+    @Override
+    public boolean shouldCache(HttpServletRequest request) {
+        String pageEntries = request.getParameter(PAGE_ENTRIES_PARAM);
+        if (CommonUtils.isNullEmptyOrWhitespace(pageEntries)) {
+            // Missing page size — not eligible (no explicit large-page intent).
+            return false;
+        }
+        try {
+            int requestedPageSize = Integer.parseInt(pageEntries.trim());
+            return requestedPageSize >= minPageSize;
+        } catch (NumberFormatException e) {
+            // Non-numeric page size — bypass cache rather than fail the request.
+            return false;
+        }
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/component/ComponentCacheCriteriaTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/component/ComponentCacheCriteriaTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.eclipse.sw360.rest.resourceserver.cache.CacheCondition;
+import org.eclipse.sw360.rest.resourceserver.cache.CachedEndpoint;
+import org.eclipse.sw360.rest.resourceserver.component.cache.ComponentCachingCriteria;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * Foundational unit tests for the component cache condition/criteria contracts
+ * (Phase 2 — Foundational, plus allDetails/sort/first-page follow-ups). Verifies endpoint
+ * identity and eligibility wiring for both the {@code componentsWithoutDetailsCacheCondition}
+ * and {@code componentsAllDetailsCacheCondition} beans.
+ *
+ * <p>Uses {@code Strictness.LENIENT} for flexibility across the small number of
+ * {@code HttpServletRequest} stubs shared via {@code @BeforeEach}.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ComponentCacheCriteriaTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private ComponentCachingCriteria alwaysEligibleCriterion;
+
+    @Mock
+    private ComponentCachingCriteria alwaysRejectingCriterion;
+
+    private final ComponentCacheCondition conditionConfig = new ComponentCacheCondition();
+
+    @BeforeEach
+    void setUp() {
+        when(request.getRequestURI()).thenReturn("/api/components");
+        when(request.getQueryString()).thenReturn(null);
+        when(request.getParameterMap()).thenReturn(Map.of());
+    }
+
+    @Test
+    void withoutDetailsConditionShouldTargetComponentsWithoutDetailsEndpoint() {
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.endpoint()).isEqualTo(CachedEndpoint.COMPONENTS_WITHOUT_DETAILS);
+    }
+
+    @Test
+    void allDetailsConditionShouldTargetComponentsAllDetailsEndpoint() {
+        CacheCondition condition = conditionConfig.componentsAllDetailsCacheCondition(List.of());
+
+        assertThat(condition.endpoint()).isEqualTo(CachedEndpoint.COMPONENTS_ALL_DETAILS);
+    }
+
+    @Test
+    void shouldBeCacheable_whenPlainListingAndAllCriteriaPass() {
+        when(alwaysEligibleCriterion.shouldCache(request)).thenReturn(true);
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of(alwaysEligibleCriterion));
+
+        assertThat(condition.isCacheable(request)).isTrue();
+    }
+
+    @Test
+    void shouldBypass_whenAnyCriterionRejects() {
+        when(alwaysEligibleCriterion.shouldCache(request)).thenReturn(true);
+        when(alwaysRejectingCriterion.shouldCache(request)).thenReturn(false);
+        when(alwaysRejectingCriterion.name()).thenReturn("AlwaysRejecting");
+
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(
+                List.of(alwaysEligibleCriterion, alwaysRejectingCriterion));
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    @Test
+    void shouldBypass_whenRequestTargetsSubResource() {
+        when(request.getRequestURI()).thenReturn("/api/components/1234");
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    @Test
+    void shouldBypass_whenFilterParametersArePresent() {
+        doReturn(Map.of("searchText", new String[]{"apache"})).when(request).getParameterMap();
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    @Test
+    void shouldBypass_whenLuceneSearchRequested() {
+        doReturn(Map.of("luceneSearch", new String[]{"true"})).when(request).getParameterMap();
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    @Test
+    void shouldBypass_whenUnrecognizedFutureParameterIsPresent() {
+        // Acceptance/allow-list guard: a brand-new query parameter this class has never heard
+        // of must default to "unsafe" (bypass), not "safe" (cached). This is the behavior a
+        // deny-list cannot guarantee once a new filter is added to the controller.
+        doReturn(Map.of("someNewFilterAddedLater", new String[]{"x"})).when(request).getParameterMap();
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    @Test
+    void shouldBeCacheable_whenOnlyPaginationAndSortParamsArePresent() {
+        doReturn(Map.of(
+                "page", new String[]{"0"},
+                "page_entries", new String[]{"5000"},
+                "sort", new String[]{"name,asc"}
+        )).when(request).getParameterMap();
+        when(alwaysEligibleCriterion.shouldCache(request)).thenReturn(true);
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of(alwaysEligibleCriterion));
+
+        assertThat(condition.isCacheable(request)).isTrue();
+    }
+
+    @Test
+    void shouldBypass_whenPageIsNotFirstPage() {
+        // Only page=0 represents "the whole listing" for the shared single-blob cache; any
+        // other page number is a different result subset and must bypass.
+        doReturn(Map.of("page", new String[]{"1"})).when(request).getParameterMap();
+        when(request.getParameter("page")).thenReturn("1");
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    @Test
+    void shouldBeCacheable_whenPageIsExplicitlyZero() {
+        doReturn(Map.of("page", new String[]{"0"})).when(request).getParameterMap();
+        when(request.getParameter("page")).thenReturn("0");
+        when(alwaysEligibleCriterion.shouldCache(request)).thenReturn(true);
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of(alwaysEligibleCriterion));
+
+        assertThat(condition.isCacheable(request)).isTrue();
+    }
+
+    @Test
+    void shouldBypass_whenNoCriteriaRegistered() {
+        // Per spec edge case: empty criteria list = no positive match = bypass.
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    // --- allDetails split ---
+
+    @Test
+    void withoutDetailsCondition_shouldBypass_whenAllDetailsTrue() {
+        doReturn(Map.of("allDetails", new String[]{"true"})).when(request).getParameterMap();
+        when(request.getParameter("allDetails")).thenReturn("true");
+        when(alwaysEligibleCriterion.shouldCache(request)).thenReturn(true);
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of(alwaysEligibleCriterion));
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    @Test
+    void allDetailsCondition_shouldBeCacheable_whenAllDetailsTrue() {
+        doReturn(Map.of("allDetails", new String[]{"true"})).when(request).getParameterMap();
+        when(request.getParameter("allDetails")).thenReturn("true");
+        when(alwaysEligibleCriterion.shouldCache(request)).thenReturn(true);
+        CacheCondition condition = conditionConfig.componentsAllDetailsCacheCondition(List.of(alwaysEligibleCriterion));
+
+        assertThat(condition.isCacheable(request)).isTrue();
+    }
+
+    @Test
+    void allDetailsCondition_shouldBypass_whenAllDetailsAbsent() {
+        // Absent/false allDetails belongs to the "without details" bucket, not this one.
+        when(alwaysEligibleCriterion.shouldCache(request)).thenReturn(true);
+        CacheCondition condition = conditionConfig.componentsAllDetailsCacheCondition(List.of(alwaysEligibleCriterion));
+
+        assertThat(condition.isCacheable(request)).isFalse();
+    }
+
+    // --- sort-aware cache variant ---
+
+    @Test
+    void variantSuffix_shouldBeEmpty_whenNoSortRequested() {
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.variantSuffix(request)).isEmpty();
+    }
+
+    @Test
+    void variantSuffix_shouldReflectSortParameter() {
+        when(request.getParameterValues("sort")).thenReturn(new String[]{"name,asc"});
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        assertThat(condition.variantSuffix(request)).isEqualTo("sort-name-asc");
+    }
+
+    @Test
+    void variantSuffix_shouldDifferForDifferentSortValues_preventingCollision() {
+        CacheCondition condition = conditionConfig.componentsWithoutDetailsCacheCondition(List.of());
+
+        when(request.getParameterValues("sort")).thenReturn(new String[]{"name,asc"});
+        String nameAscSuffix = condition.variantSuffix(request);
+
+        when(request.getParameterValues("sort")).thenReturn(new String[]{"createdOn,desc"});
+        String createdOnDescSuffix = condition.variantSuffix(request);
+
+        assertThat(nameAscSuffix).isNotEqualTo(createdOnDescSuffix);
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/component/cache/PageSizeCriteriaTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/component/cache/PageSizeCriteriaTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.component.cache;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class PageSizeCriteriaTest {
+
+    private static final int TEST_MIN_PAGE_SIZE = 1000;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private final PageSizeCriteria criteria = new PageSizeCriteria(TEST_MIN_PAGE_SIZE);
+
+    @Test
+    void shouldReturnFalse_whenPageEntriesParamMissing() {
+        when(request.getParameter("page_entries")).thenReturn(null);
+
+        assertThat(criteria.shouldCache(request)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenPageEntriesParamBlank() {
+        when(request.getParameter("page_entries")).thenReturn("   ");
+
+        assertThat(criteria.shouldCache(request)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenPageEntriesParamNonNumeric() {
+        when(request.getParameter("page_entries")).thenReturn("abc");
+
+        assertThat(criteria.shouldCache(request)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenPageEntriesParamZeroOrNegative() {
+        when(request.getParameter("page_entries")).thenReturn("0");
+        assertThat(criteria.shouldCache(request)).isFalse();
+
+        when(request.getParameter("page_entries")).thenReturn("-5");
+        assertThat(criteria.shouldCache(request)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenPageEntriesBelowThreshold() {
+        when(request.getParameter("page_entries")).thenReturn("50");
+
+        assertThat(criteria.shouldCache(request)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrue_whenPageEntriesMeetsThreshold() {
+        when(request.getParameter("page_entries")).thenReturn(String.valueOf(TEST_MIN_PAGE_SIZE));
+
+        assertThat(criteria.shouldCache(request)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrue_whenPageEntriesExceedsThreshold() {
+        when(request.getParameter("page_entries")).thenReturn(String.valueOf(TEST_MIN_PAGE_SIZE * 5));
+
+        assertThat(criteria.shouldCache(request)).isTrue();
+    }
+
+    @Test
+    void shouldExposeStableCriterionName() {
+        assertThat(criteria.name()).isEqualTo("PageSizeCriteria");
+    }
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Description

This PR extends the shared file-based API response cache introduced in #3720 (`getAllReleases`) to the `GET /api/components` endpoint, so that large, filter-free listing requests can be served from cache instead of hitting CouchDB on every call.

### What changed

- Added `CachedEndpoint.COMPONENTS_ALL` and registered `/api/components` as a cacheable path in `CacheReadFilter`.
- Added `ComponentCacheCondition`, a `CacheCondition` bean that decides whether a given `/api/components` request is eligible for caching.
- Added a small, extensible criteria chain (`ComponentCachingCriteria`, `ComponentCacheDecisionContext`, `PageSizeCriteria`) so additional eligibility rules can be plugged in later without touching the condition class.
- Caching rules implemented:
  - Only plain listing requests are eligible (no `searchText`, `luceneSearch`, `name`, or other filter/search query parameters present).
  - Request must ask for at least a configurable minimum `page_entries` (default `1000`, via `rest.cache.components-all.min.page.size` in `sw360.properties`) — small/paginated requests bypass the cache.
  - Caching for the endpoint can be toggled independently via `rest.cache.components-all.enabled`.
  - If no criteria are registered, requests bypass the cache by default (fail-safe).
- Annotated `ComponentController#getComponents` with `@CachedResponse` for documentation/traceability (actual caching decision is made by the servlet filter + condition bean, not the annotation).
- Added `sw360.properties` config keys: `rest.cache.components-all.enabled`, `rest.cache.components-all.min.page.size`.


### How To Test?

1. Start the app with an admin user and CouchDB seeded with components.
2. `GET /api/components?page=0&page_entries=5000` (no filters) — first call is a cache miss (hits backend), subsequent identical calls are served from the file cache (`<cache-dir>/components-all-*.json`).
3. `GET /api/components?page=0&page_entries=25` — bypasses cache (below threshold).
4. `GET /api/components?page=0&page_entries=5000&searchText=apache` (or `luceneSearch=true`, or `name=...`) — bypasses cache (filter present).
5. Cache admin endpoints can be used to verify hit/miss counters and to invalidate the component cache:
   - `GET /api/admin/cache/stats`
   - `GET /api/admin/cache/stats/components-all`
   - `DELETE /api/admin/cache/components-all`

Unit tests added:
- `ComponentCacheCriteriaTest` — covers `ComponentCacheCondition` eligibility logic (filters present, no criteria registered, plain listing eligible).
- `PageSizeCriteriaTest` — covers `PageSizeCriteria` threshold behavior (below/at/above threshold, missing/blank/non-numeric/zero/negative `page_entries`).

### Suggest Reviewer
@GMishx 

### Checklist

Must:
- [x] All related issues are referenced in commit messages and in PR
- [x] AI-Assisted: GitHub Copilot (Claude Sonnet 4.5).



