### PR TITLE
fix(release): add main and other licenses

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/components/summary/ReleaseSummary.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/components/summary/ReleaseSummary.java
@@ -110,6 +110,8 @@ public class ReleaseSummary extends DocumentSummary<Release> {
         copyField(document, copy, _Fields.SOURCE_CODE_DOWNLOADURL);
         copyField(document, copy, _Fields.BINARY_DOWNLOADURL);
         copyField(document, copy, _Fields.PACKAGE_IDS);
+        copyField(document, copy, _Fields.MAIN_LICENSE_IDS);
+        copyField(document, copy, _Fields.OTHER_LICENSE_IDS);
     }
 
     private void setAdditionalFieldsForSummariesOtherThanShortAndDetailedExport(Release document, Release copy){


### PR DESCRIPTION
Fix Embedded Releases to have main and other licenses, used by `/licenseClearing` endpoint in frontend.