### PR TITLE
fix: resolve release links to real frontend host instead of hardcoded localhost

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -85,7 +85,7 @@ public class SW360ConfigsDatabaseHandler {
             .put(PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, getOrDefault(configContainer, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, UserGroup.USER.name()))
             .put(IS_ADMIN_PRIVATE_ACCESS_ENABLED, getOrDefault(configContainer, IS_ADMIN_PRIVATE_ACCESS_ENABLED, "false"))
             .put(SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, getOrDefault(configContainer, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, SW360Constants.DEFAULT_DOMAIN_PATTERN_SKIP_FOR_SOURCECODE))
-            .put(RELEASE_FRIENDLY_URL, getOrDefault(configContainer, RELEASE_FRIENDLY_URL, "http://localhost:3000/components/releases/detail/releaseId"))
+            .put(RELEASE_FRIENDLY_URL, getOrDefault(configContainer, RELEASE_FRIENDLY_URL, defaultReleaseFriendlyUrl()))
             .put(COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, getOrDefault(configContainer, COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, ""))
                 .put(VCS_HOSTS, getOrDefault(configContainer, VCS_HOSTS, "[]"))
                 .put(NON_PKG_MANAGED_COMPS_PROP, getOrDefault(configContainer, NON_PKG_MANAGED_COMPS_PROP, ""))
@@ -129,6 +129,17 @@ public class SW360ConfigsDatabaseHandler {
         if (configContainer == null)
             return defaultValue;
         return configContainer.getConfigKeyToValues().getOrDefault(configKey, new HashSet<>()).stream().findFirst().orElse(defaultValue);
+    }
+
+    // Falls back to the SW360_FRONTEND_URL used to configure the REST/UI containers so release
+    // links in generated reports resolve to the real frontend instead of localhost when the
+    // release.friendly.url config key was never explicitly set by an admin.
+    private static String defaultReleaseFriendlyUrl() {
+        String frontendUrl = System.getenv("SW360_FRONTEND_URL");
+        if (frontendUrl == null || frontendUrl.isBlank()) {
+            frontendUrl = "http://localhost:3000";
+        }
+        return frontendUrl.replaceAll("/+$", "") + "/components/releases/detail/releaseId";
     }
 
     private boolean isBooleanValue(String value) {

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -459,7 +459,7 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
     }
 
     private static void addHyperlink(XWPFParagraph paragraph, String releaseVersion, String releaseId) {
-        String friendlyReleaseUrl = SW360Utils.readConfig(SW360ConfigKeys.RELEASE_FRIENDLY_URL, "http://localhost:3000/release/releaseId");
+        String friendlyReleaseUrl = SW360Utils.readConfig(SW360ConfigKeys.RELEASE_FRIENDLY_URL, "http://localhost:3000/components/releases/detail/releaseId");
         String id = paragraph.getDocument().getPackagePart().addExternalRelationship(
                 friendlyReleaseUrl.replace("releaseId", releaseId), XWPFRelation.HYPERLINK.getRelation()).getId();
 


### PR DESCRIPTION

[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
 * The release links in chapter 2.4 of the project clearing report were hardcoded to localhost:3000, so they only worked on the SW360 server itself and failed for anyone else opening the report. This PR makes the link use the environment's real frontend URL instead. #4596 

Issue: #4596 

### Suggest Reviewer
> @GMishx


