### PR TITLE
Refactor controller

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.sw360.rest.resourceserver.release;
 
-import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_PACKAGE_PORTLET_ENABLED;
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.SPDX_DOCUMENT_ENABLED;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -21,7 +20,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
-import java.util.Map.Entry;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
@@ -82,13 +80,11 @@ import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.cache.ApiResponseCacheManager;
 import org.eclipse.sw360.rest.resourceserver.cache.CachedEndpoint;
 import org.eclipse.sw360.rest.resourceserver.cache.CachedResponse;
-import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
 import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.OpenAPIPaginationHelper;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
-import org.eclipse.sw360.rest.resourceserver.packages.PackageController;
 import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -132,17 +132,14 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     private static final String PACKAGE_INFORMATION = "packageInformation";
     private static final Logger log = LogManager.getLogger(ReleaseController.class);
     private static final Map<String, ReentrantLock> mapOfLocks = new HashMap<String, ReentrantLock>();
-    private static final ImmutableMap<Release._Fields,String> mapOfFieldsTobeEmbedded = ImmutableMap.of(
-            Release._Fields.MODERATORS, "sw360:moderators",
-            Release._Fields.ATTACHMENTS, "sw360:attachments",
-            Release._Fields.COTS_DETAILS, "sw360:cotsDetails",
-            Release._Fields.RELEASE_ID_TO_RELATIONSHIP,"sw360:releaseIdToRelationship",
-            Release._Fields.CLEARING_INFORMATION, "sw360:clearingInformation");
-    private static final ImmutableMap<Release._Fields, String[]> mapOfBackwardCompatible_Field_OldFieldNames_NewFieldNames = ImmutableMap.<Release._Fields, String[]>builder()
-            .put(Release._Fields.SOURCE_CODE_DOWNLOADURL, new String[] { "downloadurl", "sourceCodeDownloadurl" })
-            .build();
     private static final ImmutableMap<String, String> RESPONSE_BODY_FOR_MODERATION_REQUEST = ImmutableMap.<String, String>builder()
             .put("message", "Moderation request is created").build();
+
+    @NonNull
+    private final ReleaseModelAssembler releaseModelAssembler;
+
+    @NonNull
+    private final ReleaseRequestMapper releaseRequestMapper;
 
     @NonNull
     private Sw360ReleaseService releaseService;
@@ -267,7 +264,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
                 .map(sw360Release -> {
                     EntityModel<Release> releaseResource;
                     if (allDetails) {
-                        releaseResource = createHalReleaseResourceWithAllDetails(sw360Release);
+                        releaseResource = releaseModelAssembler.createHalReleaseResourceWithAllDetails(sw360Release);
                     } else {
                         Release embeddedRelease = restControllerHelper.convertToEmbeddedRelease(sw360Release, fields);
                         releaseResource = EntityModel.of(embeddedRelease);
@@ -308,7 +305,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     ) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Release sw360Release = releaseService.getReleaseForUserById(id, sw360User);
-        HalResource<Release> halRelease = createHalReleaseResource(sw360Release, true);
+        HalResource<Release> halRelease = releaseModelAssembler.createHalReleaseResource(sw360Release, true);
         restControllerHelper.addEmbeddedDataToHalResourceRelease(halRelease, sw360Release);
         List<ReleaseLink> linkedReleaseRelations = releaseService.getLinkedReleaseRelations(sw360Release, sw360User);
 
@@ -573,7 +570,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     ) throws URISyntaxException, TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Release sw360Release = releaseService.getReleaseForUserById(id, user);
-        Release updateRelease = setBackwardCompatibleFieldsInRelease(reqBodyMap);
+        Release updateRelease = releaseRequestMapper.setBackwardCompatibleFieldsInRelease(reqBodyMap);
         // Normalize vendorId from a possible self-link URI to a bare ID and drop the
         // DB-loaded vendor object so ThriftValidate.prepareRelease cannot overwrite it.
         if (updateRelease.isSetVendorId()) {
@@ -609,7 +606,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         releaseService.setComponentNameAsReleaseName(sw360Release, user);
         RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, user);
         sw360Release = releaseService.getReleaseForUserById(id, user);
-        HalResource<Release> halRelease = createHalReleaseResource(sw360Release, true);
+        HalResource<Release> halRelease = releaseModelAssembler.createHalReleaseResource(sw360Release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }
@@ -719,7 +716,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
             @RequestBody Map<String, Object> reqBodyMap
     ) throws URISyntaxException, TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-        Release release = setBackwardCompatibleFieldsInRelease(reqBodyMap);
+        Release release = releaseRequestMapper.setBackwardCompatibleFieldsInRelease(reqBodyMap);
         if (release.isSetComponentId()) {
             URI componentURI = new URI(release.getComponentId());
             String path = componentURI.getPath();
@@ -747,7 +744,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
 
         release.unsetClearingState();
         Release sw360Release = releaseService.createRelease(release, sw360User);
-        HalResource<Release> halResource = createHalReleaseResource(sw360Release, true);
+        HalResource<Release> halResource = releaseModelAssembler.createHalReleaseResource(sw360Release, true);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest().path("/{id}")
@@ -789,7 +786,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         if (CommonUtils.isNullEmptyOrWhitespace(spdxId)) {
             throw new BadRequestClientException("Update SPDXDocument Failed!");
         }
-        HalResource<Release> halRelease = createHalReleaseResource(release, false);
+        HalResource<Release> halRelease = releaseModelAssembler.createHalReleaseResource(release, false);
 
         if(reqBodyMap.isEmpty()) {
             return ResponseEntity.ok(halRelease);
@@ -927,7 +924,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
 
         release.addToAttachments(attachment);
         RequestStatus updateReleaseStatus = releaseService.updateRelease(release, sw360User);
-        HalResource<Release> halRelease = createHalReleaseResource(release, true);
+        HalResource<Release> halRelease = releaseModelAssembler.createHalReleaseResource(release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }
@@ -986,7 +983,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         log.debug("Deleting the following attachments from release " + releaseId + ": " + attachmentsToDelete);
         release.getAttachments().removeAll(attachmentsToDelete);
         RequestStatus updateReleaseStatus = releaseService.updateRelease(release, user);
-        HalResource<Release> halRelease = createHalReleaseResource(release, true);
+        HalResource<Release> halRelease = releaseModelAssembler.createHalReleaseResource(release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }
@@ -1535,7 +1532,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         }
 
         RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, sw360User);
-        HalResource<Release> halRelease = createHalReleaseResource(sw360Release, true);
+        HalResource<Release> halRelease = releaseModelAssembler.createHalReleaseResource(sw360Release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity<>(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }
@@ -1973,93 +1970,6 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         return item;
     }
 
-    private HalResource<Release> createHalReleaseResource(Release release, boolean verbose) throws TException {
-        HalResource<Release> halRelease = new HalResource<>(release);
-        Link componentLink = linkTo(ReleaseController.class)
-                .slash("api" + ComponentController.COMPONENTS_URL + "/" + release.getComponentId()).withRel("component");
-        halRelease.add(componentLink);
-        release.setComponentId(null);
-        if (verbose) {
-            if (release.getModerators() != null) {
-                Set<String> moderators = release.getModerators();
-                restControllerHelper.addEmbeddedModerators(halRelease, moderators);
-                release.setModerators(null);
-            }
-            if (release.getAttachments() != null) {
-                Set<Attachment> attachments = release.getAttachments();
-                restControllerHelper.addEmbeddedAttachments(halRelease, attachments);
-                release.setAttachments(null);
-            }
-            if (release.getVendor() != null) {
-                Vendor vendor = release.getVendor();
-                HalResource<Vendor> vendorHalResource = restControllerHelper.addEmbeddedVendor(vendor);
-                halRelease.addEmbeddedResource("sw360:vendors", vendorHalResource);
-                release.setVendor(null);
-            }
-            if (release.getMainLicenseIds() != null) {
-                restControllerHelper.addEmbeddedLicenses(halRelease, release.getMainLicenseIds());
-            }
-            if (release.getOtherLicenseIds() != null) {
-                restControllerHelper.addEmbeddedOtherLicenses(halRelease, release.getOtherLicenseIds());
-            }
-            Set<String> packageIds = release.getPackageIds();
-
-            if (packageIds != null) {
-                restControllerHelper.addEmbeddedPackages(halRelease, packageIds, packageService);
-                release.setPackageIds(null);
-            }
-        }
-        return halRelease;
-    }
-
-    private @NonNull HalResource<Release> createHalReleaseResourceWithAllDetails(Release release) {
-        HalResource<Release> halRelease = new HalResource<>(release);
-        Link componentLink = linkTo(ReleaseController.class)
-                .slash("api" + ComponentController.COMPONENTS_URL + "/" + release.getComponentId())
-                .withRel("component");
-        halRelease.add(componentLink);
-        release.setComponentId(null);
-        if (SW360Utils.readConfig(IS_PACKAGE_PORTLET_ENABLED, true) && release.getPackageIds() != null) {
-            for (String id : release.getPackageIds()) {
-                Link packageLink = linkTo(ReleaseController.class)
-                        .slash("api" + PackageController.PACKAGES_URL + "/" + id).withRel("packages");
-                halRelease.add(packageLink);
-            }
-            release.setPackageIds(null);
-        }
-        for (Entry<Release._Fields, String> field : mapOfFieldsTobeEmbedded.entrySet()) {
-            restControllerHelper.addEmbeddedFields(field.getValue(), release.getFieldValue(field.getKey()), halRelease);
-        }
-        // Do not add attachment as it is an embedded field
-        release.unsetAttachments();
-        return halRelease;
-    }
-
-    private Release setBackwardCompatibleFieldsInRelease(Map<String, Object> reqBodyMap) {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.registerModule(sw360Module);
-
-        Set<Attachment> attachments = attachmentService.getAttachmentsFromRequest(reqBodyMap.get("attachments"), mapper);
-        if (null != reqBodyMap.get("attachments")) {
-            reqBodyMap.remove("attachments");
-        }
-        Release release = mapper.convertValue(reqBodyMap, Release.class);
-        if (null != attachments) {
-            release.setAttachments(attachments);
-        }
-
-        mapOfBackwardCompatible_Field_OldFieldNames_NewFieldNames.entrySet().stream().forEach(entry -> {
-            Release._Fields field = entry.getKey();
-            String oldFieldName = entry.getValue()[0];
-            String newFieldName = entry.getValue()[1];
-            if (!reqBodyMap.containsKey(newFieldName) && reqBodyMap.containsKey(oldFieldName)) {
-                release.setFieldValue(field, CommonUtils.nullToEmptyString(reqBodyMap.get(oldFieldName)));
-            }
-        });
-
-        return release;
-    }
     @PreAuthorize("hasAuthority('WRITE')")
     @Operation(
             summary = "Bulk delete releases.",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseModelAssembler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseModelAssembler.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright Siemens AG, 2026.
+ * Copyright Sandip Mandal<sandipmandal02.sm@gmail.com>, 2026.
+ * Copyright Bosch Software Innovations GmbH, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.rest.resourceserver.release;
 
 import com.google.common.collect.ImmutableMap;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseModelAssembler.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseModelAssembler.java
@@ -1,0 +1,107 @@
+package org.eclipse.sw360.rest.resourceserver.release;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.NonNull;
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
+import org.eclipse.sw360.rest.resourceserver.core.HalResource;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.packages.PackageController;
+import org.eclipse.sw360.rest.resourceserver.packages.SW360PackageService;
+import org.springframework.hateoas.Link;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_PACKAGE_PORTLET_ENABLED;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+@Component
+public class ReleaseModelAssembler {
+
+    private static final ImmutableMap<Release._Fields,String> mapOfFieldsTobeEmbedded = ImmutableMap.of(
+            Release._Fields.MODERATORS, "sw360:moderators",
+            Release._Fields.ATTACHMENTS, "sw360:attachments",
+            Release._Fields.COTS_DETAILS, "sw360:cotsDetails",
+            Release._Fields.RELEASE_ID_TO_RELATIONSHIP,"sw360:releaseIdToRelationship",
+            Release._Fields.CLEARING_INFORMATION, "sw360:clearingInformation");
+
+    @NonNull
+    private final RestControllerHelper restControllerHelper;
+
+    @NonNull
+    private final SW360PackageService packageService;
+
+    ReleaseModelAssembler(@NonNull RestControllerHelper restControllerHelper, @NonNull SW360PackageService packageService) {
+        this.restControllerHelper = restControllerHelper;
+        this.packageService = packageService;
+    }
+
+    HalResource<Release> createHalReleaseResource(Release release, boolean verbose) throws TException {
+        HalResource<Release> halRelease = new HalResource<>(release);
+        Link componentLink = linkTo(ReleaseController.class)
+                .slash("api" + ComponentController.COMPONENTS_URL + "/" + release.getComponentId()).withRel("component");
+        halRelease.add(componentLink);
+        release.setComponentId(null);
+        if (verbose) {
+            if (release.getModerators() != null) {
+                Set<String> moderators = release.getModerators();
+                restControllerHelper.addEmbeddedModerators(halRelease, moderators);
+                release.setModerators(null);
+            }
+            if (release.getAttachments() != null) {
+                Set<Attachment> attachments = release.getAttachments();
+                restControllerHelper.addEmbeddedAttachments(halRelease, attachments);
+                release.setAttachments(null);
+            }
+            if (release.getVendor() != null) {
+                Vendor vendor = release.getVendor();
+                HalResource<Vendor> vendorHalResource = restControllerHelper.addEmbeddedVendor(vendor);
+                halRelease.addEmbeddedResource("sw360:vendors", vendorHalResource);
+                release.setVendor(null);
+            }
+            if (release.getMainLicenseIds() != null) {
+                restControllerHelper.addEmbeddedLicenses(halRelease, release.getMainLicenseIds());
+            }
+            if (release.getOtherLicenseIds() != null) {
+                restControllerHelper.addEmbeddedOtherLicenses(halRelease, release.getOtherLicenseIds());
+            }
+            Set<String> packageIds = release.getPackageIds();
+
+            if (packageIds != null) {
+                restControllerHelper.addEmbeddedPackages(halRelease, packageIds, packageService);
+                release.setPackageIds(null);
+            }
+        }
+        return halRelease;
+    }
+
+    @NonNull HalResource<Release> createHalReleaseResourceWithAllDetails(Release release) {
+        HalResource<Release> halRelease = new HalResource<>(release);
+        Link componentLink = linkTo(ReleaseController.class)
+                .slash("api" + ComponentController.COMPONENTS_URL + "/" + release.getComponentId())
+                .withRel("component");
+        halRelease.add(componentLink);
+        release.setComponentId(null);
+        if (SW360Utils.readConfig(IS_PACKAGE_PORTLET_ENABLED, true) && release.getPackageIds() != null) {
+            for (String id : release.getPackageIds()) {
+                Link packageLink = linkTo(ReleaseController.class)
+                        .slash("api" + PackageController.PACKAGES_URL + "/" + id).withRel("packages");
+                halRelease.add(packageLink);
+            }
+            release.setPackageIds(null);
+        }
+        for (Map.Entry<Release._Fields, String> field : mapOfFieldsTobeEmbedded.entrySet()) {
+            restControllerHelper.addEmbeddedFields(field.getValue(), release.getFieldValue(field.getKey()), halRelease);
+        }
+        // Do not add attachment as it is an embedded field
+        release.unsetAttachments();
+        return halRelease;
+    }
+
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseRequestMapper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseRequestMapper.java
@@ -1,0 +1,59 @@
+package org.eclipse.sw360.rest.resourceserver.release;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import lombok.NonNull;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class ReleaseRequestMapper {
+
+    private static final ImmutableMap<Release._Fields, String[]> mapOfBackwardCompatible_Field_OldFieldNames_NewFieldNames = ImmutableMap.<Release._Fields, String[]>builder()
+            .put(Release._Fields.SOURCE_CODE_DOWNLOADURL, new String[] { "downloadurl", "sourceCodeDownloadurl" })
+            .build();
+    @NonNull
+    private final com.fasterxml.jackson.databind.Module sw360Module;
+
+    @NonNull
+    private final Sw360AttachmentService attachmentService;
+
+    public ReleaseRequestMapper(@NonNull Module sw360Module, @NonNull Sw360AttachmentService attachmentService) {
+        this.sw360Module = sw360Module;
+        this.attachmentService = attachmentService;
+    }
+
+     Release setBackwardCompatibleFieldsInRelease(Map<String, Object> reqBodyMap) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.registerModule(sw360Module);
+
+        Set<Attachment> attachments = attachmentService.getAttachmentsFromRequest(reqBodyMap.get("attachments"), mapper);
+        if (null != reqBodyMap.get("attachments")) {
+            reqBodyMap.remove("attachments");
+        }
+        Release release = mapper.convertValue(reqBodyMap, Release.class);
+        if (null != attachments) {
+            release.setAttachments(attachments);
+        }
+
+        mapOfBackwardCompatible_Field_OldFieldNames_NewFieldNames.entrySet().stream().forEach(entry -> {
+            Release._Fields field = entry.getKey();
+            String oldFieldName = entry.getValue()[0];
+            String newFieldName = entry.getValue()[1];
+            if (!reqBodyMap.containsKey(newFieldName) && reqBodyMap.containsKey(oldFieldName)) {
+                release.setFieldValue(field, CommonUtils.nullToEmptyString(reqBodyMap.get(oldFieldName)));
+            }
+        });
+
+        return release;
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseRequestMapper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseRequestMapper.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright Siemens AG, 2026.
+ * Copyright Sandip Mandal<sandipmandal02.sm@gmail.com>, 2026.
+ * Copyright Bosch Software Innovations GmbH, 2017.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.rest.resourceserver.release;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> This PR is aimed at solving the issue #3907 

## Summary
The issue states that the ReleaseController is oversized and is performing more activities than a REST controller actually should. Thus this PR is an attempt to reduce the functionality of the ReleaseController and to only handle REST APIs. 

> Functionalities shifted to another class
Primarily, 3 different functions were removed from the original functioin and has been shifted to new classes namely ReleaseRequestMapper which now implements the function setBackwardCompatibleFieldsInRelease(), and ReleaseModelAssembler which implements the function createHalReleaseResource() and createHalReleaseResourceWithAllDetails().
I have simply shifted all these functions to different classes and introduced 2 new dependencies in the original ReleaseController. 


Issue: 

### Suggest Reviewer
@GMishx @rudra-superrr @akshitjoshii 


Must I say I have very little knowledge regarding the licencing of a class, Both the new classes proposed contain the same licence as ReleaseController with the current year. 

Please let me know if anything needs to change or if there is any issue with the proposed changes.
Thank you.