### PR TITLE
fix(rest): Reset obligation status to OPEN when duplicating projects.

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -894,30 +894,6 @@ public class SW360Utils {
         return PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user) || users.contains(user.getEmail());
     }
 
-    public static void copyLinkedObligationsForClonedProject(Project newProject, Project sourceProject, ProjectService.Iface client, User user) {
-        try {
-            ObligationList obligation = client.getLinkedObligations(sourceProject.getLinkedObligationId(), user);
-            Set<String> newLinkedReleaseIds = newProject.getReleaseIdToUsage().keySet();
-            Set<String> sourceLinkedReleaseIds = sourceProject.getReleaseIdToUsage().keySet();
-            Map<String, ObligationStatusInfo> linkedObligations = obligation.getLinkedObligationStatus();
-            if (!newLinkedReleaseIds.equals(sourceLinkedReleaseIds)) {
-                linkedObligations = obligation.getLinkedObligationStatus().entrySet().stream().filter(entry -> {
-                    Set<String> releaseIds = entry.getValue().getReleaseIdToAcceptedCLI().keySet();
-                    releaseIds.retainAll(newLinkedReleaseIds);
-                    if (releaseIds.isEmpty()) {
-                        return false;
-                    }
-                    return true;
-                }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            }
-            if (!linkedObligations.isEmpty()) {
-                client.addLinkedObligations(new ObligationList().setProjectId(newProject.getId()).setLinkedObligationStatus(linkedObligations), user);
-            }
-        } catch (TException e) {
-            log.error("Error duplicating obligations for project: " + newProject.getId(), e);
-        }
-    }
-
     public static void removeReleaseVulnerabilityRelation(String releaseId, User user){
         VulnerabilityService.Iface vulnerabilityService = ThriftClients.makeVulnerabilityClient();
         try {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -83,15 +83,6 @@ import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.projects.*;
 import org.eclipse.sw360.datahandler.thrift.packages.Package;
-import org.eclipse.sw360.datahandler.thrift.projects.ObligationList;
-import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
-import org.eclipse.sw360.datahandler.thrift.projects.Project;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectProjectRelationship;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
-import org.eclipse.sw360.datahandler.thrift.projects.ProjectDTO;
-import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ProjectVulnerabilityRating;
@@ -856,11 +847,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         sw360Project.unsetAttachments();
         sw360Project.unsetClearingRequestId();
         sw360Project.setClearingState(ProjectClearingState.OPEN);
-        String linkedObligationId = sw360Project.getLinkedObligationId();
         sw360Project.unsetLinkedObligationId();
         Project createDuplicateProject = projectService.createProject(sw360Project, user);
-        sw360Project.setLinkedObligationId(linkedObligationId);
-        projectService.copyLinkedObligationsForClonedProject(createDuplicateProject, sw360Project, user);
 
         HalResource<Project> halResource = createHalProject(createDuplicateProject, user);
 
@@ -4808,12 +4796,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         duplicatedProject.unsetAttachments();
         duplicatedProject.unsetClearingRequestId();
         duplicatedProject.setClearingState(ProjectClearingState.OPEN);
-        String linkedObligationId = duplicatedProject.getLinkedObligationId();
         duplicatedProject.unsetLinkedObligationId();
-
         Project createdProject = projectService.createProject(duplicatedProject, sw360User);
-        createdProject.setLinkedObligationId(linkedObligationId);
-        projectService.copyLinkedObligationsForClonedProject(createdProject, duplicatedProject, sw360User);
 
         HalResource<ProjectDTO> projectDTOHalResource = createHalProjectDTO(createdProject, sw360User);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}")

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1348,12 +1348,6 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         Map<PaginationData, List<Project>> get(int page) throws TException;
     }
 
-    public void copyLinkedObligationsForClonedProject(Project createDuplicateProject, Project sw360Project, User user)
-            throws TException {
-        SW360Utils.copyLinkedObligationsForClonedProject(createDuplicateProject, sw360Project, getThriftProjectClient(),
-                user);
-    }
-
     private List<Project> getAllRequiredProjects(ProjectData projectData, User sw360User) throws TException {
         List<Project> listOfProjects = projectData.getFirst250Projects();
         List<String> projectIdsOfRemainingProject = projectData.getProjectIdsOfRemainingProject();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -107,8 +107,6 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.attachmentServiceMock.getResourcesFromList(any())).willReturn(CollectionModel.of(attachmentResources));
         given(this.attachmentServiceMock.uploadAttachment(any(), any(), any())).willReturn(attachment);
         given(this.attachmentServiceMock.updateAttachment(any(), any(), any(), any())).willReturn(att2);
-        Mockito.doNothing().when(projectServiceMock).copyLinkedObligationsForClonedProject(any(), any(),
-                any());
 
         Map<String, ProjectReleaseRelationship> linkedReleases = new HashMap<>();
         Map<String, ProjectProjectRelationship> linkedProjects = new HashMap<>();


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary

Previously, when a project was duplicated, the obligations in the new project retained the same status as the original. This caused completed acknowledgments to be incorrectly carried over. With this update, duplicating a project will now automatically reset all obligation statuses to "OPEN" in the new project to ensure a fresh compliance review.

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

1. Log in to SW360.
2. Identify or create a project that contains at least one obligation.
3. Ensure the existing project's obligation status is not "OPEN" (e.g., set it to "Fulfilled" or "In Progress").
4. Duplicate the project using the "Duplicate" button.
5. Verify the obligation status in the newly created project; it should be reset to "OPEN" regardless of the original project's status.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
