### PR TITLE
test(rest): cover FossologyAdminController configData endpoint

### DIFF
--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/architecture/TestCoverageCompletenessRulesTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/architecture/TestCoverageCompletenessRulesTest.java
@@ -122,8 +122,6 @@ class TestCoverageCompletenessRulesTest extends SW360ArchitectureTest {
      * As tests are added, entries should be removed from this list.
      */
     private static final Set<String> ENDPOINT_RATIO_EXCLUDED = Set.of(
-            // TODO: Add 1 more test to cover all 3 endpoints
-            "FossologyAdminController",  // 3 endpoints, 2 tests -- 1 gap
             // Test exists (CleanUpAttachmentSpecTest) but reversed naming
             "AttachmentCleanUpController"
     );

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/FossologySpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/FossologySpecTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Siemens AG, 2023-2024,2026.
+ * Copyright Vishakha Kumari, 2026.
  * Part of the SW360 Portal Project.
  *
  * This program and the accompanying materials are made
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class FossologySpecTest extends TestRestDocsSpecBase {
@@ -78,5 +80,22 @@ public class FossologySpecTest extends TestRestDocsSpecBase {
                 .contentType(MediaTypes.HAL_JSON)
                 .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void should_document_get_connection_configuration_data() throws Exception {
+        Map<String, Object> configData = new HashMap<>();
+        configData.put("isTokenSet", true);
+        configData.put("url", "http://localhost:8000/url");
+        configData.put("folderId", "1");
+        given(this.fossologyAdminServices.getConfig(any())).willReturn(configData);
+
+        mockMvc.perform(get("/api/fossology/configData")
+                .contentType(MediaTypes.HAL_JSON)
+                .header("Authorization", TestHelper.generateAuthHeader(testUserId, testUserPassword)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isTokenSet").value(true))
+                .andExpect(jsonPath("$.url").value("http://localhost:8000/url"))
+                .andExpect(jsonPath("$.folderId").value("1"));
     }
 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Adds the missing test for the third `FossologyAdminController` endpoint
> (`GET /api/fossology/configData`) and removes the now-obsolete exclusion
> from the ArchUnit endpoint-coverage rule.

Issue: N/A - test-coverage gap was tracked inline in `TestCoverageCompletenessRulesTest`

### Summary
- `FossologySpecTest`: new test `should_document_get_connection_configuration_data` exercises `GET /api/fossology/configData` and asserts the returned config JSON.
- `TestCoverageCompletenessRulesTest`: removed `FossologyAdminController` from `ENDPOINT_RATIO_EXCLUDED` (previously `3 endpoints, 2 tests -- 1 gap`). The ArchUnit rule now enforces this controller directly.

### Suggest Reviewer
@GMishx

### How To Test?
```
./scripts/startCouchdbForTests.sh
mvn -pl rest/resource-server -am test -Dtest=FossologySpecTest,TestCoverageCompletenessRulesTest -Dbase.deploy.dir=$TOMCAT_HOME
```
No new dependencies were added.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR