### PR TITLE
fix(rest): populate acknowledgements in XHTML/TXT license disclosure.

### DIFF
--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -393,9 +393,9 @@ public abstract class OutputGenerator<T> {
         vc.put(LICENSE_REFERENCE_ID_MAP_CONTEXT_PROPERTY, licenseNameWithTextToRefId);
         vc.put(LICENSE_INFO_RESULTS_CONTEXT_PROPERTY, sortedReleases);
         vc.put(LICENSE_INFO_ERROR_RESULTS_CONTEXT_PROPERTY, failedResults);
-
         // also display acknowledgments
-        Map<String, Set<String>> acknowledgements = buildAcknowledgements(sortedReleases);
+        // templates expect releaseName -> licenseName -> acknowledgement texts
+        Map<String, Map<String, Set<String>>> acknowledgements = getSortedAcknowledgements(sortedReleases);
         vc.put(ACKNOWLEDGEMENTS_CONTEXT_PROPERTY, acknowledgements);
 
         vc.put(EXTERNAL_IDS, externalIds);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Acknowledgements section was empty in the generated License Disclosure (ReadMe_OSS XHTML and TXT), even when the CLI attachment contained acknowledgement text for the license (reported for ffmpeg n6.0). After this change, we can see the content of the acknowledgements.

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?
### Rest Api
1. Ensure a project has a release whose CLI attachment contains license acknowledgement text (e.g. `ffmpeg n6.0`).
2. Disable mail-based report delivery locally so the file downloads directly instead of emailing:
   ```bash
   curl -s -u '<user>:<password>' -X PATCH \
     'http://localhost:8080/resource/api/configurations/container/SW360_CONFIGURATION' \
     -H 'Content-Type: application/json' \
     -d '{"send.export.to.mail.enabled": "false"}'

### UI 

1. Log in to SW360.
2. Navigate to Component → Release → Attachment.
3. Add the XML file, select type "XML," and save.
4. Navigate to the Projects page and select any project.
5. Edit the project, link the release, and save.
6. Go to the project's License Clearing tab, click "Generate License Info," download the XHTML file, and check the **"Acknowledgements"** section.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
