### PR TITLE
feat(config): add configuration to edit  user general information

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -112,6 +112,7 @@ public class SW360ConfigsDatabaseHandler {
                 .put(UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP, getOrDefault(configContainer, UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP, "[\"DEPT1\",\"DEPT2\",\"DEPT3\"]"))
                 .put(UI_REST_APITOKEN_GENERATOR_ENABLE, getOrDefault(configContainer, UI_REST_APITOKEN_GENERATOR_ENABLE, "true"))
                 .put(UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED, getOrDefault(configContainer, UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED, "true"))
+                .put(UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS, getOrDefault(configContainer, UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS, "false"))
                 .put(UI_PROGRAMMING_LANGUAGES, getOrDefault(configContainer, UI_PROGRAMMING_LANGUAGES, "[\"ActionScript\",\"AppleScript\",\"Asp\",\"Bash\",\"BASIC\",\"C\",\"C++\",\"C#\",\"Cocoa\",\"Clojure\",\"COBOL\",\"ColdFusion\",\"D\",\"Delphi\",\"Erlang\",\"Fortran\",\"Go\",\"Groovy\",\"Haskell\",\"JSP\",\"Java\",\"JavaScript\",\"Objective-C\",\"Ocaml\",\"Lisp\",\"Perl\",\"PHP\",\"Python\",\"Ruby\",\"SQL\",\"SVG\",\"Scala\",\"SmallTalk\",\"Scheme\",\"Tcl\",\"XML\",\"Node.js\",\"JSON\"]"))
                 .put(UI_PROJECT_EXTERNALKEYS, getOrDefault(configContainer, UI_PROJECT_EXTERNALKEYS, "[\"internal.id\"]"))
                 .put(UI_PROJECT_EXTERNALURLS, getOrDefault(configContainer, UI_PROJECT_EXTERNALURLS, "[\"wiki\",\"issue-tracker\"]"))
@@ -211,7 +212,8 @@ public class SW360ConfigsDatabaseHandler {
                  UI_ENABLE_ADD_LICENSE_INFO_TO_RELEASE_BUTTON,
                  UI_ENABLE_SECURITY_VULNERABILITY_MONITORING,
                  UI_REST_APITOKEN_GENERATOR_ENABLE,
-                 UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED
+                 UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED,
+                 UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS
                     -> isBooleanValue(configValue);
 
             // Validate string value

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java
@@ -114,6 +114,8 @@ public class SW360ConfigKeys {
     public static final String UI_REST_APITOKEN_GENERATOR_ENABLE = "ui.rest.apitoken.generator.enable";
     // This property is used to show/hide write-access API token controls in user preferences.
     public static final String UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED = "ui.rest.api.write.access.token.in.preferences.enabled";
+    // This property is used to control write access to user general information in the UI.
+    public static final String UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS = "ui.enable.user.general.information.write.access";
     // This property is used to create Project Programming Languages
     public static final String UI_PROGRAMMING_LANGUAGES = "ui.programming.languages";
     // This property is used to create Project External Keys
@@ -166,6 +168,7 @@ public class SW360ConfigKeys {
             UI_ENABLE_ADD_LICENSE_INFO_TO_RELEASE_BUTTON, UI_ENABLE_SECURITY_VULNERABILITY_MONITORING,
             UI_OPERATING_SYSTEMS, UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP,
             UI_REST_APITOKEN_GENERATOR_ENABLE, UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED,
+            UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS,
             UI_PROGRAMMING_LANGUAGES, UI_PROJECT_EXTERNALKEYS, UI_PROJECT_EXTERNALURLS,
             UI_PROJECT_TAG, UI_PROJECT_TYPE, UI_RELEASE_EXTERNALKEYS, UI_SOFTWARE_PLATFORMS, UI_STATE,
             UI_ENABLE_LINKED_PROJECTS_DISPLAY

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeysTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeysTest.java
@@ -41,10 +41,18 @@ public class SW360ConfigKeysTest {
     }
 
     @Test
-    public void bothApiTokenUiKeysAreRegisteredAsKnownConfigKeys() {
+    public void userGeneralInformationWriteAccessKeyMatchesFrontendContract() {
+        assertEquals("ui.enable.user.general.information.write.access",
+                SW360ConfigKeys.UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS);
+    }
+
+    @Test
+    public void uiKeysAreRegisteredAsKnownConfigKeys() {
         assertTrue(SW360ConfigKeys.ALL_KNOWN_CONFIG_KEYS.contains(
                 SW360ConfigKeys.UI_REST_APITOKEN_GENERATOR_ENABLE));
         assertTrue(SW360ConfigKeys.ALL_KNOWN_CONFIG_KEYS.contains(
                 SW360ConfigKeys.UI_REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES_ENABLED));
+        assertTrue(SW360ConfigKeys.ALL_KNOWN_CONFIG_KEYS.contains(
+                SW360ConfigKeys.UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS));
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.sw360.rest.resourceserver.user;
-
 import com.google.common.collect.ImmutableSet;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -16,13 +16,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.thrift.TException;
@@ -32,6 +30,7 @@ import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
+import org.eclipse.sw360.datahandler.thrift.ConfigFor;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -58,7 +57,6 @@ import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-
 import org.springframework.data.domain.Pageable;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
@@ -69,16 +67,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Collections;
 import java.util.stream.Collectors;
-
 import static org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer.API_TOKEN_HASH_SALT;
 import static org.eclipse.sw360.rest.resourceserver.user.Sw360UserService.AUTHORITIES_READ;
 import static org.eclipse.sw360.rest.resourceserver.user.Sw360UserService.AUTHORITIES_WRITE;
 import static org.eclipse.sw360.rest.resourceserver.user.Sw360UserService.EXPIRATION_DATE_PROPERTY;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-
 @BasePathAwareController
 @RequiredArgsConstructor
 @RestController
@@ -89,27 +86,31 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
         "`lastname`, `email`, `deactivated`, `department`, `primaryRoles` or `score`].")
 public class UserController implements RepresentationModelProcessor<RepositoryLinksResource> {
     private static final Logger log = LogManager.getLogger(UserController.class);
-
     protected final EntityLinks entityLinks;
-
     static final String USERS_URL = "/users";
-
     @NonNull
     private final Sw360UserService userService;
-
     @NonNull
     private final PasswordEncoder passwordEncoder;
-
     @NonNull
     private final RestControllerHelper restControllerHelper;
-
     @NonNull
     private final SW360ConfigurationsService sw360ConfigurationsService;
-
     private static final ImmutableSet<User._Fields> setOfUserProfileFields =
             ImmutableSet.<User._Fields>builder().add(User._Fields.WANTS_MAIL_NOTIFICATION)
                     .add(User._Fields.NOTIFICATION_PREFERENCES).build();
-
+    private static final ImmutableSet<User._Fields> readOnlyUserGeneralInformationFields =
+            ImmutableSet.<User._Fields>builder()
+                    .add(User._Fields.EMAIL)
+                    .add(User._Fields.USER_GROUP)
+                    .add(User._Fields.EXTERNALID)
+                    .add(User._Fields.FULLNAME)
+                    .add(User._Fields.GIVENNAME)
+                    .add(User._Fields.LASTNAME)
+                    .add(User._Fields.DEPARTMENT)
+                    .add(User._Fields.PRIMARY_ROLES)
+                    .add(User._Fields.FORMER_EMAIL_ADDRESSES)
+                    .build();
     @Operation(summary = "List all of the service's users.",
             description = "List all of the service's users.", tags = {"Users"})
     @ApiResponses(value = {
@@ -139,7 +140,6 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     ) throws TException, URISyntaxException, PaginationParameterException, ResourceClassNotFoundException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         restControllerHelper.throwIfSecurityUser(user);
-
         Map<PaginationData, List<User>> paginatedUsers = null;
         if (CommonUtils.isNotNullEmptyOrWhitespace(searchText)) {
             paginatedUsers = userService.searchUsersByNameOrEmail(searchText.trim(), pageable);
@@ -156,25 +156,21 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         }
         PaginationResult<User> paginationResult = restControllerHelper.paginationResultFromPaginatedList(
                 request, pageable, paginatedUsers);
-
         List<EntityModel<User>> userResources = new ArrayList<>();
         for (User sw360User : paginationResult.getResources()) {
             User embeddedUser = restControllerHelper.convertToEmbeddedGetUsers(sw360User);
             EntityModel<User> userResource = EntityModel.of(embeddedUser);
             userResources.add(userResource);
         }
-
         CollectionModel<EntityModel<User>> resources;
         if (userResources.size() == 0) {
             resources = restControllerHelper.emptyPageResource(User.class, paginationResult);
         } else {
             resources = restControllerHelper.generatePagesResource(paginationResult, userResources);
         }
-
         HttpStatus status = resources == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
         return new ResponseEntity<>(resources, status);
     }
-
     // '/users/{xyz}' searches by email, as opposed to by id, as is customary,
     // for compatibility with older version of the REST API
     @Operation(summary = "Get a single user.", description = "Get a single user by email.",
@@ -190,7 +186,6 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         String decodedEmail;
         decodedEmail = URLDecoder.decode(email, StandardCharsets.UTF_8);
         User sw360User;
-
         try {
             sw360User = userService.getUserByEmail(decodedEmail);
         } catch (RuntimeException e) {
@@ -199,7 +194,6 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         HalResource<User> halResource = createHalUser(sw360User);
         return new ResponseEntity<>(halResource, HttpStatus.OK);
     }
-
     // unusual URL mapping for compatibility with older version of the REST API (see
     // getUserByEmail())
     @Operation(summary = "Get a single user.", description = "Get a single user by id.",
@@ -216,7 +210,6 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         HalResource<User> halResource = createHalUser(sw360User);
         return new ResponseEntity<>(halResource, HttpStatus.OK);
     }
-
     @Operation(summary = "Create a new user.", description = "Create a user (not in Liferay).",
             tags = {"Users"})
     @PreAuthorize("hasAuthority('ADMIN')")
@@ -242,10 +235,8 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         HalResource<User> halResource = createHalUser(createdUser);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}")
                 .buildAndExpand(createdUser.getId()).toUri();
-
         return ResponseEntity.created(location).body(halResource);
     }
-
     @Operation(summary = "Get current user's profile.", description = "Get current user's profile.",
             tags = {"Users"})
     @ApiResponses(value = {
@@ -257,7 +248,6 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         HalResource<User> halUserResource = new HalResource<>(sw360User);
         return ResponseEntity.ok(halUserResource);
     }
-
     @Operation(summary = "Update user's profile.", description = "Update user's profile.",
             tags = {"Users"})
     @ApiResponses(value = {
@@ -301,7 +291,6 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         HalResource<User> halUserResource = new HalResource<>(sw360User);
         return ResponseEntity.ok(halUserResource);
     }
-
     @Operation(summary = "List all of rest api tokens.",
             description = "List all of rest api tokens of current user.",
             responses = {@ApiResponse(responseCode = "200", description = "List of tokens.")},
@@ -310,16 +299,13 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
     public ResponseEntity<CollectionModel<EntityModel<RestApiToken>>> getUserRestApiTokens() {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         List<RestApiToken> restApiTokens = sw360User.getRestApiTokens();
-
         if (restApiTokens == null) {
             return new ResponseEntity<>(CollectionModel.of(Collections.emptyList()), HttpStatus.OK);
         }
-
         List<EntityModel<RestApiToken>> restApiResources =
                 restApiTokens.stream().map(EntityModel::of).collect(Collectors.toList());
         return new ResponseEntity<>(CollectionModel.of(restApiResources), HttpStatus.OK);
     }
-
     @Operation(summary = "Create rest api token.",
             description = "Create rest api token for current user.",
             responses = {
@@ -357,10 +343,8 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         restApiToken.setToken(BCrypt.hashpw(token, API_TOKEN_HASH_SALT));
         sw360User.addToRestApiTokens(restApiToken);
         userService.updateUser(sw360User);
-
         return new ResponseEntity<>(token, HttpStatus.CREATED);
     }
-
     @Operation(summary = "Delete rest api token.",
             description = "Delete rest api token by name for current user.",
             responses = {
@@ -374,26 +358,21 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             @RequestParam("name") String tokenName
     ) throws TException {
         User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-
         if (!userService.isTokenNameExisted(sw360User, tokenName)) {
             throw new ResourceNotFoundException("Token not found: " + StringEscapeUtils.escapeHtml4(tokenName));
         }
-
         sw360User.getRestApiTokens().removeIf(t -> t.getName().equals(tokenName));
         userService.updateUser(sw360User);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
-
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(UserController.class).slash("api/users").withRel("users"));
         return resource;
     }
-
     private HalResource<User> createHalUser(User sw360User) {
         return new HalResource<>(sw360User);
     }
-
     @Operation(summary = "Fetch group list of a user.",
             description = "Fetch the list of group for a particular user.", tags = {"Users"})
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "User and its groups.",
@@ -423,7 +402,6 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
         userGroupMap.put("secondaryGrpList", secondaryGrpList);
         return new ResponseEntity<>(userGroupMap, HttpStatus.OK);
     }
-
     @Operation(summary = "Update an existing user.", description = "Update an existing user",
             tags = {"Users"})
     @ApiResponses(value = {
@@ -442,16 +420,13 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             String encodedPassword = passwordEncoder.encode(user.getPassword());
             user.setPassword(encodedPassword);
         }
-
         User userToUpdate = userService.getUser(id);
+        preserveReadOnlyGeneralInformationFields(userToUpdate, user);
         userToUpdate = this.restControllerHelper.updateUser(userToUpdate, user);
-
         userService.updateUser(userToUpdate);
         HalResource<User> halResource = createHalUser(userToUpdate);
-
         return new ResponseEntity<>(halResource, HttpStatus.OK);
     }
-
     @Operation(summary = "Get existing departments.", description = "Get existing departments from all users",
             tags = {"Users"})
     @ApiResponses(value = {
@@ -472,5 +447,34 @@ public class UserController implements RepresentationModelProcessor<RepositoryLi
             case "secondary" -> new ResponseEntity<>(userService.getExistingSecondaryDepartments(), HttpStatus.OK);
             default -> new ResponseEntity<>("Type must be: primary or secondary", HttpStatus.BAD_REQUEST);
         };
+    }
+    private void preserveReadOnlyGeneralInformationFields(User persistedUser, User requestedUser) {
+        if (isUserGeneralInformationWriteAccessEnabled() || requestedUser == null) {
+            return;
+        }
+        for (User._Fields field : readOnlyUserGeneralInformationFields) {
+            Object requestedValue = requestedUser.getFieldValue(field);
+            Object persistedValue = persistedUser.getFieldValue(field);
+            if (requestedValue != null && !Objects.equals(requestedValue, persistedValue)) {
+                log.info("Ignoring update to user general information field '{}' for user '{}' because '{}' is disabled.",
+                        field.getFieldName(), persistedUser.getEmail(),
+                        SW360ConfigKeys.UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS);
+            }
+            requestedUser.setFieldValue(field, null);
+        }
+    }
+    private boolean isUserGeneralInformationWriteAccessEnabled() {
+        try {
+            Map<String, String> uiConfigs = sw360ConfigurationsService.getSW360ConfigFromDb(ConfigFor.UI_CONFIGURATION);
+            if (uiConfigs == null) {
+                return false;
+            }
+            return Boolean.parseBoolean(uiConfigs.getOrDefault(
+                    SW360ConfigKeys.UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS, "false"));
+        } catch (TException e) {
+            log.warn("Could not read '{}' from SW360 configs; defaulting to disabled.",
+                    SW360ConfigKeys.UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS, e);
+            return false;
+        }
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
@@ -1,33 +1,17 @@
 /*
  * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
-  * This program and the accompanying materials are made
+ * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-
 package org.eclipse.sw360.rest.resourceserver.integration;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.Map;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.ConfigFor;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.users.RestApiToken;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -41,24 +25,32 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.MediaType;
-
+import org.springframework.http.ResponseEntity;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 public class UserTest extends TestIntegrationBase {
-
     @Value("${local.server.port}")
     private int port;
-
     private List<User> userList;
     private User user;
     private List<RestApiToken> restApiTokens;
     private final ObjectMapper objectMapper = new ObjectMapper();
-
     @BeforeEach
     public void before() throws TException {
         userList = new ArrayList<>();
         restApiTokens = new ArrayList<>();
-
         // Setup User 1
         user = new User();
         user.setId("4784587578e87989");
@@ -74,7 +66,6 @@ public class UserTest extends TestIntegrationBase {
         user.setNotificationPreferences(getNotificationPreferences());
         user.setRestApiTokens(getRestApiTokens());
         userList.add(user);
-
         // Setup User 2
         User user2 = new User();
         user2.setId("frwey45786rwe");
@@ -87,61 +78,51 @@ public class UserTest extends TestIntegrationBase {
         user2.setWantsMailNotification(false);
         user2.setSecondaryDepartmentsAndRoles(getSecondaryDepartmentsAndRoles());
         userList.add(user2);
-
         given(this.userServiceMock.getUsersWithPagination(any())).willReturn(
                 Collections.singletonMap(
                         new PaginationData().setRowsPerPage(userList.size()).setDisplayStart(0).setTotalRowCount(userList.size()),
                         userList.stream().toList()
                 )
         );
-
         given(this.userServiceMock.getUser(user.getId())).willReturn(user);
         given(this.userServiceMock.getUser("frwey45786rwe")).willReturn(user2);
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
         given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
         given(this.userServiceMock.getUserByEmail("jane@sw360.org")).willReturn(user2);
         given(this.userServiceMock.getAllUsers()).willReturn(userList);
-
         // For user creation
         given(this.userServiceMock.addUser(any())).willReturn(
                 new User("test@sw360.org", "DEPARTMENT").setId("1234567890").setFullname("FTest lTest")
                         .setGivenname("FTest").setLastname("lTest").setUserGroup(UserGroup.USER)
         );
-
         // For update
         doNothing().when(this.userServiceMock).updateUser(any());
-
-
         // For tokens
         given(this.userServiceMock.convertToRestApiToken(any(), any())).willReturn(getRestApiTokens().getFirst());
         given(this.userServiceMock.isTokenNameExisted(any(), any())).willReturn(true);
-
         // For departments - use the correct method names
         given(this.userServiceMock.getAvailableDepartments()).willReturn(Set.of("SW360 Administration", "SW360 BA"));
         given(this.userServiceMock.getExistingPrimaryDepartments()).willReturn(Set.of("SW360 Administration"));
         given(this.userServiceMock.getExistingSecondaryDepartments()).willReturn(Set.of("SW360 BA"));
-
         // Default config for API token length
         Map<String, String> defaultConfigs = new HashMap<>();
         defaultConfigs.put("rest.apitoken.length", "20");
         given(this.sw360ConfigurationsServiceMock.getSW360Configs()).willReturn(defaultConfigs);
-
+        given(this.sw360ConfigurationsServiceMock.getSW360ConfigFromDb(ConfigFor.UI_CONFIGURATION))
+                .willReturn(Map.of("ui.enable.user.general.information.write.access", "true"));
     }
-
     @Test
     public void should_get_all_users() throws IOException {
         ResponseEntity<String> response = sendGet("/api/users");
         assertEquals(HttpStatus.OK, response.getStatusCode());
         TestHelper.checkResponse(response.getBody(), "users", 2);
     }
-
     @Test
     public void should_get_single_user_by_id() throws IOException {
         String url = "/api/users/byid/" + user.getId();
         ResponseEntity<String> response = sendGet(url);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         JsonNode body = objectMapper.readTree(response.getBody());
-
         // Verify all user data fields are returned correctly
         assertEquals(user.getEmail(), body.get("email").textValue());
         assertEquals(user.getUserGroup().toString(), body.get("userGroup").textValue());
@@ -151,25 +132,20 @@ public class UserTest extends TestIntegrationBase {
         assertEquals(user.getDepartment(), body.get("department").textValue());
         assertEquals(user.isWantsMailNotification(), body.get("wantsMailNotification").booleanValue());
         assertFalse(body.get("deactivated").booleanValue());
-
         // Verify complex nested objects exist
         assertTrue(body.has("secondaryDepartmentsAndRoles"), "Should have secondaryDepartmentsAndRoles");
         assertTrue(body.has("formerEmailAddresses"), "Should have formerEmailAddresses");
         assertTrue(body.has("notificationPreferences"), "Should have notificationPreferences");
-
         // Verify the self link contains the user ID
         JsonNode selfLink = body.get("_links").get("self").get("href");
         assertTrue(selfLink.textValue().contains(user.getId()), "Self link should contain user ID");
     }
-
-
     @Test
     public void should_get_single_user_by_email() throws IOException {
         String url = "/api/users/" + user.getEmail();
         ResponseEntity<String> response = sendGet(url);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         JsonNode body = objectMapper.readTree(response.getBody());
-
         // Verify all user data fields are returned correctly (same as by ID)
         assertEquals(user.getEmail(), body.get("email").textValue());
         assertEquals(user.getUserGroup().toString(), body.get("userGroup").textValue());
@@ -179,20 +155,17 @@ public class UserTest extends TestIntegrationBase {
         assertEquals(user.getDepartment(), body.get("department").textValue());
         assertEquals(user.isWantsMailNotification(), body.get("wantsMailNotification").booleanValue());
         assertFalse(body.get("deactivated").booleanValue());
-
         // Verify complex nested objects exist
         assertTrue(body.has("secondaryDepartmentsAndRoles"), "Should have secondaryDepartmentsAndRoles");
         assertTrue(body.has("formerEmailAddresses"), "Should have formerEmailAddresses");
         assertTrue(body.has("notificationPreferences"), "Should have notificationPreferences");
     }
-
     @Test
     public void should_get_user_profile() throws IOException {
         String url = "/api/users/profile";
         ResponseEntity<String> response = sendGet(url);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         JsonNode body = objectMapper.readTree(response.getBody());
-
         // Verify all user profile fields are returned correctly
         assertEquals(user.getEmail(), body.get("email").textValue());
         assertEquals(user.getUserGroup().toString(), body.get("userGroup").textValue());
@@ -202,20 +175,17 @@ public class UserTest extends TestIntegrationBase {
         assertEquals(user.getDepartment(), body.get("department").textValue());
         assertEquals(user.isWantsMailNotification(), body.get("wantsMailNotification").booleanValue());
         assertFalse(body.get("deactivated").booleanValue());
-
         // Verify complex nested objects exist
         assertTrue(body.has("secondaryDepartmentsAndRoles"), "Should have secondaryDepartmentsAndRoles");
         assertTrue(body.has("formerEmailAddresses"), "Should have formerEmailAddresses");
         assertTrue(body.has("notificationPreferences"), "Should have notificationPreferences");
     }
-
     @Test
     public void should_update_user_profile() throws Exception {
         String url = "/api/users/profile";
         Map<String, Object> updatedProfile = new HashMap<>();
         updatedProfile.put("wantsMailNotification", false);
         updatedProfile.put("notificationPreferences", getNotificationPreferences());
-
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
@@ -228,7 +198,6 @@ public class UserTest extends TestIntegrationBase {
         JsonNode body = objectMapper.readTree(response.getBody());
         assertEquals(user.getEmail(), body.get("email").textValue());
     }
-
     @Test
     public void should_create_user() throws Exception {
         String url = "/api/users";
@@ -239,7 +208,6 @@ public class UserTest extends TestIntegrationBase {
         newUser.put("email", "test@sw360.org");
         newUser.put("department", "DEPARTMENT");
         newUser.put("password", "12345");
-
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
@@ -250,7 +218,6 @@ public class UserTest extends TestIntegrationBase {
         );
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         JsonNode body = objectMapper.readTree(response.getBody());
-
         // Verify all created user fields are returned correctly
         assertEquals("test@sw360.org", body.get("email").textValue());
         assertEquals("USER", body.get("userGroup").textValue());
@@ -262,16 +229,13 @@ public class UserTest extends TestIntegrationBase {
         assertTrue(body.has("wantsMailNotification"), "Should have wantsMailNotification field");
         assertTrue(body.has("_links"), "Should have _links section");
     }
-
     @Test
     public void should_update_existing_user() throws Exception {
         String url = "/api/users/" + user.getId();
         Map<String, Object> updateInfo = new HashMap<>();
         updateInfo.put("department", "DEPARTMENT");
-
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
-
         ResponseEntity<String> response = new TestRestTemplate().exchange(
                 "http://localhost:" + port + url,
                 HttpMethod.PATCH,
@@ -282,7 +246,33 @@ public class UserTest extends TestIntegrationBase {
         JsonNode body = objectMapper.readTree(response.getBody());
         assertEquals("DEPARTMENT", body.get("department").textValue());
     }
-
+    @Test
+    public void should_ignore_general_information_updates_when_write_access_is_disabled() throws Exception {
+        given(this.sw360ConfigurationsServiceMock.getSW360ConfigFromDb(ConfigFor.UI_CONFIGURATION))
+                .willReturn(Map.of("ui.enable.user.general.information.write.access", "false"));
+        String url = "/api/users/" + user.getId();
+        Map<String, Object> updateInfo = new HashMap<>();
+        updateInfo.put("department", "KEYCLOAK-OWNED-DEPARTMENT");
+        updateInfo.put("givenName", "ChangedGivenName");
+        updateInfo.put("userGroup", UserGroup.USER.name());
+        updateInfo.put("secondaryDepartmentsAndRoles",
+                Map.of("NEW-DEPARTMENT", Set.of(UserGroup.CLEARING_ADMIN.name())));
+        HttpHeaders headers = getHeaders(port);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> response = new TestRestTemplate().exchange(
+                "http://localhost:" + port + url,
+                HttpMethod.PATCH,
+                new HttpEntity<>(objectMapper.writeValueAsString(updateInfo), headers),
+                String.class
+        );
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode body = objectMapper.readTree(response.getBody());
+        assertEquals("SW360 Administration", body.get("department").textValue());
+        assertEquals("John", body.get("givenName").textValue());
+        assertEquals("ADMIN", body.get("userGroup").textValue());
+        assertTrue(body.get("secondaryDepartmentsAndRoles").has("NEW-DEPARTMENT"));
+        assertTrue(body.get("secondaryDepartmentsAndRoles").get("NEW-DEPARTMENT").isArray());
+    }
     @Test
     public void should_list_all_user_tokens() throws IOException {
         String url = "/api/users/tokens";
@@ -291,7 +281,6 @@ public class UserTest extends TestIntegrationBase {
         JsonNode body = objectMapper.readTree(response.getBody());
         assertTrue(body.get("_embedded").has("sw360:restApiTokens"));
     }
-
     @Test
     public void should_create_user_token() throws Exception {
         String url = "/api/users/tokens";
@@ -299,7 +288,6 @@ public class UserTest extends TestIntegrationBase {
         tokenRequest.put("name", "Token3");
         tokenRequest.put("expirationDate", "2023-12-29");
         tokenRequest.put("authorities", List.of("READ", "WRITE"));
-
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
@@ -310,19 +298,16 @@ public class UserTest extends TestIntegrationBase {
         );
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
     }
-
     @Test
     public void should_return_bad_request_when_db_config_is_empty() throws Exception {
         // Simulate DB not having the rest.apitoken.length value (empty config)
         Map<String, String> emptyConfigs = new HashMap<>();
         given(this.sw360ConfigurationsServiceMock.getSW360Configs()).willReturn(emptyConfigs);
-
         String url = "/api/users/tokens";
         Map<String, Object> tokenRequest = new HashMap<>();
         tokenRequest.put("name", "TokenWithDefaultLength");
         tokenRequest.put("expirationDate", "2027-12-31");
         tokenRequest.put("authorities", List.of("READ"));
-
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
@@ -334,8 +319,6 @@ public class UserTest extends TestIntegrationBase {
         // When DB config is empty, we should get a BAD_REQUEST since token length must be configured
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
     }
-
-
     @Test
     public void should_create_user_token_with_length_from_db_config() throws Exception {
         // Simulate DB having the rest.apitoken.length value set to 32
@@ -343,13 +326,11 @@ public class UserTest extends TestIntegrationBase {
         Map<String, String> dbConfigs = new HashMap<>();
         dbConfigs.put("rest.apitoken.length", String.valueOf(dbConfiguredTokenLength));
         given(this.sw360ConfigurationsServiceMock.getSW360Configs()).willReturn(dbConfigs);
-
         String url = "/api/users/tokens";
         Map<String, Object> tokenRequest = new HashMap<>();
         tokenRequest.put("name", "TokenWithDbConfigLength");
         tokenRequest.put("expirationDate", "2027-12-31");
         tokenRequest.put("authorities", List.of("READ"));
-
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
         ResponseEntity<String> response = new TestRestTemplate().exchange(
@@ -359,15 +340,13 @@ public class UserTest extends TestIntegrationBase {
                 String.class
         );
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
-
         // Verify the token length matches the DB configured value
         String responseBody = response.getBody();
         assertFalse(responseBody == null || responseBody.isEmpty(), "Response body should not be null or empty");
-
         String generatedToken = objectMapper.readValue(responseBody, String.class);
-        assertEquals(dbConfiguredTokenLength, generatedToken.length(), "Token length should match DB configured value of " + dbConfiguredTokenLength);
+        assertEquals(dbConfiguredTokenLength, generatedToken.length(),
+                "Token length should match DB configured value of " + dbConfiguredTokenLength);
     }
-
     @Test
     public void should_revoke_user_token() throws Exception {
         String url = "/api/users/tokens?name=Token1";
@@ -381,23 +360,18 @@ public class UserTest extends TestIntegrationBase {
         );
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
     }
-
     @Test
     public void should_get_grouplist() throws Exception {
         String url = "/api/users/groupList";
         ResponseEntity<String> response = sendGet(url);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
-
     @Test
     public void should_get_all_departments() throws Exception {
         String url = "/api/users/departments";
         ResponseEntity<String> response = sendGet(url);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
-
-    // --- Helper methods ---
-
     private ResponseEntity<String> sendGet(String url) throws IOException {
         HttpHeaders headers = getHeaders(port);
         return new TestRestTemplate().exchange("http://localhost:" + port + url,
@@ -405,14 +379,12 @@ public class UserTest extends TestIntegrationBase {
                 new HttpEntity<>(null, headers),
                 String.class);
     }
-
     private Map<String, Set<UserGroup>> getSecondaryDepartmentsAndRoles() {
         Map<String, Set<UserGroup>> secondaryDepartmentsAndRoles = new HashMap<>();
         secondaryDepartmentsAndRoles.put("DEPARTMENT1", Set.of(UserGroup.CLEARING_EXPERT, UserGroup.ECC_ADMIN));
         secondaryDepartmentsAndRoles.put("DEPARTMENT2", Set.of(UserGroup.SW360_ADMIN, UserGroup.SECURITY_ADMIN));
         return secondaryDepartmentsAndRoles;
     }
-
     private Map<String, Boolean> getNotificationPreferences() {
         Map<String, Boolean> notificationPreferences = new HashMap<>();
         notificationPreferences.put("releaseCONTRIBUTORS", true);
@@ -437,28 +409,26 @@ public class UserTest extends TestIntegrationBase {
         notificationPreferences.put("releaseMODERATORS", true);
         return notificationPreferences;
     }
-
     private List<RestApiToken> getRestApiTokens() {
-        if (!restApiTokens.isEmpty()) return restApiTokens;
+        if (!restApiTokens.isEmpty()) {
+            return restApiTokens;
+        }
         RestApiToken token1 = new RestApiToken();
         token1.setName("Token1");
         token1.setNumberOfDaysValid(10);
         token1.setCreatedOn("2023-12-19 02:31:52");
         token1.setAuthorities(Set.of("READ", "WRITE"));
-
         RestApiToken token2 = new RestApiToken();
         token2.setName("Token2");
         token2.setNumberOfDaysValid(11);
         token2.setCreatedOn("2023-12-19 02:31:52");
         token2.setAuthorities(Set.of("READ"));
-
         RestApiToken token3 = new RestApiToken();
         token3.setName("Token3");
         token3.setNumberOfDaysValid(10);
         token3.setCreatedOn("2023-12-19 02:31:52");
         token3.setAuthorities(Set.of("READ", "WRITE"));
         token3.setToken("MockedToken");
-
         restApiTokens = new ArrayList<>(List.of(token1, token2, token3));
         return restApiTokens;
     }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

This PR implements backend enforcement of read-only Keycloak-owned user general information fields via a new configuration toggle `ui.enable.user.general.information.write.access`.

### Problem Statement

Currently, the UI allows administrators to edit Keycloak-managed user fields (email, fullName, givenName, lastName, department, userGroup, externalId, primaryRoles, formerEmailAddresses) directly in the database, which bypasses Keycloak's source-of-truth for these fields. This can lead to data inconsistency between SW360 and Keycloak.

### Solution

- **New configuration key**: `UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS` (default: `"false"` — safe fail-closed)
- **Backend enforcement**: When disabled, the PATCH endpoint silently preserves Keycloak-managed fields, preventing direct DB manipulation
- **Logging**: All blocked update attempts are logged at INFO level for audit purposes
- **Secondary data preserved**: Secondary departments and roles remain editable even when the toggle is disabled

### How It Works

#### When Toggle is **DISABLED** (default, recommended):
```
User admin attempts to PATCH /api/users/{id} with updated email/department
↓
UserController.patchUser() called
↓
preserveReadOnlyGeneralInformationFields() checks toggle value
↓
Blocked fields are restored to their persisted values
↓
Secondary departments/roles are still updated
↓
Result: Keycloak remains single source-of-truth
```

#### When Toggle is **ENABLED** (legacy behavior):
```
User admin can edit all fields including Keycloak-managed ones

```

### Files Modified

#### Configuration:
1. **`libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeys.java`**
   - Added `UI_ENABLE_USER_GENERAL_INFORMATION_WRITE_ACCESS` constant
   - Registered in `ALL_KNOWN_CONFIG_KEYS` for frontend exposure

2. **`backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java`**
   - Default value: `"false"` (fail-closed)
   - Added to UI config loader (`loadToConfigsInMemForUi`)
   - Registered in `isConfigValid()` boolean validation switch

#### User Update Enforcement:
3. **`rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserController.java`**
   - New private method: `preserveReadOnlyGeneralInformationFields(User persistedUser, User requestedUser)`
     - Preserves 9 Keycloak-owned fields when toggle is disabled
     - Logs each blocked update attempt at INFO level
   - New helper method: `isUserGeneralInformationWriteAccessEnabled()`
     - Fail-closed: catches exceptions and defaults to disabled
   - Integration: Called in `patchUser()` before general user update

#### Tests:
4. **`rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java`**
   - New test: `should_ignore_general_information_updates_when_write_access_is_disabled()`
   - Verifies blocked updates and preserved secondary data

5. **`rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/configuration/ConfigurationsTest.java`**
   - New test: validates configuration key persistence to DB

6. **`libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/common/SW360ConfigKeysTest.java`**
   - Regression tests: pin exact frontend-facing key values


### Behavior Summary

| Scenario | Behavior |
|----------|----------|
| Toggle = **"true"** (enabled) | Frontend can edit user general information (Keycloak sync disabled) |
| Toggle = **"false"** (disabled, default) | Backend preserves persisted Keycloak fields; secondary departments/roles still editable |
| Config read fails / missing | Defaults to disabled (fail-closed safety) |

### Frontend Integration
https://github.com/eclipse-sw360/sw360-frontend/pull/2051

### Suggested Reviewers
@GMishx 