### PR TITLE
feat(projects): add permission check to lucene

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -12,17 +12,21 @@ package org.eclipse.sw360.datahandler.db;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.BaseNouveauSearchHandler;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
-import org.eclipse.sw360.datahandler.permissions.ProjectPermissions;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_ADMIN_PRIVATE_ACCESS_ENABLED;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_ID_FIELD;
 import static org.eclipse.sw360.datahandler.common.SearchUtils.INDEX_PROJECT_RELEASE_RELATION_NETWORK;
 import static org.eclipse.sw360.nouveau.LuceneAwareCouchDbConnector.SCORE_SORTING_FIELD;
@@ -44,12 +49,14 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
      * Fields common to all projects, grouped by index category.
      *
      * <ul>
-     *   <li><b>emptyAware</b>: {@code businessUnit} (ngram 2–10), {@code tag} (ngram 2–10) -
+     *   <li><b>emptyAware</b>: {@code businessUnit} (ngram 2-10), {@code tag} (ngram 2-10) -
      *       documents with no value are indexed under
      *       {@link SW360Constants#PROJECT_SEARCH_EMPTY_TOKEN} so "no value" filter queries work.</li>
      *   <li><b>standard</b>: {@code name}, {@code version} - full prefix-search support.</li>
      *   <li><b>simple</b>: {@code projectType}, {@code projectResponsible} (email analyzer),
-     *       {@code description}, {@code state} (keyword), {@code clearingState} (keyword).</li>
+     *       {@code description}, {@code state} (keyword), {@code clearingState} (keyword),
+     *       {@code visbility} (keyword), {@code createdBy} (email), {@code leadArchitect} (email) -
+     *       used for permission/visibility filter queries.</li>
      *   <li><b>date</b>: {@code createdOn} - stored as sortable yyyyMMdd double.</li>
      * </ul>
      */
@@ -63,12 +70,17 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
             IndexField.simple("projectResponsible", "email"),
             IndexField.simple("state", "keyword"),
             IndexField.simple("clearingState", "keyword"),
+            IndexField.simple("visbility", "keyword"),
+            IndexField.simple("createdBy", "email"),
+            IndexField.simple("leadArchitect", "email"),
             IndexField.date("createdOn")
     );
 
     /**
-     * Handler-specific JS: index {@code additionalData} as a concatenated text blob and
-     * index the creator email of every attachment.
+     * Handler-specific JS: index {@code additionalData} as a concatenated text blob,
+     * index the creator email of every attachment, and index each element of the
+     * {@code moderators} and {@code contributors} arrays individually so that
+     * per-user visibility queries work correctly.
      */
     private static final String PROJECT_CUSTOM_JS =
             "    arrayToStringIndex(doc.additionalData, 'additionalData');" +
@@ -79,6 +91,16 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
             "        }" +
             "      }" +
             "    }" +
+            "    if(doc.moderators && doc.moderators.length > 0) {" +
+            "      for(var i in doc.moderators) {" +
+            "        index('text', 'moderators', doc.moderators[i]);" +
+            "      }" +
+            "    }" +
+            "    if(doc.contributors && doc.contributors.length > 0) {" +
+            "      for(var i in doc.contributors) {" +
+            "        index('text', 'contributors', doc.contributors[i]);" +
+            "      }" +
+            "    }" +
             INDEX_PROJECT_RELEASE_RELATION_NETWORK +
             INDEX_ID_FIELD;
 
@@ -87,12 +109,16 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
      * <ul>
      *   <li>{@code attachmentCreatedBy} -> {@code email} (custom JS field)</li>
      *   <li>{@code additionalData_sort} -> {@code keyword} (created by {@code arrayToStringIndex})</li>
+     *   <li>{@code moderators} -> {@code email} (custom JS loop, array elements)</li>
+     *   <li>{@code contributors} -> {@code email} (custom JS loop, array elements)</li>
      * </ul>
      */
     private static final Map<String, String> PROJECT_CUSTOM_ANALYZERS = Map.of(
             "attachmentCreatedBy", "email",
             "additionalData_sort", "keyword",
             "releaseRelationNetwork", "keyword",
+            "moderators", "email",
+            "contributors", "email",
             "id", "keyword"
     );
 
@@ -139,15 +165,8 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
             @Nullable User user,
             PaginationData pageData
     ) {
-        Map<PaginationData, List<Project>> resultProjectList = baseSearch(connector, subQueryRestrictions, pageData);
-        PaginationData respPageData = resultProjectList.keySet().iterator().next();
-        List<Project> projectList = resultProjectList.values().iterator().next();
-
-        if (user != null) {
-            projectList = projectList.stream().filter(ProjectPermissions.isVisible(user)).toList();
-        }
-
-        return Collections.singletonMap(respPageData, projectList);
+        String visibilityQuery = buildVisibilityLuceneQuery(user);
+        return baseSearch(connector, subQueryRestrictions, visibilityQuery, pageData);
     }
 
     public Map<PaginationData, List<Project>> searchFilteredProjects(
@@ -159,15 +178,8 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
         for (Project._Fields field : QUICK_FILTER_FIELDS) {
             subQueryRestrictions.put(field.getFieldName(), Collections.singleton(searchText));
         }
-        Map<PaginationData, List<Project>> resultProjectList = baseSearchWithOr(connector, subQueryRestrictions, pageData);
-        PaginationData respPageData = resultProjectList.keySet().iterator().next();
-        List<Project> projectList = resultProjectList.values().iterator().next();
-
-        if (user != null) {
-            projectList = projectList.stream().filter(ProjectPermissions.isVisible(user)).toList();
-        }
-
-        return Collections.singletonMap(respPageData, projectList);
+        String visibilityQuery = buildVisibilityLuceneQuery(user);
+        return baseSearchWithOr(connector, subQueryRestrictions, visibilityQuery, pageData);
     }
 
     public Set<Project> searchByReleaseId(String id, User user) {
@@ -182,6 +194,98 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
         Map<PaginationData, List<Project>> result = search(filterMap, user, pageData);
         List<Project> projectsByReleaseIds = NouveauLuceneAwareDatabaseConnector.convertPaginatorToList(result);
         return new HashSet<>(projectsByReleaseIds);
+    }
+
+    // -------------------------------------------------------------------------
+    //  Visibility / permission Lucene query
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a Lucene query string that enforces project visibility rules for the given user,
+     * mirroring the Mango selector produced by
+     * {@link ProjectRepository#getAccessibleProjectSelector}.
+     *
+     * <p>The returned string is suitable for AND-ing with any caller-supplied search query so
+     * that Nouveau applies the permission check inside the index rather than as a post-filter.
+     * This fixes pagination: every page returned will contain exactly the requested number of
+     * accessible projects (no silent gaps caused by post-filter removals).</p>
+     *
+     * <p>Check the <a href="https://eclipse.dev/sw360/docs/administrationguide/user-management-roles/#project-visibility">
+     *     Project Visibility documentation for more.
+     * </a></p>
+     *
+     * @param user The requesting user, or {@code null} (no filter applied when null).
+     * @return A Lucene query string, or {@code null} if no restriction should be applied.
+     */
+    @Nullable
+    public static String buildVisibilityLuceneQuery(@Nullable User user) {
+        if (user == null) {
+            return null;
+        }
+
+        boolean isAdmin = PermissionUtils.isAdmin(user);
+        boolean isSecurityUser = PermissionUtils.isSecurityUser(user);
+        if ((SW360Utils.readConfig(IS_ADMIN_PRIVATE_ACCESS_ENABLED, false) && isAdmin) || isSecurityUser) {
+            return null;
+        }
+
+        boolean isClearingAdmin = PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user);
+        String email = user.getEmail();
+        String primaryBU = SW360Utils.getBUFromOrganisation(user.getDepartment());
+
+        // Collect all BUs (primary + secondary)
+        Set<String> allBUs = new HashSet<>();
+        allBUs.add(primaryBU);
+        Map<String, Set<UserGroup>> secondaryDepartmentsAndRoles = user.getSecondaryDepartmentsAndRoles();
+        if (!CommonUtils.isNullOrEmptyMap(secondaryDepartmentsAndRoles)) {
+            secondaryDepartmentsAndRoles.keySet().stream()
+                    .map(SW360Utils::getBUFromOrganisation)
+                    .forEach(allBUs::add);
+        }
+
+        // Clause 1: PRIVATE projects owned by the user
+        String privateClause = "(visbility:\"PRIVATE\" AND createdBy:\"" + email + "\")";
+
+        // Clause 2: visible to everyone
+        String everyoneClause = "visbility:\"EVERYONE\"";
+
+        // Clause 3: ME_AND_MODERATORS - user must be a direct member
+        String memberCheck = buildMemberCheckQuery(email);
+        String meAndModeratorClause =
+                "(visbility:\"ME_AND_MODERATORS\" AND (" + memberCheck + "))";
+
+        // Clause 4: BUISNESSUNIT_AND_MODERATORS
+        String buAndModeratorClause;
+        if (isClearingAdmin) {
+            // Clearing admins can see all BU+Moderator projects regardless of BU match
+            buAndModeratorClause = "visbility:\"BUISNESSUNIT_AND_MODERATORS\"";
+        } else {
+            List<String> buOrMemberParts = new ArrayList<>();
+            for (String bu : allBUs) {
+                buOrMemberParts.add("businessUnit_exact:\"" + bu + "\"");
+            }
+            buOrMemberParts.add(memberCheck);
+            buAndModeratorClause = "(visbility:\"BUISNESSUNIT_AND_MODERATORS\" AND ("
+                    + String.join(" OR ", buOrMemberParts) + "))";
+        }
+
+        return privateClause
+                + " OR " + everyoneClause
+                + " OR " + meAndModeratorClause
+                + " OR " + buAndModeratorClause;
+    }
+
+    /**
+     * Build an OR query that checks whether {@code email} appears in any of the
+     * project-member fields: {@code createdBy}, {@code projectResponsible},
+     * {@code leadArchitect}, {@code moderators}, {@code contributors}.
+     */
+    private static @NonNull String buildMemberCheckQuery(@NonNull String email) {
+        return "createdBy:\"" + email + "\""
+                + " OR projectResponsible:\"" + email + "\""
+                + " OR leadArchitect:\"" + email + "\""
+                + " OR moderators:\"" + email + "\""
+                + " OR contributors:\"" + email + "\"";
     }
 
     // -------------------------------------------------------------------------

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandlerTest.java
@@ -21,10 +21,12 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectSortColumn;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -65,6 +67,7 @@ class ProjectSearchHandlerTest {
         TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
         DatabaseConnectorCloudant db = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
         for (Project p : createSeedProjects()) { db.add(p); }
+        for (Project p : createVisibilitySeedProjects()) { db.add(p); }
         searchHandler = new ProjectSearchHandler(DatabaseSettingsTest.getConfiguredClient(), dbName);
     }
 
@@ -389,6 +392,224 @@ class ProjectSearchHandlerTest {
         int adminCount = items(searchHandler.searchFilteredProjects("FT_", user1, allPages())).size();
         int otherCount = items(searchHandler.searchFilteredProjects("FT_", user2, allPages())).size();
         assertTrue(otherCount <= adminCount);
+    }
+
+    // --- Visibility filter functional tests ----------------------------------
+    // Seed projects for visibility tests use the "VIS_" prefix so they are
+    // isolated from the sort/pagination tests above.
+    //
+    // Users involved:
+    //   visUser     - dept "AB CD EF" (BU "AB CD EF"), role USER
+    //   visOutsider - dept "XY ZZ AA" (BU "XY ZZ AA"), role USER  (different BU)
+    //   visOwner    - the createdBy email of some projects
+    //   visMod      - added as a moderator on some projects
+    //   visContrib  - added as a contributor on some projects
+    //   visLead     - added as a leadArchitect on some projects
+    //   visResp     - added as a projectResponsible on some projects
+    // -------------------------------------------------------------------------
+
+    private static final User visUser     = new User().setEmail("vis_user@test.com")    .setDepartment("AB CD EF").setUserGroup(UserGroup.USER);
+    private static final User visOutsider = new User().setEmail("vis_outsider@test.com").setDepartment("XY ZZ AA").setUserGroup(UserGroup.USER);
+    private static final User visClearingAdmin = new User().setEmail("vis_ca@test.com") .setDepartment("XY ZZ AA").setUserGroup(UserGroup.CLEARING_ADMIN);
+
+    private static final String VIS_OWNER   = "vis_user@test.com";      // same email as visUser
+    private static final String VIS_MOD     = "vis_mod@test.com";
+    private static final String VIS_CONTRIB = "vis_contrib@test.com";
+    private static final String VIS_LEAD    = "vis_lead@test.com";
+    private static final String VIS_RESP    = "vis_resp@test.com";
+
+    // Project IDs for visibility seed data
+    private static final String VIS_EVERYONE    = "vis-prj-everyone";
+    private static final String VIS_PRIVATE_OWN = "vis-prj-private-own";       // createdBy=visUser
+    private static final String VIS_PRIVATE_OTHER = "vis-prj-private-other";   // createdBy=someone else
+    private static final String VIS_ME_MOD_OWN    = "vis-prj-me-mod-own";      // ME_AND_MODERATORS, createdBy=visUser
+    private static final String VIS_ME_MOD_MOD    = "vis-prj-me-mod-mod";      // ME_AND_MODERATORS, visUser is moderator
+    private static final String VIS_ME_MOD_CONTRIB = "vis-prj-me-mod-contrib"; // ME_AND_MODERATORS, visUser is contributor
+    private static final String VIS_ME_MOD_LEAD    = "vis-prj-me-mod-lead";    // ME_AND_MODERATORS, visUser is leadArchitect
+    private static final String VIS_ME_MOD_RESP    = "vis-prj-me-mod-resp";    // ME_AND_MODERATORS, visUser is projectResponsible
+    private static final String VIS_ME_MOD_NONE    = "vis-prj-me-mod-none";    // ME_AND_MODERATORS, visUser is NOT a member
+    private static final String VIS_BU_SAME         = "vis-prj-bu-same";       // BU+MOD, same BU as visUser
+    private static final String VIS_BU_OTHER        = "vis-prj-bu-other";      // BU+MOD, different BU (XY ZZ AA)
+    private static final String VIS_BU_MOD_MEMBER   = "vis-prj-bu-mod-member"; // BU+MOD, different BU but visUser is moderator
+
+    private static List<Project> createVisibilitySeedProjects() {
+        List<Project> projects = new ArrayList<>();
+
+        // EVERYONE - any user should see this
+        projects.add(new Project().setId(VIS_EVERYONE).setType("project")
+                .setName("VIS_Everyone Project").setVisbility(Visibility.EVERYONE)
+                .setBusinessUnit("AB CD EF").setCreatedBy("other@test.com").setCreatedOn("2025-01-01"));
+
+        // PRIVATE - only the owner (visUser)
+        projects.add(new Project().setId(VIS_PRIVATE_OWN).setType("project")
+                .setName("VIS_Private Own").setVisbility(Visibility.PRIVATE)
+                .setBusinessUnit("AB CD EF").setCreatedBy(VIS_OWNER).setCreatedOn("2025-01-01"));
+
+        // PRIVATE - owned by someone else, nobody should see it except the owner
+        projects.add(new Project().setId(VIS_PRIVATE_OTHER).setType("project")
+                .setName("VIS_Private Other").setVisbility(Visibility.PRIVATE)
+                .setBusinessUnit("AB CD EF").setCreatedBy("private_owner@test.com").setCreatedOn("2025-01-01"));
+
+        // ME_AND_MODERATORS - visUser is the creator
+        projects.add(new Project().setId(VIS_ME_MOD_OWN).setType("project")
+                .setName("VIS_MeAndMod Own").setVisbility(Visibility.ME_AND_MODERATORS)
+                .setBusinessUnit("AB CD EF").setCreatedBy(VIS_OWNER).setCreatedOn("2025-01-01"));
+
+        // ME_AND_MODERATORS - visUser is a moderator
+        projects.add(new Project().setId(VIS_ME_MOD_MOD).setType("project")
+                .setName("VIS_MeAndMod Mod").setVisbility(Visibility.ME_AND_MODERATORS)
+                .setBusinessUnit("AB CD EF").setCreatedBy("other@test.com")
+                .setModerators(Set.of(VIS_OWNER)).setCreatedOn("2025-01-01"));
+
+        // ME_AND_MODERATORS - visUser is a contributor
+        projects.add(new Project().setId(VIS_ME_MOD_CONTRIB).setType("project")
+                .setName("VIS_MeAndMod Contrib").setVisbility(Visibility.ME_AND_MODERATORS)
+                .setBusinessUnit("AB CD EF").setCreatedBy("other@test.com")
+                .setContributors(Set.of(VIS_OWNER)).setCreatedOn("2025-01-01"));
+
+        // ME_AND_MODERATORS - visUser is the leadArchitect
+        projects.add(new Project().setId(VIS_ME_MOD_LEAD).setType("project")
+                .setName("VIS_MeAndMod Lead").setVisbility(Visibility.ME_AND_MODERATORS)
+                .setBusinessUnit("AB CD EF").setCreatedBy("other@test.com")
+                .setLeadArchitect(VIS_OWNER).setCreatedOn("2025-01-01"));
+
+        // ME_AND_MODERATORS - visUser is the projectResponsible
+        projects.add(new Project().setId(VIS_ME_MOD_RESP).setType("project")
+                .setName("VIS_MeAndMod Resp").setVisbility(Visibility.ME_AND_MODERATORS)
+                .setBusinessUnit("AB CD EF").setCreatedBy("other@test.com")
+                .setProjectResponsible(VIS_OWNER).setCreatedOn("2025-01-01"));
+
+        // ME_AND_MODERATORS - visUser has no role → should NOT be visible
+        projects.add(new Project().setId(VIS_ME_MOD_NONE).setType("project")
+                .setName("VIS_MeAndMod None").setVisbility(Visibility.ME_AND_MODERATORS)
+                .setBusinessUnit("AB CD EF").setCreatedBy("other@test.com").setCreatedOn("2025-01-01"));
+
+        // BUISNESSUNIT_AND_MODERATORS - same BU as visUser ("AB CD EF")
+        projects.add(new Project().setId(VIS_BU_SAME).setType("project")
+                .setName("VIS_BuAndMod SameBU").setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setBusinessUnit("AB CD EF").setCreatedBy("other@test.com").setCreatedOn("2025-01-01"));
+
+        // BUISNESSUNIT_AND_MODERATORS - different BU ("XY ZZ AA"), visUser not a member
+        projects.add(new Project().setId(VIS_BU_OTHER).setType("project")
+                .setName("VIS_BuAndMod OtherBU").setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setBusinessUnit("XY ZZ AA").setCreatedBy("other@test.com").setCreatedOn("2025-01-01"));
+
+        // BUISNESSUNIT_AND_MODERATORS - different BU but visUser is a moderator → should be visible
+        projects.add(new Project().setId(VIS_BU_MOD_MEMBER).setType("project")
+                .setName("VIS_BuAndMod Member").setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setBusinessUnit("XY ZZ AA").setCreatedBy("other@test.com")
+                .setModerators(Set.of(VIS_OWNER)).setCreatedOn("2025-01-01"));
+
+        return projects;
+    }
+
+    private Set<String> visIds(User user) {
+        return items(searchHandler.search(Map.of("name", Set.of("VIS_")), user, allPages()))
+                .stream().map(Project::getId).collect(Collectors.toSet());
+    }
+
+    @Test
+    void visibility_everyone_isVisibleToAllUsers() {
+        assertTrue(visIds(visUser).contains(VIS_EVERYONE));
+        assertTrue(visIds(visOutsider).contains(VIS_EVERYONE));
+        assertTrue(visIds(visClearingAdmin).contains(VIS_EVERYONE));
+        assertTrue(visIds(null).contains(VIS_EVERYONE));
+    }
+
+    @Test
+    void visibility_private_onlyOwnerCanSee() {
+        // visUser is the owner
+        assertTrue(visIds(visUser).contains(VIS_PRIVATE_OWN));
+        // outsider cannot see it
+        assertFalse(visIds(visOutsider).contains(VIS_PRIVATE_OWN));
+        // clearing admin cannot see other's private projects
+        assertFalse(visIds(visClearingAdmin).contains(VIS_PRIVATE_OWN));
+    }
+
+    @Test
+    void visibility_private_othersProjectNotVisible() {
+        assertFalse(visIds(visUser).contains(VIS_PRIVATE_OTHER));
+        assertFalse(visIds(visOutsider).contains(VIS_PRIVATE_OTHER));
+    }
+
+    @Test
+    void visibility_meAndModerators_creatorCanSee() {
+        assertTrue(visIds(visUser).contains(VIS_ME_MOD_OWN));
+        assertFalse(visIds(visOutsider).contains(VIS_ME_MOD_OWN));
+    }
+
+    @Test
+    void visibility_meAndModerators_moderatorCanSee() {
+        assertTrue(visIds(visUser).contains(VIS_ME_MOD_MOD));
+        assertFalse(visIds(visOutsider).contains(VIS_ME_MOD_MOD));
+    }
+
+    @Test
+    void visibility_meAndModerators_contributorCanSee() {
+        assertTrue(visIds(visUser).contains(VIS_ME_MOD_CONTRIB));
+        assertFalse(visIds(visOutsider).contains(VIS_ME_MOD_CONTRIB));
+    }
+
+    @Test
+    void visibility_meAndModerators_leadArchitectCanSee() {
+        assertTrue(visIds(visUser).contains(VIS_ME_MOD_LEAD));
+        assertFalse(visIds(visOutsider).contains(VIS_ME_MOD_LEAD));
+    }
+
+    @Test
+    void visibility_meAndModerators_projectResponsibleCanSee() {
+        assertTrue(visIds(visUser).contains(VIS_ME_MOD_RESP));
+        assertFalse(visIds(visOutsider).contains(VIS_ME_MOD_RESP));
+    }
+
+    @Test
+    void visibility_meAndModerators_nonMemberCannotSee() {
+        assertFalse(visIds(visUser).contains(VIS_ME_MOD_NONE));
+        assertFalse(visIds(visOutsider).contains(VIS_ME_MOD_NONE));
+    }
+
+    @Test
+    void visibility_buAndModerators_sameBuUserCanSee() {
+        assertTrue(visIds(visUser).contains(VIS_BU_SAME));
+        assertFalse(visIds(visOutsider).contains(VIS_BU_SAME));
+    }
+
+    @Test
+    void visibility_buAndModerators_differentBuUserCannotSee() {
+        assertFalse(visIds(visUser).contains(VIS_BU_OTHER));
+    }
+
+    @Test
+    void visibility_buAndModerators_memberOverridesDifferentBu() {
+        // visUser is a moderator on VIS_BU_MOD_MEMBER even though BU differs
+        assertTrue(visIds(visUser).contains(VIS_BU_MOD_MEMBER));
+    }
+
+    @Test
+    void visibility_clearingAdmin_seesAllBuAndModeratorProjects() {
+        Set<String> ids = visIds(visClearingAdmin);
+        // Clearing admin sees all BUISNESSUNIT_AND_MODERATORS regardless of BU
+        assertTrue(ids.contains(VIS_BU_SAME));
+        assertTrue(ids.contains(VIS_BU_OTHER));
+        assertTrue(ids.contains(VIS_BU_MOD_MEMBER));
+    }
+
+    @Test
+    void visibility_clearingAdmin_cannotSeeOthersPrivateProjects() {
+        Set<String> ids = visIds(visClearingAdmin);
+        assertFalse(ids.contains(VIS_PRIVATE_OTHER));
+        assertFalse(ids.contains(VIS_PRIVATE_OWN));  // not their project
+    }
+
+    @Test
+    void visibility_nullUser_seesAll() {
+        Set<String> ids = visIds(null);
+        // null user → no filter → all VIS_ projects should be returned
+        assertTrue(ids.containsAll(Set.of(
+                VIS_EVERYONE, VIS_PRIVATE_OWN, VIS_PRIVATE_OTHER,
+                VIS_ME_MOD_OWN, VIS_ME_MOD_MOD, VIS_ME_MOD_CONTRIB,
+                VIS_ME_MOD_LEAD, VIS_ME_MOD_RESP, VIS_ME_MOD_NONE,
+                VIS_BU_SAME, VIS_BU_OTHER, VIS_BU_MOD_MEMBER)));
     }
 
     // --- Edge case tests -----------------------------------------------------

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/BaseNouveauSearchHandler.java
@@ -11,6 +11,7 @@ package org.eclipse.sw360.datahandler.cloudantclient;
 
 import com.google.common.base.Joiner;
 import com.google.gson.Gson;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -572,6 +573,30 @@ public abstract class BaseNouveauSearchHandler<T> {
     }
 
     /**
+     * Perform a AND'd base search with an additional pre-built Lucene query clause AND'd into
+     * the final query. Use this overload when the caller has already constructed a query fragment
+     * (e.g. a visibility/permission filter) that must be combined with the field restrictions.
+     *
+     * @param connector            Nouveau Aware DB Connector to use.
+     * @param subQueryRestrictions Map of field names to their accepted values.
+     * @param additionalQuery      A pre-built Lucene query string AND'd with the restriction query.
+     *                             When {@code null} or empty, falls back to the plain
+     *                             {@link #baseSearch(NouveauLuceneAwareDatabaseConnector, Map, PaginationData)}.
+     * @param pageData             Pagination information.
+     * @return Paginated search results.
+     */
+    protected final @NonNull @Unmodifiable Map<PaginationData, List<T>> baseSearch(
+            NouveauLuceneAwareDatabaseConnector connector,
+            final @NonNull Map<String, Set<String>> subQueryRestrictions,
+            @Nullable String additionalQuery,
+            PaginationData pageData
+    ) {
+        return genericBaseSearch(connector, subQueryRestrictions,
+                restrictions -> appendAdditionalQuery(buildQueryFromRestrictionsWithAnd(restrictions), additionalQuery),
+                pageData);
+    }
+
+    /**
      * Perform a OR'd base search for a given type with the provided field restrictions and pagination.
      *
      * <p>Query routing is metadata-driven from the {@link BuiltIndexDefinition} passed to
@@ -588,6 +613,46 @@ public abstract class BaseNouveauSearchHandler<T> {
             PaginationData pageData
     ) {
         return genericBaseSearch(connector, subQueryRestrictions, this::buildQueryFromRestrictionsWithOr, pageData);
+    }
+
+    /**
+     * Perform a OR'd base search with an additional pre-built Lucene query clause AND'd into
+     * the final query. Use this overload when the caller has already constructed a query fragment
+     * (e.g. a visibility/permission filter) that must be combined with the OR'd field restrictions.
+     *
+     * @param connector            Nouveau Aware DB Connector to use.
+     * @param subQueryRestrictions Map of field names to their accepted values.
+     * @param additionalQuery      A pre-built Lucene query string AND'd with the OR restriction query.
+     *                             When {@code null} or empty, falls back to the plain
+     *                             {@link #baseSearchWithOr(NouveauLuceneAwareDatabaseConnector, Map, PaginationData)}.
+     * @param pageData             Pagination information.
+     * @return Paginated search results.
+     */
+    protected final @NonNull @Unmodifiable Map<PaginationData, List<T>> baseSearchWithOr(
+            NouveauLuceneAwareDatabaseConnector connector,
+            final @NonNull Map<String, Set<String>> subQueryRestrictions,
+            @Nullable String additionalQuery,
+            PaginationData pageData
+    ) {
+        return genericBaseSearch(connector, subQueryRestrictions,
+                restrictions -> appendAdditionalQuery(buildQueryFromRestrictionsWithOr(restrictions), additionalQuery),
+                pageData);
+    }
+
+    /**
+     * AND an extra Lucene clause onto an existing query string.
+     * If either part is absent the other is returned unchanged.
+     */
+    private static @NonNull String appendAdditionalQuery(
+            @NonNull String baseQuery, @Nullable String additionalQuery
+    ) {
+        if (CommonUtils.isNullEmptyOrWhitespace(additionalQuery)) {
+            return baseQuery;
+        }
+        if (baseQuery.isBlank()) {
+            return additionalQuery;
+        }
+        return "(" + baseQuery + ") AND (" + additionalQuery + ")";
     }
 
     /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -43,7 +43,6 @@ import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseNode;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;

--- a/third-party/keycloak-tf/r-sw360-groups.tf
+++ b/third-party/keycloak-tf/r-sw360-groups.tf
@@ -6,7 +6,7 @@
 locals {
   sw360_groups = toset([
     "USER", "ADMIN", "CLEARING_ADMIN", "ECC_ADMIN", "SECURITY_ADMIN",
-    "SW360_ADMIN", "CLEARING_EXPERT"
+    "SW360_ADMIN", "CLEARING_EXPERT", "SECURITY_USER"
   ])
 }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Add permission check to lucene query itself. Currently, the checks are added after fetching the paginated records and this can cause less amount of data in page, leading to confusion.

The change replicates the behviour of
`ProjectRepository#getAccessibleProjectSelector` (from mango to lucene).

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Check if the response pages and total element count is correct for Projects. And you cannot see any "nu-intended" Projects.