### PR TITLE
fix(ModerationRequest): Reject duplicate attachment requests with a clear comment

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -65,6 +65,8 @@ public class SW360Constants {
     public static final String PACKAGE_IDS = "packageIds";
     public static final String PROJECT_SEARCH_EMPTY_TOKEN = "__EMPTY__";
     public static final String PROJECT_FILTER_KEY_ATTACHMENT_CREATED_BY = "attachmentCreatedBy";
+    public static final String DUPLICATE_ATTACHMENT_REJECTION_COMMENT =
+            "Duplicate attachment already present. Hence, rejected.";
 
     // Proper values of the "type" member to deserialize to CouchDB
     public static final String TYPE_OBLIGATION = "obligation";

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/moderationrequest/Sw360ModerationRequestService.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
 import org.eclipse.sw360.datahandler.thrift.PaginationData;
@@ -330,6 +331,11 @@ public class Sw360ModerationRequestService {
         if (actionStatus != null && actionStatus.equals(RequestStatus.SUCCESS)) {
             getThriftModerationClient().acceptRequest(request, moderatorComment, reviewer.getEmail());
             return ModerationState.APPROVED;
+        } else if (actionStatus != null && actionStatus.equals(RequestStatus.DUPLICATE_ATTACHMENT)) {
+            // Applying the changes would add a duplicate attachment (same name and SHA1) - reject instead.
+            log.warn("Rejecting moderation request {} because it would introduce a duplicate attachment.",
+                    request.getId());
+            return rejectRequest(request, SW360Constants.DUPLICATE_ATTACHMENT_REJECTION_COMMENT, reviewer);
         } else {
             return ModerationState.REJECTED;
         }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

>
When a Moderation Request (MR) for a **Release** adds an attachment (name + SHA1) that is concurrently added directly to the same Release by another user, accepting the MR previously reported a misleading result: `Sw360ModerationRequestService.acceptRequest()`only checked for `RequestStatus.SUCCESS` and, for any other status (including `RequestStatus.DUPLICATE_ATTACHMENT` returned by`ComponentDatabaseHandler.updateRelease`), it simply returned `ModerationState.REJECTED` to the caller **without ever calling `ModerationService.refuseRequest(...)`**. As a result:

- The Release was **not** updated (correctly, since it would violate the no-duplicate-attachment constraint), but
- The moderation request was **left open** (`PENDING`/`INPROGRESS`) in the database, even though the API response looked like a completed/successful action.

> * Which issue is this pull request belonging to and how is it solving it? (* https://github.com/eclipse-sw360/sw360/issues/4599*)
> * Did you add or update any new dependencies that are required for your change?

Closes: https://github.com/eclipse-sw360/sw360/issues/4599

### Suggest Reviewer
> @GMishx 

### How To Test?
1. Create a Release with an attachment `A` (type `SOURCE`, filename `foo.jar`, SHA1 `X`).
2. Submit a moderation request for the same Release that adds an attachment with the  same filename (`foo.jar`) and SHA1 (`X`) as an addition.
3. As a different user with write access, directly add the same attachment (`foo.jar` / `X`)  to the Release, so it is now already present when the MR is later reviewed.
4. As a moderator, accept the moderation request via  `PATCH /moderationrequest/{id}` with `{"action": "ACCEPT"}`.
5. Verify:
   - The response reports the MR status as `REJECTED` (HTTP 202).
   - The moderation request is now closed (`REJECTED`) when fetched via
     `GET /moderationrequest/{id}` — it no longer appears under open/pending requests.
   - The moderation request's decision comment is
     `"Duplicate attachment already present. Hence, rejected."`
   - The Release itself is unchanged (no duplicate attachment was added).

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
