### PR TITLE
fix(projects): fix sorting by state in projects in lucene search

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -80,7 +80,10 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
      * Handler-specific JS: index {@code additionalData} as a concatenated text blob,
      * index the creator email of every attachment, and index each element of the
      * {@code moderators} and {@code contributors} arrays individually so that
-     * per-user visibility queries work correctly.
+     * per-user visibility queries work correctly and build a {@code stateClearing_sort} composite
+     * key that mirrors {@link ProjectRepository#BY_STATE_VIEW} (state grouped, clearing progress
+     * as tiebreaker, falling back to a fixed tiebreaker when clearing state is absent) for the
+     * {@code BY_STATE} sort column.
      */
     private static final String PROJECT_CUSTOM_JS =
             "    arrayToStringIndex(doc.additionalData, 'additionalData');" +
@@ -101,6 +104,13 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
             "        index('text', 'contributors', doc.contributors[i]);" +
             "      }" +
             "    }" +
+            "    function indexStateByClearingState(state, clearingState, indexName) {" +
+            "      if (!state) return;" +
+            "      var tieBreaker = {'OPEN': '0', 'IN_PROGRESS': '1', 'CLOSED': '2'}[clearingState];" +
+            "      if (tieBreaker === undefined) tieBreaker = '9';" +
+            "      index('string', indexName, state + tieBreaker);" +
+            "    }" +
+            "    indexStateByClearingState(doc.state, doc.clearingState, 'stateClearing_sort');" +
             INDEX_PROJECT_RELEASE_RELATION_NETWORK +
             INDEX_ID_FIELD;
 
@@ -109,6 +119,7 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
      * <ul>
      *   <li>{@code attachmentCreatedBy} -> {@code email} (custom JS field)</li>
      *   <li>{@code additionalData_sort} -> {@code keyword} (created by {@code arrayToStringIndex})</li>
+     *   <li>{@code stateClearing_sort} -> {@code keyword} (composite {@code state}+{@code clearingState} sort key)</li>
      *   <li>{@code moderators} -> {@code email} (custom JS loop, array elements)</li>
      *   <li>{@code contributors} -> {@code email} (custom JS loop, array elements)</li>
      * </ul>
@@ -116,6 +127,7 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
     private static final Map<String, String> PROJECT_CUSTOM_ANALYZERS = Map.of(
             "attachmentCreatedBy", "email",
             "additionalData_sort", "keyword",
+            "stateClearing_sort", "keyword",
             "releaseRelationNetwork", "keyword",
             "moderators", "email",
             "contributors", "email",
@@ -299,7 +311,7 @@ public class ProjectSearchHandler extends BaseNouveauSearchHandler<Project> {
             case ProjectSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");
             case ProjectSortColumn.BY_DESCRIPTION -> List.of("description_sort", SCORE_SORTING_FIELD, revDir + "createdOn");
             case ProjectSortColumn.BY_RESPONSIBLE -> List.of("projectResponsible_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
-            case ProjectSortColumn.BY_STATE -> List.of("state_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_STATE -> List.of("stateClearing_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
             case ProjectSortColumn.BY_CREATEDON -> List.of("createdOn");
             case ProjectSortColumn.BY_TYPE -> List.of("projectType_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
             // Default sort by scoring

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandlerTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandlerTest.java
@@ -48,7 +48,7 @@ class ProjectSearchHandlerTest {
             case ProjectSortColumn.BY_NAME -> List.of("name_sort", revDir + "version_sort", revDir + "createdOn");
             case ProjectSortColumn.BY_DESCRIPTION -> List.of("description_sort", SCORE_SORTING_FIELD, revDir + "createdOn");
             case ProjectSortColumn.BY_RESPONSIBLE -> List.of("projectResponsible_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
-            case ProjectSortColumn.BY_STATE -> List.of("state_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
+            case ProjectSortColumn.BY_STATE -> List.of("stateClearing_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
             case ProjectSortColumn.BY_CREATEDON -> List.of("createdOn");
             case ProjectSortColumn.BY_TYPE -> List.of("projectType_sort", SCORE_SORTING_FIELD, "name_sort", revDir + "version_sort", revDir + "createdOn");
             case null, default -> List.of(SCORE_SORTING_FIELD);
@@ -96,7 +96,7 @@ class ProjectSearchHandlerTest {
 
     @Test
     void byState_shouldReturnStateSortWithFullTiebreakers() {
-        assertEquals(List.of("state_sort", SCORE_SORTING_FIELD, "name_sort", "-version_sort", "-createdOn"),
+        assertEquals(List.of("stateClearing_sort", SCORE_SORTING_FIELD, "name_sort", "-version_sort", "-createdOn"),
                 mapSortColumnDirect(ProjectSortColumn.BY_STATE.getValue()));
     }
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

On sorting by ascending order by ```state``` in ```/projects```, the order by which projects should by sorted by clearing state is ```OPEN```, ```IN_PROGRESS```, ```CLOSED```.

Fixed that in lucene search.

### How To Test?
Make the following api request:
```
curl 'http://localhost:8080/resource/api/projects?page=0&page_entries=10&sort=state%2Casc&allDetails=true' \
  -H 'Accept: application/*' \
  -H 'Authorization: Basic xyz' \
```
Change the state param to desc as well. The projects should be sorted in the order mentioned above.

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
