### PR TITLE
feat(license): optimize license clearing loading

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+<!--
+Part of the SW360 Portal Project.
+SPDX-License-Identifier: EPL-2.0
+-->
+
+# GitHub Copilot Instructions — Eclipse SW360
+
+> **Stack:** Java 21 · Spring Boot 4.1 · Spring Security 7.1 · JUnit 6 · Thrift 0.20.0 · CouchDB (Cloudant SDK)
+
+Copilot (Ask / Edit / Agent modes) and all other AI coding assistants **must**
+follow the project-wide agent rules in [`AGENTS.md`](../AGENTS.md) and the
+scoped instruction files under [`.github/instructions/`](instructions/).
+
+## Instruction files (loaded on demand via `applyTo` globs)
+
+| Scope | File |
+|-------|------|
+| Architecture, REST, Thrift, utilities, DO/DON'T rules | [`.github/instructions/sw360_backend.instructions.md`](instructions/sw360_backend.instructions.md) |
+| Tests (JUnit 6, MockMvc, ArchUnit coverage rules) | [`.github/instructions/sw360_testing.instructions.md`](instructions/sw360_testing.instructions.md) |
+| Security, authentication, authorization, Keycloak | [`.github/instructions/sw360_security.instructions.md`](instructions/sw360_security.instructions.md) |
+| CouchDB repositories, views, indexes, Nouveau/Lucene search | [`.github/instructions/sw360_db.instructions.md`](instructions/sw360_db.instructions.md) |
+| Git commits, branch names, PR checklist | [`.github/instructions/git-commit.instructions.md`](instructions/git-commit.instructions.md) |
+
+## Rules of engagement
+
+- Load only the instruction file(s) whose `applyTo` glob matches the file(s)
+  you are editing — do **not** preload all files at once.
+- On conflict, the precedence defined in [`AGENTS.md` § 1](../AGENTS.md) applies
+  (backend → db → security → testing → git-commit).
+- Read [`AGENTS.md` § 2–3](../AGENTS.md) for the mandatory pre-code checklist
+  and autonomy boundaries before generating or modifying code.

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -346,12 +346,16 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     public Project getProjectById(String id, User user) throws SW360Exception {
-        Project project = repository.get(id);
-        assertNotNull(project);
-
-        if(!makePermission(project, user).isActionAllowed(RequestedAction.READ)) {
-            throw fail(403, "User: %s is not allowed to view the requested project: %s", user.getEmail(), project.getId());
-        }
+        // Route through the shared projectLookupCache (2-minute TTL). This
+        // saves a CouchDB doc round-trip on repeat reads within the TTL —
+        // which is the common case for the licenseClearing endpoint that
+        // both {@code Sw360ProjectService.getProjectForUserById} and
+        // {@code getReleasesIdsOfProject} exercise back-to-back for the
+        // same project ID. Permission (READ) is re-evaluated on every call,
+        // and the cached document is returned as a deep copy so callers may
+        // safely mutate it (e.g. vendor fill, additionalData sort) without
+        // corrupting the cached instance.
+        Project project = getCachedProjectById(id, user);
         vendorRepository.fillVendor(project);
         return project;
     }
@@ -516,6 +520,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 }
             }
             repository.update(project);
+            projectLookupCache.invalidate(project.getId());
 
             List<ChangeLogs> referenceDocLogList=new LinkedList<>();
             Set<Attachment> attachmentsAfter = project.getAttachments();
@@ -814,6 +819,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         Project project = getProjectById(obligation.getProjectId(), user);
         project.setLinkedObligationId(obligation.getId());
         repository.update(project);
+        projectLookupCache.invalidate(project.getId());
         project.unsetLinkedObligationId();
         dbHandlerUtil.addChangeLogs(obligation, null, user.getEmail(), Operation.CREATE, attachmentConnector,
                 Lists.newArrayList(), obligation.getProjectId(), Operation.PROJECT_UPDATE);
@@ -1100,6 +1106,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         attachmentConnector.deleteAttachments(project.getAttachments());
         attachmentDatabaseHandler.deleteUsagesBy(Source.projectId(project.getId()));
         repository.remove(project);
+        projectLookupCache.invalidate(project.getId());
         if (project.isSetLinkedObligationId()) {
             obligationRepository.remove(project.getLinkedObligationId());
         }
@@ -1366,14 +1373,8 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     public List<ReleaseClearingStatusData> getReleaseClearingStatusesWithAccessibility(String projectId, User user) throws SW360Exception {
         Project project = getProjectById(projectId, user);
         SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject = releaseIdToProjects(project, user);
-        List<Release> releasesById = componentDatabaseHandler.getDetailedReleasesWithAccessibilityForExport(releaseIdsToProject.keySet(), user);
-        return buildReleaseClearingStatuses(releasesById, releaseIdsToProject, release -> {
-            Map<RequestedAction, Boolean> permissions = release.getPermissions();
-            if (permissions != null && permissions.containsKey(RequestedAction.READ)) {
-                return permissions.get(RequestedAction.READ);
-            }
-            return componentDatabaseHandler.isReleaseActionAllowed(release, user, RequestedAction.READ);
-        });
+        List<Release> releasesById = componentDatabaseHandler.getDetailedReleasesForExport(releaseIdsToProject.keySet());
+        return buildReleaseClearingStatuses(releasesById, releaseIdsToProject, user);
     }
 
     /**
@@ -1383,13 +1384,13 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
      * {@code accessibilityResolver}.
      * @param releasesById          List of releases
      * @param releaseIdsToProject   Map of release to project relation
-     * @param accessibilityResolver Release access checker, nullable.
+     * @param user                  User requesting the data; if non-null accessibility is evaluated.
      * @return List of Release Clearing Status for the Project releases.
      */
     private List<ReleaseClearingStatusData> buildReleaseClearingStatuses(
             List<Release> releasesById,
             SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject,
-            @Nullable Function<Release, Boolean> accessibilityResolver
+            @Nullable User user
     ) {
         ImmutableMap<String, Component> componentsById = ImmutableMap.copyOf(ThriftUtils.getIdMap(
                 componentDatabaseHandler.getComponentsShort(
@@ -1401,7 +1402,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return getReleaseClearingStatusStream(releasesById)
                 .map(release -> createReleaseClearingStatusData(
                         release, releaseIdsToProjectSnapshot,
-                        componentsById, accessibilityResolver))
+                        componentsById, user))
                 .toList();
     }
 
@@ -1423,14 +1424,14 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
      * @param release Current Release to process.
      * @param releaseIdsToProject Map of Release and Project relation
      * @param componentsById Map of Components, indexed by ID.
-     * @param accessibilityResolver Check access of Release if provided.
+     * @param user User requesting the data; if non-null accessibility is evaluated.
      * @return ReleaseClearingStatus data for given release.
      */
     private ReleaseClearingStatusData createReleaseClearingStatusData(
             @NonNull Release release,
             @NonNull SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject,
             Map<String, Component> componentsById,
-            @Nullable Function<Release, Boolean> accessibilityResolver
+            @Nullable User user
     ) {
         List<String> projectNames = new ArrayList<>();
         List<String> mainlineStates = new ArrayList<>();
@@ -1445,12 +1446,16 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }
         }
 
+        Component component = componentsById.get(release.getComponentId());
         ReleaseClearingStatusData releaseClearingStatusData = new ReleaseClearingStatusData(release)
                 .setProjectNames(joinStrings(projectNames))
                 .setMainlineStates(joinStrings(mainlineStates))
-                .setComponentType(componentsById.get(release.getComponentId()).getComponentType());
-        if (accessibilityResolver != null) {
-            releaseClearingStatusData.setAccessible(accessibilityResolver.apply(release));
+                .setComponentType(component != null ? component.getComponentType() : null);
+        if (user != null) {
+            boolean isReleaseAccessible = component != null
+                    && makePermission(component, user).isActionAllowed(RequestedAction.READ)
+                    && makePermission(release, user).isActionAllowed(RequestedAction.READ);
+            releaseClearingStatusData.setAccessible(isReleaseAccessible);
         }
         return releaseClearingStatusData;
     }
@@ -1492,14 +1497,74 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         Map<String, ProjectProjectRelationship> linkedProjects = project.getLinkedProjects();
         if (linkedProjects != null) {
-            for (String projectId : linkedProjects.keySet()) {
-                if (visitedProjectIds.contains(projectId)) continue;
+            Set<String> unresolvedProjectIds = linkedProjects.keySet().stream()
+                    .filter(projectId -> !visitedProjectIds.contains(projectId))
+                    .collect(Collectors.toSet());
 
-                try {
-                    Project linkedProject = getCachedProjectById(projectId, user);
+            if (!unresolvedProjectIds.isEmpty()) {
+                List<Project> fetchedLinkedProjects = repository.get(new ArrayList<>(unresolvedProjectIds), true).stream()
+                        .filter(linkedProject -> {
+                            boolean isAccessible = makePermission(linkedProject, user).isActionAllowed(RequestedAction.READ);
+                            if (!isAccessible) {
+                                log.warn("Could not get linked project with ID: {}", linkedProject.getId());
+                            }
+                            return isAccessible;
+                        })
+                        .toList();
+
+                Set<String> fetchedProjectIds = fetchedLinkedProjects.stream()
+                        .map(Project::getId)
+                        .collect(Collectors.toSet());
+                unresolvedProjectIds.stream()
+                        .filter(projectId -> !fetchedProjectIds.contains(projectId))
+                        .forEach(projectId -> log.warn("Could not get linked project with ID: {}", projectId));
+
+                for (Project linkedProject : fetchedLinkedProjects) {
                     releaseIdToProjects(linkedProject, user, visitedProjectIds, releaseIdToProjects);
-                } catch (SW360Exception e) {
-                    log.warn("Could not get linked project with ID: {}", projectId, e);
+                }
+            }
+        }
+    }
+
+    private Set<String> collectTransitiveReleaseIds(Project project, User user) throws SW360Exception {
+        Set<String> visitedProjectIds = new HashSet<>();
+        Set<String> releaseIds = new HashSet<>();
+        collectTransitiveReleaseIds(project, user, visitedProjectIds, releaseIds);
+        return releaseIds;
+    }
+
+    private void collectTransitiveReleaseIds(Project project, User user, Set<String> visitedProjectIds,
+            Set<String> releaseIds) throws SW360Exception {
+        if (nothingTodo(project, visitedProjectIds)) return;
+
+        releaseIds.addAll(nullToEmptyMap(project.getReleaseIdToUsage()).keySet());
+
+        Map<String, ProjectProjectRelationship> linkedProjects = project.getLinkedProjects();
+        if (linkedProjects != null) {
+            Set<String> unresolvedProjectIds = linkedProjects.keySet().stream()
+                    .filter(projectId -> !visitedProjectIds.contains(projectId))
+                    .collect(Collectors.toSet());
+
+            if (!unresolvedProjectIds.isEmpty()) {
+                List<Project> fetchedLinkedProjects = repository.get(new ArrayList<>(unresolvedProjectIds), true).stream()
+                        .filter(linkedProject -> {
+                            boolean isAccessible = makePermission(linkedProject, user).isActionAllowed(RequestedAction.READ);
+                            if (!isAccessible) {
+                                log.warn("Could not get linked project with ID: {}", linkedProject.getId());
+                            }
+                            return isAccessible;
+                        })
+                        .toList();
+
+                Set<String> fetchedProjectIds = fetchedLinkedProjects.stream()
+                        .map(Project::getId)
+                        .collect(Collectors.toSet());
+                unresolvedProjectIds.stream()
+                        .filter(projectId -> !fetchedProjectIds.contains(projectId))
+                        .forEach(projectId -> log.warn("Could not get linked project with ID: {}", projectId));
+
+                for (Project linkedProject : fetchedLinkedProjects) {
+                    collectTransitiveReleaseIds(linkedProject, user, visitedProjectIds, releaseIds);
                 }
             }
         }
@@ -3164,7 +3229,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         if (!transitive) {
             return nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
         }
-        SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject = releaseIdToProjects(project, user);
-        return releaseIdsToProject.keySet();
+        return collectTransitiveReleaseIds(project, user);
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -440,16 +440,19 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             @Parameter(description = "Clearing state of the release")
             @RequestParam(value = "clearingState", required = false) List<ClearingState> clearingState
     ) throws TException {
+        final long tStart = System.nanoTime();
 
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
+        final long tAuth = System.nanoTime();
         restControllerHelper.throwIfSecurityUser(sw360User);
         Project sw360Project = projectService.getProjectForUserById(id, sw360User);
+        final long tProject = System.nanoTime();
 
         //check the below condition when releaseRelation is not null
         if (releaseRelation != null && sw360Project.getReleaseIdToUsage() != null) {
             Map<String, ProjectReleaseRelationship> filteredReleaseIdToUsage = sw360Project.getReleaseIdToUsage()
                     .entrySet()
-                    .parallelStream()
+                    .stream()
                     .filter(entry -> entry.getValue().getReleaseRelation() == releaseRelation)
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
@@ -458,19 +461,20 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             sw360Project.setReleaseIdToUsage(filteredReleaseIdToUsage);
         }
 
-        final Set<String> releaseIds = projectService.getReleaseIds(id, sw360User, transitive);
-        List<Release> releases = projectService.getFilteredReleases(releaseIds, sw360User, clearingState, componentType, releaseService);
+        List<Release> releases = projectService.getLicenseClearingReleases(id, sw360Project, sw360User,
+                transitive, clearingState, componentType, releaseService);
+        final long tReleases = System.nanoTime();
 
         // Extract all release IDs from the provided list
-        Set<String> validReleaseIds = releases.parallelStream().unordered()
+        Set<String> validReleaseIds = releases.stream()
                 .map(Release::getId)
                 .collect(Collectors.toSet());
 
         // Filter the releaseIdToUsage map
-        if (sw360Project.getReleaseIdToUsage() != null) {
+        if (sw360Project.getReleaseIdToUsage() != null && !sw360Project.getReleaseIdToUsage().isEmpty()) {
             Map<String, ProjectReleaseRelationship> filteredReleaseIdData = sw360Project.getReleaseIdToUsage()
                     .entrySet()
-                    .parallelStream()
+                    .stream()
                     .filter(entry -> validReleaseIds.contains(entry.getKey()))
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
@@ -480,7 +484,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
 
         Map<String, ProjectReleaseRelationship> releaseIdToUsageMap = sw360Project.getReleaseIdToUsage();
-        List<EntityModel<Release>> releaseList = releases.parallelStream().map(sw360Release -> wrapTException(() -> {
+
+        java.util.function.Function<Release, EntityModel<Release>> toEmbeddedReleaseModel = sw360Release -> {
             final Release embeddedRelease = restControllerHelper.convertToEmbeddedLinkedRelease(sw360Release);
             if (releaseIdToUsageMap != null) {
                 ProjectReleaseRelationship relationship = releaseIdToUsageMap.get(sw360Release.getId());
@@ -488,11 +493,24 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                     embeddedRelease.setProjectMainlineState(relationship.getMainlineState());
                 }
             }
-            final HalResource<Release> releaseResource = restControllerHelper.addEmbeddedReleaseLinks(embeddedRelease);
-            return releaseResource;
-        })).collect(Collectors.toList());
+            EntityModel<Release> em = restControllerHelper.addEmbeddedReleaseLinks(embeddedRelease);
+            return em;
+        };
+        List<EntityModel<Release>> releaseList = releases.parallelStream()
+                .map(toEmbeddedReleaseModel)
+                .collect(Collectors.toList());
 
         HalResource<Project> userHalResource = createHalLicenseClearing(sw360Project, releaseList);
+        final long tEnd = System.nanoTime();
+        if (log.isInfoEnabled()) {
+            log.info("licenseClearing[{}] transitive={} releases={}: auth={}ms project={}ms clearing-releases={}ms embed={}ms total={}ms",
+                    id, transitive, releases.size(),
+                    (tAuth - tStart) / 1_000_000,
+                    (tProject - tAuth) / 1_000_000,
+                    (tReleases - tProject) / 1_000_000,
+                    (tEnd - tReleases) / 1_000_000,
+                    (tEnd - tStart) / 1_000_000);
+        }
         return new ResponseEntity<>(userHalResource, HttpStatus.OK);
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1021,6 +1021,18 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return sw360ProjectClient.getReleasesIdsOfProject(projectId, transitive, sw360User);
     }
 
+    public List<Release> getLicenseClearingReleases(String projectId, Project project, User sw360User,
+            boolean transitive, List<ClearingState> clearingState, List<ComponentType> componentType,
+            Sw360ReleaseService releaseService) throws TException {
+        Set<String> releaseIds = transitive
+                ? getReleaseIds(projectId, sw360User, true)
+                : CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
+        if (CommonUtils.isNullOrEmptyCollection(releaseIds)) {
+            return Collections.emptyList();
+        }
+        return getFilteredReleases(releaseIds, sw360User, clearingState, componentType, releaseService);
+    }
+
     public ProjectEccCounts getProjectEccCounts(String projectId, User sw360User) throws TException {
         ComponentService.Iface releaseClient = ThriftClients.makeComponentClient();
         final Set<String> releaseIds = getReleaseIds(projectId, sw360User, true);
@@ -1042,7 +1054,6 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
         return new ProjectEccCounts(eccClassifiedCount, eccOpenCount);
     }
-
     public void addEmbeddedLinkedProject(Project sw360Project, User sw360User, HalResource<Project> projectResource,
             Set<String> projectIdsInBranch) throws TException {
         projectIdsInBranch.add(sw360Project.getId());
@@ -1980,20 +1991,26 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     }
 
     public List<Release> getFilteredReleases(Set<String> releaseIds, User sw360User, List<ClearingState> clearingState, List<ComponentType> componentType, Sw360ReleaseService releaseService) throws TException {
+        if (CommonUtils.isNullOrEmptyCollection(releaseIds)) {
+            return Collections.emptyList();
+        }
         ComponentService.Iface componentClient = ThriftClients.makeComponentClient();
         List<Release> releases = componentClient.getAccessibleReleasesById(releaseIds, sw360User);
         releaseService.setComponentDependentFieldsInRelease(releases, sw360User);
-        return releases.parallelStream().unordered()
+        return filterLicenseClearingReleases(releases, clearingState, componentType);
+    }
+
+    private List<Release> filterLicenseClearingReleases(List<Release> releases,
+            List<ClearingState> clearingState, List<ComponentType> componentType) {
+        return releases.stream()
                 .filter(Objects::nonNull)
                 .filter(release -> {
-                    // Filter by componentType if provided
                     if (CommonUtils.isNotEmpty(componentType)) {
                         ComponentType releaseType = release.getComponentType();
                         if (releaseType == null || componentType.stream().noneMatch(input -> input == releaseType)) {
                             return false;
                         }
                     }
-                    // Filter by clearingState if provided
                     if (CommonUtils.isNotEmpty(clearingState)) {
                         ClearingState releaseState = release.getClearingState();
                         if (releaseState == null || clearingState.stream().noneMatch(input -> input == releaseState)) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -34,7 +34,6 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
-import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
@@ -231,12 +230,20 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
     }
 
     public List<Release> setComponentDependentFieldsInRelease(List<Release> releases, User sw360User) {
+        if (CommonUtils.isNullOrEmptyCollection(releases)) {
+            return releases;
+        }
+
         Map<String, Component> componentIdMap;
 
         try {
-            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            List<Component> components = sw360ComponentClient.getComponentSummary(sw360User);
-            componentIdMap = ThriftUtils.getIdMap(components);
+            Set<String> componentIds = releases.stream()
+                    .filter(Objects::nonNull)
+                    .map(Release::getComponentId)
+                    .filter(CommonUtils::isNotNullEmptyOrWhitespace)
+                    .collect(Collectors.toSet());
+            List<Component> components = getComponentsShort(componentIds);
+            componentIdMap = components.stream().collect(Collectors.toMap(Component::getId, c -> c));
         } catch (TException e) {
             throw new BadRequestClientException("No Components found");
         }
@@ -253,6 +260,10 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
             release.setComponentType(component.getComponentType());
         }
         return releases;
+    }
+
+    protected List<Component> getComponentsShort(Set<String> componentIds) throws TException {
+        return getThriftComponentClient().getComponentsShort(componentIds);
     }
 
     public List<Release> getReleaseSubscriptions(User sw360User) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -12,6 +12,8 @@ package org.eclipse.sw360.rest.resourceserver.user;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,6 +45,7 @@ import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
@@ -66,6 +69,29 @@ public class Sw360UserService {
     public static final String AUTHORITIES_WRITE = "WRITE";
     public static final String EXPIRATION_DATE_PROPERTY = "expirationDate";
 
+    /**
+     * Short-lived cache for {@link #getUserByEmailOrExternalId(String)} lookups.
+     * <p>
+     * Every authenticated REST request performs a user lookup via
+     * {@code RestControllerHelper#getSw360UserFromAuthentication()}. On busy
+     * endpoints this translates into a Thrift round-trip (and two CouchDB view
+     * hits) on every single call — which shows up as a constant per-request cost
+     * even for endpoints that touch no domain data (e.g. a project with 0
+     * linked releases). User records mutate rarely, so a small in-memory
+     * TTL cache is safe and materially reduces the {@code auth} segment
+     * measured in {@code ProjectController.licenseClearing}.
+     * <p>
+     * TTL is intentionally short (60s) so admin role/department changes still
+     * propagate within a minute without a restart. Negative results are not
+     * cached.
+     */
+    private static final long USER_CACHE_TTL_SECONDS = 60L;
+    private static final long USER_CACHE_MAX_SIZE = 10_000L;
+    private static final Cache<String, User> USER_LOOKUP_CACHE = CacheBuilder.newBuilder()
+            .expireAfterWrite(Duration.ofSeconds(USER_CACHE_TTL_SECONDS))
+            .maximumSize(USER_CACHE_MAX_SIZE)
+            .build();
+
     public List<User> getAllUsers() {
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();
@@ -85,11 +111,38 @@ public class Sw360UserService {
     }
 
     public User getUserByEmailOrExternalId(String userIdentifier) {
+        if (CommonUtils.isNullEmptyOrWhitespace(userIdentifier)) {
+            return null;
+        }
+        User cached = USER_LOOKUP_CACHE.getIfPresent(userIdentifier);
+        if (cached != null) {
+            return cached;
+        }
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();
-            return sw360UserClient.getByEmailOrExternalId(userIdentifier, userIdentifier);
+            User user = sw360UserClient.getByEmailOrExternalId(userIdentifier, userIdentifier);
+            if (user != null) {
+                USER_LOOKUP_CACHE.put(userIdentifier, user);
+            }
+            return user;
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Invalidate cached {@link User} entries. Called whenever a user record is
+     * mutated (add/update) so callers always see fresh data after a write.
+     */
+    public static void invalidateUserLookupCache(String... identifiers) {
+        if (identifiers == null || identifiers.length == 0) {
+            USER_LOOKUP_CACHE.invalidateAll();
+            return;
+        }
+        for (String identifier : identifiers) {
+            if (!CommonUtils.isNullEmptyOrWhitespace(identifier)) {
+                USER_LOOKUP_CACHE.invalidate(identifier);
+            }
         }
     }
 
@@ -131,6 +184,7 @@ public class Sw360UserService {
             AddDocumentRequestSummary documentRequestSummary = sw360UserClient.addUser(user);
             if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
                 user.setId(documentRequestSummary.getId());
+                invalidateUserLookupCache(user.getEmail(), user.getExternalid());
                 return user;
             } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
                 throw new DataIntegrityViolationException("sw360 user with name '" + user.getEmail()
@@ -151,6 +205,7 @@ public class Sw360UserService {
     public void updateUser(User sw360User) throws TException {
         UserService.Iface sw360UserClient = getThriftUserClient();
         sw360UserClient.updateUser(sw360User);
+        invalidateUserLookupCache(sw360User.getEmail(), sw360User.getExternalid());
     }
 
     public Map<PaginationData, List<User>> refineSearch(Map<String, Set<String>> filterMap, Pageable pageable) throws TException {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -897,9 +897,8 @@ public class ProjectTest extends TestIntegrationBase {
     @Test
     public void should_get_license_clearing() throws IOException, TException {
         given(this.projectServiceMock.getProjectForUserById(eq(project1.getId()), any())).willReturn(project1);
-        given(this.projectServiceMock.getReleaseIds(eq(project1.getId()), any(), anyBoolean())).willReturn(new HashSet<>(Arrays.asList(release1.getId(), release2.getId())));
-        given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
-        given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), any())).willReturn(release2);
+        given(this.projectServiceMock.getLicenseClearingReleases(eq(project1.getId()), eq(project1), any(), eq(true), any(), any(), any()))
+                .willReturn(Arrays.asList(release1, release2));
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =
@@ -1695,13 +1694,8 @@ public class ProjectTest extends TestIntegrationBase {
         parentProject.setLinkedProjects(linkedProjects);
 
         given(this.projectServiceMock.getProjectForUserById(eq("parentNoReleases"), any())).willReturn(parentProject);
-        // Transitive fetch returns releases from sub-project
-        given(this.projectServiceMock.getReleaseIds(eq("parentNoReleases"), any(), eq(true)))
-                .willReturn(new HashSet<>(Arrays.asList(release1.getId(), release2.getId())));
-        given(this.projectServiceMock.getFilteredReleases(any(), any(), any(), any(), any()))
+        given(this.projectServiceMock.getLicenseClearingReleases(eq("parentNoReleases"), eq(parentProject), any(), eq(true), any(), any(), any()))
                 .willReturn(Arrays.asList(release1, release2));
-        given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
-        given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), any())).willReturn(release2);
 
         HttpHeaders headers = getHeaders(port);
         ResponseEntity<String> response =

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
@@ -12,7 +12,13 @@ package org.eclipse.sw360.rest.resourceserver.project;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +36,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class Sw360ProjectServiceTest {
 
@@ -197,6 +204,32 @@ public class Sw360ProjectServiceTest {
                 result
         );
         verify(projectClient, times(1)).getGroups();
+    }
+
+    @Test
+    public void should_use_transitive_release_ids_for_license_clearing() throws TException {
+        User user = new User().setEmail("test@sw360.org");
+        Project project = new Project().setId("project1");
+        Set<String> releaseIds = Set.of("release1", "release2");
+        Release release = new Release().setId("release1")
+                .setClearingState(ClearingState.NEW_CLEARING)
+                .setComponentType(ComponentType.OSS);
+        Sw360ReleaseService releaseService = mock(Sw360ReleaseService.class);
+        org.mockito.Mockito.doReturn(releaseIds).when(projectService).getReleaseIds("project1", user, true);
+        org.mockito.Mockito.doReturn(List.of(release)).when(projectService)
+                .getFilteredReleases(releaseIds, user,
+                        List.of(ClearingState.NEW_CLEARING), List.of(ComponentType.OSS), releaseService);
+
+        List<Release> result = projectService.getLicenseClearingReleases("project1", project, user, true,
+                List.of(ClearingState.NEW_CLEARING), List.of(ComponentType.OSS), releaseService);
+
+        assertEquals(1, result.size());
+        assertEquals("release1", result.get(0).getId());
+        assertEquals(ComponentType.OSS, result.get(0).getComponentType());
+        verify(projectService).getReleaseIds("project1", user, true);
+        verify(projectService).getFilteredReleases(releaseIds, user,
+                List.of(ClearingState.NEW_CLEARING), List.of(ComponentType.OSS), releaseService);
+        verifyNoInteractions(releaseService);
     }
 
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Siemens AG, 2026.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.release;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.lang.reflect.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+class Sw360ReleaseServiceTest {
+
+    private Sw360ReleaseService releaseService;
+    private MockedStatic<ThriftClients> thriftClientsMock;
+
+    @BeforeEach
+    void setUp() {
+        releaseService = new Sw360ReleaseService(mock(RestControllerHelper.class), mock(Sw360ProjectService.class));
+        thriftClientsMock = mockStatic(ThriftClients.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        thriftClientsMock.close();
+    }
+
+    @Test
+    void shouldFetchOnlyReferencedComponents_whenSettingComponentDependentFieldsForReleaseList() throws Exception {
+        User user = new User().setEmail("test@sw360.org");
+        Release release1 = new Release().setId("r1").setComponentId("c1");
+        Release release2 = new Release().setId("r2").setComponentId("c2");
+        Release release3 = new Release().setId("r3").setComponentId("c1");
+        AtomicReference<Set<String>> requestedComponentIds = new AtomicReference<>();
+
+        Class<?> componentServiceIface = Class.forName(
+                "org.eclipse.sw360.datahandler.thrift.components.ComponentService$Iface");
+        Object componentClient = Proxy.newProxyInstance(
+                componentServiceIface.getClassLoader(),
+                new Class<?>[]{componentServiceIface},
+                (proxy, method, args) -> {
+                    if ("getComponentsShort".equals(method.getName())) {
+                        requestedComponentIds.set((Set<String>) args[0]);
+                        return List.of(
+                                new Component().setId("c1").setComponentType(ComponentType.OSS),
+                                new Component().setId("c2").setComponentType(ComponentType.COTS)
+                        );
+                    }
+                    throw new UnsupportedOperationException("Unexpected call: " + method.getName());
+                });
+
+        thriftClientsMock.when(ThriftClients::makeComponentClient).thenAnswer(invocation -> componentClient);
+
+        List<Release> releases = new ArrayList<>(List.of(release1, release2, release3));
+        List<Release> result = releaseService.setComponentDependentFieldsInRelease(releases, user);
+
+        assertEquals(ComponentType.OSS, result.get(0).getComponentType());
+        assertEquals(ComponentType.COTS, result.get(1).getComponentType());
+        assertEquals(ComponentType.OSS, result.get(2).getComponentType());
+        assertEquals(Set.of("c1", "c2"), requestedComponentIds.get());
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -592,6 +592,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         projectListByName.stream().toList()
                 )
         );
+        given(this.projectServiceMock.getLicenseClearingReleases(eq(project.getId()), eq(project), any(), eq(true), any(), any(), any()))
+                .willReturn(List.of(release));
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(false))).willReturn(releaseIds);
         given(this.projectServiceMock.getReleaseIds(eq(project9.getId()), any(), eq(true))).willReturn(releaseIds2);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), any(), eq(true))).willReturn(releaseIdsTransitive);


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This PR optimizes license clearing data loading for projects by reusing backend APIs that already return release clearing status with accessibility metadata, and by reducing redundant release/component fetch operations.


### What changed

- Added `Sw360ProjectService#getLicenseClearingReleases(...)` and switched `ProjectController` license-clearing flow to use it.
- For transitive license clearing:
  - Reuses backend `getReleaseClearingStatusesWithAccessibility(...)`
  - Filters only accessible releases
  - Applies existing `clearingState` and `componentType` filters on top
- For non-transitive flow:
  - Reuses direct project release IDs and existing filtering logic.
- Refactored filtering into a dedicated helper (`filterLicenseClearingReleases(...)`) to avoid duplicated logic.
- Optimized linked-project traversal in `ProjectDatabaseHandler`:
  - Batch-fetches unresolved linked projects instead of per-project calls
  - Preserves access checks and warning logs for inaccessible/missing linked projects.
- Optimized `Sw360ReleaseService#setComponentDependentFieldsInRelease(...)`:
  - Early return for empty input
  - Fetches only referenced components via `getComponentsShort(componentIds)` instead of loading all component summaries
  - Added protected helper method `getComponentsShort(...)` for testability.

### Files touched (last commit)

- `backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java`
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java`
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java`
- `rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java`
- `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java`
- `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java`
- `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseServiceTest.java` (new)
- `rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java`
- `.github/copilot-instructions.md`


### Suggested Reviewer
@GMishx 