### PR TITLE
fix(sbom): return 400 when project has no linked releases or packages on sbom export (#4101)

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMExporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMExporter.java
@@ -124,7 +124,8 @@ public class CycloneDxBOMExporter {
                 List<org.cyclonedx.model.Component> sbomComponents = getCycloneDxComponentsFromSw360Releases(linkedReleases, components);
                 bom.setComponents(sbomComponents);
             } else {
-                log.warn("Cannot export SBOM for project without linked releases: " + projectId);
+                log.warn("Cannot export SBOM for project without linked releases or packages: " + projectId);
+                summary.setMessage("Cannot export SBOM: The project does not contain any linked releases or packages.");
                 summary.setRequestStatus(RequestStatus.FAILED_SANITY_CHECK);
                 return summary;
             }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -68,6 +68,7 @@ import org.eclipse.sw360.exporter.LicenseInfoExporter;
 import org.eclipse.sw360.exporter.ReleaseExporter;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.jetbrains.annotations.Contract;
@@ -544,8 +545,9 @@ public class SW360ReportService {
                 RequestSummary summary = projectclient.exportCycloneDxSbom(projectId, bomType, withSubProject, user);
                 RequestStatus status = summary.getRequestStatus();
                 if (RequestStatus.FAILED_SANITY_CHECK.equals(status)) {
-                    bomString = status.name();
-                    throw new SW360Exception(bomString);
+                    String msg = CommonUtils.isNotNullEmptyOrWhitespace(summary.getMessage()) ?
+                            summary.getMessage() : "Cannot export SBOM: The project does not contain any linked releases or packages.";
+                    throw new BadRequestClientException(msg);
                 } else if (RequestStatus.ACCESS_DENIED.equals(status)) {
                     bomString = status.name() + ", only user with role " + SW360Utils.readConfig(SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE, UserGroup.USER).name() + " can access.";
                     throw new AccessDeniedException(bomString);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportServiceTest.java
@@ -41,11 +41,16 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
+import org.eclipse.sw360.rest.resourceserver.core.BadRequestClientException;
 
 @ExtendWith(MockitoExtension.class)
 public class SW360ReportServiceTest {
@@ -167,5 +172,24 @@ public class SW360ReportServiceTest {
         // Verify that attachment usages were fetched for BOTH parent and sub-project
         verify(attachmentService, times(1)).getAttachmentUsages("parentId");
         verify(attachmentService, times(1)).getAttachmentUsages("subId");
+    }
+
+    @Test
+    public void should_throw_BadRequestClientException_when_sbom_export_fails_sanity_check() throws TException {
+        ProjectService.Iface projectClientMock = mock(ProjectService.Iface.class);
+        sw360ReportService.projectclient = projectClientMock;
+
+        RequestSummary summary = new RequestSummary();
+        summary.setRequestStatus(RequestStatus.FAILED_SANITY_CHECK);
+        summary.setMessage("Cannot export SBOM: The project does not contain any linked releases or packages.");
+        given(projectClientMock.exportCycloneDxSbom(eq("parentId"), eq("JSON"), eq(true), any()))
+                .willReturn(summary);
+
+        BadRequestClientException exception = assertThrows(
+                BadRequestClientException.class,
+                () -> sw360ReportService.getProjectSBOMBuffer(testUser, "parentId", "JSON", true)
+        );
+
+        assertTrue(exception.getMessage().contains("Cannot export SBOM: The project does not contain any linked releases or packages."));
     }
 }


### PR DESCRIPTION

### Summary of Changes
When attempting to export a CycloneDX SBOM for a project that has no linked releases or packages (or whose sub-projects have no linked releases),`CycloneDxBOMExporter` returns `RequestStatus.FAILED_SANITY_CHECK`. 

Previously, `SW360ReportService` threw a generic `SW360Exception`, which caused an internal 500 error and an unhelpful generic error dialog on the frontend.

### What this PR does:
1. **`CycloneDxBOMExporter.java`**: Sets the summary message to `"Cannot export SBOM: The project does not contain any linked releases or packages."` when sanity check fails.
2. **`SW360ReportService.java`**: Handles `RequestStatus.FAILED_SANITY_CHECK` by throwing `BadRequestClientException` (HTTP 400) with the explanatory message instead of a generic 500 `SW360Exception`.
3. **`SW360ReportServiceTest.java`**: Adds unit test `should_throw_BadRequestClientException_when_sbom_export_fails_sanity_check()` to verify this behavior.

Fixes #4101
