### PR TITLE
fix(nouveau): prevent shared authenticator mutation

### DIFF
--- a/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
+++ b/libraries/nouveau-handler/src/main/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnector.java
@@ -18,6 +18,7 @@ import com.ibm.cloud.cloudant.v1.model.PutDesignDocumentOptions;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.ResponseConverter;
 import com.ibm.cloud.sdk.core.http.ServiceCall;
+import com.ibm.cloud.sdk.core.service.BaseService;
 import com.ibm.cloud.sdk.core.service.exception.ConflictException;
 import com.ibm.cloud.sdk.core.service.exception.NotFoundException;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
@@ -48,7 +49,8 @@ public class LuceneAwareCouchDbConnector {
                 lucenePrefix, gson);
     }
 
-    public static class NouveauAwareDatabase extends Cloudant {
+    public static class NouveauAwareDatabase extends BaseService {
+        private final Cloudant client;
         private final String db;
         private final String ddoc;
         private final String lucenePrefix;
@@ -58,6 +60,8 @@ public class LuceneAwareCouchDbConnector {
                                     String ddoc, String lucenePrefix, Gson gson) {
             super(client.getName(), client.getAuthenticator());
             this.setServiceUrl(client.getServiceUrl());
+            this.setClient(client.getClient());
+            this.client = client;
             this.db = db;
             this.ddoc = ddoc;
             this.lucenePrefix = lucenePrefix;
@@ -153,7 +157,7 @@ public class LuceneAwareCouchDbConnector {
 
             DocumentResult response;
             try {
-                response = this.putDesignDocument(designDocumentOptions)
+                response = this.client.putDesignDocument(designDocumentOptions)
                         .execute().getResult();
             } catch (ConflictException | TooManyRequestsException e) {
                 try {
@@ -167,7 +171,7 @@ public class LuceneAwareCouchDbConnector {
                         designDocument.setId(existingDoc.getId());
                         designDocument.setRev(existingDoc.getRev());
                     }
-                    response = this.putDesignDocument(designDocumentOptions)
+                    response = this.client.putDesignDocument(designDocumentOptions)
                             .execute().getResult();
                 } catch (InterruptedException ex) {
                     throw e;

--- a/libraries/nouveau-handler/src/test/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnectorTest.java
+++ b/libraries/nouveau-handler/src/test/java/org/eclipse/sw360/nouveau/LuceneAwareCouchDbConnectorTest.java
@@ -10,7 +10,13 @@
 
 package org.eclipse.sw360.nouveau;
 
+import com.google.gson.Gson;
+import com.ibm.cloud.cloudant.security.CouchDbSessionAuthenticator;
+import com.ibm.cloud.cloudant.v1.Cloudant;
+import com.ibm.cloud.sdk.core.security.Authenticator;
 import junit.framework.TestCase;
+
+import java.lang.reflect.Field;
 
 public class LuceneAwareCouchDbConnectorTest extends TestCase {
 
@@ -20,5 +26,30 @@ public class LuceneAwareCouchDbConnectorTest extends TestCase {
 
     public void testEnsureDesignIdContaining() {
         assert (LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX + "lucene").equals(LuceneAwareCouchDbConnector.ensureDesignId(LuceneAwareCouchDbConnector.DEFAULT_DESIGN_PREFIX + "lucene"));
+    }
+
+    public void testConnectorConstructionDoesNotMutateSharedAuthenticator() throws Exception {
+        Authenticator auth = CouchDbSessionAuthenticator.newAuthenticator("sw360", "sw360");
+        Cloudant client = new Cloudant("sw360-couchdb", auth);
+        client.setServiceUrl("http://couchdb:5984");
+
+        Field sessionUrlField = CouchDbSessionAuthenticator.class.getDeclaredField("sessionUrl");
+        sessionUrlField.setAccessible(true);
+        assertEquals("http://couchdb:5984/_session", sessionUrlField.get(auth).toString());
+
+        Field tokenDataField = auth.getClass().getSuperclass().getSuperclass().getDeclaredField("tokenData");
+        tokenDataField.setAccessible(true);
+
+        Class<?> tokenClass = Class.forName("com.ibm.cloud.cloudant.security.CouchDbSessionAuthenticator$CouchDbSessionToken");
+        java.lang.reflect.Constructor<?> tokenCtor = tokenClass.getDeclaredConstructor(long.class);
+        tokenCtor.setAccessible(true);
+        Object mockToken = tokenCtor.newInstance(System.currentTimeMillis() + 3600_000L);
+        tokenDataField.set(auth, mockToken);
+        assertNotNull(tokenDataField.get(auth));
+
+        new LuceneAwareCouchDbConnector(client, "ddoc", "sw360db", new Gson());
+
+        assertEquals("http://couchdb:5984/_session", sessionUrlField.get(auth).toString());
+        assertNotNull("Active session token must not be invalidated by connector construction", tokenDataField.get(auth));
     }
 }


### PR DESCRIPTION
## Description

Fixes #4558.

### Problem

During SW360 startup, `NouveauAwareDatabase` was creating a new
`Cloudant` instance using the shared `CouchDbSessionAuthenticator`.

The Cloudant constructor mutates the shared authenticator by resetting its
session URL and invalidating its token. With multiple search handlers
initializing concurrently, this can cause authentication failures against
CouchDB and eventually trigger CouchDB account lockout.

### Solution

Change `NouveauAwareDatabase` to extend `BaseService` instead of `Cloudant`
and reuse the existing `Cloudant` client.

This avoids constructing a new `Cloudant` instance with the shared
authenticator while retaining the existing SDK request pipeline and
configured HTTP client.

### Testing

- `mvn test -pl libraries/nouveau-handler -Dbase.deploy.dir=.`
- `mvn spotless:check -pl libraries/nouveau-handler -Dbase.deploy.dir=.`

Both pass successfully.

A regression test was added to verify that constructing the search connector
does not mutate the shared CouchDB authenticator.
