### PR TITLE
docs(rest): update OAuth2 token request documentation (#2956)

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/api-guide.adoc
+++ b/rest/resource-server/src/docs/asciidoc/api-guide.adoc
@@ -134,7 +134,7 @@ This chapter provides information about the sw360 authorization token.
 [[token-request]]
 === Token Request - Json Web Tokens (JWT)
 
-Access JWT are issued via OAuth 2.0 endpoints: /authorize and /oauth/token. +
+Access JWT are issued via OAuth 2.0 endpoint: /authorization/oauth2/token. +
 You can use cURL command line tool in the Terminal
 
 Request
@@ -142,15 +142,13 @@ Request
 curl
     -X POST
     --user 'client-id:client-secret'
-    -d 'grant_type=password&username=<USERNAME>&password=<PASSWORD>' https://sw360.org/authorization/oauth/token -k
+    -H 'Content-Type: application/x-www-form-urlencoded'
+    -d 'grant_type=client_credentials' https://sw360.org/authorization/oauth2/token -k
 ----
 
 The 'client-id' and 'client-secret' can be found in the https://github.com/eclipse/sw360/blob/master/rest/authorization-server/src/main/resources/application.yml[application.yml] configuration.
 client-id: trusted-sw360-client
 client-secret: sw360-secret
-
-The <USERNAME> and <PASSWORD> are the credentials of your liferay login.
-e.g. admin@sw360.org, 12345
 
 [[token-response]]
 === Token Response


### PR DESCRIPTION
## Description

The REST API documentation currently contains outdated OAuth2 instructions using the legacy `/authorization/oauth/token` endpoint and `grant_type=password`.

This updates the documentation to match the current OAuth2 implementation:

- `POST /oauth2/token`
- HTTP Basic authentication using client ID and client secret
- `grant_type=client_credentials`
- `application/x-www-form-urlencoded` request body

This also removes the outdated Liferay credential references.

Fixes #2956

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Issue

#2956

### Suggest Reviewer

<!-- @mention a reviewer here if you have one -->

### How To Test?

- Review the updated OAuth2 instructions in `api-guide.adoc`.
- Verify that the documented endpoint is `/oauth2/token`.
- Verify that the documented grant type is `client_credentials`.
- Verify that the request uses HTTP Basic authentication with the client ID and client secret.
- Verify that the request body uses `application/x-www-form-urlencoded`.

No additional tests were added because this change only updates outdated documentation; the existing authorization-server tests already cover the client-credentials flow.

### Checklist

Must:
- [ ] All related issues are referenced in commit messages and in PR
