### PR TITLE
fix(rest): Avoid duplicate release names in DOCX disclosure

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -179,12 +179,6 @@ public class DocxUtils {
         CTR ctr = CTR.Factory.newInstance();
         ctr.setTArray(new CTText[] { ctText });
 
-        // format the hyperlink (underline + color)
-        XWPFRun run = paragraph.createRun();
-        run.setText(hyperlinkText);
-        run.setColor("0000FF"); // Set the color to blue
-        run.setUnderline(UnderlinePatterns.SINGLE); // Set underline
-
         cLink.setRArray(new CTR[] { ctr });
     }
 

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGeneratorTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGeneratorTest.java
@@ -14,10 +14,12 @@ package org.eclipse.sw360.licenseinfo.outputGenerators;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationAtProject;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationParsingResult;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -53,5 +55,16 @@ public class DocxGeneratorTest {
 
         mostCommonLicenses = DocxGenerator.extractMostCommonLicenses(obligationParsingResults, 3);
         assertThat(mostCommonLicenses.size(), is(98));
+    }
+
+    @Test
+    public void testLinkedBulletListDoesNotAddDuplicatePlainTextRun() throws Exception {
+        XWPFDocument document = new XWPFDocument();
+
+        DocxUtils.addBulletList(document, Collections.singletonList("Henry Maddocks NIkesh-Test 1.01"), true);
+
+        assertThat(document.getParagraphs().get(0).getRuns().size(), is(0));
+        assertThat(document.getParagraphs().get(0).getCTP().getHyperlinkArray(0).getRArray(0).getTArray(0).getStringValue(),
+                is("Henry Maddocks NIkesh-Test 1.01"));
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

The fix updates DOCX hyperlink generation so the release name is written only inside the hyperlink run. The overview entry now appears once while still linking to the corresponding detailed release section.

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?
### Rest api: 

curl -L -u 'username:password' \
  'http://localhost:8080/resource/api/reports?withlinkedreleases=false&projectId=<project-id>&module=licenseInfo&withSubProject=false&generatorClassName=DocxGenerator&variant=DISCLOSURE' \
  -o /tmp/licenseinfo.docx

### Start SW360 backend and frontend locally.
1. Login to SW360.
2. Navigate to:
3. Projects -> <project> -> License Clearing -> Generate License Information
Or open directly:
### Note : http://localhost:3000/projects/generateLicenseInfo/<project-id>?withSubProjects=false
4. Select at least one license info attachment/release.
5. Click Download.
6. Select License Disclosure as DOCX.
7. Download and open the generated DOCX.
10. Check the Releases Overview section.
11. Verify each release name appears only once in the bullet list and still links to its detailed release section.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
