### PR TITLE
feat(ReadmeOSS): Fix issues on license info generation

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -2610,8 +2610,8 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return repository.searchByType(type, user);
     }
 
-	public ByteBuffer getReportDataStream(User user, boolean extendedByReleases, String projectId) throws TException {
-	    List<Project> projectList = null;
+    public ByteBuffer getReportDataStream(User user, boolean extendedByReleases, String projectId) throws TException {
+        List<Project> projectList = null;
         try {
             if (!isNullOrEmpty(projectId)) {
                 projectList = getProjectDetailsBasedOnId(user, projectId);
@@ -2626,7 +2626,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     private ProjectExporter getProjectExporterObject(List<Project> documents, User user, boolean extendedByReleases) throws SW360Exception {
-    	return new ProjectExporter(ThriftClients.makeComponentClient(),
+        return new ProjectExporter(ThriftClients.makeComponentClient(),
                 ThriftClients.makeProjectClient(), user, documents, extendedByReleases);
     }
 
@@ -2680,7 +2680,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         } catch (IOException e) {
             throw new SW360Exception(e.getMessage());
         }
-	}
+    }
 
     public List<ReleaseLink> getReleaseLinksOfProjectNetWorkByTrace(List<String> trace, String projectId, User user) throws TException{
         Project project = repository.get(projectId);
@@ -3305,9 +3305,8 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
      * <p>To maximize throughput over large release sets (e.g., 8000+ items):
      * <ul>
      *   <li>Filter collections are converted into {@link EnumSet} for constant-time lookups.</li>
-     *   <li>Early filtering on {@link ClearingState} and permissions discards ineligible releases
-     *       before querying CouchDB for parent {@link Component}s.</li>
-     *   <li>Parent components are batch-fetched in a single request only for surviving releases.</li>
+     *   <li>Early filtering on {@link ClearingState} and release permissions discards ineligible releases.</li>
+     *   <li>Parent components are batch-fetched once for both read permission checks and component types.</li>
      *   <li>Both clearing state and component type conditions are evaluated concurrently.</li>
      * </ul>
      *
@@ -3330,10 +3329,10 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         final Set<ClearingState> clearingStateSet = filterByClearingState ? EnumSet.copyOf(clearingStates) : Collections.emptySet();
         final Set<ComponentType> componentTypeSet = filterByComponentType ? EnumSet.copyOf(componentTypes) : Collections.emptySet();
 
-        // 1. Early filter by user read permission & clearingState
+        // Check release permissions without fetching the parent component per release.
         List<Release> candidateReleases = getReleaseClearingStatusStream(releases)
                 .filter(Objects::nonNull)
-                .filter(release -> componentDatabaseHandler.isReleaseActionAllowed(release, user, RequestedAction.READ))
+                .filter(release -> makePermission(release, user).isActionAllowed(RequestedAction.READ))
                 .filter(release -> !filterByClearingState || (release.getClearingState() != null && clearingStateSet.contains(release.getClearingState())))
                 .toList();
 
@@ -3352,8 +3351,20 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 componentDatabaseHandler.getComponentsByIds(componentIds)
         ));
 
-        // 3. Populate componentType and apply componentType filter
+        Set<String> accessibleComponentIds = componentsById.values().stream()
+                .filter(component -> makePermission(component, user).isActionAllowed(RequestedAction.READ))
+                .map(Component::getId)
+                .collect(Collectors.toSet());
+
         return candidateReleases.stream()
+                .filter(release -> {
+                    if (!componentsById.containsKey(release.getComponentId())) {
+                        log.warn("Cannot include release {}: parent component {} was not found",
+                                release.getId(), release.getComponentId());
+                        return false;
+                    }
+                    return accessibleComponentIds.contains(release.getComponentId());
+                })
                 .peek(release -> {
                     Component component = componentsById.get(release.getComponentId());
                     if (component != null) {

--- a/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerLicenseClearingTest.java
+++ b/backend/common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerLicenseClearingTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Siemens AG, 2026. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.thrift.MainlineState;
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.Visibility;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.IS_COMPONENT_VISIBILITY_RESTRICTION_ENABLED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class ProjectDatabaseHandlerLicenseClearingTest {
+    private final User user = new User().setEmail("reader@example.org").setUserGroup(UserGroup.USER);
+    private ProjectDatabaseHandler handler;
+    private ComponentDatabaseHandler components;
+
+    @Before
+    public void setUp() throws Exception {
+        // Avoid constructing repositories: these regressions must not contact a database.
+        handler = mock(ProjectDatabaseHandler.class, CALLS_REAL_METHODS);
+        components = mock(ComponentDatabaseHandler.class);
+        Field field = ProjectDatabaseHandler.class.getDeclaredField("componentDatabaseHandler");
+        field.setAccessible(true);
+        field.set(handler, components);
+    }
+
+    private void givenReleases(List<Release> releases) throws Exception {
+        Map<String, ProjectReleaseRelationship> usages = releases.stream().collect(Collectors.toMap(
+                Release::getId,
+                release -> new ProjectReleaseRelationship(ReleaseRelationship.CONTAINED, MainlineState.MAINLINE)));
+        doReturn(new Project().setId("project").setReleaseIdToUsage(usages))
+                .when(handler).getProjectById("project", user);
+        if (!usages.isEmpty()) {
+            when(components.getReleasesByIds(usages.keySet())).thenReturn(releases);
+        }
+    }
+
+    @Test
+    public void shouldFetchSharedComponentsOnceForThousandsOfReleases() throws Exception {
+        List<Release> releases = IntStream.range(0, 3129)
+                .mapToObj(i -> new Release().setId("r" + i).setComponentId("component"))
+                .collect(Collectors.toCollection(ArrayList::new));
+        givenReleases(releases);
+        when(components.getComponentsByIds(Set.of("component"))).thenReturn(List.of(
+                new Component().setId("component").setCreatedBy(user.getEmail()).setComponentType(ComponentType.OSS)));
+
+        List<Release> result = handler.getReleasesForLicenseClearing("project", user, false, null, null, null);
+
+        assertEquals(3129, result.size());
+        assertTrue(result.stream().allMatch(release -> release.getComponentType() == ComponentType.OSS));
+        verify(components).getReleasesByIds(releases.stream().map(Release::getId).collect(Collectors.toSet()));
+        verify(components).getComponentsByIds(Set.of("component"));
+        verify(components, never()).isReleaseActionAllowed(any(), any(), any());
+    }
+
+    @Test
+    public void shouldStillEnforceParentComponentVisibility() throws Exception {
+        givenReleases(List.of(
+                new Release().setId("publicRelease").setComponentId("public"),
+                new Release().setId("privateRelease").setComponentId("private")));
+        when(components.getComponentsByIds(Set.of("public", "private"))).thenReturn(List.of(
+                new Component().setId("public").setVisbility(Visibility.EVERYONE).setComponentType(ComponentType.OSS),
+                new Component().setId("private").setVisbility(Visibility.PRIVATE).setCreatedBy("other@example.org")));
+        try (MockedStatic<SW360Utils> utils = mockStatic(SW360Utils.class, CALLS_REAL_METHODS)) {
+            utils.when(() -> SW360Utils.readConfig(IS_COMPONENT_VISIBILITY_RESTRICTION_ENABLED, false))
+                    .thenReturn(true);
+
+            List<Release> result = handler.getReleasesForLicenseClearing("project", user, false, null, null, null);
+
+            assertEquals(List.of("publicRelease"), result.stream().map(Release::getId).toList());
+        }
+    }
+
+    @Test
+    public void shouldRetainClearingStateAndComponentTypeFilters() throws Exception {
+        givenReleases(List.of(
+                new Release().setId("approved").setComponentId("oss").setClearingState(ClearingState.APPROVED),
+                new Release().setId("new").setComponentId("unused").setClearingState(ClearingState.NEW_CLEARING),
+                new Release().setId("other").setComponentId("other").setClearingState(ClearingState.APPROVED)));
+        when(components.getComponentsByIds(Set.of("oss", "other"))).thenReturn(List.of(
+                new Component().setId("oss").setCreatedBy(user.getEmail()).setComponentType(ComponentType.OSS),
+                new Component().setId("other").setCreatedBy(user.getEmail()).setComponentType(ComponentType.COTS)));
+
+        List<Release> result = handler.getReleasesForLicenseClearing("project", user, false,
+                List.of(ClearingState.APPROVED), List.of(ComponentType.OSS), null);
+
+        assertEquals(List.of("approved"), result.stream().map(Release::getId).toList());
+        verify(components).getComponentsByIds(Set.of("oss", "other"));
+    }
+
+    @Test
+    public void shouldNotReadComponentsForEmptyProjects() throws Exception {
+        givenReleases(List.of());
+        assertTrue(handler.getReleasesForLicenseClearing("project", user, false, null, null, null).isEmpty());
+        verifyNoInteractions(components);
+    }
+
+    @Test
+    public void shouldNotExposeReleasesWhoseParentComponentIsMissing() throws Exception {
+        givenReleases(List.of(new Release().setId("orphan").setComponentId("missing")));
+        when(components.getComponentsByIds(Set.of("missing"))).thenReturn(List.of());
+        assertTrue(handler.getReleasesForLicenseClearing("project", user, false, null, null, null).isEmpty());
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -2382,24 +2382,6 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
 
 
 
-    public Map<String, Integer> countMap(Collection<AttachmentType> attachmentTypes, UsageData filter, Project project, User sw360User, String id) throws TException {
-        boolean projectWithSubProjects = project.getLinkedProjects() != null && !project.getLinkedProjects().isEmpty();
-        List<ProjectLink> mappedProjectLinks =
-                (!SW360Constants.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP)
-                        ? projectService.createLinkedProjects(project,
-                        projectService.filterAndSortAttachments(attachmentTypes), true, true, sw360User)
-                        : projectService.createLinkedProjectsWithAllReleases(project,
-                        projectService.filterAndSortAttachments(attachmentTypes), true, sw360User);
-
-        if (!projectWithSubProjects) {
-            mappedProjectLinks = mappedProjectLinks.stream()
-                    .filter(projectLink -> projectLink.getId().equals(id)).collect(Collectors.toList());
-        }
-
-        Map<String, Integer> countMap = projectService.storeAttachmentUsageCount(mappedProjectLinks, filter);
-        return countMap;
-    }
-
     @Operation(
             description = "Get all attachmentUsages of the projects.",
             tags = {"Projects"}
@@ -2427,17 +2409,8 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(sw360User);
         Project sw360Project = projectService.getProjectForUserById(id, sw360User);
-        final Set<String> releaseIds = projectService.getReleaseIds(id, sw360User, transitive);
-        List<Release> releases = null;
-        if (filter != null) {
-            releases = filterReleases(sw360User, filter, releaseIds);
-        } else {
-            releases = releaseIds.stream().map(relId -> wrapTException(() -> {
-                final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-                releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-                return sw360Release;
-            })).collect(Collectors.toList());
-        }
+        List<Release> releases = filterReleases(
+                projectService.getReleasesForLicenseClearing(id, sw360User, transitive, null, null, null), filter);
         List<EntityModel<Release>> releaseList = releases.stream().map(sw360Release -> wrapTException(() -> {
             final Release embeddedRelease = restControllerHelper.convertToEmbeddedReleaseAttachments(sw360Release);
             final HalResource<Release> releaseResource = restControllerHelper.addEmbeddedReleaseLinks(embeddedRelease);
@@ -2473,18 +2446,15 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
             }
         }
 
-        Collection<AttachmentType> attachmentTypes;
         UsageData type;
         List<Map<String, Object>> releaseObjMap = new ArrayList<>();
         if ("withCliAttachment".equalsIgnoreCase(filter)) {
-            attachmentTypes = SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES;
             type = UsageData.licenseInfo(new LicenseInfoUsage(Sets.newHashSet()));
-            Map<String, Integer> count = countMap(attachmentTypes, type, sw360Project, sw360User, id);
+            Map<String, Integer> count = projectService.getAttachmentUsageCountsForReleases(releases, type);
             releaseObjMap = getReleaseObjectMapper(releaseList, count);
         } else if ("withSourceAttachment".equalsIgnoreCase(filter)) {
-            attachmentTypes = SW360Constants.SOURCE_CODE_ATTACHMENT_TYPES;
             type = UsageData.sourcePackage(new SourcePackageUsage());
-            Map<String, Integer> count = countMap(attachmentTypes, type, sw360Project, sw360User, id);
+            Map<String, Integer> count = projectService.getAttachmentUsageCountsForReleases(releases, type);
             releaseObjMap = getReleaseObjectMapper(releaseList, count);
         } else {
             releaseObjMap = getReleaseObjectMapper(releaseList, null);
@@ -2558,85 +2528,34 @@ public class ProjectController implements RepresentationModelProcessor<Repositor
         return modifiedList;
     }
 
-    public List<Release> filterReleases(User sw360User, String filter, Set<String> releaseIds) {
-        List<Release> releasesSrc = new ArrayList<>();
-
-        switch (filter) {
-            case "withSourceAttachment":
-                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
-                            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-                            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-                            List<Attachment> sourceAttachments = nullToEmptySet(sw360Release.getAttachments()).stream()
-                                    .filter(attachment ->
-                                            attachment.getAttachmentType() == AttachmentType.SOURCE ||
-                                                    attachment.getAttachmentType() == AttachmentType.SOURCE_SELF)
-                                    .toList();
-                            Set<Attachment> sourceAttachmentsSet = new HashSet<>(sourceAttachments);
-                            sw360Release.setAttachments(sourceAttachmentsSet);
-                            return sourceAttachmentsSet.isEmpty() ? null : sw360Release;
-                        }))
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-                break;
-            case "withoutSourceAttachment":
-                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
-                            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-                            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-                            List<Attachment> withoutSourceAttachments = nullToEmptySet(sw360Release.getAttachments()).stream()
-                                    .filter(attachment ->
-                                            attachment.getAttachmentType() != AttachmentType.SOURCE &&
-                                                    attachment.getAttachmentType() != AttachmentType.SOURCE_SELF)
-                                    .toList();
-                            Set<Attachment> withoutSourceAttachmentsSet = new HashSet<>(withoutSourceAttachments);
-                            sw360Release.setAttachments(withoutSourceAttachmentsSet);
-                            return withoutSourceAttachmentsSet.isEmpty() ? null : sw360Release;
-                        }))
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-                break;
-            case "withoutAttachment":
-                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
-                            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-                            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-                            return nullToEmptySet(sw360Release.getAttachments()).isEmpty() ? sw360Release : null;
-                        }))
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-                break;
-            case "withAttachment":
-                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
-                            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-                            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-                            return nullToEmptySet(sw360Release.getAttachments()).isEmpty() ? null : sw360Release;
-                        }))
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-                break;
-            case "withCliAttachment":
-                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
-                            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-                            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-                            List<Attachment> cliAttachments = nullToEmptySet(sw360Release.getAttachments()).stream()
-                                    .filter(attachment -> attachment.getAttachmentType() == AttachmentType.COMPONENT_LICENSE_INFO_XML || attachment.getAttachmentType() == AttachmentType.COMPONENT_LICENSE_INFO_COMBINED)
-                                    .toList();
-                            Set<Attachment> cliAttachmentsSet = new HashSet<>(cliAttachments);
-                            sw360Release.setAttachments(cliAttachmentsSet);
-                            return cliAttachmentsSet.isEmpty() ? null : sw360Release;
-                        }))
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
-                break;
-            default:
-                releasesSrc = releaseIds.stream().map(relId -> wrapTException(() -> {
-                            final Release sw360Release = releaseService.getReleaseForUserById(relId, sw360User);
-                            releaseService.setComponentDependentFieldsInRelease(sw360Release, sw360User);
-                            return sw360Release;
-                        }))
-                        .collect(Collectors.toList());
-                break;
+    private List<Release> filterReleases(List<Release> releases, String filter) {
+        if (filter == null) {
+            return releases;
         }
-
-        return releasesSrc;
+        return releases.stream().filter(release -> {
+            Set<Attachment> attachments = nullToEmptySet(release.getAttachments());
+            switch (filter) {
+                case "withoutAttachment":
+                    return attachments.isEmpty();
+                case "withAttachment":
+                    return !attachments.isEmpty();
+                case "withSourceAttachment":
+                case "withoutSourceAttachment":
+                case "withCliAttachment":
+                    Set<Attachment> filteredAttachments = attachments.stream().filter(attachment -> {
+                        boolean source = SW360Constants.SOURCE_CODE_ATTACHMENT_TYPES.contains(attachment.getAttachmentType());
+                        return switch (filter) {
+                            case "withSourceAttachment" -> source;
+                            case "withoutSourceAttachment" -> !source;
+                            default -> SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES.contains(attachment.getAttachmentType());
+                        };
+                    }).collect(Collectors.toSet());
+                    release.setAttachments(filteredAttachments);
+                    return !filteredAttachments.isEmpty();
+                default:
+                    return true;
+            }
+        }).collect(Collectors.toList());
     }
 
     private HalResource attachmentUsageReleases(Project sw360Project, List<Map<String, Object>> releases, List<Map<String, Object>> attachmentUsageMap) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -1142,19 +1142,37 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
 
     public Map<String, Integer> storeAttachmentUsageCount(List<ProjectLink> mappedProjectLinks, UsageData filter) throws TException {
         try {
-            AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
-            Map<Source, Set<String>> containedAttachments = extractContainedAttachments(mappedProjectLinks);
-            Map<Map<Source, String>, Integer> attachmentUsages = attachmentClient.getAttachmentUsageCount(containedAttachments,
-                    filter);
-            Map<String, Integer> countMap = attachmentUsages.entrySet().stream().collect(Collectors.toMap(entry -> {
-                Entry<Source, String> key = entry.getKey().entrySet().iterator().next();
-                return key.getKey().getFieldValue() + "_" + key.getValue();
-            }, Entry::getValue));
-            return countMap;
+            return getAttachmentUsageCounts(extractContainedAttachments(mappedProjectLinks), filter);
         } catch (TException e) {
             log.error(e.getMessage());
             return Collections.emptyMap();
         }
+    }
+
+    public Map<String, Integer> getAttachmentUsageCountsForReleases(Collection<Release> releases, UsageData filter)
+            throws TException {
+        Map<Source, Set<String>> containedAttachments = new HashMap<>();
+        for (Release release : releases) {
+            for (Attachment attachment : CommonUtils.nullToEmptySet(release.getAttachments())) {
+                containedAttachments.computeIfAbsent(Source.releaseId(release.getId()), key -> new HashSet<>())
+                        .add(attachment.getAttachmentContentId());
+            }
+        }
+        return getAttachmentUsageCounts(containedAttachments, filter);
+    }
+
+    private Map<String, Integer> getAttachmentUsageCounts(Map<Source, Set<String>> containedAttachments, UsageData filter)
+            throws TException {
+        if (containedAttachments.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        AttachmentService.Iface attachmentClient = ThriftClients.makeAttachmentClient();
+        Map<Map<Source, String>, Integer> attachmentUsages =
+                attachmentClient.getAttachmentUsageCount(containedAttachments, filter);
+        return attachmentUsages.entrySet().stream().collect(Collectors.toMap(entry -> {
+            Entry<Source, String> key = entry.getKey().entrySet().iterator().next();
+            return key.getKey().getFieldValue() + "_" + key.getValue();
+        }, Entry::getValue));
     }
 
     /**

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -28,6 +28,9 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.LicenseInfoUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.SourcePackageUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStateSummary;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
@@ -85,6 +88,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.clearInvocations;
 
 public class ProjectTest extends TestIntegrationBase {
 
@@ -1733,10 +1739,8 @@ public class ProjectTest extends TestIntegrationBase {
         parentProject.setLinkedProjects(linkedProjects);
 
         given(this.projectServiceMock.getProjectForUserById(eq("parentNoReleases2"), any())).willReturn(parentProject);
-        given(this.projectServiceMock.getReleaseIds(eq("parentNoReleases2"), any(), eq(true)))
-                .willReturn(new HashSet<>(Arrays.asList(release1.getId())));
-        given(this.releaseServiceMock.getReleaseForUserById(eq(release1.getId()), any())).willReturn(release1);
-        given(this.releaseServiceMock.setComponentDependentFieldsInRelease(any(Release.class), any(User.class))).willReturn(release1);
+        given(this.projectServiceMock.getReleasesForLicenseClearing(
+                eq("parentNoReleases2"), any(), eq(true), any(), any(), any())).willReturn(List.of(release1));
         given(this.attachmentServiceMock.getAllAttachmentUsage(eq("parentNoReleases2")))
                 .willReturn(new ArrayList<>());
 
@@ -1754,5 +1758,95 @@ public class ProjectTest extends TestIntegrationBase {
         assertTrue(responseJson.has("_embedded"), "Response should contain _embedded field");
         JsonNode embedded = responseJson.get("_embedded");
         assertTrue(embedded.has("sw360:release"), "Embedded should contain sw360:release");
+        assertEquals(1, embedded.get("sw360:release").size());
+        verify(releaseServiceMock, never()).getReleaseForUserById(any(), any());
+        verify(projectServiceMock, never()).getReleaseIds(any(), any(), anyBoolean());
+    }
+
+    @Test
+    public void should_filter_loaded_attachment_metadata_without_refetching_releases() throws Exception {
+        for (Map.Entry<String, Integer> testCase : Map.of(
+                "withCliAttachment", 2, "withSourceAttachment", 2, "withoutSourceAttachment", 2,
+                "withAttachment", 2, "withoutAttachment", 1, "unknownFilter", 3).entrySet()) {
+            setupMockerUser();
+            clearInvocations(projectServiceMock, releaseServiceMock);
+            assertAttachmentFilter(testCase.getKey(), testCase.getValue());
+        }
+    }
+
+    private void assertAttachmentFilter(String filter, int expectedCount) throws Exception {
+        Release mixed = release1.deepCopy().setAttachments(Set.of(
+                new Attachment().setAttachmentContentId("cli").setFilename("cli.xml")
+                        .setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_XML),
+                new Attachment().setAttachmentContentId("source").setFilename("source.zip")
+                        .setAttachmentType(AttachmentType.SOURCE)));
+        Release combined = release2.deepCopy().setAttachments(Set.of(
+                new Attachment().setAttachmentContentId("combined").setFilename("combined.xml")
+                        .setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_COMBINED),
+                new Attachment().setAttachmentContentId("self").setFilename("self.zip")
+                        .setAttachmentType(AttachmentType.SOURCE_SELF)));
+        Release empty = new Release().setId("empty").setName("Empty").setVersion("1");
+        given(projectServiceMock.getReleasesForLicenseClearing(
+                eq(project1.getId()), any(), eq(true), any(), any(), any()))
+                .willReturn(List.of(mixed, combined, empty));
+        given(attachmentServiceMock.getAllAttachmentUsage(project1.getId())).willReturn(List.of());
+        given(projectServiceMock.getAttachmentUsageCountsForReleases(any(), any())).willReturn(
+                Map.of(release1.getId() + "_cli", 3, release1.getId() + "_source", 4));
+
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api/projects/" + project1.getId()
+                        + "/attachmentUsage?transitive=true&filter=" + filter,
+                HttpMethod.GET, new HttpEntity<>(null, getHeaders(port)), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(), filter);
+        JsonNode releases = new ObjectMapper().readTree(response.getBody()).path("_embedded").path("sw360:release");
+        assertEquals(expectedCount, releases.size());
+        if ("withCliAttachment".equals(filter) || "withSourceAttachment".equals(filter)) {
+            assertEquals(1, releases.get(0).path("attachments").size());
+            assertEquals("withCliAttachment".equals(filter) ? 3 : 4,
+                    releases.get(0).path("attachments").get(0).path("attachmentUsageCount").asInt());
+            UsageData expectedFilter = "withCliAttachment".equals(filter)
+                    ? UsageData.licenseInfo(new LicenseInfoUsage(Set.of()))
+                    : UsageData.sourcePackage(new SourcePackageUsage());
+            verify(projectServiceMock).getAttachmentUsageCountsForReleases(
+                    org.mockito.ArgumentMatchers.argThat(selected ->
+                            selected.size() == 2 && selected.stream().allMatch(r -> r.getAttachmentsSize() == 1)),
+                    eq(expectedFilter));
+        }
+        verify(releaseServiceMock, never()).getReleaseForUserById(any(), any());
+        verify(projectServiceMock, never()).createLinkedProjects(any(), any(), anyBoolean(), anyBoolean(), any());
+    }
+
+    @Test
+    public void should_preserve_path_specific_attachment_usages() throws Exception {
+        UsageData firstPath = UsageData.licenseInfo(new LicenseInfoUsage(Set.of("MIT"))
+                .setProjectPath("p001:child1").setIncludeConcludedLicense(false));
+        UsageData secondPath = UsageData.licenseInfo(new LicenseInfoUsage(Set.of("Apache-2.0"))
+                .setProjectPath("p001:child2").setIncludeConcludedLicense(true));
+        List<AttachmentUsage> usages = List.of(
+                new AttachmentUsage(Source.releaseId("r1"), "cli", Source.projectId(project1.getId()))
+                        .setUsageData(firstPath),
+                new AttachmentUsage(Source.releaseId("r1"), "cli", Source.projectId(project1.getId()))
+                        .setUsageData(secondPath));
+        given(projectServiceMock.getReleasesForLicenseClearing(
+                eq(project1.getId()), any(), eq(false), any(), any(), any())).willReturn(List.of(release1));
+        given(attachmentServiceMock.getAllAttachmentUsage(project1.getId())).willReturn(usages);
+
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + "/api/projects/" + project1.getId() + "/attachmentUsage",
+                HttpMethod.GET, new HttpEntity<>(null, getHeaders(port)), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode result = new ObjectMapper().readTree(response.getBody())
+                .path("_embedded").path("sw360:attachmentUsages");
+        assertEquals(2, result.size());
+        JsonNode first = result.get(0).path("usageData").path("licenseInfo");
+        JsonNode second = result.get(1).path("usageData").path("licenseInfo");
+        assertEquals("p001:child1", first.path("projectPath").asText());
+        assertEquals("MIT", first.path("excludedLicenseIds").get(0).asText());
+        assertFalse(first.path("includeConcludedLicense").asBoolean());
+        assertEquals("p001:child2", second.path("projectPath").asText());
+        assertEquals("Apache-2.0", second.path("excludedLicenseIds").get(0).asText());
+        assertTrue(second.path("includeConcludedLicense").asBoolean());
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectServiceTest.java
@@ -12,6 +12,13 @@ package org.eclipse.sw360.rest.resourceserver.project;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
+import org.eclipse.sw360.datahandler.thrift.attachments.LicenseInfoUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,12 +27,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.mockito.MockedStatic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -197,6 +209,55 @@ public class Sw360ProjectServiceTest {
                 result
         );
         verify(projectClient, times(1)).getGroups();
+    }
+
+    @Test
+    public void should_count_only_loaded_attachments_in_one_request() throws TException {
+        Release first = new Release().setId("r1").setAttachments(Set.of(
+                new Attachment().setAttachmentContentId("a1"),
+                new Attachment().setAttachmentContentId("a2")));
+        Release second = new Release().setId("r2").setAttachments(Set.of(
+                new Attachment().setAttachmentContentId("a1")));
+        UsageData filter = UsageData.licenseInfo(new LicenseInfoUsage(Set.of()));
+        Map<Source, Set<String>> keys = Map.of(
+                Source.releaseId("r1"), Set.of("a1", "a2"),
+                Source.releaseId("r2"), Set.of("a1"));
+        AttachmentService.Iface client = mock(AttachmentService.Iface.class);
+        try (MockedStatic<ThriftClients> clients = mockStatic(ThriftClients.class)) {
+            clients.when(ThriftClients::makeAttachmentClient).thenReturn(client);
+            when(client.getAttachmentUsageCount(keys, filter)).thenReturn(Map.of(
+                    Map.of(Source.releaseId("r1"), "a1"), 7,
+                    Map.of(Source.releaseId("r2"), "a1"), 2));
+
+            assertEquals(Map.of("r1_a1", 7, "r2_a1", 2),
+                    projectService.getAttachmentUsageCountsForReleases(List.of(first, second, first), filter));
+            verify(client).getAttachmentUsageCount(keys, filter);
+            clients.verify(ThriftClients::makeAttachmentClient, times(1));
+        }
+    }
+
+    @Test
+    public void should_skip_attachment_count_request_when_no_attachments_exist() throws TException {
+        try (MockedStatic<ThriftClients> clients = mockStatic(ThriftClients.class)) {
+            assertTrue(projectService.getAttachmentUsageCountsForReleases(List.of(), null).isEmpty());
+            assertTrue(projectService.getAttachmentUsageCountsForReleases(
+                    List.of(new Release().setId("r1")), null).isEmpty());
+            clients.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    public void should_propagate_attachment_count_failure() throws TException {
+        Release release = new Release().setId("r1").setAttachments(
+                Set.of(new Attachment().setAttachmentContentId("a1")));
+        Map<Source, Set<String>> keys = Map.of(Source.releaseId("r1"), Set.of("a1"));
+        AttachmentService.Iface client = mock(AttachmentService.Iface.class);
+        try (MockedStatic<ThriftClients> clients = mockStatic(ThriftClients.class)) {
+            clients.when(ThriftClients::makeAttachmentClient).thenReturn(client);
+            when(client.getAttachmentUsageCount(keys, null)).thenThrow(new TException("count unavailable"));
+            assertThrows(TException.class,
+                    () -> projectService.getAttachmentUsageCountsForReleases(List.of(release), null));
+        }
     }
 
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -709,6 +709,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), any())).willReturn(release);
         given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), any())).willReturn(release2);
+        given(projectServiceMock.getReleasesForLicenseClearing(
+                eq(project.getId()), any(), eq(true), any(), any(), any()))
+                .willReturn(List.of(release, release2));
         given(this.releaseServiceMock.getReleaseForUserById(eq(release7.getId()), any())).willReturn(release7);
         given(this.releaseServiceMock.getReleasesWithPermissions(eq(Set.of(rel.getId())), any()))
                 .willReturn(new ArrayList<>(List.of(rel)));


### PR DESCRIPTION

Improve attachment-usage loading for large projects by batch-fetching releases and parent components, avoiding repeated hierarchy traversal, and calculating usage counts from already-loaded attachments.

Preserve attachment filters, component visibility checks, and path-specific saved usages. Count-service errors now propagate instead of appearing as zero counts; releases with missing or inaccessible parent components are omitted.

How to test

1. Open license-info generation for a large project, with and without subprojects. Confirm releases, attachments, and usage counts load correctly.
2. Exercise  withSourceAttachment ,  withoutSourceAttachment ,  withCliAttachment ,  withAttachment , and  withoutAttachment ; confirm only matching data is returned.
3. Confirm saved selections, excluded licenses, and concluded-license settings remain distinct across linked-project paths.
4. With component visibility restrictions enabled, confirm inaccessible releases are excluded.
5. Generate a report and compare its contents with the expected selections.

