### PR TITLE
fix(rest): Reset duplicated project state and phase-out date defaults

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -842,6 +842,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         Project updateProject = convertToProject(reqBodyMap);
         sw360Project = this.restControllerHelper.updateProject(sw360Project, updateProject, reqBodyMap,
                 mapOfProjectFieldsToRequestBody);
+        normalizeStateForDuplicatedProject(sw360Project);
         sw360Project.unsetId();
         sw360Project.unsetRevision();
         sw360Project.unsetAttachments();
@@ -4819,6 +4820,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         }
 
         projectService.syncReleaseRelationNetworkAndReleaseIdToUsage(duplicatedProject, sw360User);
+        normalizeStateForDuplicatedProject(duplicatedProject);
         duplicatedProject.unsetId();
         duplicatedProject.unsetRevision();
         duplicatedProject.unsetAttachments();
@@ -4832,6 +4834,11 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
                 .buildAndExpand(createdProject.getId()).toUri();
 
         return ResponseEntity.created(location).body(projectDTOHalResource);
+    }
+
+    private void normalizeStateForDuplicatedProject(Project duplicatedProject) {
+        duplicatedProject.setState(ProjectState.ACTIVE);
+        duplicatedProject.unsetPhaseOutSince();
     }
 
     @Operation(


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)
### Summary

This fix ensures duplicated projects no longer inherit PHASE_OUT from the source project: during duplication, project state is explicitly reset to ACTIVE and any phaseOutSince value is cleared.
It is applied to both duplicate flows (/projects/duplicate/{id} and /projects/network/duplicate/{id}), while keeping existing clearing-state behavior unchanged (OPEN on the new project).

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

1. Log in to SW360.
2. Open a project where:
    1. Project State = PHASE_OUT
     2. Clearing State != OPEN (for example IN_PROGRESS or CLOSED)
3. Click Duplicate and create the new project (use normal duplicate flow).
4. Open the newly created duplicate project and verify:
      > * Project State = ACTIVE
      > * Clearing State = OPEN
5. Phase-out date (phaseOutSince) is cleared/unset
6. Optional Additional Check

7. Repeat the same test via dependency-network duplicate flow (if enabled) to verify same behavior there too.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
