### PR TITLE
fix(rest): Exempt security user on allowed apis

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilter.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilter.java
@@ -36,9 +36,12 @@ public class EndpointsFilter extends OncePerRequestFilter {
      * Endpoints which may look like write but aren't, thus allow security user
      * to use them.
      */
-    private static final Set<String> SECURITY_USER_EXEMPT_ENDPOINTS = Set.of(
+    public static final Set<String> SECURITY_USER_EXEMPT_ENDPOINTS_POST = Set.of(
             "/api/releases/batch-summary", // Get Release in batch
             "/api/users/tokens"            // Allow token generation from UI
+    );
+    public static final Set<String> SECURITY_USER_EXEMPT_ENDPOINTS_DELETE = Set.of(
+            "/api/users/tokens"            // Allow token revoke from UI
     );
 
     private final Map<Pattern, Set<String>> endpointHttpMethods;
@@ -54,7 +57,7 @@ public class EndpointsFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        if (isAllowedSecurityUserReadSummaryRequest(request)) {
+        if (isAllowedSecurityUserRequest(request)) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -82,15 +85,18 @@ public class EndpointsFilter extends OncePerRequestFilter {
     private boolean isSecurityUserWriteBlocked(@NonNull HttpServletRequest request) {
         return isWriteMethod(request.getMethod())
                 && PermissionUtils.isSecurityUser(restControllerHelper.getSw360UserFromAuthentication())
-                && !isAllowedSecurityUserReadSummaryRequest(request);
+                && !isAllowedSecurityUserRequest(request);
     }
 
-    private boolean isAllowedSecurityUserReadSummaryRequest(@NonNull HttpServletRequest request) {
-        if (!request.getMethod().equalsIgnoreCase("POST")) {
-            return false;
+    private boolean isAllowedSecurityUserRequest(@NonNull HttpServletRequest request) {
+        if (request.getMethod().equalsIgnoreCase("POST")) {
+            String requestUri = request.getRequestURI();
+            return SECURITY_USER_EXEMPT_ENDPOINTS_POST.stream().anyMatch(requestUri::endsWith);
+        } else if (request.getMethod().equalsIgnoreCase("DELETE")) {
+            String requestUri = request.getRequestURI();
+            return SECURITY_USER_EXEMPT_ENDPOINTS_DELETE.stream().anyMatch(requestUri::endsWith);
         }
-        String requestUri = request.getRequestURI();
-        return SECURITY_USER_EXEMPT_ENDPOINTS.stream().anyMatch(requestUri::endsWith);
+        return false;
     }
 
     private boolean isWriteMethod(String method) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/security/ResourceServerConfiguration.java
@@ -55,6 +55,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.eclipse.sw360.rest.common.security.TokenCapabilityAuthorities.*;
+import static org.eclipse.sw360.rest.resourceserver.filter.EndpointsFilter.SECURITY_USER_EXEMPT_ENDPOINTS_DELETE;
+import static org.eclipse.sw360.rest.resourceserver.filter.EndpointsFilter.SECURITY_USER_EXEMPT_ENDPOINTS_POST;
 
 @Profile("!SECURITY_MOCK")
 @Configuration
@@ -110,6 +112,8 @@ public class ResourceServerConfiguration {
                     auth.requestMatchers(HttpMethod.GET, PUBLIC_API_GET_ENDPOINTS).permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/api/info").hasAuthority(TOKEN_WRITE);
                     auth.requestMatchers(HttpMethod.GET, "/api/**").hasAuthority(TOKEN_READ);
+                    auth.requestMatchers(HttpMethod.POST, SECURITY_USER_EXEMPT_ENDPOINTS_POST.toArray(String[]::new)).hasAuthority(TOKEN_READ);
+                    auth.requestMatchers(HttpMethod.DELETE, SECURITY_USER_EXEMPT_ENDPOINTS_DELETE.toArray(String[]::new)).hasAuthority(TOKEN_READ);
                     auth.requestMatchers(HttpMethod.POST, "/api/**").hasAuthority(TOKEN_WRITE);
                     auth.requestMatchers(HttpMethod.PUT, "/api/**").hasAuthority(TOKEN_WRITE);
                     auth.requestMatchers(HttpMethod.DELETE, "/api/**").hasAuthority(TOKEN_WRITE);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilterTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/filter/EndpointsFilterTest.java
@@ -44,6 +44,30 @@ class EndpointsFilterTest {
     }
 
     @Test
+    void should_allow_security_user_for_tokens_post_and_delete() throws Exception {
+        RestControllerHelper<?> restControllerHelper = Mockito.mock(RestControllerHelper.class);
+        User securityUser = new User();
+        securityUser.setUserGroup(UserGroup.SECURITY_USER);
+        when(restControllerHelper.getSw360UserFromAuthentication()).thenReturn(securityUser);
+
+        EndpointsFilter filter = new EndpointsFilter(restControllerHelper, "");
+
+        MockHttpServletRequest postRequest = new MockHttpServletRequest("POST", "/api/users/tokens");
+        MockHttpServletResponse postResponse = new MockHttpServletResponse();
+        FilterChain postFilterChain = Mockito.mock(FilterChain.class);
+        filter.doFilterInternal(postRequest, postResponse, postFilterChain);
+        verify(postFilterChain).doFilter(postRequest, postResponse);
+        assertEquals(HttpServletResponse.SC_OK, postResponse.getStatus());
+
+        MockHttpServletRequest deleteRequest = new MockHttpServletRequest("DELETE", "/api/users/tokens");
+        MockHttpServletResponse deleteResponse = new MockHttpServletResponse();
+        FilterChain deleteFilterChain = Mockito.mock(FilterChain.class);
+        filter.doFilterInternal(deleteRequest, deleteResponse, deleteFilterChain);
+        verify(deleteFilterChain).doFilter(deleteRequest, deleteResponse);
+        assertEquals(HttpServletResponse.SC_OK, deleteResponse.getStatus());
+    }
+
+    @Test
     void should_block_security_user_for_non_exempt_write_endpoint() throws Exception {
         RestControllerHelper<?> restControllerHelper = Mockito.mock(RestControllerHelper.class);
         User securityUser = new User();


### PR DESCRIPTION
Exempted `SECURITY_USER` role to access below APIs:
 - `POST` and `DELETE` calls to token generation and token revoke APIs at Preference page
 - `POST` call to `/releases/batch-summary` API

### Suggest Reviewer
@GMishx 

