### PR TITLE
fix(report): generate valid release links

### DIFF
--- a/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
+++ b/backend/common/src/main/java/org/eclipse/sw360/datahandler/db/SW360ConfigsDatabaseHandler.java
@@ -36,6 +36,9 @@ import java.util.Collections;
 import static org.eclipse.sw360.datahandler.common.SW360ConfigKeys.*;
 
 public class SW360ConfigsDatabaseHandler {
+    private static final String DEFAULT_FRONTEND_URL = "http://localhost:3000";
+    private static final String RELEASE_DETAIL_PATH = "/components/releases/detail/releaseId";
+    private static final String LEGACY_DEFAULT_RELEASE_URL = DEFAULT_FRONTEND_URL + RELEASE_DETAIL_PATH;
     private final Logger log = LogManager.getLogger(this.getClass());
     private final ConfigContainerRepository repository;
     private static final Map<ConfigFor, Map<String, String>> configsMapInMem = new HashMap<>();
@@ -85,7 +88,7 @@ public class SW360ConfigsDatabaseHandler {
             .put(PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, getOrDefault(configContainer, PACKAGE_PORTLET_WRITE_ACCESS_USER_ROLE, UserGroup.USER.name()))
             .put(IS_ADMIN_PRIVATE_ACCESS_ENABLED, getOrDefault(configContainer, IS_ADMIN_PRIVATE_ACCESS_ENABLED, "false"))
             .put(SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, getOrDefault(configContainer, SKIP_DOMAINS_FOR_VALID_SOURCE_CODE, SW360Constants.DEFAULT_DOMAIN_PATTERN_SKIP_FOR_SOURCECODE))
-            .put(RELEASE_FRIENDLY_URL, getOrDefault(configContainer, RELEASE_FRIENDLY_URL, "http://localhost:3000/components/releases/detail/releaseId"))
+            .put(RELEASE_FRIENDLY_URL, getReleaseFriendlyUrl(configContainer))
             .put(COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, getOrDefault(configContainer, COMBINED_CLI_PARSER_EXTERNAL_ID_CORRELATION_KEY, ""))
                 .put(VCS_HOSTS, getOrDefault(configContainer, VCS_HOSTS, "[]"))
                 .put(NON_PKG_MANAGED_COMPS_PROP, getOrDefault(configContainer, NON_PKG_MANAGED_COMPS_PROP, ""))
@@ -93,6 +96,16 @@ public class SW360ConfigsDatabaseHandler {
                 .put(INHERIT_ATTACHMENT_USAGES, getOrDefault(configContainer, INHERIT_ATTACHMENT_USAGES, "false"))
             .build();
         putInMemory(ConfigFor.SW360_CONFIGURATION, configMap);
+    }
+
+    private String defaultReleaseFriendlyUrl() {
+        return System.getenv().getOrDefault("SW360_FRONTEND_URL", DEFAULT_FRONTEND_URL)
+                .replaceAll("/$", "") + RELEASE_DETAIL_PATH;
+    }
+
+    private String getReleaseFriendlyUrl(ConfigContainer configContainer) {
+        String configuredUrl = getOrDefault(configContainer, RELEASE_FRIENDLY_URL, LEGACY_DEFAULT_RELEASE_URL);
+        return LEGACY_DEFAULT_RELEASE_URL.equals(configuredUrl) ? defaultReleaseFriendlyUrl() : configuredUrl;
     }
 
     private void loadToConfigsInMemForUi(ConfigContainer configContainer) {

--- a/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -57,6 +57,8 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyString
 import static org.eclipse.sw360.licenseinfo.outputGenerators.DocxUtils.*;
 
 public class DocxGenerator extends OutputGenerator<byte[]> {
+    private static final String DEFAULT_FRONTEND_URL = "http://localhost:3000";
+    private static final String RELEASE_DETAIL_PATH = "/components/releases/detail/releaseId";
     private static final String NO_ORGANISATION_OBLIGATIONS = "No Organisation Obligations.";
     private static final String NO_PROJECT_OBLIGATIONS = "No Project Obligations.";
     private static final String NO_COMPONENT_OBLIGATIONS = "No Component Obligations.";
@@ -459,7 +461,9 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
     }
 
     private static void addHyperlink(XWPFParagraph paragraph, String releaseVersion, String releaseId) {
-        String friendlyReleaseUrl = SW360Utils.readConfig(SW360ConfigKeys.RELEASE_FRIENDLY_URL, "http://localhost:3000/release/releaseId");
+        String friendlyReleaseUrl = SW360Utils.readConfig(SW360ConfigKeys.RELEASE_FRIENDLY_URL,
+                System.getenv().getOrDefault("SW360_FRONTEND_URL", DEFAULT_FRONTEND_URL)
+                        .replaceAll("/$", "") + RELEASE_DETAIL_PATH);
         String id = paragraph.getDocument().getPackagePart().addExternalRelationship(
                 friendlyReleaseUrl.replace("releaseId", releaseId), XWPFRelation.HYPERLINK.getRelation()).getId();
 


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

## Summary

- generate project clearing report release links using the configured frontend URL
- preserve explicit custom release URL settings
- migrate the legacy localhost default to the current frontend configuration

Fixes #4596

## How To Test

- Verify generated chapter 2.4 release links use the configured `SW360_FRONTEND_URL` host.
- Verify the release route remains `/components/releases/detail/{releaseId}`.
- `git diff --check` passes.

Full Maven compilation was attempted with Java 21 and the repository-compatible Thrift 0.20 compiler; the checkout currently reports unrelated generated Thrift compilation errors.
