### PR TITLE
fix(clients): prevent sequence() from dropping duplicate/null results

### DIFF
--- a/clients/client/src/main/java/org/eclipse/sw360/clients/utils/FutureUtils.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/utils/FutureUtils.java
@@ -15,12 +15,13 @@ import org.eclipse.sw360.http.utils.HttpConstants;
 import org.eclipse.sw360.http.utils.HttpUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -202,7 +203,7 @@ public class FutureUtils {
      */
     public static <T> CompletableFuture<Collection<T>> sequence(Collection<CompletableFuture<T>> futures,
                                                                 Function<Throwable, Boolean> exceptionHandler) {
-        final ConcurrentMap<T, Boolean> results = new ConcurrentHashMap<>();
+        final List<T> results = Collections.synchronizedList(new ArrayList<>());
         final AtomicReference<Throwable> exception = new AtomicReference<>();
         CompletableFuture<?>[] futuresArray = futures.stream().map(f -> f.handle((result, ex) -> {
             if (ex != null) {
@@ -210,7 +211,7 @@ public class FutureUtils {
                     exception.compareAndSet(null, ex);
                 }
             } else {
-                results.put(result, Boolean.TRUE);
+                results.add(result);
             }
             return result;
         })).toArray(CompletableFuture[]::new);
@@ -218,7 +219,7 @@ public class FutureUtils {
         return CompletableFuture.allOf(futuresArray).thenCompose(v -> {
             Throwable failure = exception.get();
             return failure != null ? failedFuture(failure) :
-                    CompletableFuture.completedFuture(results.keySet());
+                    CompletableFuture.completedFuture(results);
         });
     }
 

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/utils/FutureUtilsTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/utils/FutureUtilsTest.java
@@ -189,6 +189,35 @@ public class FutureUtilsTest {
     }
 
     @Test
+    public void testSequenceWithDuplicateValues() {
+        List<CompletableFuture<Integer>> futures = Arrays.asList(
+                CompletableFuture.completedFuture(1),
+                CompletableFuture.completedFuture(1),
+                CompletableFuture.completedFuture(2));
+
+        CompletableFuture<Collection<Integer>> sequence = FutureUtils.sequence(futures, ex -> true);
+        Collection<Integer> values = FutureUtils.block(sequence);
+
+        assertThat(values).hasSize(3);
+        assertThat(values).containsExactlyInAnyOrder(1, 1, 2);
+    }
+
+    @Test
+    public void testSequenceWithNullResult() {
+        List<CompletableFuture<Integer>> futures = Arrays.asList(
+                CompletableFuture.completedFuture(1),
+                CompletableFuture.completedFuture(null),
+                CompletableFuture.completedFuture(2));
+
+        CompletableFuture<Collection<Integer>> sequence = FutureUtils.sequence(futures, ex -> true);
+        Collection<Integer> values = FutureUtils.block(sequence);
+
+        assertThat(values).hasSize(3);
+        assertThat(values).contains(1, 2);
+        assertThat(values).containsNull();
+    }
+
+    @Test
     public void testWrapInFutureSuccess() {
         final Integer result = 42;
         Callable<Integer> action = () -> result;


### PR DESCRIPTION
> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

`FutureUtils.sequence()` collects results into a `ConcurrentHashMap<T, Boolean>` keyed by the result value itself, instead of a list. Two problems from that:
- If two different futures happen to complete with equal values, the map only keeps one entry - the other silently disappears from the returned collection. No error, no log, just fewer results than futures you passed in.
- If any future completes with `null`, it throws an NPE, since `ConcurrentHashMap` doesn't allow null keys.

Fixed by swapping the map for a `Collections.synchronizedList(new ArrayList<>())` - still thread-safe for concurrent completions, but now every successful future contributes its own entry regardless of duplicates or nulls.

Fixes https://github.com/eclipse-sw360/sw360/issues/4562

No new dependencies added.

### Suggest Reviewer
@GMishx 

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

Added two regression tests to `FutureUtilsTest`

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
