### PR TITLE
fix(fossology): FOSSology Clearing Process Stuck at Step 2

### DIFF
--- a/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -400,6 +400,11 @@ public class FossologyHandler implements FossologyService.Iface {
 
                         // Persist any IN_WORK or DONE updates from handleReportStepV2
                         updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
+                    } else {
+                        // Report download is disabled: mark process as DONE after scan completes
+                        log.info("Report generation disabled, marking FOSSology process as DONE after scan completion");
+                        fossologyProcess.setProcessStatus(ExternalToolProcessStatus.DONE);
+                        updateFossologyProcessInRelease(fossologyProcess, release, user, componentClient);
                     }
                 } else if (status == -1) {
                     // SCAN FAILED

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -1015,17 +1015,23 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
     ) throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(user);
+        // Always fetch fresh release data to ensure we get the latest process status
         Release release = releaseService.getReleaseForUserById(releaseId, user);
         Map<String, Object> responseMap = new HashMap<>();
         ExternalToolProcess fossologyProcess = releaseService.getExternalToolProcess(release);
-        ReentrantLock lock = mapOfLocks.get(releaseId);
-        if (lock != null && lock.isLocked()) {
-            responseMap.put("status", RequestStatus.PROCESSING);
-        } else if (fossologyProcess != null && releaseService.isFOSSologyProcessCompleted(fossologyProcess)) {
+
+        // Check actual process completion status first, regardless of lock
+        if (fossologyProcess != null && releaseService.isFOSSologyProcessCompleted(fossologyProcess)) {
             log.info("FOSSology process for Release : " + releaseId + " is complete.");
             responseMap.put("status", RequestStatus.SUCCESS);
         } else {
-            responseMap.put("status", RequestStatus.FAILURE);
+            // Only return PROCESSING if lock is held and process is not yet completed
+            ReentrantLock lock = mapOfLocks.get(releaseId);
+            if (lock != null && lock.isLocked()) {
+                responseMap.put("status", RequestStatus.PROCESSING);
+            } else {
+                responseMap.put("status", RequestStatus.FAILURE);
+            }
         }
         responseMap.put("fossologyProcessInfo", fossologyProcess);
         return new ResponseEntity<>(responseMap, HttpStatus.OK);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -80,6 +80,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus
 import com.google.common.collect.Sets;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyString;
@@ -945,17 +946,23 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
 
     public boolean isFOSSologyProcessCompleted(ExternalToolProcess fossologyProcess) {
         List<ExternalToolProcessStep> processSteps = fossologyProcess.getProcessSteps();
-        if (fossologyProcess.processStatus == ExternalToolProcessStatus.DONE && processSteps != null
-                && processSteps.size() == 3) {
-            long countOfIncompletedSteps = processSteps.stream().filter(step -> {
-                String result = step.getResult();
-                return step.getStepStatus() != ExternalToolProcessStatus.DONE || result == null || result.equals("-1");
-            }).count();
-            if (countOfIncompletedSteps == 0)
-                return true;
+        if (fossologyProcess.processStatus != ExternalToolProcessStatus.DONE || processSteps == null) {
+            return false;
         }
 
-        return false;
+        boolean reportDownloadDisabled = SW360Utils.readConfig(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, false);
+        int expectedStepCount = reportDownloadDisabled ? 2 : 3;
+
+        if (processSteps.size() != expectedStepCount) {
+            return false;
+        }
+
+        long countOfIncompletedSteps = processSteps.stream().filter(step -> {
+            String result = step.getResult();
+            return step.getStepStatus() != ExternalToolProcessStatus.DONE || result == null || result.equals("-1");
+        }).count();
+
+        return countOfIncompletedSteps == 0;
     }
 
     public void executeFossologyProcess(User user, Sw360AttachmentService attachmentService,
@@ -1092,21 +1099,31 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
                     fossologyProcessLocal.getProcessSteps().get(1).getProcessStepIdInTool(),
                     timeIntervalToCheckUnpackScanStatus, releaseId)) {
 
-                while (++reportGenerateTriggerRetries < maxRetries
-                        && !isReportTriggerSuccessfull(fossologyProcessLocal, releaseId)) {
-                    log.info("Release : " + releaseId + " .Triggering Report Step.");
-                    future = service.schedule(processRunnable, 5, TimeUnit.SECONDS);
-                    fossologyProcessLocal = getFutureResult(future);
-                }
-            }
+                // Only trigger report if report download is enabled
+                boolean reportDownloadDisabled = SW360Utils.readConfig(DISABLE_CLEARING_FOSSOLOGY_REPORT_DOWNLOAD, false);
+                if (!reportDownloadDisabled) {
+                    while (++reportGenerateTriggerRetries < maxRetries
+                            && !isReportTriggerSuccessfull(fossologyProcessLocal, releaseId)) {
+                        log.info("Release : " + releaseId + " .Triggering Report Step.");
+                        future = service.schedule(processRunnable, 5, TimeUnit.SECONDS);
+                        fossologyProcessLocal = getFutureResult(future);
+                    }
 
-            if (isReportTriggerSuccessfull(fossologyProcessLocal, releaseId)) {
-                do {
-                    log.info("Release : " + releaseId + " .Triggering Report Generation and attach to Release.");
-                    future = service.schedule(processRunnable, 10, TimeUnit.SECONDS);
-                    fossologyProcessLocal = getFutureResult(future);
-                } while (++reportGeneratestatusCheckCount < maxRetries
-                        && isReportGenerationInProgress(fossologyProcessLocal, releaseId));
+                    if (isReportTriggerSuccessfull(fossologyProcessLocal, releaseId)) {
+                        do {
+                            log.info("Release : " + releaseId + " .Triggering Report Generation and attach to Release.");
+                            future = service.schedule(processRunnable, 10, TimeUnit.SECONDS);
+                            fossologyProcessLocal = getFutureResult(future);
+                        } while (++reportGeneratestatusCheckCount < maxRetries
+                                && isReportGenerationInProgress(fossologyProcessLocal, releaseId));
+                    }
+                } else {
+                    log.info("Release : " + releaseId + " .Report download is disabled, skipping report generation step.");
+                    // Trigger one final process call to ensure handler marks status as DONE
+                    fossologyProcessLocal = fossologyProcess(releaseId, user, uploadDescription);
+                    log.info("Release : " + releaseId + " .Final process status after scan completion: {}", 
+                            fossologyProcessLocal.getProcessStatus());
+                }
             }
         }
     }


### PR DESCRIPTION
Problem Statement
When the feature flag disable.clearing.fossology.report.download=true is enabled, the FOSSology clearing process gets stuck at "Scanning source in progress" status with a PROCESSING response from the backend. The process should complete after the scan (step 2) is finished with:

- Process status: DONE
- Message: "Scanning source done"
- Progress bar: 100%
- Process steps: 2 (upload/01 and scan/02, no report/03)

Instead, the frontend remains stuck polling indefinitely because the backend continues returning PROCESSING status even after the scan completes.

Root Causes Identified

1. Hardcoded 3-Step Validation - The completion check expected exactly 3 steps (upload, scan, report), but when report generation is disabled, only 2 steps exist, causing the completion logic to always return false.

2. Process Status Never Set to DONE - When report download is disabled, the handler wasn't explicitly setting processStatus = DONE after scan completion, leaving it in IN_WORK status.

3. Lock-Based Blocking - The REST endpoint checked if a lock was held before verifying actual process completion, so even if the process was done, it returned PROCESSING while the lock was being held.

4. No Final Persistence - The orchestration service didn't make a final call to trigger the handler's completion logic when report generation was skipped.


How the Fix Solves the Problem
Data Flow (After Fix):

1. Scan Completes (FOSSologyHandler.java)

- Scan job returns success status (≥ 0)
- Handler checks if report download is disabled
- If disabled → Sets processStatus = DONE and persists to database

2. Orchestration Finalizes (Sw360ReleaseService.java)

- Service detects scan complete
- Makes final fossologyProcess() call if report disabled
- Handler runs again, confirms DONE status, persists it

3. Endpoint Validates (ReleaseController.java)

- Calls isFOSSologyProcessCompleted(fossologyProcess)
- Method checks: status=DONE, step count=2, all steps complete
- Returns status = SUCCESS ✅

