### PR TITLE
fix(sort): fix sorting by timestamp in moderation requests

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -144,9 +144,10 @@ public class ModerationSearchHandler extends BaseNouveauSearchHandler<Moderation
             case ModerationSortColumn.BY_DOCUMENT_TYPE -> List.of("documentType_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
             case ModerationSortColumn.BY_COMPONENT_TYPE -> List.of("componentType_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
             case ModerationSortColumn.BY_REQUESTING_USER -> List.of("requestingUser_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
+            case ModerationSortColumn.BY_TIMESTAMP -> List.of("timestamp", SCORE_SORTING_FIELD);
             case ModerationSortColumn.BY_MODERATION_STATE -> List.of("moderationState_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
             case ModerationSortColumn.BY_REQUESTING_USER_DEPT -> List.of("requestingUserDepartment_sort", SCORE_SORTING_FIELD, revDir + "timestamp");
-            case null, default -> List.of(SCORE_SORTING_FIELD, revDir + "timestamp");
+            case null, default -> List.of(revDir + "timestamp", SCORE_SORTING_FIELD);
         };
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Sort by request date in descending order in ```GET /moderationrequest``` endpoint.

### How To Test?
Make curl request to moderation requests endpoint with following parameters:
1. No parameters - The entries must be sorted by request date in descending order by default
2. sort='requestDate,asc' -  he entries must be sorted by request date in ascending order
3. sort='requestDate,desc' -  he entries must be sorted by request date in descending order
4. sort='requestDate,desc&luceneSearch=false' -  he entries must be sorted by request date in descending order
5. sort='requestDate,asc&luceneSearch=false' -  he entries must be sorted by request date in descending order

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
