### PR TITLE
feat(Project): Excel export for obligation

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -167,6 +167,7 @@ public class SW360Constants {
     public static final String DEPARTMENT_KEY = "departmentKey";
     public static final String DELETE_LIST_EMAIL = "deleteEmail";
     public static final String SBOM = "sbom";
+    public static final String OBLIGATIONS = "obligations";
 
     public static final String IMPORT_DEPARTMENT_LAST_RUNNING_TIME = "lastRunningTime";
     public static final String IMPORT_DEPARTMENT_NEXT_RUNNING_TIME = "nextRunningTime";

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ObligationExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ObligationExporter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Siemens AG, 2024. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.exporter;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
+import org.eclipse.sw360.exporter.helper.ExporterHelper;
+import org.eclipse.sw360.exporter.utils.SubTable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Exporter for project obligations (license, project, organisation and component level),
+ * following the same structure as {@link ProjectExporter}/{@link LicenseExporter}: a dedicated
+ * {@link ExcelExporter} whose {@link ObligationHelper} renders a single {@link ObligationStatusInfo}
+ * into a {@link SubTable} row.
+ */
+public class ObligationExporter extends ExcelExporter<ObligationStatusInfo, ObligationExporter.ObligationHelper> {
+
+    public static final List<String> HEADERS = List.of(
+            "Obligation Level", "Obligation Id", "Obligation Text", "Obligation Type",
+            "Status", "Comment", "License Ids", "Releases");
+
+    public ObligationExporter() {
+        super(new ObligationHelper());
+    }
+
+    public static class ObligationHelper implements ExporterHelper<ObligationStatusInfo> {
+
+        @Override
+        public int getColumns() {
+            return HEADERS.size();
+        }
+
+        @Override
+        public List<String> getHeaders() {
+            return HEADERS;
+        }
+
+        @Override
+        public SubTable makeRows(ObligationStatusInfo osi) {
+            List<String> row = new ArrayList<>();
+            row.add(obligationLevelLabel(osi));
+            row.add(CommonUtils.nullToEmptyString(osi.getId()));
+            row.add(CommonUtils.nullToEmptyString(osi.getText()));
+            row.add(osi.isSetObligationType() ? osi.getObligationType().name() : "");
+            row.add(osi.isSetStatus() ? osi.getStatus().name() : "");
+            row.add(CommonUtils.nullToEmptyString(osi.getComment()));
+            row.add(osi.isSetLicenseIds() ? String.join(", ", osi.getLicenseIds()) : "");
+            row.add(osi.isSetReleases()
+                    ? osi.getReleases().stream().map(Release::getName).collect(Collectors.joining(", "))
+                    : "");
+            return new SubTable(row);
+        }
+
+        private static String obligationLevelLabel(ObligationStatusInfo osi) {
+            if (!osi.isSetObligationLevel()) {
+                return "";
+            }
+            return switch (osi.getObligationLevel()) {
+                case ORGANISATION_OBLIGATION -> "Organisation";
+                case PROJECT_OBLIGATION -> "Project";
+                case COMPONENT_OBLIGATION -> "Component";
+                case LICENSE_OBLIGATION -> "License";
+            };
+        }
+    }
+}
+
+

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportController.java
@@ -115,7 +115,7 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             @Parameter(description = "Module name.", schema = @Schema(allowableValues = {
                     SW360Constants.PROJECTS, SW360Constants.COMPONENTS, SW360Constants.LICENSES,
                     LICENSE_INFO, LICENSES_RESOURCE_BUNDLE, SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO,
-                    EXPORT_CREATE_PROJ_CLEARING_REPORT,SW360Constants.SBOM
+                    EXPORT_CREATE_PROJ_CLEARING_REPORT, SW360Constants.SBOM, SW360Constants.OBLIGATIONS
             }))
             @RequestParam(value = "module", required = true) String module,
             @Parameter(description = "Exclude release version from the license info file")
@@ -188,6 +188,8 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             exportProjectCreateClearingRequest(response, sw360User, module, projectId, reportBean);
         } else if (SW360Constants.SBOM.equalsIgnoreCase(module)) {
             exportSBOM(response, sw360User, module, projectId, reportBean);
+        } else if (SW360Constants.OBLIGATIONS.equalsIgnoreCase(module)) {
+            getObligationsReports(response, sw360User, module, projectId, reportBean);
         }
     }
 
@@ -378,6 +380,10 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
             } else if (SW360Constants.PROJECT_RELEASE_SPREADSHEET_WITH_ECCINFO.equals(module)) {
                 buff = sw360ReportService.getProjectReleaseSpreadSheetWithEcc(user, projectId);
                 fileName = sw360ReportService.getDocumentName(user, projectId, module);
+            } else if (SW360Constants.OBLIGATIONS.equalsIgnoreCase(module)) {
+                buff = sw360ReportService.getObligationsReportBuffer(user, projectId, reportBean.getFormat());
+                fileName = sw360ReportService.getObligationsFileName(user, projectId, reportBean.getFormat());
+                setContentTypeForFormat(response, reportBean.getFormat());
             }
             if (null == buff) {
                 throw new TException("No data available for the user " + user.getEmail());
@@ -405,8 +411,18 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         }
     }
 
+    /**
+     * Writes only the buffer's valid bytes to the response, since some exporters return a
+     * {@link ByteBuffer} whose backing array can be larger than the actual data written.
+     */
     private void copyDataStreamToResponse(HttpServletResponse response, ByteBuffer buffer) throws IOException {
-        FileCopyUtils.copy(buffer.array(), response.getOutputStream());
+        if (buffer.hasArray()) {
+            response.getOutputStream().write(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+        } else {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.duplicate().get(bytes);
+            FileCopyUtils.copy(bytes, response.getOutputStream());
+        }
     }
 
     private void setContentDisposition(HttpServletResponse response, String fileName) {
@@ -551,6 +567,23 @@ public class SW360ReportController implements RepresentationModelProcessor<Repos
         } catch (IOException e) {
             log.error(e);
             throw new SW360Exception("Unable to generate SBOM report.");
+        }
+    }
+
+    /**
+     * Exports the license, project, organisation and component level obligations of a project
+     * as a downloadable report (xlsx), following the same flow as the other report modules.
+     */
+    private void getObligationsReports(
+            HttpServletResponse response, User sw360User, String module, String projectId, SW360ReportBean reportBean
+    ) throws SW360Exception {
+        try {
+            downloadExcelReport(response, sw360User, module, projectId, reportBean);
+        } catch (ResourceNotFoundException | AccessDeniedException | BadRequestClientException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(e);
+            throw new SW360Exception(e.getMessage());
         }
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/report/SW360ReportService.java
@@ -52,11 +52,13 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseService;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatInfo;
+import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
@@ -65,6 +67,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentStreamConnector;
 import org.eclipse.sw360.exporter.LicenseInfoExporter;
+import org.eclipse.sw360.exporter.ObligationExporter;
 import org.eclipse.sw360.exporter.ReleaseExporter;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
@@ -574,6 +577,119 @@ public class SW360ReportService {
             }
         }
         return documentName;
+    }
+
+    /**
+     * Obligation levels aggregated into the obligations report, in export order. Each holds the
+     * level label expected by {@code setObligationsFromAdminSection} and its matching enum.
+     */
+    private enum ObligationReportLevel {
+        LICENSE("License", ObligationLevel.LICENSE_OBLIGATION),
+        PROJECT("Project", ObligationLevel.PROJECT_OBLIGATION),
+        ORGANIZATION("Organization", ObligationLevel.ORGANISATION_OBLIGATION),
+        COMPONENT("Component", ObligationLevel.COMPONENT_OBLIGATION);
+
+        private final String label;
+        private final ObligationLevel level;
+
+        ObligationReportLevel(String label, ObligationLevel level) {
+            this.label = label;
+            this.level = level;
+        }
+    }
+
+    /**
+     * Builds the obligations report (license, project, organisation and component level
+     * obligations) for the given project. Only {@link ReportFormat#EXCEL} is supported.
+     */
+    public ByteBuffer getObligationsReportBuffer(User user, String projectId, ReportFormat format) throws TException {
+        if (CommonUtils.isNullEmptyOrWhitespace(projectId)) {
+            throw new SW360Exception("Project Id cannot be empty");
+        }
+        if (!ReportFormat.EXCEL.equals(format)) {
+            throw new SW360Exception("Only xlsx format is supported for the obligations report");
+        }
+        if (!validateProject(projectId, user)) {
+            throw new SW360Exception("No project record found for the project Id : " + projectId);
+        }
+        Project project = projectService.getProjectForUserById(projectId, user);
+
+        List<ObligationStatusInfo> obligations = new ArrayList<>();
+        for (ObligationReportLevel level : ObligationReportLevel.values()) {
+            getObligationDataForLevel(project, user, level).forEach((id, osi) -> {
+                if (!osi.isSetId()) {
+                    osi.setId(id);
+                }
+                if (!osi.isSetObligationLevel()) {
+                    osi.setObligationLevel(level.level);
+                }
+                obligations.add(osi);
+            });
+        }
+
+        try {
+            return new ObligationExporter().toByteBuffer(obligations);
+        } catch (IOException e) {
+            throw new SW360Exception("Failed to generate obligations report: " + e.getMessage());
+        }
+    }
+
+
+    public String getObligationsFileName(User user, String projectId, ReportFormat format) throws TException {
+        String extension = getFileExtension(format);
+        String timestamp = SW360Utils.getCreatedOn();
+        if (CommonUtils.isNotNullEmptyOrWhitespace(projectId) && !projectId.equalsIgnoreCase("null")) {
+            Project project = projectclient.getProjectById(projectId, user);
+            return String.format("obligations-%s-%s-%s.%s", project.getName(), project.getVersion(), timestamp, extension);
+        }
+        return String.format("obligations-%s.%s", timestamp, extension);
+    }
+
+    /**
+     * Fetches and filters the obligation status map for a single obligation level, reusing the
+     * same lookup logic as {@code ProjectController#getObligations}.
+     */
+    private Map<String, ObligationStatusInfo> getObligationDataForLevel(
+            Project project, User user, ObligationReportLevel level) throws TException {
+        Map<String, ObligationStatusInfo> statusMap = CommonUtils.isNotNullEmptyOrWhitespace(project.getLinkedObligationId())
+                ? CommonUtils.nullToEmptyMap(projectService
+                        .getObligationData(project.getLinkedObligationId(), user).getLinkedObligationStatus())
+                : new HashMap<>();
+
+        if (level != ObligationReportLevel.LICENSE) {
+            return filterObligationsByLevel(
+                    projectService.setObligationsFromAdminSection(user, statusMap, project, level.label), level.level);
+        }
+
+        Map<String, ObligationStatusInfo> licenseData = filterObligationsByLevel(statusMap, null);
+        Map<String, String> releaseIdToAcceptedCLI = new HashMap<>(
+                SW360Utils.getReleaseIdtoAcceptedCLIMappings(licenseData));
+        List<Release> releases = getReleases(CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet(), user)
+                .filter(release -> release.getAttachmentsSize() > 0).toList();
+
+        Map<String, ObligationStatusInfo> oblData =
+                projectService.setLicenseInfoWithObligations(licenseData, releaseIdToAcceptedCLI, releases, user);
+        // Populate the "Releases" column from each obligation's releaseIdToAcceptedCLI.
+        oblData.forEach((id, osi) -> {
+            osi.setId(id);
+            osi.setReleases(getReleases(CommonUtils.nullToEmptyMap(osi.getReleaseIdToAcceptedCLI()).keySet(), user)
+                    .collect(Collectors.toSet()));
+        });
+        return oblData;
+    }
+
+    private Map<String, ObligationStatusInfo> filterObligationsByLevel(
+            Map<String, ObligationStatusInfo> obligationStatusMap, ObligationLevel targetLevel) {
+        return obligationStatusMap.entrySet().stream()
+                .filter(e -> e.getValue().getObligationLevel() == null
+                        || e.getValue().getObligationLevel() == targetLevel)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private Stream<Release> getReleases(Collection<String> releaseIds, User user) {
+        return releaseIds.stream()
+                .map(releaseId -> componentService.getReleaseById(releaseId, user))
+                .filter(Objects::nonNull);
     }
 
     @NonNull


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
This PR adds support for exporting a project's obligations (license, project, organisation and component level) as a downloadable Excel (`.xlsx`) report.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360/issues/4585*)
> * Did you add or update any new dependencies that are required for your change?

Closes: https://github.com/eclipse-sw360/sw360/issues/4585

* Added a new `OBLIGATIONS` module value to the existing `/api/reports` export endpoint (`SW360ReportController`).
* Added `SW360Constants.OBLIGATIONS` constant.
* Added `ObligationExporter` (`libraries/exporters`) to build the obligation spreadsheet from a project's linked license, project, organisation and component obligations.
* Added corresponding service methods in `SW360ReportService` (`getObligationsReportBuffer`, `getObligationsFileName`) to fetch the data and generate the report buffer/file name.
* Hardened `copyDataStreamToResponse` in `SW360ReportController` to only write the valid/remaining bytes of the `ByteBuffer` to the response (instead of the full, potentially oversized, backing array), fixing a latent bug that could corrupt generated report files.

### Suggest Reviewer
> @GMishx 

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

### Frontend Related PR 
https://github.com/eclipse-sw360/sw360-frontend/pull/2044
