### PR TITLE
fix(licenseinfo): style docx hyperlinks blue underline, no dup text

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxUtils.java
@@ -174,9 +174,14 @@ public class DocxUtils {
     public static void addHyperLink(XWPFParagraph paragraph, String hyperlinkAnchor, String hyperlinkText) {
         CTHyperlink cLink = paragraph.getCTP().addNewHyperlink();
         cLink.setAnchor(hyperlinkAnchor);
+
+        CTR ctr = CTR.Factory.newInstance();
+        CTRPr ctrPr = ctr.addNewRPr();
+        ctrPr.addNewColor().setVal("0563C1");
+        ctrPr.addNewU().setVal(STUnderline.SINGLE);
+
         CTText ctText = CTText.Factory.newInstance();
         ctText.setStringValue(hyperlinkText);
-        CTR ctr = CTR.Factory.newInstance();
         ctr.setTArray(new CTText[] { ctText });
 
         cLink.setRArray(new CTR[] { ctr });


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Each release/license name in the DOCX now appears exactly once. All hyperlinked text (Releases Overview bullets, License names) is shown in blue with a single underline, consistent with standard hyperlink styling.

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: Closes #4546 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Rest api

Rest api:
curl -L -u 'username:password'
'http://localhost:8080/resource/api/reports?withlinkedreleases=false&projectId=&module=licenseInfo&withSubProject=false&generatorClassName=DocxGenerator&variant=DISCLOSURE'
-o /tmp/licenseinfo.docx

### Start SW360 backend and frontend locally.
1. Login to SW360.
2 avigate to: Projects -> -> License Clearing -> Generate License Information
Or open directly:
### Note : http://localhost:[port-number]/projects/generateLicenseInfo/?withSubProjects=false
4. Select at least one license info attachment/release.
5. Click Download.
6. Select License Disclosure as DOCX.
7. Download and open the generated DOCX.
8. Check the Releases Overview section.
9. Verify each release name appears only once in the bullet list and still links to its detailed release section.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
