### PR TITLE
feat(projects): add strict closed project check

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/cyclonedx/CycloneDxBOMImporter.java
@@ -299,7 +299,15 @@ public class CycloneDxBOMImporter {
 
                         RequestStatus updateStatus = projectDatabaseHandler.updateProject(project, user);
                         if (RequestStatus.SUCCESS.equals(updateStatus)) {
-                            log.info("linking packages to project successfull: " + projId);
+                            log.info("linking packages to project successfully: {}", projId);
+                        } else if (RequestStatus.CLOSED_UPDATE_NOT_ALLOWED.equals(updateStatus)) {
+                            log.error("User is not allowed to update the closed project: {}", projId);
+                            requestSummary.setRequestStatus(RequestStatus.CLOSED_UPDATE_NOT_ALLOWED);
+                            requestSummary.setMessage(
+                                    "SBOM import aborted: user is not allowed to update a project with clearing state CLOSED.");
+                            return requestSummary;
+                        } else {
+                            log.error("Failed to link packages to project: {} with status: {}", projId, updateStatus);
                         }
                         // all components does not have VCS, so return & show appropriate error in UI
                         messageMap.put(INVALID_COMPONENT, String.join(JOINER, componentsWithoutVcs));
@@ -442,7 +450,7 @@ public class CycloneDxBOMImporter {
         } else {
             messageMap = importAllComponentsAsReleases(vcsToComponentMap, project);
         }
-        RequestStatus updateStatus = projectDatabaseHandler.updateProject(project, user, true);
+        RequestStatus updateStatus = projectDatabaseHandler.updateProject(project, user, false);
         if (RequestStatus.SUCCESS.equals(updateStatus)) {
             log.info("project updated successfully: " + project.getId());
         } else {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1425,86 +1425,12 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
      * @param update The updated release from the user
      * @return true if there are NO changes, false if there are changes
      */
-    private boolean hasNoChanges(Release actual, Release update) {
+    private static boolean hasNoChanges(Release actual, Release update) {
         // Normalize vendor IDs for consistent comparison
         SW360Utils.setVendorId(actual);
         SW360Utils.setVendorId(update);
 
-        return compareThriftObjects(actual, update, Release._Fields.values());
-    }
-
-    /**
-     * Generalized method to compare two Thrift objects field by field
-     * This automatically handles ALL fields using Thrift's reflection capabilities
-     *
-     * @param obj1 First Thrift object
-     * @param obj2 Second Thrift object
-     * @param fields Array of field enums (e.g., Release._Fields.values())
-     * @return true if objects are equal (no changes), false if different
-     */
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private <T extends org.apache.thrift.TBase<T, F>, F extends org.apache.thrift.TFieldIdEnum>
-            boolean compareThriftObjects(T obj1, T obj2, F[] fields) {
-
-        if (obj1 == null && obj2 == null) {
-            return true;
-        }
-        if (obj1 == null || obj2 == null) {
-            return false;
-        }
-
-        // Iterate through all fields automatically using Thrift reflection
-        for (F field : fields) {
-            // Get field values using Thrift's getFieldValue
-            Object value1 = obj1.isSet(field) ? obj1.getFieldValue(field) : null;
-            Object value2 = obj2.isSet(field) ? obj2.getFieldValue(field) : null;
-
-            // Compare field values
-            if (!areFieldValuesEqual(value1, value2, field.getFieldName())) {
-                return false;
-            }
-        }
-
-        // All fields are equal
-        log.debug("No changes detected - all fields are equal");
-        return true;
-    }
-
-    /**
-     * Compare two field values with proper null handling and type-specific comparison
-     * Includes detailed logging to track which fields differ
-     *
-     * @param value1 First value
-     * @param value2 Second value
-     * @param fieldName Name of field (for logging)
-     * @return true if values are equal, false otherwise
-     */
-    private boolean areFieldValuesEqual(Object value1, Object value2, String fieldName) {
-        // Both null = equal
-        if (value1 == null && value2 == null) {
-            return true;
-        }
-
-        // One null, one not = not equal
-        if (value1 == null || value2 == null) {
-            return false;
-        }
-
-        // For Comparable types, use compareTo
-        if (value1 instanceof Comparable && value2 instanceof Comparable &&
-            value1.getClass().equals(value2.getClass())) {
-            try {
-                @SuppressWarnings("unchecked")
-                int comparison = ((Comparable<Object>) value1).compareTo(value2);
-                return comparison == 0;
-            } catch (ClassCastException e) {
-                // Fall back to equals if compareTo fails
-                return Objects.equals(value1, value2);
-            }
-        }
-
-        // For all other types (collections, maps, objects), use equals
-        return Objects.equals(value1, value2);
+        return ThriftUtils.compareThriftObjects(actual, update, Release._Fields.values());
     }
 
     public boolean hasChangesInEccFields(Release release, Release actual) {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -174,11 +174,19 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
      * Server managed or computed fields which must not be taken into account when checking
      * whether a closed project update only modifies allowed fields.
      */
-    private static final ImmutableSet<Project._Fields> CLOSED_PROJECT_UPDATE_CHECK_IGNORED_FIELDS = ImmutableSet.of(
-            Project._Fields.ID, Project._Fields.REVISION, Project._Fields.TYPE, Project._Fields.DOCUMENT_STATE,
-            Project._Fields.PERMISSIONS, Project._Fields.RELEASE_CLEARING_STATE_SUMMARY, Project._Fields.CREATED_ON,
-            Project._Fields.CREATED_BY, Project._Fields.MODIFIED_ON, Project._Fields.MODIFIED_BY,
-            Project._Fields.VENDOR, Project._Fields.VENDOR_ID);
+    private static final ImmutableSet<String> CLOSED_PROJECT_UPDATE_CHECK_IGNORED_FIELDS = ImmutableSet.of(
+            Project._Fields.ID.getFieldName(),
+            Project._Fields.REVISION.getFieldName(),
+            Project._Fields.TYPE.getFieldName(),
+            Project._Fields.DOCUMENT_STATE.getFieldName(),
+            Project._Fields.PERMISSIONS.getFieldName(),
+            Project._Fields.RELEASE_CLEARING_STATE_SUMMARY.getFieldName(),
+            Project._Fields.CREATED_ON.getFieldName(),
+            Project._Fields.CREATED_BY.getFieldName(),
+            Project._Fields.MODIFIED_ON.getFieldName(),
+            Project._Fields.MODIFIED_BY.getFieldName(),
+            Project._Fields.VENDOR.getFieldName(),
+            Project._Fields.VENDOR_ID.getFieldName());
 
     private final LoadingCache<String, Project> projectLookupCache;
     private Map<String, Project> cachedAllProjectsIdMap;
@@ -962,10 +970,11 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     ) {
         for (Project._Fields field : Project._Fields.values()) {
             if (CLOSED_PROJECT_EDITABLE_FIELDS.contains(field)
-                    || CLOSED_PROJECT_UPDATE_CHECK_IGNORED_FIELDS.contains(field)) {
+                    || CLOSED_PROJECT_UPDATE_CHECK_IGNORED_FIELDS.contains(field.getFieldName())) {
                 continue;
             }
-            if (!ThriftUtils.areFieldValuesEqual(actual.getFieldValue(field), updated.getFieldValue(field))) {
+            if (!ThriftUtils.areFieldValuesEqual(actual.getFieldValue(field), updated.getFieldValue(field),
+                    CLOSED_PROJECT_UPDATE_CHECK_IGNORED_FIELDS)) {
                 log.info("User {} is not allowed to modify field '{}' of closed project {}.", user.getEmail(),
                         field.getFieldName(), actual.getId());
                 return false;

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -161,6 +161,25 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             Project._Fields.SPECIAL_RISKS3RD_PARTY, Project._Fields.DELIVERY_CHANNELS,
             Project._Fields.REMARKS_ADDITIONAL_REQUIREMENTS, Project._Fields.OBLIGATIONS_TEXT,
             Project._Fields.LICENSE_INFO_HEADER_TEXT);
+
+    /**
+     * Fields a project member (without clearing admin rights) may still modify on a project
+     * with clearing state CLOSED when
+     * {@value org.eclipse.sw360.datahandler.common.SW360ConfigKeys#PROJECTS_CLOSED_UPDATE_STRICT} is enabled.
+     */
+    private static final ImmutableSet<Project._Fields> CLOSED_PROJECT_EDITABLE_FIELDS = ImmutableSet.of(
+            Project._Fields.STATE, Project._Fields.EXTERNAL_IDS, Project._Fields.ADDITIONAL_DATA);
+
+    /**
+     * Server managed or computed fields which must not be taken into account when checking
+     * whether a closed project update only modifies allowed fields.
+     */
+    private static final ImmutableSet<Project._Fields> CLOSED_PROJECT_UPDATE_CHECK_IGNORED_FIELDS = ImmutableSet.of(
+            Project._Fields.ID, Project._Fields.REVISION, Project._Fields.TYPE, Project._Fields.DOCUMENT_STATE,
+            Project._Fields.PERMISSIONS, Project._Fields.RELEASE_CLEARING_STATE_SUMMARY, Project._Fields.CREATED_ON,
+            Project._Fields.CREATED_BY, Project._Fields.MODIFIED_ON, Project._Fields.MODIFIED_BY,
+            Project._Fields.VENDOR, Project._Fields.VENDOR_ID);
+
     private final LoadingCache<String, Project> projectLookupCache;
     private Map<String, Project> cachedAllProjectsIdMap;
     private Instant cachedAllProjectsIdMapLoadingInstant;
@@ -487,7 +506,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return RequestStatus.DUPLICATE;
         } else if (duplicateAttachmentExist(project)) {
             return RequestStatus.DUPLICATE_ATTACHMENT;
-        } else if (!updateProjectAllowed(actual, user)) {
+        } else if (!forceUpdate && !updateProjectAllowed(actual, project, user)) {
             return RequestStatus.CLOSED_UPDATE_NOT_ALLOWED;
         } else if (!changePassesSanityCheck(project, actual)){
             return RequestStatus.FAILED_SANITY_CHECK;
@@ -531,8 +550,13 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 updateProjectDependentFieldsInClearingRequest(project, actual, user);
             }
             sendMailNotificationsForProjectUpdate(project, actual, user);
-            dbHandlerUtil.addChangeLogs(project, actual, user.getEmail(), Operation.UPDATE, attachmentConnector,
-                    referenceDocLogList, null, null);
+            if (!Objects.equals(project.getLinkedObligationId(), actual.getLinkedObligationId())) {
+                dbHandlerUtil.addChangeLogs(project, actual, user.getEmail(), Operation.UPDATE, attachmentConnector,
+                        referenceDocLogList, null, Operation.OBLIGATION_ADD);
+            } else {
+                dbHandlerUtil.addChangeLogs(project, actual, user.getEmail(), Operation.UPDATE, attachmentConnector,
+                        referenceDocLogList, null, null);
+            }
             return RequestStatus.SUCCESS;
         } else {
             return moderator.updateProject(project, user);
@@ -813,18 +837,18 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         obligationRepository.add(obligation);
         Project project = getProjectById(obligation.getProjectId(), user);
         project.setLinkedObligationId(obligation.getId());
-        repository.update(project);
-        project.unsetLinkedObligationId();
+        updateProject(project, user);
         dbHandlerUtil.addChangeLogs(obligation, null, user.getEmail(), Operation.CREATE, attachmentConnector,
                 Lists.newArrayList(), obligation.getProjectId(), Operation.PROJECT_UPDATE);
-        dbHandlerUtil.addChangeLogs(getProjectById(obligation.getProjectId(), user), project, user.getEmail(),
-                Operation.UPDATE, attachmentConnector, Lists.newArrayList(), null, Operation.OBLIGATION_ADD);
 
         return RequestStatus.SUCCESS;
     }
 
     public RequestStatus updateLinkedObligations(ObligationList obligation, User user) throws TException {
         Project project = getProjectById(obligation.getProjectId(), user);
+        if (nonStrictClosedProjectUpdateBlocked(project, user)) {
+            return RequestStatus.CLOSED_UPDATE_NOT_ALLOWED;
+        }
         ObligationList projectObligationbefore = obligationRepository.get(obligation.getId());
         if (isWriteActionAllowedOnProject(project, user)) {
             obligationRepository.update(obligation);
@@ -895,12 +919,78 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return false;
     }
 
-    private boolean updateProjectAllowed(Project project, User user) {
-        if (project.clearingState != null && project.clearingState.equals(ProjectClearingState.CLOSED)
-                && !PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user) && !SW360Utils.isUserAllowedToEditClosedProject(project, user)) {
+    private boolean updateProjectAllowed(Project actual, Project updated, User user) {
+        return isProjectUpdateAllowed(actual, updated, user,
+                SW360Utils.readConfig(PROJECTS_CLOSED_UPDATE_STRICT, false));
+    }
+
+    /**
+     * Decides whether the given user is allowed to apply the given update to the given project.
+     * Only relevant for projects with clearing state {@link ProjectClearingState#CLOSED}.
+     *
+     * @param actual       project as currently stored in the database
+     * @param updated      project as it should be stored
+     * @param user         user requesting the update
+     * @param strictUpdate value of the {@code projects.closed.update.strict} configuration
+     * @return true if the update may be performed
+     */
+    @VisibleForTesting
+    static boolean isProjectUpdateAllowed(Project actual, Project updated, User user, boolean strictUpdate) {
+        if (!ProjectClearingState.CLOSED.equals(actual.getClearingState())) {
+            return true;
+        }
+        // Clearing admins (and SW360 admins) may always modify a closed project
+        if (PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)) {
+            return true;
+        }
+        if (!SW360Utils.isUserAllowedToEditClosedProject(actual, user)) {
             return false;
         }
+        // If strict update not enabled, no need to check for fields
+        if (!strictUpdate) {
+            return true;
+        }
+        return onlyClosedProjectEditableFieldsChanged(actual, updated, user);
+    }
+
+    /**
+     * Verifies that the update of a closed project only touches the fields a project member
+     * (without clearing admin rights) is allowed to modify.
+     */
+    private static boolean onlyClosedProjectEditableFieldsChanged(
+            Project actual, Project updated, User user
+    ) {
+        for (Project._Fields field : Project._Fields.values()) {
+            if (CLOSED_PROJECT_EDITABLE_FIELDS.contains(field)
+                    || CLOSED_PROJECT_UPDATE_CHECK_IGNORED_FIELDS.contains(field)) {
+                continue;
+            }
+            if (!ThriftUtils.areFieldValuesEqual(actual.getFieldValue(field), updated.getFieldValue(field))) {
+                log.info("User {} is not allowed to modify field '{}' of closed project {}.", user.getEmail(),
+                        field.getFieldName(), actual.getId());
+                return false;
+            }
+        }
         return true;
+    }
+
+    /**
+     * Check to see if Project is Closed and user not at-least CLEARING_ADMIN
+     * and user is not special member of Project and strict checks are enabled.
+     * This check does not check for fields like {@link isProjectUpdateAllowed}
+     * or {@link updateProjectAllowed} with backwards compatibility (will not
+     * report blocked if {@code PROJECTS_CLOSED_UPDATE_STRICT} is disabled).
+     * @param project Project to check permission in
+     * @param user    User to check permission for
+     * @return False if update is not blocked, true if blocked.
+     */
+    private static boolean nonStrictClosedProjectUpdateBlocked(
+            @NotNull Project project, @NotNull User user
+    ) {
+        return ProjectClearingState.CLOSED.equals(project.getClearingState())
+                && SW360Utils.readConfig(PROJECTS_CLOSED_UPDATE_STRICT, false)
+                && !PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user)
+                && !SW360Utils.isUserAllowedToEditClosedProject(project, user);
     }
 
     private ObligationList deleteObligationsOfUnlinkedReleases(Project updated) {

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -77,6 +77,7 @@ public class SW360ConfigsDatabaseHandler {
             .put(IS_BULK_RELEASE_DELETING_ENABLED, getOrDefault(configContainer, IS_BULK_RELEASE_DELETING_ENABLED, "false"))
             .put(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, getOrDefault(configContainer, DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, "false"))
             .put(IS_FORCE_UPDATE_ENABLED, getOrDefault(configContainer, IS_FORCE_UPDATE_ENABLED, "false"))
+            .put(PROJECTS_CLOSED_UPDATE_STRICT, getOrDefault(configContainer, PROJECTS_CLOSED_UPDATE_STRICT, "false"))
             .put(SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE, getOrDefault(configContainer, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE, UserGroup.USER.name()))
             .put(TOOL_NAME, getOrDefault(configContainer, TOOL_NAME, SW360Constants.DEFAULT_SBOM_TOOL_NAME))
             .put(TOOL_VENDOR, getOrDefault(configContainer, TOOL_VENDOR, SW360Constants.DEFAULT_SBOM_TOOL_VENDOR))
@@ -198,6 +199,7 @@ public class SW360ConfigsDatabaseHandler {
                  AUTO_SET_ECC_STATUS,
                  MAIL_REQUEST_FOR_REPORT,
                  IS_FORCE_UPDATE_ENABLED,
+                 PROJECTS_CLOSED_UPDATE_STRICT,
                  DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD,
                  IS_BULK_RELEASE_DELETING_ENABLED,
                  IS_PACKAGE_PORTLET_ENABLED,

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerClosedUpdateTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerClosedUpdateTest.java
@@ -10,14 +10,22 @@
 
 package org.eclipse.sw360.datahandler.db;
 
+import org.eclipse.sw360.datahandler.thrift.MainlineState;
+import org.eclipse.sw360.datahandler.thrift.ProjectPackageRelationship;
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -163,5 +171,81 @@ public class ProjectDatabaseHandlerClosedUpdateTest {
         assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated, contributor, true));
         assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated, leadArchitect, true));
         assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated, projectResponsible, true));
+    }
+
+    @Test
+    public void testNestedThriftObjectsWithIgnoredFieldsAreTreatedAsEqual() {
+        Project actual = closedProject();
+        Map<String, ProjectReleaseRelationship> actualReleases = new HashMap<>();
+        actualReleases.put("r1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)
+                .setCreatedBy("admin@sw360.org")
+                .setCreatedOn("2026-01-01"));
+        actual.setReleaseIdToUsage(actualReleases);
+
+        Map<String, ProjectPackageRelationship> actualPackages = new HashMap<>();
+        actualPackages.put("pkg1", new ProjectPackageRelationship()
+                .setComment("a package")
+                .setCreatedBy("admin@sw360.org")
+                .setCreatedOn("2026-01-01"));
+        actual.setPackageIds(actualPackages);
+
+        // Updated project from API does not contain createdBy / createdOn on nested relationships
+        Project updated = actual.deepCopy().setState(ProjectState.PHASE_OUT);
+        Map<String, ProjectReleaseRelationship> updatedReleases = new HashMap<>();
+        updatedReleases.put("r1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE));
+        updated.setReleaseIdToUsage(updatedReleases);
+
+        Map<String, ProjectPackageRelationship> updatedPackages = new HashMap<>();
+        updatedPackages.put("pkg1", new ProjectPackageRelationship()
+                .setComment("a package"));
+        updated.setPackageIds(updatedPackages);
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(MEMBER_EMAIL, UserGroup.USER), true));
+    }
+
+    @Test
+    public void testNestedThriftObjectsWithActualFieldChangesAreDetected() {
+        Project actual = closedProject();
+        Map<String, ProjectReleaseRelationship> actualReleases = new HashMap<>();
+        actualReleases.put("r1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)
+                .setCreatedBy("admin@sw360.org")
+                .setCreatedOn("2026-01-01"));
+        actual.setReleaseIdToUsage(actualReleases);
+
+        // Member attempts to change releaseRelationship from CONTAINED to REFERRED on closed project
+        Project updated = actual.deepCopy();
+        Map<String, ProjectReleaseRelationship> updatedReleases = new HashMap<>();
+        updatedReleases.put("r1", new ProjectReleaseRelationship(ReleaseRelationship.REFERRED, MainlineState.MAINLINE));
+        updated.setReleaseIdToUsage(updatedReleases);
+
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(MEMBER_EMAIL, UserGroup.USER), true));
+    }
+
+    @Test
+    public void testNestedLinkedProjectsWithChangesAreDetected() {
+        Project actual = closedProject();
+        Map<String, ProjectProjectRelationship> actualLinked = new HashMap<>();
+        actualLinked.put("P2", new ProjectProjectRelationship(ProjectRelationship.CONTAINED));
+        actual.setLinkedProjects(actualLinked);
+
+        // Matching linked project allowed
+        Project updatedSame = actual.deepCopy().setState(ProjectState.PHASE_OUT);
+        Map<String, ProjectProjectRelationship> sameLinked = new HashMap<>();
+        sameLinked.put("P2", new ProjectProjectRelationship(ProjectRelationship.CONTAINED));
+        updatedSame.setLinkedProjects(sameLinked);
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updatedSame,
+                user(MEMBER_EMAIL, UserGroup.USER), true));
+
+        // Modified relationship blocked for member
+        Project updatedDiff = actual.deepCopy();
+        Map<String, ProjectProjectRelationship> diffLinked = new HashMap<>();
+        diffLinked.put("P2", new ProjectProjectRelationship(ProjectRelationship.REFERRED));
+        updatedDiff.setLinkedProjects(diffLinked);
+
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updatedDiff,
+                user(MEMBER_EMAIL, UserGroup.USER), true));
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerClosedUpdateTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerClosedUpdateTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectState;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the update rules applied to projects with clearing state CLOSED.
+ */
+public class ProjectDatabaseHandlerClosedUpdateTest {
+
+    private static final String MEMBER_EMAIL = "member@sw360.org";
+    private static final String STRANGER_EMAIL = "stranger@sw360.org";
+
+    private static User user(String email, UserGroup userGroup) {
+        return new User().setEmail(email).setUserGroup(userGroup);
+    }
+
+    private static Project closedProject() {
+        return new Project()
+                .setId("P1")
+                .setName("Project1")
+                .setClearingState(ProjectClearingState.CLOSED)
+                .setState(ProjectState.ACTIVE)
+                .setCreatedBy(MEMBER_EMAIL);
+    }
+
+    @Test
+    public void testOpenProjectIsAlwaysUpdatable() {
+        Project actual = closedProject().setClearingState(ProjectClearingState.OPEN);
+        Project updated = actual.deepCopy().setName("Project1new");
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(STRANGER_EMAIL, UserGroup.USER), true));
+    }
+
+    @Test
+    public void testClearingAdminMayChangeAnyFieldOfClosedProject() {
+        Project actual = closedProject();
+        Project updated = actual.deepCopy().setName("Project1new");
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(STRANGER_EMAIL, UserGroup.CLEARING_ADMIN), true));
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(STRANGER_EMAIL, UserGroup.ADMIN), true));
+    }
+
+    @Test
+    public void testNonMemberMayNotUpdateClosedProject() {
+        Project actual = closedProject();
+        Project updated = actual.deepCopy().setState(ProjectState.PHASE_OUT);
+
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(STRANGER_EMAIL, UserGroup.USER), true));
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(STRANGER_EMAIL, UserGroup.USER), false));
+    }
+
+    @Test
+    public void testMemberMayChangeAnyFieldWhenStrictModeIsDisabled() {
+        Project actual = closedProject();
+        Project updated = actual.deepCopy().setName("Project1new");
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(MEMBER_EMAIL, UserGroup.USER), false));
+    }
+
+    @Test
+    public void testMemberMayChangeAllowedFieldsInStrictMode() {
+        Project actual = closedProject();
+        User member = user(MEMBER_EMAIL, UserGroup.USER);
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
+                actual.deepCopy().setState(ProjectState.PHASE_OUT), member, true));
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
+                actual.deepCopy().setExternalIds(Collections.singletonMap("internal.id", "4711")), member, true));
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
+                actual.deepCopy().setAdditionalData(Collections.singletonMap("key", "value")), member, true));
+    }
+
+    @Test
+    public void testMemberMayNotChangeOtherFieldsInStrictMode() {
+        Project actual = closedProject();
+        User member = user(MEMBER_EMAIL, UserGroup.USER);
+
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
+                actual.deepCopy().setName("Project1new"), member, true));
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
+                actual.deepCopy().setClearingState(ProjectClearingState.OPEN), member, true));
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
+                actual.deepCopy().setDescription("new description"), member, true));
+    }
+
+    @Test
+    public void testMemberMayNotChangeAttachmentsInStrictMode() {
+        Project actual = closedProject();
+        Project updated = actual.deepCopy();
+        updated.addToAttachments(new org.eclipse.sw360.datahandler.thrift.attachments.Attachment()
+                .setAttachmentContentId("A1").setFilename("file.txt"));
+
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(MEMBER_EMAIL, UserGroup.USER), true));
+    }
+
+    @Test
+    public void testServerManagedFieldsAreIgnoredInStrictMode() {
+        Project actual = closedProject().setModifiedBy("someone@sw360.org").setModifiedOn("2026-01-01");
+        Project updated = actual.deepCopy()
+                .setModifiedBy(MEMBER_EMAIL)
+                .setModifiedOn("2026-02-02")
+                .setRevision("2")
+                .setState(ProjectState.PHASE_OUT);
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(MEMBER_EMAIL, UserGroup.USER), true));
+    }
+
+    @Test
+    public void testNullAndEmptyValuesAreTreatedAsEqual() {
+        Project actual = closedProject();
+        Project updated = actual.deepCopy()
+                .setDescription("")
+                .setModerators(Collections.emptySet())
+                .setExternalUrls(Collections.emptyMap());
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated,
+                user(MEMBER_EMAIL, UserGroup.USER), true));
+    }
+
+    @Test
+    public void testMembersOtherThanCreatorAreRecognised() {
+        User moderator = user("moderator@sw360.org", UserGroup.USER);
+        User contributor = user("contributor@sw360.org", UserGroup.USER);
+        User leadArchitect = user("architect@sw360.org", UserGroup.USER);
+        User projectResponsible = user("responsible@sw360.org", UserGroup.USER);
+
+        Project actual = closedProject()
+                .setModerators(Collections.singleton(moderator.getEmail()))
+                .setContributors(Collections.singleton(contributor.getEmail()))
+                .setLeadArchitect(leadArchitect.getEmail())
+                .setProjectResponsible(projectResponsible.getEmail());
+        Project updated = actual.deepCopy().setState(ProjectState.PHASE_OUT);
+
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated, moderator, true));
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated, contributor, true));
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated, leadArchitect, true));
+        assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual, updated, projectResponsible, true));
+    }
+}

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -45,6 +45,11 @@ public class SW360ConfigKeys {
     // This property enable force update feature
     public static final String IS_FORCE_UPDATE_ENABLED = "rest.force.update.enabled";
 
+    // This property enables strict update rules for projects with clearing state CLOSED.
+    // When enabled, users below clearing admin may only modify the project state, external ids
+    // and additional data of a closed project.
+    public static final String PROJECTS_CLOSED_UPDATE_STRICT = "projects.closed.update.strict";
+
     // This property is used to control the user role for SBOM import and export
     public static final String SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE = "sbom.import.export.access.usergroup";
 
@@ -150,7 +155,8 @@ public class SW360ConfigKeys {
             ATTACHMENT_DELETE_NO_OF_DAYS, ATTACHMENT_STORE_FILE_SYSTEM_LOCATION,
             COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, AUTO_SET_ECC_STATUS, MAIL_REQUEST_FOR_REPORT,
             IS_BULK_RELEASE_DELETING_ENABLED,
-            DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, IS_FORCE_UPDATE_ENABLED, SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE,
+            DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, IS_FORCE_UPDATE_ENABLED, PROJECTS_CLOSED_UPDATE_STRICT,
+            SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE,
             TOOL_NAME, TOOL_VENDOR, IS_PACKAGE_PORTLET_ENABLED, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, INHERIT_ATTACHMENT_USAGES,
             RELEASE_FRIENDLY_URL, IS_ADMIN_PRIVATE_ACCESS_ENABLED, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, VCS_HOSTS,
             NON_PKG_MANAGED_COMPS_PROP, REST_API_TOKEN_LENGTH,

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -882,16 +882,23 @@ public class SW360Utils {
                         LinkedHashMap<String, ObligationStatusInfo>::new));
     }
 
-    public static boolean isUserAllowedToEditClosedProject(Project project, User user) {
-        Set<String> users = new HashSet<String>();
-        Set<String> moderators = project.getModerators();
-        users.addAll(moderators);
+    /**
+     * Based on membership, check if user is allowed to modify closed Project.
+     * @param project Project to check membership in
+     * @param user    User to check for special membership
+     * @return True if user is a special member of the project to allow
+     *         modification of closed Project.
+     */
+    public static boolean isUserAllowedToEditClosedProject(
+            @NotNull Project project,
+            @NotNull User user
+    ) {
+        Set<String> users = new HashSet<>(nullToEmptySet(project.getModerators()));
+        users.addAll(nullToEmptySet(project.getContributors()));
         users.add(project.getCreatedBy());
         users.add(project.getProjectResponsible());
-        Set<String> contributors = project.getContributors();
-        users.addAll(contributors);
         users.add(project.getLeadArchitect());
-        return PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user) || users.contains(user.getEmail());
+        return users.contains(user.getEmail());
     }
 
     public static void copyLinkedObligationsForClonedProject(Project newProject, Project sourceProject, ProjectService.Iface client, User user) {

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -47,9 +47,11 @@ import com.ibm.cloud.cloudant.v1.model.Document;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -215,15 +217,35 @@ public class ThriftUtils {
     /**
      * Generalized method to compare two Thrift objects field by field
      * This automatically handles ALL fields using Thrift's reflection capabilities
-     *
+     * <p>
+     * TODO: Rework this comparison logic after Thrift removal. Once Thrift is removed
+     * from SW360 and model classes become developer-controlled POJOs, comparison logic
+     * can be implemented directly on the POJOs (overriding equals/compareTo or using
+     * dedicated comparators) rather than relying on reflection-based utility functions.
+     * </p>
      * @param obj1 First Thrift object
      * @param obj2 Second Thrift object
      * @param fields Array of field enums (e.g., Release._Fields.values())
      * @return true if objects are equal (no changes), false if different
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T extends TBase<T, F>, F extends TFieldIdEnum>
             boolean compareThriftObjects(T obj1, T obj2, F[] fields) {
+        return compareThriftObjects(obj1, obj2, fields, Collections.emptySet());
+    }
+
+    /**
+     * Generalized method to compare two Thrift objects field by field, ignoring specified field names.
+     * <p>
+     * TODO: Rework after Thrift removal when model classes become POJOs.
+     * </p>
+     * @param obj1 First Thrift object
+     * @param obj2 Second Thrift object
+     * @param fields Array of field enums
+     * @param ignoredFieldNames Set of field names to ignore during comparison
+     * @return true if objects are equal, false if different
+     */
+    public static <T extends TBase<T, F>, F extends TFieldIdEnum>
+            boolean compareThriftObjects(T obj1, T obj2, F[] fields, Set<String> ignoredFieldNames) {
 
         if (obj1 == null && obj2 == null) {
             return true;
@@ -234,12 +256,15 @@ public class ThriftUtils {
 
         // Iterate through all fields automatically using Thrift reflection
         for (F field : fields) {
+            if (ignoredFieldNames != null && ignoredFieldNames.contains(field.getFieldName())) {
+                continue;
+            }
             // Get field values using Thrift's getFieldValue
             Object value1 = obj1.isSet(field) ? obj1.getFieldValue(field) : null;
             Object value2 = obj2.isSet(field) ? obj2.getFieldValue(field) : null;
 
             // Compare field values
-            if (!areFieldValuesEqual(value1, value2)) {
+            if (!areFieldValuesEqual(value1, value2, ignoredFieldNames)) {
                 return false;
             }
         }
@@ -256,12 +281,32 @@ public class ThriftUtils {
      * A {@code null} value is considered equal to an empty {@link String},
      * {@link Collection} or {@link Map}, since unset and empty Thrift fields
      * carry the same meaning.
-     *
+     * <p>
+     * TODO: Rework this after Thrift removal. Once Thrift is removed from SW360,
+     * the classes will be POJOs controlled by us, allowing standard Java comparison/equality
+     * overrides directly on domain objects rather than complex reflective comparisons.
+     * </p>
      * @param value1 First value
      * @param value2 Second value
      * @return true if values are equal, false otherwise
      */
     public static boolean areFieldValuesEqual(Object value1, Object value2) {
+        return areFieldValuesEqual(value1, value2, Collections.emptySet());
+    }
+
+    /**
+     * Compare two field values with proper null handling, type-specific comparison,
+     * and recursive traversal for nested Thrift objects, Collections and Maps while
+     * ignoring specified field names.
+     * <p>
+     * TODO: Rework after Thrift removal when model classes become POJOs.
+     * </p>
+     * @param value1 First value
+     * @param value2 Second value
+     * @param ignoredFieldNames Set of field names to ignore when comparing Thrift structs
+     * @return true if values are equal, false otherwise
+     */
+    public static boolean areFieldValuesEqual(Object value1, Object value2, Set<String> ignoredFieldNames) {
         // Treat unset and empty values as equal
         if (isNullOrEmptyValue(value1) && isNullOrEmptyValue(value2)) {
             return true;
@@ -271,7 +316,22 @@ public class ThriftUtils {
             return false;
         }
 
-        // For Comparable types, use compareTo
+        // If both are Thrift structs, compare recursively ignoring specified fields
+        if (value1 instanceof TBase<?, ?> t1 && value2 instanceof TBase<?, ?> t2) {
+            return areTBaseEqual(t1, t2, ignoredFieldNames);
+        }
+
+        // If both are Maps, compare entry by entry recursively
+        if (value1 instanceof Map<?, ?> map1 && value2 instanceof Map<?, ?> map2) {
+            return areMapsEqual(map1, map2, ignoredFieldNames);
+        }
+
+        // If both are Collections, compare elements recursively
+        if (value1 instanceof Collection<?> col1 && value2 instanceof Collection<?> col2) {
+            return areCollectionsEqual(col1, col2, ignoredFieldNames);
+        }
+
+        // For Comparable types (enums, numbers, strings, etc.), use compareTo
         if (value1 instanceof Comparable && value2 instanceof Comparable &&
             value1.getClass().equals(value2.getClass())) {
             try {
@@ -284,8 +344,80 @@ public class ThriftUtils {
             }
         }
 
-        // For all other types (collections, maps, objects), use equals
+        // For all other types, use equals
         return Objects.equals(value1, value2);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static boolean areTBaseEqual(TBase t1, TBase t2, Set<String> ignoredFieldNames) {
+        if (!t1.getClass().equals(t2.getClass())) {
+            return false;
+        }
+        Map<? extends TFieldIdEnum, org.apache.thrift.meta_data.FieldMetaData> metaDataMap =
+                org.apache.thrift.meta_data.FieldMetaData.getStructMetaDataMap((Class<? extends TBase>) t1.getClass());
+        if (metaDataMap == null) {
+            if (t1 instanceof Comparable c1 && t2 instanceof Comparable c2) {
+                return c1.compareTo(c2) == 0;
+            }
+            return Objects.equals(t1, t2);
+        }
+        for (TFieldIdEnum field : metaDataMap.keySet()) {
+            if (ignoredFieldNames != null && ignoredFieldNames.contains(field.getFieldName())) {
+                continue;
+            }
+            Object val1 = t1.isSet(field) ? t1.getFieldValue(field) : null;
+            Object val2 = t2.isSet(field) ? t2.getFieldValue(field) : null;
+            if (!areFieldValuesEqual(val1, val2, ignoredFieldNames)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean areMapsEqual(Map<?, ?> map1, Map<?, ?> map2, Set<String> ignoredFieldNames) {
+        if (map1.size() != map2.size()) {
+            return false;
+        }
+        for (Map.Entry<?, ?> entry : map1.entrySet()) {
+            Object key = entry.getKey();
+            if (!map2.containsKey(key)) {
+                return false;
+            }
+            if (!areFieldValuesEqual(entry.getValue(), map2.get(key), ignoredFieldNames)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean areCollectionsEqual(Collection<?> col1, Collection<?> col2, Set<String> ignoredFieldNames) {
+        if (col1.size() != col2.size()) {
+            return false;
+        }
+        if (col1 instanceof List<?> list1 && col2 instanceof List<?> list2) {
+            for (int i = 0; i < list1.size(); i++) {
+                if (!areFieldValuesEqual(list1.get(i), list2.get(i), ignoredFieldNames)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        List<Object> unmatched = new java.util.ArrayList<>(col2);
+        for (Object item1 : col1) {
+            boolean found = false;
+            for (java.util.Iterator<Object> it = unmatched.iterator(); it.hasNext(); ) {
+                Object item2 = it.next();
+                if (areFieldValuesEqual(item1, item2, ignoredFieldNames)) {
+                    it.remove();
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return unmatched.isEmpty();
     }
 
     /**

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -49,6 +49,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -209,5 +210,99 @@ public class ThriftUtils {
             gson = gsonBuilder.create();
         }
         return gson;
+    }
+
+    /**
+     * Generalized method to compare two Thrift objects field by field
+     * This automatically handles ALL fields using Thrift's reflection capabilities
+     *
+     * @param obj1 First Thrift object
+     * @param obj2 Second Thrift object
+     * @param fields Array of field enums (e.g., Release._Fields.values())
+     * @return true if objects are equal (no changes), false if different
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <T extends TBase<T, F>, F extends TFieldIdEnum>
+            boolean compareThriftObjects(T obj1, T obj2, F[] fields) {
+
+        if (obj1 == null && obj2 == null) {
+            return true;
+        }
+        if (obj1 == null || obj2 == null) {
+            return false;
+        }
+
+        // Iterate through all fields automatically using Thrift reflection
+        for (F field : fields) {
+            // Get field values using Thrift's getFieldValue
+            Object value1 = obj1.isSet(field) ? obj1.getFieldValue(field) : null;
+            Object value2 = obj2.isSet(field) ? obj2.getFieldValue(field) : null;
+
+            // Compare field values
+            if (!areFieldValuesEqual(value1, value2)) {
+                return false;
+            }
+        }
+
+        // All fields are equal
+        log.debug("No changes detected - all fields are equal");
+        return true;
+    }
+
+    /**
+     * Compare two field values with proper null handling and type-specific comparison
+     * Includes detailed logging to track which fields differ
+     * <p>
+     * A {@code null} value is considered equal to an empty {@link String},
+     * {@link Collection} or {@link Map}, since unset and empty Thrift fields
+     * carry the same meaning.
+     *
+     * @param value1 First value
+     * @param value2 Second value
+     * @return true if values are equal, false otherwise
+     */
+    public static boolean areFieldValuesEqual(Object value1, Object value2) {
+        // Treat unset and empty values as equal
+        if (isNullOrEmptyValue(value1) && isNullOrEmptyValue(value2)) {
+            return true;
+        }
+
+        if (value1 == null || value2 == null) {
+            return false;
+        }
+
+        // For Comparable types, use compareTo
+        if (value1 instanceof Comparable && value2 instanceof Comparable &&
+            value1.getClass().equals(value2.getClass())) {
+            try {
+                @SuppressWarnings("unchecked")
+                int comparison = ((Comparable<Object>) value1).compareTo(value2);
+                return comparison == 0;
+            } catch (ClassCastException e) {
+                // Fall back to equals if compareTo fails
+                return Objects.equals(value1, value2);
+            }
+        }
+
+        // For all other types (collections, maps, objects), use equals
+        return Objects.equals(value1, value2);
+    }
+
+    /**
+     * Checks whether the given field value is unset, i.e. either {@code null},
+     * an empty {@link String}, an empty {@link Collection} or an empty
+     * {@link Map}.
+     *
+     * @param value value to check
+     * @return true if the value carries no information
+     */
+    public static boolean isNullOrEmptyValue(Object value) {
+        return switch (value) {
+            case null -> true;
+            case String string -> string.isEmpty();
+            case Collection<?> collection -> collection.isEmpty();
+            case Map<?, ?> map -> map.isEmpty();
+            default -> false;
+        };
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -948,6 +948,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Set<String> idsSentToModerator = new HashSet<>();
         Set<String> idsWithCyclicPath = new HashSet<>();
         Set<String> linkedProjectIds = new HashSet<>();
+        Set<String> idsNotAllowedToUpdate = new HashSet<>();
         int count = 0;
 
         try {
@@ -975,7 +976,14 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                         continue;
                     }
 
-                    RequestStatus updatedstatus = projectService.updateProject(proj, sw360User);
+                    RequestStatus updatedstatus;
+                    try {
+                        updatedstatus = projectService.updateProject(proj, sw360User);
+                    } catch (AccessDeniedException e) {
+                        log.warn("Project {} could not be linked: {}", projId, e.getMessage());
+                        idsNotAllowedToUpdate.add(projId);
+                        continue;
+                    }
                     if (updatedstatus == RequestStatus.SUCCESS) {
                         linkedProjectIds.add(projId);
                     }
@@ -995,6 +1003,12 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 responseMap.put("Message regarding project(s) having cyclic path",
                         "Cyclic linked project path: " + idsWithCyclicPath);
                 status = HttpStatus.CONFLICT;
+                count++;
+            }
+            if (!idsNotAllowedToUpdate.isEmpty()) {
+                responseMap.put("Message regarding project(s) which could not be updated",
+                        "Project ids are: " + idsNotAllowedToUpdate);
+                status = HttpStatus.FORBIDDEN;
                 count++;
             }
             if (!idsSentToModerator.isEmpty()) {
@@ -1497,6 +1511,13 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     ) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         Project project = projectService.getProjectForUserById(id, sw360User);
+
+        boolean isWriteActionAllowed = restControllerHelper.isWriteActionAllowed(project, sw360User);
+        boolean isSecurityAdminWriteActionAllowedForVulRating = restControllerHelper.isSecurityAdminWriteActionAllowedForVulRating(project, sw360User);
+        if (!(isWriteActionAllowed || isSecurityAdminWriteActionAllowedForVulRating) && comment == null) {
+            throw new BadRequestClientException(RESPONSE_BODY_FOR_MODERATION_REQUEST_WITH_COMMIT.toString());
+        }
+
         List<VulnerabilityDTO> actualVDto = vulnerabilityService.getVulnerabilitiesByProjectId(id, sw360User);
         Set<String> actualExternalId = actualVDto.stream().map(VulnerabilityDTO::getExternalId).collect(Collectors.toSet());
         Set<String> externalIdsFromRequestDto = vulnDTOs.stream().map(VulnerabilityDTO::getExternalId).collect(Collectors.toSet());
@@ -1516,11 +1537,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
         Optional<ProjectVulnerabilityRating> projectVulnerabilityRatings = wrapThriftOptionalReplacement(vulnerabilityService.getProjectVulnerabilityRatingByProjectId(id, sw360User));
         ProjectVulnerabilityRating link = updateProjectVulnerabilityRatingFromRequest(projectVulnerabilityRatings, vulnDTOs, id, sw360User);
-        boolean isWriteActionAllowed = restControllerHelper.isWriteActionAllowed(project, sw360User);
-        boolean isSecurityAdminWriteActionAllowedForVulRating = restControllerHelper.isSecurityAdminWriteActionAllowedForVulRating(project, sw360User);
-        if (!(isWriteActionAllowed || isSecurityAdminWriteActionAllowedForVulRating) && comment == null) {
-            throw new BadRequestClientException(RESPONSE_BODY_FOR_MODERATION_REQUEST_WITH_COMMIT.toString());
-        }
 
         sw360User.setCommentMadeDuringModerationRequest(comment);
         final RequestStatus requestStatus = vulnerabilityService.updateProjectVulnerabilityRating(link, sw360User);
@@ -1940,7 +1956,9 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Project successfully updated"),
-        @ApiResponse(responseCode = "202", description = "Accepted - update request was sent to moderation")
+        @ApiResponse(responseCode = "202", description = "Accepted - update request was sent to moderation"),
+        @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to modify this project",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class)))
     })
     @PatchMapping(value = PROJECTS_URL + "/{id}")
     public ResponseEntity<EntityModel<Project>> patchProject(
@@ -2886,6 +2904,12 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             summary = "Update a project with dependencies network.",
             tags = {"Projects"}
     )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Project successfully updated"),
+        @ApiResponse(responseCode = "202", description = "Accepted - update request was sent to moderation"),
+        @ApiResponse(responseCode = "403", description = "Forbidden - user does not have permission to modify this project",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorMessage.class)))
+    })
     @PatchMapping(value = PROJECTS_URL + "/network/{id}")
     public ResponseEntity<?> patchProjectWithNetwork(
             @Parameter(description = "Project ID", example = "376576")
@@ -3553,6 +3577,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
         if (status == RequestStatus.SUCCESS) {
             return new ResponseEntity<>("Orphaned Obligation Removed Successfully", HttpStatus.OK);
+        } else if (status == RequestStatus.CLOSED_UPDATE_NOT_ALLOWED) {
+            throw new AccessDeniedException(Sw360ProjectService.CLOSED_PROJECT_UPDATE_NOT_ALLOWED_MESSAGE);
         }
         throw new ResourceNotFoundException("Failed to Remove Orphaned Obligation");
     }
@@ -3941,6 +3967,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 return ResponseEntity
                         .status(HttpStatus.CREATED)
                         .body("License Obligation Updated Successfully");
+            } else if (updateStatus == RequestStatus.CLOSED_UPDATE_NOT_ALLOWED) {
+                throw new AccessDeniedException(Sw360ProjectService.CLOSED_PROJECT_UPDATE_NOT_ALLOWED_MESSAGE);
             }
 
             throw new DataIntegrityViolationException("Cannot update License Obligation");

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -43,7 +43,6 @@ import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseNode;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
@@ -132,6 +131,9 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
     private static final Logger log = LogManager.getLogger(Sw360ProjectService.class);
+
+    public static final String CLOSED_PROJECT_UPDATE_NOT_ALLOWED_MESSAGE =
+            "User is not allowed to modify the requested fields of a project with clearing state CLOSED.";
 
     @NonNull
     private RestControllerHelper rch;
@@ -940,7 +942,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         }
 
         if (requestStatus == RequestStatus.CLOSED_UPDATE_NOT_ALLOWED) {
-            throw new RuntimeException("User cannot modify a closed project");
+            throw new AccessDeniedException(CLOSED_PROJECT_UPDATE_NOT_ALLOWED_MESSAGE);
         }
         if (requestStatus == RequestStatus.DUPLICATE_ATTACHMENT) {
             return requestStatus;
@@ -1640,7 +1642,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             return requestStatus;
         }
         if (requestStatus == RequestStatus.CLOSED_UPDATE_NOT_ALLOWED) {
-            throw new RuntimeException("User cannot modify a closed project");
+            throw new AccessDeniedException(CLOSED_PROJECT_UPDATE_NOT_ALLOWED_MESSAGE);
         }
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new BadRequestClientException("Dependent document Id/ids not valid.");


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Add new flag `PROJECTS_CLOSED_UPDATE_STRICT` to enable strict checks on closed Projects. This enables check on field levels which are allowed to be updated on a closed Project.

If this flag is false, the existing behavior is retained.

Without strict check, if Project is closed:
1. Clearing Admin or Above can update the Project.
2. Moderators, Creator, Project Responsible, Contributors and Lead Architects of the Project can update it.

With strict check enabled, on closed Project:
1. Clearing Admin or Above can update all fields.
2. Moderators, Creator, Project Responsible, Contributors and Lead Architects can update only Project State, External IDs and Additional Data.

!BREAKING: This PR changes response status of closed project update from 500 to 403.