### PR TITLE
fix(backend): add self-merge guard to mergeVendors, mergeComponents, …

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -957,6 +957,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public RequestStatus mergeComponents(String mergeTargetId, String mergeSourceId, Component mergeSelection,
                                          User sessionUser) throws TException {
+        if (Objects.equals(mergeTargetId, mergeSourceId)) {
+            return RequestStatus.INVALID_INPUT;
+        }
+
         Component mergeTarget = getComponent(mergeTargetId, sessionUser);
         Component mergeSource = getComponent(mergeSourceId, sessionUser);
         Component mergeTargetOriginal = mergeTarget.deepCopy();
@@ -1723,6 +1727,9 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public RequestStatus mergeReleases(String mergeTargetId, String mergeSourceId, Release mergeSelection,
                                        User sessionUser) throws TException {
+        if (Objects.equals(mergeTargetId, mergeSourceId)) {
+            return RequestStatus.INVALID_INPUT;
+        }
 
         Release mergeTarget = getRelease(mergeTargetId, sessionUser);
         Release mergeSource = getRelease(mergeSourceId, sessionUser);

--- a/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -1241,4 +1241,26 @@ public class ComponentDatabaseHandlerTest {
         changed.getEccInformation().setEccStatus(ECCStatus.APPROVED).setAssessorDepartment("XYZ").setAssessorContactPerson("");
         assertFalse(handler.hasChangesInEccFields(changed, original));
     }
+
+    @Test
+    public void testMergeComponentsSelfMerge() throws Exception {
+        Component component = handler.getComponent("C1", user1);
+        RequestStatus status = handler.mergeComponents("C1", "C1", component, user1);
+        assertEquals(RequestStatus.INVALID_INPUT, status);
+        // Verify component C1 still exists
+        Component actual = handler.getComponent("C1", user1);
+        assertNotNull(actual);
+        assertEquals("C1", actual.getId());
+    }
+
+    @Test
+    public void testMergeReleasesSelfMerge() throws Exception {
+        Release release = handler.getRelease("R1A", user1);
+        RequestStatus status = handler.mergeReleases("R1A", "R1A", release, user1);
+        assertEquals(RequestStatus.INVALID_INPUT, status);
+        // Verify release R1A still exists
+        Release actual = handler.getRelease("R1A", user1);
+        assertNotNull(actual);
+        assertEquals("R1A", actual.getId());
+    }
 }

--- a/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
+++ b/backend/vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
@@ -41,6 +41,7 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;
@@ -156,6 +157,10 @@ public class VendorDatabaseHandler {
     }
 
     public RequestStatus mergeVendors(String mergeTargetId, String mergeSourceId, Vendor mergeSelection, User user) throws TException {
+        if (Objects.equals(mergeTargetId, mergeSourceId)) {
+            return RequestStatus.INVALID_INPUT;
+        }
+
         Vendor mergeTarget = getByID(mergeTargetId);
         Vendor mergeSource = getByID(mergeSourceId);
 

--- a/backend/vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
+++ b/backend/vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
@@ -14,6 +14,8 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.db.VendorRepository;
 import org.junit.After;
@@ -145,5 +147,16 @@ public class VendorHandlerTest {
         assertEquals(1, vendors.size());
         assertEquals(1, pagination.getTotalRowCount());
         assertEquals(vendorList.get(1).getShortname(), vendors.getFirst().getShortname());
+    }
+
+    @Test
+    public void testMergeVendorsSelfMerge() throws Exception {
+        Vendor vendor = vendorList.get(0);
+        User user = new User().setEmail("admin@sw360.org");
+        RequestStatus status = vendorHandler.mergeVendors(vendor.getId(), vendor.getId(), vendor, user);
+        assertEquals(RequestStatus.INVALID_INPUT, status);
+        Vendor actual = vendorHandler.getByID(vendor.getId());
+        assertNotNull(actual);
+        assertEquals(vendor.getId(), actual.getId());
     }
 }


### PR DESCRIPTION
…mergeReleases

Guards against self-merge in mergeVendors, mergeComponents, and mergeReleases by checking if mergeTargetId and mergeSourceId are identical and returning RequestStatus.INVALID_INPUT immediately.

Fixes #4519

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
