### PR TITLE
fix(clients): prevent sequence() from dropping duplicate/null results

### DIFF
--- a/clients/client/src/main/java/org/eclipse/sw360/clients/utils/FutureUtils.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/utils/FutureUtils.java
@@ -15,12 +15,12 @@ import org.eclipse.sw360.http.utils.HttpConstants;
 import org.eclipse.sw360.http.utils.HttpUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -202,7 +202,7 @@ public class FutureUtils {
      */
     public static <T> CompletableFuture<Collection<T>> sequence(Collection<CompletableFuture<T>> futures,
                                                                 Function<Throwable, Boolean> exceptionHandler) {
-        final ConcurrentMap<T, Boolean> results = new ConcurrentHashMap<>();
+        final Collection<T> results = Collections.synchronizedList(new ArrayList<>());
         final AtomicReference<Throwable> exception = new AtomicReference<>();
         CompletableFuture<?>[] futuresArray = futures.stream().map(f -> f.handle((result, ex) -> {
             if (ex != null) {
@@ -210,7 +210,7 @@ public class FutureUtils {
                     exception.compareAndSet(null, ex);
                 }
             } else {
-                results.put(result, Boolean.TRUE);
+                results.add(result);
             }
             return result;
         })).toArray(CompletableFuture[]::new);
@@ -218,7 +218,7 @@ public class FutureUtils {
         return CompletableFuture.allOf(futuresArray).thenCompose(v -> {
             Throwable failure = exception.get();
             return failure != null ? failedFuture(failure) :
-                    CompletableFuture.completedFuture(results.keySet());
+                    CompletableFuture.completedFuture(results);
         });
     }
 

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/utils/FutureUtilsTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/utils/FutureUtilsTest.java
@@ -162,6 +162,30 @@ public class FutureUtilsTest {
     }
 
     @Test
+    public void testSequenceWithDuplicateValues() {
+        List<CompletableFuture<Integer>> futures = Arrays.asList(
+                CompletableFuture.completedFuture(1),
+                CompletableFuture.completedFuture(1),
+                CompletableFuture.completedFuture(2));
+
+        CompletableFuture<Collection<Integer>> sequence = FutureUtils.sequence(futures, ex -> true);
+        Collection<Integer> values = FutureUtils.block(sequence);
+        assertThat(values).containsExactlyInAnyOrder(1, 1, 2);
+    }
+
+    @Test
+    public void testSequenceWithNullValue() {
+        List<CompletableFuture<Integer>> futures = Arrays.asList(
+                CompletableFuture.completedFuture(1),
+                CompletableFuture.completedFuture(null),
+                CompletableFuture.completedFuture(2));
+
+        CompletableFuture<Collection<Integer>> sequence = FutureUtils.sequence(futures, ex -> true);
+        Collection<Integer> values = FutureUtils.block(sequence);
+        assertThat(values).containsExactlyInAnyOrder(1, null, 2);
+    }
+
+    @Test
     public void testSequenceWithFailure() throws InterruptedException {
         Throwable exception = new Exception("Failed");
         List<CompletableFuture<Integer>> futures = Arrays.asList(CompletableFuture.completedFuture(1),


### PR DESCRIPTION
Fixes #4562.

## What changes did you make?
Replaced the use of `ConcurrentHashMap` in `FutureUtils.sequence()` with `Collections.synchronizedList(new ArrayList<>())`. 

Previously, `ConcurrentHashMap` would drop results if multiple futures completed with equal values (since map keys must be unique) and threw a `NullPointerException` if any future completed with `null`. Using a thread-safe list resolves both problems while correctly collecting results asynchronously.

Additionally, I added two new automated test cases to `FutureUtilsTest.java`:
- `testSequenceWithDuplicateValues`: Verifies that duplicate results are preserved.
- `testSequenceWithNullValue`: Ensures null results are collected correctly without throwing NPE.

## Pre-Code Checklist
- [x] Verified architectural layer (clients)
- [x] Ensured no new test class was strictly required (updated existing `FutureUtilsTest.java`)
- [x] Ensured EPL-2.0 file headers are intact

## PR Checks 
*(Ensure these pass once the CI runs)*
- [x] Code builds and formats cleanly (`mvn spotless:check`)
- [x] Conventional commit format applied
- [x] ECA (Eclipse Contributor Agreement) is signed