### PR TITLE
feat(api): exit early if auth fails

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilter.java
@@ -70,6 +70,7 @@ public class ApiTokenAuthenticationFilter implements Filter {
                 log.error("Authentication failed: {}", e.getMessage());
                 SecurityContextHolder.clearContext();
                 authenticationEntryPoint.commence(httpRequest, httpResponse, e);
+                return;
             }
         }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilterTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/security/apiToken/ApiTokenAuthenticationFilterTest.java
@@ -86,4 +86,24 @@ public class ApiTokenAuthenticationFilterTest {
         verify(authenticationManager, never()).authenticate(ArgumentMatchers.any());
         verify(filterChain, times(1)).doFilter(request, response);
     }
+
+    @Test
+    public void shouldStopFilterChainWhenApiTokenAuthenticationFails() throws IOException, ServletException {
+        ApiTokenAuthenticationFilter filter = new ApiTokenAuthenticationFilter(authenticationManager, authenticationEntryPoint);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("authorization", "Token invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(authenticationManager.authenticate(ArgumentMatchers.any()))
+                .thenThrow(new org.springframework.security.authentication.AuthenticationServiceException("bad token"));
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(authenticationEntryPoint, times(1)).commence(
+                ArgumentMatchers.same(request),
+                ArgumentMatchers.same(response),
+                ArgumentMatchers.any(org.springframework.security.core.AuthenticationException.class)
+        );
+        verify(filterChain, never()).doFilter(request, response);
+    }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Exit early in the auth chain if the auth fails. Don't send the request down the chain.