### PR TITLE
fix: fix invalid XHTML in license info output

### DIFF
--- a/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -28,7 +28,7 @@
         }
 
         p {
-            font-weight: normal
+            font-weight: normal;
         }
 
         body {
@@ -84,7 +84,7 @@
 <body>
     <h1>$projectTitle</h1>
     <h2>Open Source Software</h2>
-    $licenseInfoHeader
+    <p>$licenseInfoHeader</p>
     #set($anchorRegEx = '(?s).*?<(\s)*?a(\s)+href\s*=.*?>.*?<(\s)*?[\/](\s)*?a(\s)*?>.*?')
     #set($scriptRegEx = '(?s).*?<(\s)*?script(\s)*?>.*?<(\s)*?[\/](\s)*?script(\s)*?>.*?')
     #if($externalIds.keySet().size() > 0)
@@ -111,61 +111,83 @@
 
     #if($licenseInfoResults.keySet().size() > 0)
         <ul id="releaseOverview">
+            #set($releaseCountOv = 0)
             #foreach($releaseName in $licenseInfoResults.keySet())
+                #set($releaseCountOv = $releaseCountOv + 1)
+                #set($releaseIdOv = $esc.xml($releaseName).replace(" ","_").replace(",","-").replace("+","_").replace("~","_").replace("/","_").replace("(","_").replace(")","_").replace(":","_"))
+                #if(!$releaseIdOv.matches('[a-zA-Z].*'))
+                    #set($releaseIdOv = "r${releaseIdOv}")
+                #end
+                #set($releaseIdOv = $releaseIdOv.concat("_").concat($releaseCountOv.toString()))
                 <li>
-                    <a href="#h3$esc.xml($releaseName).replace(" ","_").replace(",","-")">$esc.xml($releaseName)</a>
+                    <a href="#h3${releaseIdOv}">$esc.xml($releaseName)</a>
                 </li>
             #end
         </ul>
 
+        <p>
+            <strong>
+                Please note the following license conditions and copyright notices applicable to Open Source Software and/or other components (or parts thereof):
+            </strong>
+        </p>
         <ul id="releases" style="list-style-type:none">
+            #set($releaseCount = 0)
             #foreach($releaseName in $licenseInfoResults.keySet())
-                <li id="$esc.xml($releaseName).replace(" ","_").replace(",","-")" class="release" title="$esc.xml($releaseName)">
+                #set($releaseCount = $releaseCount + 1)
+                #set($releaseId = $esc.xml($releaseName).replace(" ","_").replace(",","-").replace("+","_").replace("~","_").replace("/","_").replace("(","_").replace(")","_").replace(":","_"))
+                #if(!$releaseId.matches('[a-zA-Z].*'))
+                    #set($releaseId = "r${releaseId}")
+                #end
+                #set($releaseId = $releaseId.concat("_").concat($releaseCount.toString()))
+                <li id="$releaseId" class="release" title="$esc.xml($releaseName)">
                     #foreach($errorResult in $licenseInfoErrorResults.get($releaseName))
                         <div class="inset error">ERROR when reading license information from file $esc.xml($errorResult.licenseInfo.filenames[0]): $esc.xml($errorResult.message)</div>
                     #end
                     <div class="inset">
-                        <h3 id="h3$esc.xml($releaseName).replace(" ","_").replace(",","-")">$esc.xml($releaseName)
+                        <h3 id="h3${releaseId}">$esc.xml($releaseName)
                             <a class="top" href="#releaseHeader">&#8679;</a>
                         </h3>
                     </div>
 
 
                     #if(${acknowledgements.get($releaseName)})
-                        Acknowledgements:<br/>
+                        <p>Acknowledgements:</p>
                         #set($licenseAckMap = $acknowledgements.get($releaseName))
     <pre class="acknowledgements">
 #foreach($licenseName in $licenseAckMap.keySet())
     #set($acks = $licenseAckMap.get($licenseName))
 #foreach($ack in ${acks})
-     <strong>$esc.xml($licenseName)</strong><br/>
-     #set($containsLink = $ack.matches($anchorRegEx))
-     #set($containsScript = $ack.matches($scriptRegEx))
-     #set($ackAsHtml = $esc.xml($ack))
-     #if($containsLink && !$containsScript)
-     #set($ackAsHtml = $ack)
-     #end
-     $ackAsHtml<br/>
-  <br/>
-     #end
-     #end
-         </pre>
-                #end
+    <strong>$esc.xml($licenseName)</strong><br/>
+    #set($containsLink = $ack.matches($anchorRegEx))
+    #set($containsScript = $ack.matches($scriptRegEx))
+    #set($ackAsHtml = $esc.xml($ack))
+    #if($containsLink && !$containsScript)
+    #set($ackAsHtml = $ack)
+    #end
+    $ackAsHtml<br/>
+ <br/>
+    #end
+    #end
+</pre>
+#end
 
 
-                    Licenses:<br/>
+                    <p>Licenses:</p>
                     #set($licenses = [])
                     #if(${licenseInfoResults.get($releaseName).licenseInfo})
                         #set($licenses = $licenseInfoResults.get($releaseName).licenseInfo.licenseNamesWithTexts)
                         #if($licenses.size() > 0)
                             <ul style="list-style-type:none" class="licenseEntries">
+                            #set($licenseEntryCount = 0)
                             #foreach($license in ${licenses})
+                                #set($licenseEntryCount = $licenseEntryCount + 1)
                                 #set($licenseName = "&lt;no license name available&gt;")
                                 #if($license.licenseName)
                                     #set($licenseName = $esc.xml($license.licenseName))
                                 #end
                                 #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
-                                <li class="licenseEntry" id="licenseEntry$licenseId" title="$licenseName">
+                                #set($licenseEntryId = $releaseId.concat("_").concat($licenseId.toString()).concat("_").concat($licenseEntryCount.toString()))
+                                <li class="licenseEntry" id="licenseEntry_${licenseEntryId}" title="$licenseName">
                                     <a href="#licenseTextItem$licenseId">$licenseName ($licenseId)</a>
                                </li>
                             #end
@@ -185,8 +207,8 @@
     #end
 $copyrightAsHtml
 #end
-<h3><a class="top" href="#releaseHeader">&#8679;</a></h3>
-    </pre>
+</pre>
+                        <p><a class="top" href="#releaseHeader">&#8679;</a></p>
                         #end
                 </li>
             #end

--- a/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -203,7 +203,11 @@ public class XhtmlGeneratorTest {
     }
 
     private String releaseNameString(String vName, String rName, String version) {
-        return vName + "_" + rName + "_" + version;
+        return releaseNameString(vName, rName, version, 1);
+    }
+
+    private String releaseNameString(String vName, String rName, String version, int position) {
+        return vName + "_" + rName + "_" + version + "_" + position;
     }
 
     @Test
@@ -221,10 +225,10 @@ public class XhtmlGeneratorTest {
 
     @Test
     public void testGenerateOutputFile_parseCopyrightsFromTwoReleases() throws Exception {
-        String copyrights = findCopyrights(document2, releaseNameString(vendorName, releaseName, version1));
+        String copyrights = findCopyrights(document2, releaseNameString(vendorName, releaseName, version1, 1));
         assertThat(copyrights, containsString(cr1));
         assertThat(copyrights.contains(cr2), is(true));
-        copyrights = findCopyrights(document2, releaseNameString(vendorName, releaseName, version2));
+        copyrights = findCopyrights(document2, releaseNameString(vendorName, releaseName, version2, 2));
         assertThat(copyrights, containsString(CR1));
         assertThat(copyrights, containsString(CR2));
     }
@@ -243,9 +247,9 @@ public class XhtmlGeneratorTest {
 
     @Test
     public void testGenerateOutputFile_parseLicensesFromTwoReleases() throws Exception {
-        String licenses = findLicenses(document2, releaseNameString(vendorName, releaseName, version1));
+        String licenses = findLicenses(document2, releaseNameString(vendorName, releaseName, version1, 1));
         assertThat(licenses.contains(t1), is(true));
-        licenses = findLicenses(document2, releaseNameString(vendorName, releaseName, version2));
+        licenses = findLicenses(document2, releaseNameString(vendorName, releaseName, version2, 2));
         assertThat(licenses, containsString(T1));
         assertThat(licenses, containsString(T2));
     }
@@ -272,8 +276,10 @@ public class XhtmlGeneratorTest {
             for (Node liObject : element.content()) {
                 if (liObject.getNodeType() == Node.ELEMENT_NODE) {
                     Element liElement = (Element) liObject;
-                    String licenseEntryId = liElement.attribute("id").getValue();
-                    String licenseTextId = licenseEntryId.replace("licenseEntry", "licenseText");
+                    // Extract numeric license ID from <a href="#licenseTextItem{id}"> to look up <pre id="licenseText{id}">
+                    Element anchor = (Element) liElement.selectSingleNode("*[local-name()='a']");
+                    String href = anchor.attribute("href").getValue(); // "#licenseTextItem1"
+                    String licenseTextId = href.replace("#licenseTextItem", "licenseText"); // "licenseText1"
                     List licenseTexts = document
                             .selectNodes("//*[local-name()='pre'][@id='" + licenseTextId + "']/text()");
                     Object licenseText = licenseTexts.stream().map(l -> ((Text) l).getStringValue()).reduce("",


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Description:
We recently exported a ReadmeOSS html (licenseinfo html) from SW360 and noticed a very badly built HTML, with a lot of invalid code.We noticed that as we use Prettier in our Product Build Pipeline and it reported 1700+ issues when checking the License info html.Just to name examples, opening HTML tags without closing tags, deprecated tags (XHTML specified as doctype).(#4555 )

Closes: #4555  

### Suggest Reviewer
> @GMishx 

### How To Test?
> You can use https://validator.w3.org/ to check the details by file upload.

