### PR TITLE
fix(releases): allow security user to fetch batch

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilter.java
@@ -32,6 +32,14 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class EndpointsFilter extends OncePerRequestFilter {
 
     private static final Set<String> WRITE_METHODS = Set.of("POST", "PATCH", "PUT", "DELETE");
+    /**
+     * Endpoints which may look like write but aren't, thus allow security user
+     * to use them.
+     */
+    private static final Set<String> SECURITY_USER_EXEMPT_ENDPOINTS = Set.of(
+            "/api/releases/batch-summary", // Get Release in batch
+            "/api/users/tokens"            // Allow token generation from UI
+    );
 
     private final Map<Pattern, Set<String>> endpointHttpMethods;
     private final RestControllerHelper<?> restControllerHelper;
@@ -46,9 +54,14 @@ public class EndpointsFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        if (isAllowedSecurityUserReadSummaryRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         Optional<Entry<Pattern, Set<String>>> matchedEndpoint = findMatchingEndpoint(request.getRequestURI());
         if (matchedEndpoint.isEmpty()) {
-            if (isWriteMethod(request.getMethod()) && PermissionUtils.isSecurityUser(restControllerHelper.getSw360UserFromAuthentication())) {
+            if (isSecurityUserWriteBlocked(request)) {
                 sendServiceUnavailable(response);
                 return;
             }
@@ -64,6 +77,20 @@ public class EndpointsFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isSecurityUserWriteBlocked(@NonNull HttpServletRequest request) {
+        return isWriteMethod(request.getMethod())
+                && PermissionUtils.isSecurityUser(restControllerHelper.getSw360UserFromAuthentication())
+                && !isAllowedSecurityUserReadSummaryRequest(request);
+    }
+
+    private boolean isAllowedSecurityUserReadSummaryRequest(@NonNull HttpServletRequest request) {
+        if (!request.getMethod().equalsIgnoreCase("POST")) {
+            return false;
+        }
+        String requestUri = request.getRequestURI();
+        return SECURITY_USER_EXEMPT_ENDPOINTS.stream().anyMatch(requestUri::endsWith);
     }
 
     private boolean isWriteMethod(String method) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -218,6 +218,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
     public Release setComponentDependentFieldsInRelease(Release releaseById, User sw360User) {
         String componentId = releaseById.getComponentId();
         if (CommonUtils.isNullEmptyOrWhitespace(componentId)) {
+            log.error("ComponentId missing for Release: {}", releaseById.getId());
             throw new BadRequestClientException("ComponentId must be present");
         }
         Component componentById = null;
@@ -225,6 +226,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
             ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
             componentById = sw360ComponentClient.getComponentById(componentId, sw360User);
         } catch (TException e) {
+            log.error("ComponentId '{}' not found for Release '{}'", componentId, releaseById.getId());
             throw new BadRequestClientException("No Component found with Id - " + componentId);
         }
         releaseById.setComponentType(componentById.getComponentType());
@@ -239,15 +241,17 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
             List<Component> components = sw360ComponentClient.getComponentSummary(sw360User);
             componentIdMap = ThriftUtils.getIdMap(components);
         } catch (TException e) {
-            throw new BadRequestClientException("No Components found");
+            throw new BadRequestClientException("No Components found", e);
         }
 
         for (Release release : releases) {
             String componentId = release.getComponentId();
             if (CommonUtils.isNullEmptyOrWhitespace(componentId)) {
+                log.error("ComponentId missing for Release: {}", release.getId());
                 throw new BadRequestClientException("ComponentId must be present");
             }
             if (!componentIdMap.containsKey(componentId)) {
+                log.error("ComponentId '{}' not found for Release '{}'", componentId, release.getId());
             	throw new BadRequestClientException("No Component found with Id - " + componentId);
             }
             Component component = componentIdMap.get(componentId);
@@ -1121,7 +1125,7 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
                     log.info("Release : " + releaseId + " .Report download is disabled, skipping report generation step.");
                     // Trigger one final process call to ensure handler marks status as DONE
                     fossologyProcessLocal = fossologyProcess(releaseId, user, uploadDescription);
-                    log.info("Release : " + releaseId + " .Final process status after scan completion: {}", 
+                    log.info("Release : " + releaseId + " .Final process status after scan completion: {}",
                             fossologyProcessLocal.getProcessStatus());
                 }
             }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilterTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EndpointsFilterTest {
+
+    @Test
+    void should_allow_security_user_for_release_batch_summary() throws Exception {
+        RestControllerHelper<?> restControllerHelper = Mockito.mock(RestControllerHelper.class);
+        User securityUser = new User();
+        securityUser.setUserGroup(UserGroup.SECURITY_USER);
+        when(restControllerHelper.getSw360UserFromAuthentication()).thenReturn(securityUser);
+
+        EndpointsFilter filter = new EndpointsFilter(restControllerHelper, "");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/releases/batch-summary");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+    }
+
+    @Test
+    void should_block_security_user_for_non_exempt_write_endpoint() throws Exception {
+        RestControllerHelper<?> restControllerHelper = Mockito.mock(RestControllerHelper.class);
+        User securityUser = new User();
+        securityUser.setUserGroup(UserGroup.SECURITY_USER);
+        when(restControllerHelper.getSw360UserFromAuthentication()).thenReturn(securityUser);
+
+        EndpointsFilter filter = new EndpointsFilter(restControllerHelper, "");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/releases");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        Mockito.verifyNoInteractions(filterChain);
+        assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.getStatus());
+    }
+}


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

SECURITY_USER role is allowed to read releases but not create anything. But the endpoint `/releases/batch-summary` uses `POST` to fetch information, thus making it an edge-case which was not allowed.

This PR updates the `EndpointsFilter` to handle such exceptions. At the same time, improve logging on `/releases` endpoint for failures caused by missing components.