### PR TITLE
feat(projects): sort groups before returning

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -59,9 +59,6 @@ import static org.eclipse.sw360.datahandler.couchdb.lucene.NouveauLuceneAwareDat
  * @author ksoranko@verifa.io
  */
 public class ProjectRepository extends SummaryAwareRepository<Project> {
-    private static final Comparator<String> PROJECT_GROUP_COMPARATOR =
-            String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder());
-
     private static final String ALL = "function(doc) { if (doc.type == 'project') emit(null, doc._id) }";
 
     private static final String FULL_MY_PROJECTS_VIEW =
@@ -542,10 +539,7 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
     }
 
     public Set<String> getGroups() {
-        return getConnector().getDistinctSortedStringKeys(Project.class, "buprojects")
-                .stream()
-                .sorted(PROJECT_GROUP_COMPARATOR)
-                .collect(Collectors.toCollection(TreeSet::new));
+        return getConnector().getDistinctSortedStringKeys(Project.class, "buprojects");
     }
 
     @NotNull

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -4927,20 +4927,10 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     })
     @GetMapping(value = PROJECTS_URL + "/groups")
     public List<String> getAllProjectGroups() {
-        Set<String> groups;
         try {
-            groups = projectService.getGroups();
+            return projectService.getGroups();
         } catch (TException e) {
-            groups = Collections.emptySet();
+            return Collections.singletonList(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN);
         }
-
-        LinkedHashSet<String> responseGroups = new LinkedHashSet<>();
-        responseGroups.add(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN);
-        groups.stream()
-                .filter(Objects::nonNull)
-                .filter(group -> !group.isEmpty())
-                .filter(group -> !SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(group))
-                .forEach(responseGroups::add);
-        return new ArrayList<>(responseGroups);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -132,6 +132,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
     private static final Logger log = LogManager.getLogger(Sw360ProjectService.class);
+    private static final Comparator<String> PROJECT_GROUP_COMPARATOR =
+            String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder());
 
     @NonNull
     private RestControllerHelper rch;
@@ -390,18 +392,18 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public void deleteAttachmentUsages(List<AttachmentUsage> usagesToDelete) throws TException {
         AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
         attachmentClient.deleteAttachmentUsages(usagesToDelete);
-	}
+    }
 
-	public void makeAttachmentUsages(List<AttachmentUsage> usagesToCreate) throws TException {
-		AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
-		attachmentClient.makeAttachmentUsages(usagesToCreate);
-	}
+    public void makeAttachmentUsages(List<AttachmentUsage> usagesToCreate) throws TException {
+        AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
+        attachmentClient.makeAttachmentUsages(usagesToCreate);
+    }
 
-	public List<AttachmentUsage> getUsedAttachments(Source usedBy, Object object) throws TException {
-		AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
-		List<AttachmentUsage> allUsagesByProjectAfterCleanUp = attachmentClient.getUsedAttachments(usedBy, null);
-		return allUsagesByProjectAfterCleanUp;
-	}
+    public List<AttachmentUsage> getUsedAttachments(Source usedBy, Object object) throws TException {
+        AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
+        List<AttachmentUsage> allUsagesByProjectAfterCleanUp = attachmentClient.getUsedAttachments(usedBy, null);
+        return allUsagesByProjectAfterCleanUp;
+    }
 
     public String getCyclicLinkedProjectPath(Project project, User user) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
@@ -2067,9 +2069,23 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return count;
     }
 
-    public Set<String> getGroups() throws TException {
+    public List<String> getGroups() throws TException {
         ProjectService.Iface projectClient = getThriftProjectClient();
-        return projectClient.getGroups();
+        Set<String> groups = projectClient.getGroups();
+        if (groups == null) {
+            groups = Collections.emptySet();
+        }
+        List<String> responseGroups = new ArrayList<>(groups.size() + 1);
+        responseGroups.add(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN);
+        responseGroups.addAll(
+                groups.stream()
+                        .filter(Objects::nonNull)
+                        .filter(group -> !group.isEmpty())
+                        .filter(group -> !SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN.equals(group))
+                        .sorted(PROJECT_GROUP_COMPARATOR)
+                        .toList()
+        );
+        return responseGroups;
     }
 
     // =====================================================

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -643,7 +643,7 @@ public class ProjectTest extends TestIntegrationBase {
 
     @Test
     public void should_get_project_groups_with_empty_token_first() throws IOException, TException {
-        given(this.projectServiceMock.getGroups()).willReturn(new java.util.LinkedHashSet<>(Arrays.asList("", "Group A", "Group B")));
+        given(this.projectServiceMock.getGroups()).willReturn(Arrays.asList(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN, "Group A", "Group B"));
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
@@ -11,12 +11,15 @@ package org.eclipse.sw360.rest.resourceserver.project;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -155,6 +158,45 @@ public class Sw360ProjectServiceTest {
 
         assertEquals(1, result.size());
         verify(projectClient, times(1)).searchByReleaseId(releaseId, user);
+    }
+
+    @Test
+    public void should_get_groups_sorted_with_empty_token_first() throws TException {
+        Set<String> mockGroups = new HashSet<>(Arrays.asList(
+                "",
+                "group b",
+                "Group A",
+                "Group B"
+        ));
+
+        org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface projectClient =
+                mock(org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface.class);
+        org.mockito.Mockito.doReturn(projectClient).when(projectService).getThriftProjectClient();
+        org.mockito.Mockito.when(projectClient.getGroups()).thenReturn(mockGroups);
+
+        List<String> result = projectService.getGroups();
+
+        assertEquals(
+                Arrays.asList(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN, "Group A", "Group B", "group b"),
+                result
+        );
+        verify(projectClient, times(1)).getGroups();
+    }
+
+    @Test
+    public void should_get_groups_when_thrift_returns_null() throws TException {
+        org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface projectClient =
+                mock(org.eclipse.sw360.datahandler.thrift.projects.ProjectService.Iface.class);
+        org.mockito.Mockito.doReturn(projectClient).when(projectService).getThriftProjectClient();
+        org.mockito.Mockito.when(projectClient.getGroups()).thenReturn(null);
+
+        List<String> result = projectService.getGroups();
+
+        assertEquals(
+                Collections.singletonList(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN),
+                result
+        );
+        verify(projectClient, times(1)).getGroups();
     }
 
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -587,7 +587,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.searchProjectByTag(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.searchProjectByType(any(), any())).willReturn(new ArrayList<Project>(projectList));
         given(this.projectServiceMock.searchProjectByGroup(any(), any())).willReturn(new ArrayList<Project>(projectList));
-        given(this.projectServiceMock.getGroups()).willReturn(new java.util.LinkedHashSet<>(Arrays.asList("", "sw360 AR", "sw360 EX DF")));
+        given(this.projectServiceMock.getGroups()).willReturn(Arrays.asList(SW360Constants.PROJECT_SEARCH_EMPTY_TOKEN, "sw360 AR", "sw360 EX DF"));
         given(this.projectServiceMock.refineSearch(any(), any(), any())).willReturn(
                 Collections.singletonMap(
                         new PaginationData().setRowsPerPage(projectListByName.size()).setDisplayStart(0).setTotalRowCount(projectListByName.size()),
@@ -2217,7 +2217,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("variant").description("All the possible values for variants are "
                                         + Arrays.asList(OutputFormatVariant.values())),
                                 parameterWithName("excludeReleaseVersion").description("Exclude version of the components from the generated license info file. "
-                                		+ "Possible values are `<true|false>`")
+                                        + "Possible values are `<true|false>`")
                                 )));
     }
 
@@ -2536,7 +2536,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 subsectionWithPath("_embedded.sw360:moderators").description("An array of moderators"),
                                 subsectionWithPath("_embedded.sw360:vendors").description("An array of all component vendors with full name and link to their <<resources-vendor-get,Vendor resource>>"),
                                 subsectionWithPath("_links").description("<<resources-index-links,Links>> to other resources"))
-                        		));
+                                ));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Sort the list of groups returned by the endpoint `/groups` in the Project service since backend sends a Set which is non-sortable entity in Java. While at it, move the Set to sorted list in Project Service not Controller and make performance optimization.