### PR TITLE
fix(project): fix CLOSED_PROJECT_EDITABLE_FIELDS

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -168,7 +168,10 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
      * {@value org.eclipse.sw360.datahandler.common.SW360ConfigKeys#PROJECTS_CLOSED_UPDATE_STRICT} is enabled.
      */
     private static final ImmutableSet<Project._Fields> CLOSED_PROJECT_EDITABLE_FIELDS = ImmutableSet.of(
-            Project._Fields.STATE, Project._Fields.EXTERNAL_IDS, Project._Fields.ADDITIONAL_DATA);
+            Project._Fields.PROJECT_RESPONSIBLE, Project._Fields.PROJECT_OWNER, Project._Fields.ENABLE_SVM,
+            Project._Fields.ENABLE_VULNERABILITIES_DISPLAY, Project._Fields.SECURITY_RESPONSIBLES,
+            Project._Fields.STATE, Project._Fields.EXTERNAL_IDS, Project._Fields.PHASE_OUT_SINCE
+    );
 
     /**
      * Server managed or computed fields which must not be taken into account when checking

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerClosedUpdateTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerClosedUpdateTest.java
@@ -99,9 +99,9 @@ public class ProjectDatabaseHandlerClosedUpdateTest {
         assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
                 actual.deepCopy().setState(ProjectState.PHASE_OUT), member, true));
         assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
-                actual.deepCopy().setExternalIds(Collections.singletonMap("internal.id", "4711")), member, true));
+                actual.deepCopy().setSecurityResponsibles(Collections.singleton(STRANGER_EMAIL)), member, true));
         assertTrue(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
-                actual.deepCopy().setAdditionalData(Collections.singletonMap("key", "value")), member, true));
+                actual.deepCopy().setExternalIds(Collections.singletonMap("internal.id", "4711")), member, true));
     }
 
     @Test
@@ -115,6 +115,8 @@ public class ProjectDatabaseHandlerClosedUpdateTest {
                 actual.deepCopy().setClearingState(ProjectClearingState.OPEN), member, true));
         assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
                 actual.deepCopy().setDescription("new description"), member, true));
+        assertFalse(ProjectDatabaseHandler.isProjectUpdateAllowed(actual,
+                actual.deepCopy().setAdditionalData(Collections.singletonMap("key", "value")), member, true));
     }
 
     @Test


### PR DESCRIPTION
Update the fields which can be updated in closed Projects which the strict restriction is on:
1. Project Responsibles
2. Project Owner
3. Security Responsible
4. Enable Security Vulnerability Monitoring
5. Display Vulnerabilities
6. Project State
7. Phase-out date
8. External IDs