### PR TITLE
perf(projects): optimize license clearing endpoint

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -2171,10 +2171,14 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         switch (action) {
             case READ:
                 boolean isComponentAccessible = false;
-                String componentId = release.getComponentId();
-                if (CommonUtils.isNotNullEmptyOrWhitespace(componentId)) {
-                    Component component = componentRepository.get(componentId);
-                    isComponentAccessible = makePermission(component, user).isActionAllowed(RequestedAction.READ);
+                if (SW360Utils.readConfig(IS_COMPONENT_VISIBILITY_RESTRICTION_ENABLED, false)) {
+                    String componentId = release.getComponentId();
+                    if (CommonUtils.isNotNullEmptyOrWhitespace(componentId)) {
+                        Component component = componentRepository.get(componentId);
+                        isComponentAccessible = makePermission(component, user).isActionAllowed(RequestedAction.READ);
+                    }
+                } else {
+                    isComponentAccessible = true;
                 }
                 isAllowed = isComponentAccessible && makePermission(release, user).isActionAllowed(RequestedAction.READ);
                 break;

--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -16,9 +16,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.*;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -191,7 +188,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             Project._Fields.VENDOR.getFieldName(),
             Project._Fields.VENDOR_ID.getFieldName());
 
-    private final LoadingCache<String, Project> projectLookupCache;
     private Map<String, Project> cachedAllProjectsIdMap;
     private Instant cachedAllProjectsIdMapLoadingInstant;
 
@@ -233,16 +229,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         vendorRepository = new VendorRepository(db);
         releaseRepository = new ReleaseRepository(db, vendorRepository);
         packageRepository = new PackageRepository(db);
-        projectLookupCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(ALL_PROJECTS_ID_MAP_CACHE_LIFETIME)
-                .build(new CacheLoader<>() {
-                    @Override
-                    public @NonNull Project load(@NonNull String projectId) throws SW360Exception {
-                        Project project = repository.get(projectId);
-                        assertNotNull(project);
-                        return project;
-                    }
-                });
 
         // Create the moderator
         this.moderator = moderator;
@@ -1515,7 +1501,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
      */
     private Stream<Release> getReleaseClearingStatusStream(@NonNull List<Release> releasesById) {
         return releasesById.size() >= PARALLEL_RELEASE_CLEARING_STATUS_THRESHOLD
-                ? releasesById.parallelStream()
+                ? releasesById.parallelStream().unordered()
                 : releasesById.stream();
     }
 
@@ -1598,7 +1584,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 if (visitedProjectIds.contains(projectId)) continue;
 
                 try {
-                    Project linkedProject = getCachedProjectById(projectId, user);
+                    Project linkedProject = getProjectById(projectId, user);
                     releaseIdToProjects(linkedProject, user, visitedProjectIds, releaseIdToProjects);
                 } catch (SW360Exception e) {
                     log.warn("Could not get linked project with ID: {}", projectId, e);
@@ -1620,24 +1606,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
         visitedProjectIds.add(id);
         return false;
-    }
-
-    private Project getCachedProjectById(String id, User user) throws SW360Exception {
-        Project project;
-        try {
-            project = projectLookupCache.get(id).deepCopy();
-        } catch (ExecutionException exception) {
-            Throwable cause = exception.getCause();
-            if (cause instanceof SW360Exception sw360Exception) {
-                throw sw360Exception;
-            }
-            throw new SW360Exception(cause != null ? cause.getMessage() : exception.getMessage());
-        }
-
-        if (!makePermission(project, user).isActionAllowed(RequestedAction.READ)) {
-            throw fail(403, "User: %s is not allowed to view the requested project: %s", user.getEmail(), project.getId());
-        }
-        return project;
     }
 
     public List<Project> fillClearingStateSummaryIncludingSubprojects(List<Project> projects, User user) {
@@ -3262,11 +3230,205 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     public Set<String> getReleasesIdsOfProject(
             String projectId, boolean transitive, User user
     ) throws SW360Exception {
-        Project project = getCachedProjectById(projectId, user);
+        Project project = getProjectById(projectId, user);
         if (!transitive) {
             return nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
         }
         SetMultimap<String, ProjectWithReleaseRelationTuple> releaseIdsToProject = releaseIdToProjects(project, user);
         return releaseIdsToProject.keySet();
+    }
+
+    /**
+     * Retrieves the complete list of Releases used by a Project for license clearing.
+     *
+     * <p>If {@code transitive} is {@code true}, linked subprojects are traversed recursively
+     * in memory, collecting all distinct release IDs before batch-fetching detailed release
+     * and component data in single round-trips. Optional filters for {@link ClearingState},
+     * {@link ComponentType}, and {@link ReleaseRelationship} are applied concurrently.
+     *
+     * @param projectId           the ID of the project to retrieve releases for
+     * @param user                the user requesting the data (for authorization checks)
+     * @param transitive          {@code true} to include releases of linked projects recursively; {@code false} for root project only
+     * @param clearingStates      optional list of {@link ClearingState}s to filter by (null/empty to match all)
+     * @param componentTypes      optional list of {@link ComponentType}s to filter by (null/empty to match all)
+     * @param releaseRelationship optional {@link ReleaseRelationship} to filter by (null to match all)
+     * @return a list of filtered, accessible {@link Release}s with populated {@link ComponentType}s
+     * @throws SW360Exception if the project does not exist or user lacks read permissions
+     */
+    public List<Release> getReleasesForLicenseClearing(
+            String projectId, User user, boolean transitive,
+            List<ClearingState> clearingStates,
+            List<ComponentType> componentTypes,
+            ReleaseRelationship releaseRelationship
+    ) throws SW360Exception {
+        Project project = getProjectById(projectId, user);
+        if (!transitive) {
+            Set<String> releaseIds = getFilteredReleaseIdsFromProjectUsage(project, releaseRelationship);
+            if (CommonUtils.isNullOrEmptyCollection(releaseIds)) {
+                return Collections.emptyList();
+            }
+            List<Release> releases = componentDatabaseHandler.getReleasesByIds(releaseIds);
+            return filterReleasesOnComponentFields(releases, clearingStates, componentTypes, user);
+        }
+        return getReleasesFromProject(project, user, clearingStates, componentTypes, releaseRelationship);
+    }
+
+    /**
+     * Extracts release IDs from a project's usage map, optionally filtered by release relationship.
+     *
+     * @param project             the project containing release usages
+     * @param releaseRelationship optional relationship type to filter by
+     * @return set of matching release IDs
+     */
+    private Set<String> getFilteredReleaseIdsFromProjectUsage(
+            @NonNull Project project, @Nullable ReleaseRelationship releaseRelationship
+    ) {
+        Map<String, ProjectReleaseRelationship> usageMap = nullToEmptyMap(project.getReleaseIdToUsage());
+        if (usageMap.isEmpty()) {
+            return Collections.emptySet();
+        }
+        if (releaseRelationship == null) {
+            return usageMap.keySet();
+        }
+        Set<String> filteredIds = Sets.newHashSetWithExpectedSize(usageMap.size());
+        for (Map.Entry<String, ProjectReleaseRelationship> entry : usageMap.entrySet()) {
+            if (entry.getValue() != null && entry.getValue().getReleaseRelation() == releaseRelationship) {
+                filteredIds.add(entry.getKey());
+            }
+        }
+        return filteredIds;
+    }
+
+    /**
+     * Filters releases by user read permissions, clearing state, and component type.
+     *
+     * <p>To maximize throughput over large release sets (e.g., 8000+ items):
+     * <ul>
+     *   <li>Filter collections are converted into {@link EnumSet} for constant-time lookups.</li>
+     *   <li>Early filtering on {@link ClearingState} and permissions discards ineligible releases
+     *       before querying CouchDB for parent {@link Component}s.</li>
+     *   <li>Parent components are batch-fetched in a single request only for surviving releases.</li>
+     *   <li>Both clearing state and component type conditions are evaluated concurrently.</li>
+     * </ul>
+     *
+     * @param releases       the raw list of releases to process
+     * @param clearingStates optional list of {@link ClearingState}s to filter by
+     * @param componentTypes optional list of {@link ComponentType}s to filter by
+     * @param user           the user requesting access
+     * @return a list of matching {@link Release}s with populated {@link ComponentType}s
+     */
+    private List<Release> filterReleasesOnComponentFields(
+            List<Release> releases, List<ClearingState> clearingStates,
+            List<ComponentType> componentTypes, User user
+    ) {
+        if (CommonUtils.isNullOrEmptyCollection(releases)) {
+            return Collections.emptyList();
+        }
+
+        final boolean filterByClearingState = CommonUtils.isNotEmpty(clearingStates);
+        final boolean filterByComponentType = CommonUtils.isNotEmpty(componentTypes);
+        final Set<ClearingState> clearingStateSet = filterByClearingState ? EnumSet.copyOf(clearingStates) : Collections.emptySet();
+        final Set<ComponentType> componentTypeSet = filterByComponentType ? EnumSet.copyOf(componentTypes) : Collections.emptySet();
+
+        // 1. Early filter by user read permission & clearingState
+        List<Release> candidateReleases = getReleaseClearingStatusStream(releases)
+                .filter(Objects::nonNull)
+                .filter(release -> componentDatabaseHandler.isReleaseActionAllowed(release, user, RequestedAction.READ))
+                .filter(release -> !filterByClearingState || (release.getClearingState() != null && clearingStateSet.contains(release.getClearingState())))
+                .toList();
+
+        if (candidateReleases.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 2. Single batch lookup for parent components of surviving releases only (plain for to JIT optimization)
+        Set<String> componentIds = Sets.newHashSetWithExpectedSize(candidateReleases.size());
+        for (Release candidate : candidateReleases) {
+            componentIds.add(candidate.getComponentId());
+        }
+        componentIds.remove(null);
+
+        ImmutableMap<String, Component> componentsById = ImmutableMap.copyOf(ThriftUtils.getIdMap(
+                componentDatabaseHandler.getComponentsByIds(componentIds)
+        ));
+
+        // 3. Populate componentType and apply componentType filter
+        return candidateReleases.stream()
+                .peek(release -> {
+                    Component component = componentsById.get(release.getComponentId());
+                    if (component != null) {
+                        release.setComponentType(component.getComponentType());
+                    }
+                })
+                .filter(release -> !filterByComponentType || (release.getComponentType() != null && componentTypeSet.contains(release.getComponentType())))
+                .toList();
+    }
+
+    /**
+     * Traverses the project graph starting from the given root project, collects all unique
+     * release IDs across all linked subprojects, and retrieves their filtered release details.
+     *
+     * @param project             the root project to start traversal from
+     * @param user                the user requesting the data
+     * @param clearingStates      optional list of {@link ClearingState}s to filter by
+     * @param componentTypes      optional list of {@link ComponentType}s to filter by
+     * @param releaseRelationship optional {@link ReleaseRelationship} to filter by
+     * @return a list of filtered, accessible {@link Release}s from the project hierarchy
+     */
+    private @NonNull List<Release> getReleasesFromProject(
+            Project project, User user, List<ClearingState> clearingStates,
+            List<ComponentType> componentTypes,
+            ReleaseRelationship releaseRelationship
+    ) {
+        Set<String> visitedProjectIds = Sets.newHashSet();
+        Set<String> collectedReleaseIds = Sets.newHashSet();
+
+        getReleasesRecursive(project, user, visitedProjectIds, collectedReleaseIds, releaseRelationship);
+
+        if (CommonUtils.isNullOrEmptyCollection(collectedReleaseIds)) {
+            return Collections.emptyList();
+        }
+
+        List<Release> releases = componentDatabaseHandler.getReleasesByIds(collectedReleaseIds);
+        return filterReleasesOnComponentFields(releases, clearingStates, componentTypes, user);
+    }
+
+    /**
+     * Recursively traverses linked projects to collect all distinct release IDs
+     * into the provided set. Cycle detection is maintained via {@code visitedProjectIds}.
+     *
+     * @param project             the current project in the recursion
+     * @param user                the user requesting access
+     * @param visitedProjectIds   set of already-visited project IDs to prevent infinite loops
+     * @param collectedReleaseIds accumulator set of all unique release IDs discovered
+     * @param releaseRelationship optional relationship to filter release usages
+     */
+    private void getReleasesRecursive(
+            Project project, User user, Set<String> visitedProjectIds,
+            Set<String> collectedReleaseIds,
+            ReleaseRelationship releaseRelationship
+    ) {
+        // Project already visited, done.
+        if (nothingTodo(project, visitedProjectIds)) return;
+
+        // Add all releases of current Project matching releaseRelationship filter
+        collectedReleaseIds.addAll(getFilteredReleaseIdsFromProjectUsage(project, releaseRelationship));
+
+        // Iterate through all linked Projects.
+        Map<String, ProjectProjectRelationship> linkedProjects = project.getLinkedProjects();
+        if (linkedProjects != null) {
+            for (String projectId : linkedProjects.keySet()) {
+                if (visitedProjectIds.contains(projectId)) continue;
+
+                try {
+                    Project linkedProject = getProjectByIdIgnoringVisibility(projectId);
+                    if (ProjectPermissions.isVisible(user).test(linkedProject)) {
+                        getReleasesRecursive(linkedProject, user, visitedProjectIds, collectedReleaseIds, releaseRelationship);
+                    }
+                } catch (SW360Exception e) {
+                    log.warn("Could not get linked project with ID: {}", projectId, e);
+                }
+            }
+        }
     }
 }

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.TestUtils.assertTestString;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.printName;
@@ -58,6 +59,8 @@ public class ProjectDatabaseHandlerTest {
     ComponentDatabaseHandler componentHandler;
     AttachmentDatabaseHandler attachmentDatabaseHandler;
     PackageDatabaseHandler packageHandler;
+
+    private DatabaseConnectorCloudant databaseConnector;
 
     @Before
     public void setUp() throws Exception {
@@ -132,7 +135,7 @@ public class ProjectDatabaseHandlerTest {
         TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredClient(), dbName);
 
         // Prepare the database
-        DatabaseConnectorCloudant databaseConnector = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
+        databaseConnector = new DatabaseConnectorCloudant(DatabaseSettingsTest.getConfiguredClient(), dbName);
         for (Project project : projects) {
             databaseConnector.add(project);
         }
@@ -502,6 +505,159 @@ public class ProjectDatabaseHandlerTest {
         Assert.assertEquals(1, projectLinks.size());
         Assert.assertEquals(1, projectLinks.get(0).getSubprojects().size());
         Assert.assertEquals(2, projectLinks.get(0).getLinkedReleases().size());
+    }
+
+    @Test
+    public void testGetReleasesForLicenseClearingNoRelease() throws Exception {
+        // 1. Project with no release
+        List<Release> releases = handler.getReleasesForLicenseClearing("P3", user3, false, null, null, null);
+        Assert.assertTrue(releases.isEmpty());
+    }
+
+    @Test
+    public void testGetReleasesForLicenseClearingTwoReleases() throws Exception {
+        // 2. Project with 2 releases
+        List<Release> releases = handler.getReleasesForLicenseClearing("P4", user1, false, null, null, null);
+        Assert.assertEquals(2, releases.size());
+        Set<String> releaseIds = releases.stream().map(Release::getId).collect(Collectors.toSet());
+        Assert.assertTrue(containsInAnyOrder("r1", "r2").matches(releaseIds));
+    }
+
+    @Test
+    public void testGetReleasesForLicenseClearingSubProjectBothHavingOneRelease() throws Exception {
+        // 3. Project with 1 sub-project both having 1 release
+        Project parent = new Project().setId("P_PARENT").setName("ParentProject")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setReleaseIdToUsage(ImmutableMap.of("r1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)))
+                .setLinkedProjects(ImmutableMap.of("P_CHILD", new ProjectProjectRelationship(ProjectRelationship.CONTAINED)));
+        Project child = new Project().setId("P_CHILD").setName("ChildProject")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setReleaseIdToUsage(ImmutableMap.of("r2", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)));
+
+        databaseConnector.add(parent);
+        databaseConnector.add(child);
+
+        // Transitive: should return both r1 and r2
+        List<Release> transitiveReleases = handler.getReleasesForLicenseClearing("P_PARENT", user1, true, null, null, null);
+        Assert.assertEquals(2, transitiveReleases.size());
+        Set<String> releaseIds = transitiveReleases.stream().map(Release::getId).collect(Collectors.toSet());
+        Assert.assertTrue(containsInAnyOrder("r1", "r2").matches(releaseIds));
+
+        // Non-transitive: should return only parent's r1
+        List<Release> directReleases = handler.getReleasesForLicenseClearing("P_PARENT", user1, false, null, null, null);
+        Assert.assertEquals(1, directReleases.size());
+        Assert.assertEquals("r1", directReleases.getFirst().getId());
+    }
+
+    @Test
+    public void testGetReleasesForLicenseClearingDifferentRelationshipsAndFilter() throws Exception {
+        // 4. Project with 2 releases using different relationship, then filtering
+        Project proj = new Project().setId("P_REL_FILTER").setName("ProjectRelFilter")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setReleaseIdToUsage(ImmutableMap.of(
+                        "r1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE),
+                        "r2", new ProjectReleaseRelationship(ReleaseRelationship.DYNAMICALLY_LINKED, MainlineState.MAINLINE)
+                ));
+        databaseConnector.add(proj);
+
+        // No filter: should return both
+        List<Release> allReleases = handler.getReleasesForLicenseClearing("P_REL_FILTER", user1, false, null, null, null);
+        Assert.assertEquals(2, allReleases.size());
+
+        // Filter for CONTAINED
+        List<Release> contained = handler.getReleasesForLicenseClearing("P_REL_FILTER", user1, false, null, null, ReleaseRelationship.CONTAINED);
+        Assert.assertEquals(1, contained.size());
+        Assert.assertEquals("r1", contained.getFirst().getId());
+
+        // Filter for DYNAMICALLY_LINKED
+        List<Release> dynamic = handler.getReleasesForLicenseClearing("P_REL_FILTER", user1, false, null, null, ReleaseRelationship.DYNAMICALLY_LINKED);
+        Assert.assertEquals(1, dynamic.size());
+        Assert.assertEquals("r2", dynamic.getFirst().getId());
+
+        // Filter for STANDALONE: 0 match
+        List<Release> standalone = handler.getReleasesForLicenseClearing("P_REL_FILTER", user1, false, null, null, ReleaseRelationship.STANDALONE);
+        Assert.assertTrue(standalone.isEmpty());
+    }
+
+    @Test
+    public void testGetReleasesForLicenseClearingSubProjectsWithRelationshipFilter() throws Exception {
+        // 5. Same with sub-projects
+        Project parent = new Project().setId("P_PARENT_REL").setName("ParentRel")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setReleaseIdToUsage(ImmutableMap.of(
+                        "r1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE),
+                        "r2", new ProjectReleaseRelationship(ReleaseRelationship.DYNAMICALLY_LINKED, MainlineState.MAINLINE)
+                ))
+                .setLinkedProjects(ImmutableMap.of("P_CHILD_REL", new ProjectProjectRelationship(ProjectRelationship.CONTAINED)));
+
+        Project child = new Project().setId("P_CHILD_REL").setName("ChildRel")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.BUISNESSUNIT_AND_MODERATORS)
+                .setReleaseIdToUsage(ImmutableMap.of(
+                        "r3", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE),
+                        "r4", new ProjectReleaseRelationship(ReleaseRelationship.DYNAMICALLY_LINKED, MainlineState.MAINLINE)
+                ));
+
+        databaseConnector.add(parent);
+        databaseConnector.add(child);
+
+        // Transitive without filter: r1, r2, r3, r4
+        List<Release> allTransitive = handler.getReleasesForLicenseClearing("P_PARENT_REL", user1, true, null, null, null);
+        Assert.assertEquals(4, allTransitive.size());
+
+        // Transitive filtered by CONTAINED: r1, r3
+        List<Release> containedTransitive = handler.getReleasesForLicenseClearing("P_PARENT_REL", user1, true, null, null, ReleaseRelationship.CONTAINED);
+        Assert.assertEquals(2, containedTransitive.size());
+        Set<String> containedIds = containedTransitive.stream().map(Release::getId).collect(Collectors.toSet());
+        Assert.assertTrue(containsInAnyOrder("r1", "r3").matches(containedIds));
+
+        // Transitive filtered by DYNAMICALLY_LINKED: r2, r4
+        List<Release> dynamicTransitive = handler.getReleasesForLicenseClearing("P_PARENT_REL", user1, true, null, null, ReleaseRelationship.DYNAMICALLY_LINKED);
+        Assert.assertEquals(2, dynamicTransitive.size());
+        Set<String> dynamicIds = dynamicTransitive.stream().map(Release::getId).collect(Collectors.toSet());
+        Assert.assertTrue(containsInAnyOrder("r2", "r4").matches(dynamicIds));
+    }
+
+    @Test
+    public void testGetReleasesForLicenseClearingSubProjectPrivatePermission() throws Exception {
+        // 6. Parent Project visibility to EVERYONE, sub-project visibility PRIVATE. Both have 1 release.
+        // user3 (not user1/creator of child) queries parent: should only get parent's release.
+        Project parent = new Project().setId("P_EVERYONE").setName("PublicParent")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.EVERYONE)
+                .setReleaseIdToUsage(ImmutableMap.of("r1", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)))
+                .setLinkedProjects(ImmutableMap.of(
+                        "P_PUBLIC_CHILD", new ProjectProjectRelationship(ProjectRelationship.CONTAINED),
+                        "P_PRIVATE_CHILD", new ProjectProjectRelationship(ProjectRelationship.CONTAINED)
+                ));
+
+        Project publicChild = new Project().setId("P_PUBLIC_CHILD").setName("PublicChild")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.EVERYONE)
+                .setReleaseIdToUsage(ImmutableMap.of("r3", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)));
+
+        Project privateChild = new Project().setId("P_PRIVATE_CHILD").setName("PrivateChild")
+                .setBusinessUnit("AB CD EF").setCreatedBy("user1")
+                .setVisbility(Visibility.PRIVATE)
+                .setReleaseIdToUsage(ImmutableMap.of("r2", new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)));
+
+        databaseConnector.add(parent);
+        databaseConnector.add(publicChild);
+        databaseConnector.add(privateChild);
+
+        // user1 (creator of all) gets r1, r2, r3
+        List<Release> creatorReleases = handler.getReleasesForLicenseClearing("P_EVERYONE", user1, true, null, null, null);
+        Assert.assertEquals(3, creatorReleases.size());
+
+        // user3 has access to parent (EVERYONE) and publicChild (EVERYONE) but NOT privateChild (PRIVATE to user1) -> gets r1 and r3
+        List<Release> user3Releases = handler.getReleasesForLicenseClearing("P_EVERYONE", user3, true, null, null, null);
+        Assert.assertEquals(2, user3Releases.size());
+        Set<String> user3Ids = user3Releases.stream().map(Release::getId).collect(Collectors.toSet());
+        Assert.assertTrue(containsInAnyOrder("r1", "r3").matches(user3Ids));
     }
 
     private ProjectWithReleaseRelationTuple createTuple(Project p) {

--- a/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -27,10 +27,14 @@ import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ProjectSearchHandler;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseNode;
@@ -715,5 +719,21 @@ public class ProjectHandler implements ProjectService.Iface {
         assertNotNull(projectId);
         assertUser(user);
         return handler.getReleasesIdsOfProject(projectId, transitive, user);
+    }
+
+    @Override
+    public List<Release> getReleasesForLicenseClearing(
+            String projectId, User user, boolean transitive,
+            List<ClearingState> clearingStates,
+            List<ComponentType> componentTypes,
+            ReleaseRelationship releaseRelationship
+    ) throws TException {
+        assertNotNull(projectId);
+        assertUser(user);
+        return handler.getReleasesForLicenseClearing(projectId, user,
+                transitive, CommonUtils.nullToEmptyList(clearingStates),
+                CommonUtils.nullToEmptyList(componentTypes),
+                releaseRelationship
+        );
     }
 }

--- a/libraries/datahandler/src/main/thrift/projects.thrift
+++ b/libraries/datahandler/src/main/thrift/projects.thrift
@@ -46,6 +46,8 @@ typedef licenses.ObligationType ObligationType
 typedef licenses.ObligationLevel ObligationLevel
 typedef vendors.Vendor Vendor
 typedef components.ReleaseNode ReleaseNode
+typedef components.ClearingState ComponentClearingState
+typedef components.ComponentType ComponentType
 typedef sw360.ProjectPackageRelationship ProjectPackageRelationship
 typedef sw360.ReportFormat ReportFormat
 
@@ -792,4 +794,10 @@ service ProjectService {
      * Get a set of IDs of Releases attached/used in a Project
      */
     set<string> getReleasesIdsOfProject(1: string projectId, 2: bool transitive, 3: User user);
+
+    /**
+     * Get list of Releases for Project filled with info for license clearing.
+     * Optionally provide list of ClearingState, ComponentType, and ReleaseRelationship to filter.
+     */
+    list<Release> getReleasesForLicenseClearing(1: string projectId, 2: User user, 3: bool transitive, 4: list<ComponentClearingState> clearingStates, 5: list<ComponentType> componentTypes, 6: ReleaseRelationship releaseRelationship);
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -445,52 +445,45 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         restControllerHelper.throwIfSecurityUser(sw360User);
         Project sw360Project = projectService.getProjectForUserById(id, sw360User);
 
-        //check the below condition when releaseRelation is not null
-        if (releaseRelation != null && sw360Project.getReleaseIdToUsage() != null) {
-            Map<String, ProjectReleaseRelationship> filteredReleaseIdToUsage = sw360Project.getReleaseIdToUsage()
-                    .entrySet()
-                    .parallelStream()
-                    .filter(entry -> entry.getValue().getReleaseRelation() == releaseRelation)
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            Map.Entry::getValue
-                    ));
-            sw360Project.setReleaseIdToUsage(filteredReleaseIdToUsage);
+        List<Release> releases = projectService.getReleasesForLicenseClearing(id, sw360User, transitive, clearingState, componentType, releaseRelation);
+
+        // Pre-size set for O(1) membership checks (plain for to JIT optimization)
+        Set<String> validReleaseIds = Sets.newHashSetWithExpectedSize(releases.size());
+        for (Release release : releases) {
+            if (release != null && release.getId() != null) {
+                validReleaseIds.add(release.getId());
+            }
         }
 
-        final Set<String> releaseIds = projectService.getReleaseIds(id, sw360User, transitive);
-        List<Release> releases = projectService.getFilteredReleases(releaseIds, sw360User, clearingState, componentType, releaseService);
-
-        // Extract all release IDs from the provided list
-        Set<String> validReleaseIds = releases.parallelStream().unordered()
-                .map(Release::getId)
-                .collect(Collectors.toSet());
-
-        // Filter the releaseIdToUsage map
-        if (sw360Project.getReleaseIdToUsage() != null) {
-            Map<String, ProjectReleaseRelationship> filteredReleaseIdData = sw360Project.getReleaseIdToUsage()
-                    .entrySet()
-                    .parallelStream()
-                    .filter(entry -> validReleaseIds.contains(entry.getKey()))
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            Map.Entry::getValue
-                    ));
-            sw360Project.setReleaseIdToUsage(filteredReleaseIdData);
+        // Single-pass filter for releaseIdToUsage
+        Map<String, ProjectReleaseRelationship> rawUsage = sw360Project.getReleaseIdToUsage();
+        if (rawUsage != null) {
+            Map<String, ProjectReleaseRelationship> filteredUsage = Maps.newHashMapWithExpectedSize(
+                    Math.min(rawUsage.size(), validReleaseIds.size())
+            );
+            for (Map.Entry<String, ProjectReleaseRelationship> entry : rawUsage.entrySet()) {
+                if (validReleaseIds.contains(entry.getKey())
+                        && (releaseRelation == null || entry.getValue().getReleaseRelation() == releaseRelation)) {
+                    filteredUsage.put(entry.getKey(), entry.getValue());
+                }
+            }
+            sw360Project.setReleaseIdToUsage(filteredUsage);
         }
 
         Map<String, ProjectReleaseRelationship> releaseIdToUsageMap = sw360Project.getReleaseIdToUsage();
-        List<EntityModel<Release>> releaseList = releases.parallelStream().map(sw360Release -> wrapTException(() -> {
-            final Release embeddedRelease = restControllerHelper.convertToEmbeddedLinkedRelease(sw360Release);
+        List<EntityModel<Release>> releaseList = new ArrayList<>(releases.size());
+        // Plain for to JIT optimization
+        for (Release sw360Release : releases) {
+            if (sw360Release == null) continue;
+            Release embeddedRelease = restControllerHelper.convertToEmbeddedLinkedRelease(sw360Release);
             if (releaseIdToUsageMap != null) {
                 ProjectReleaseRelationship relationship = releaseIdToUsageMap.get(sw360Release.getId());
                 if (relationship != null) {
                     embeddedRelease.setProjectMainlineState(relationship.getMainlineState());
                 }
             }
-            final HalResource<Release> releaseResource = restControllerHelper.addEmbeddedReleaseLinks(embeddedRelease);
-            return releaseResource;
-        })).collect(Collectors.toList());
+            releaseList.add(restControllerHelper.addEmbeddedReleaseLinks(embeddedRelease));
+        }
 
         HalResource<Project> userHalResource = createHalLicenseClearing(sw360Project, releaseList);
         return new ResponseEntity<>(userHalResource, HttpStatus.OK);
@@ -2969,7 +2962,7 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         sw360.unsetVisbility();
         sw360.unsetSecurityResponsibles();
         HalResource<Project> halProject = new HalResource<>(sw360);
-        if (sw360Project.getReleaseIdToUsage() != null || (releases != null && !releases.isEmpty())) {
+        if (sw360Project.getReleaseIdToUsage() != null || !CommonUtils.isNullOrEmptyCollection(releases)) {
             restControllerHelper.addEmbeddedProjectReleases(halProject, releases);
         }
         return halProject;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -2008,6 +2008,17 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 .toList();
     }
 
+    public List<Release> getReleasesForLicenseClearing(
+            String projectId, User user, boolean transitive,
+            List<ClearingState> clearingStates,
+            List<ComponentType> componentTypes,
+            ReleaseRelationship releaseRelationship
+    ) throws TException {
+        ProjectService.Iface projectClient = getThriftProjectClient();
+        return projectClient.getReleasesForLicenseClearing(projectId, user,
+                transitive, clearingStates, componentTypes, releaseRelationship);
+    }
+
     /**
      * Converts a Pageable object to a PaginationData object.
      *

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -1698,7 +1698,7 @@ public class ProjectTest extends TestIntegrationBase {
         // Transitive fetch returns releases from sub-project
         given(this.projectServiceMock.getReleaseIds(eq("parentNoReleases"), any(), eq(true)))
                 .willReturn(new HashSet<>(Arrays.asList(release1.getId(), release2.getId())));
-        given(this.projectServiceMock.getFilteredReleases(any(), any(), any(), any(), any()))
+        given(this.projectServiceMock.getReleasesForLicenseClearing(eq("parentNoReleases"), any(), anyBoolean(), any(), any(), any()))
                 .willReturn(Arrays.asList(release1, release2));
         given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
         given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), any())).willReturn(release2);


### PR DESCRIPTION
## Description 

### Issue : 
The license clearing page at project detail page takes a lot of time to load. It is impacting the overall performance.

### Post fix metrices :

#### 1. Payload Integrity
**100% data parity**: Every single release field (`id`, `name`, `version`, `clearingState`, `componentType`, `mainLicenseIds`, `otherLicenseIds`, etc.) across all releases matches between `licenseClearing-existing.json` and `licenseClearing-optiized.json`.

#### 2. Performance Comparison

| Project Scope / Scenario | Baseline (Original) | Run 1 (Summary Methods) | Run 2 (Raw DB Methods) | Overall Improvement |
|---|---|---|---|---|
| **0 releases** | ~18,000 ms | 17 ms | **4 ms** | **~99.98% faster** |
| **57–66 releases** | ~18,000 ms | 50–60 ms | **35–62 ms** | **~99.7% faster** |
| **105 releases** | ~18,200 ms | 89 ms | **80 ms** | **~99.6% faster** |
| **1,023 releases** | ~20,000 ms | N/A | **800 ms** (417ms DB export) | **~96% faster** |
| **7,163 releases / 403 subprojects** | ~24,000 ms | 4,470–4,774 ms | **4,565–4,970 ms** | **~80% faster** |
| **Zero matching filters** | ~18,000 ms | 38 ms | **30–38 ms** | **~99.8% faster** |

### Suggest Reviewer :
@GMishx 

